### PR TITLE
docs: enable `missing_docs` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ tracing-opentelemetry = { version = "0.22.0" }
 tracing-subscriber = { version = "0.3.0" }
 typetag = { version = "0.2.13" }
 wasm-bindgen = { version = "0.2.92" }
+
+[workspace.lints.rust]
+missing_docs = "warn"

--- a/crates/proofs-sql/Cargo.toml
+++ b/crates/proofs-sql/Cargo.toml
@@ -24,3 +24,6 @@ lalrpop = { version = "0.20.0" }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/proofs-sql/build.rs
+++ b/crates/proofs-sql/build.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 extern crate lalrpop;
 
 fn main() {

--- a/crates/proofs-sql/src/decimal_unknown.rs
+++ b/crates/proofs-sql/src/decimal_unknown.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 use serde::{Deserialize, Serialize};
 
 /// An intermediate placeholder for a decimal string
@@ -5,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct DecimalUnknown {
     value: String,
     precision: u8,
+    /// TODO: add docs
     pub scale: i8,
 }
 
@@ -80,12 +82,15 @@ impl DecimalUnknown {
         }
     }
 
+    /// TODO: add docs
     pub fn value(&self) -> String {
         self.value.to_owned()
     }
+    /// TODO: add docs
     pub fn precision(&self) -> u8 {
         self.precision
     }
+    /// TODO: add docs
     pub fn scale(&self) -> i8 {
         self.scale
     }

--- a/crates/proofs-sql/src/error.rs
+++ b/crates/proofs-sql/src/error.rs
@@ -1,14 +1,19 @@
+//! TODO: add docs
 use thiserror::Error;
 
 /// Errors encountered during the parsing process
 #[derive(Debug, Error, Eq, PartialEq)]
 pub enum ParseError {
     #[error("Unable to parse query")]
+    /// TODO: add docs
     QueryParseError(String),
     #[error("Unable to parse identifier")]
+    /// TODO: add docs
     IdentifierParseError(String),
     #[error("Unable to parse resource_id")]
+    /// TODO: add docs
     ResourceIdParseError(String),
 }
 
+/// TODO: add docs
 pub type ParseResult<T> = std::result::Result<T, ParseError>;

--- a/crates/proofs-sql/src/identifier.rs
+++ b/crates/proofs-sql/src/identifier.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 use crate::{sql::IdentifierParser, ParseError, ParseResult};
 use arrayvec::ArrayString;
 use std::{cmp::Ordering, fmt, str::FromStr};

--- a/crates/proofs-sql/src/intermediate_ast.rs
+++ b/crates/proofs-sql/src/intermediate_ast.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 /***
 * These AST nodes are closely following vervolg:
 * https://docs.rs/vervolg/latest/vervolg/ast/enum.Statement.html
@@ -11,26 +12,37 @@ use serde::{Deserialize, Serialize};
 pub enum SetExpression {
     /// Query result as `SetExpression`
     Query {
+        /// TODO: add docs
         result_exprs: Vec<SelectResultExpr>,
+        /// TODO: add docs
         from: Vec<Box<TableExpression>>,
+        /// TODO: add docs
         where_expr: Option<Box<Expression>>,
+        /// TODO: add docs
         group_by: Vec<Identifier>,
     },
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+/// TODO: add docs
 pub enum SelectResultExpr {
+    /// TODO: add docs
     ALL,
+    /// TODO: add docs
     AliasedResultExpr(AliasedResultExpr),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+/// TODO: add docs
 pub struct AliasedResultExpr {
+    /// TODO: add docs
     pub expr: Box<Expression>,
+    /// TODO: add docs
     pub alias: Identifier,
 }
 
 impl AliasedResultExpr {
+    /// TODO: add docs
     pub fn new(expr: Expression, alias: Identifier) -> Self {
         Self {
             expr: Box::new(expr),
@@ -38,6 +50,7 @@ impl AliasedResultExpr {
         }
     }
 
+    /// TODO: add docs
     pub fn try_as_identifier(&self) -> Option<&Identifier> {
         match self.expr.as_ref() {
             Expression::Column(column) => Some(column),
@@ -53,6 +66,7 @@ pub enum TableExpression {
     Named {
         /// the qualified table Identifier
         table: Identifier,
+        /// TODO: add docs
         schema: Option<Identifier>,
     },
 }
@@ -97,11 +111,17 @@ pub enum UnaryOperator {
 
 // Aggregation operators
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+/// TODO: add docs
 pub enum AggregationOperator {
+    /// TODO: add docs
     Max,
+    /// TODO: add docs
     Min,
+    /// TODO: add docs
     Sum,
+    /// TODO: add docs
     Count,
+    /// TODO: add docs
     First,
 }
 
@@ -128,14 +148,19 @@ pub enum Expression {
 
     /// Unary operation
     Unary {
+        /// TODO: add docs
         op: UnaryOperator,
+        /// TODO: add docs
         expr: Box<Expression>,
     },
 
     /// Binary operation
     Binary {
+        /// TODO: add docs
         op: BinaryOperator,
+        /// TODO: add docs
         left: Box<Expression>,
+        /// TODO: add docs
         right: Box<Expression>,
     },
 
@@ -144,12 +169,15 @@ pub enum Expression {
 
     /// Aggregation operation
     Aggregation {
+        /// TODO: add docs
         op: AggregationOperator,
+        /// TODO: add docs
         expr: Box<Expression>,
     },
 }
 
 impl Expression {
+    /// TODO: add docs
     pub fn sum(self) -> Box<Self> {
         Box::new(Expression::Aggregation {
             op: AggregationOperator::Sum,
@@ -157,6 +185,7 @@ impl Expression {
         })
     }
 
+    /// TODO: add docs
     pub fn max(self) -> Box<Self> {
         Box::new(Expression::Aggregation {
             op: AggregationOperator::Max,
@@ -164,6 +193,7 @@ impl Expression {
         })
     }
 
+    /// TODO: add docs
     pub fn min(self) -> Box<Self> {
         Box::new(Expression::Aggregation {
             op: AggregationOperator::Min,
@@ -171,6 +201,7 @@ impl Expression {
         })
     }
 
+    /// TODO: add docs
     pub fn count(self) -> Box<Self> {
         Box::new(Expression::Aggregation {
             op: AggregationOperator::Count,
@@ -178,6 +209,7 @@ impl Expression {
         })
     }
 
+    /// TODO: add docs
     pub fn first(self) -> Box<Self> {
         Box::new(Expression::Aggregation {
             op: AggregationOperator::First,
@@ -189,14 +221,18 @@ impl Expression {
 /// OrderBy
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct OrderBy {
+    /// TODO: add docs
     pub expr: Identifier,
+    /// TODO: add docs
     pub direction: OrderByDirection,
 }
 
 /// OrderByDirection values
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum OrderByDirection {
+    /// TODO: add docs
     Asc,
+    /// TODO: add docs
     Desc,
 }
 

--- a/crates/proofs-sql/src/lib.rs
+++ b/crates/proofs-sql/src/lib.rs
@@ -1,3 +1,5 @@
+//! TODO: add docs
+
 pub mod decimal_unknown;
 #[macro_use]
 extern crate lalrpop_util;
@@ -23,7 +25,7 @@ pub mod resource_id;
 pub use resource_id::ResourceId;
 
 // lalrpop-generated code is not clippy-compliant
-lalrpop_mod!(#[allow(clippy::all)] pub sql);
+lalrpop_mod!(#[allow(clippy::all, missing_docs)] pub sql);
 
 /// Implement Deserialize through FromStr to avoid invalid identifiers.
 #[macro_export]

--- a/crates/proofs-sql/src/resource_id.rs
+++ b/crates/proofs-sql/src/resource_id.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 use crate::{impl_serde_from_str, sql::ResourceIdParser, Identifier, ParseError, ParseResult};
 use std::{
     fmt::{self, Display},

--- a/crates/proofs-sql/src/select_statement.rs
+++ b/crates/proofs-sql/src/select_statement.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 use super::intermediate_ast::{OrderBy, SetExpression, Slice, TableExpression};
 use crate::{sql::SelectStatementParser, Identifier, ParseError, ParseResult, ResourceId};
 use serde::{Deserialize, Serialize};

--- a/crates/proofs-wasm-test/Cargo.toml
+++ b/crates/proofs-wasm-test/Cargo.toml
@@ -11,3 +11,6 @@ version.workspace = true
 ark-std = { workspace = true }
 proofs = { path = "../proofs", default-features = false, features = ["test"] }
 wasm-bindgen = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/proofs-wasm-test/src/main.rs
+++ b/crates/proofs-wasm-test/src/main.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 use ark_std::test_rng;
 use proofs::{
     base::database::{OwnedTableTestAccessor, TestAccessor},

--- a/crates/proofs/Cargo.toml
+++ b/crates/proofs/Cargo.toml
@@ -64,3 +64,6 @@ name = "sumcheck"
 [features]
 default = ["blitzar"]
 test = ["dep:rand"]
+
+[lints]
+workspace = true

--- a/crates/proofs/benches/sumcheck.rs
+++ b/crates/proofs/benches/sumcheck.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use merlin::Transcript;
 use num_traits::{One, Zero};

--- a/crates/proofs/src/base/bit/abs_bit_mask.rs
+++ b/crates/proofs/src/base/bit/abs_bit_mask.rs
@@ -1,5 +1,6 @@
 use crate::base::scalar::Scalar;
 
+/// TODO: add docs
 pub fn make_abs_bit_mask<S: Scalar>(x: S) -> [u64; 4] {
     let (sign, x) = if S::MAX_SIGNED < x { (1, -x) } else { (0, x) };
     let mut res: [u64; 4] = x.into();

--- a/crates/proofs/src/base/bit/bit_distribution.rs
+++ b/crates/proofs/src/base/bit/bit_distribution.rs
@@ -14,10 +14,12 @@ pub struct BitDistribution {
     ///              1 if x_s & (1 << i) != x_t & (1 << i) for some s != t
     ///              0 otherwise
     pub or_all: [u64; 4],
+    /// TODO: add docs
     pub vary_mask: [u64; 4],
 }
 
 impl BitDistribution {
+    /// TODO: add docs
     pub fn new<S: Scalar, T: Into<S> + Clone>(data: &[T]) -> Self {
         if data.is_empty() {
             return Self {
@@ -37,6 +39,7 @@ impl BitDistribution {
         Self { or_all, vary_mask }
     }
 
+    /// TODO: add docs
     pub fn num_varying_bits(&self) -> usize {
         let mut res = 0_usize;
         for xi in self.vary_mask.iter() {
@@ -45,10 +48,12 @@ impl BitDistribution {
         res
     }
 
+    /// TODO: add docs
     pub fn has_varying_sign_bit(&self) -> bool {
         self.vary_mask[3] & (1 << 63) != 0
     }
 
+    /// TODO: add docs
     pub fn sign_bit(&self) -> bool {
         assert!(!self.has_varying_sign_bit());
         self.or_all[3] & (1 << 63) != 0

--- a/crates/proofs/src/base/bit/mod.rs
+++ b/crates/proofs/src/base/bit/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 mod abs_bit_mask;
 pub use abs_bit_mask::*;
 

--- a/crates/proofs/src/base/database/mod.rs
+++ b/crates/proofs/src/base/database/mod.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 //! Module with database related functionality. In particular, this module contains the
 //! accessor traits and the `OwnedTable` type along with some utility functions to convert
 //! between Arrow and `OwnedTable`.
@@ -20,7 +19,6 @@ pub use record_batch_dataframe_conversion::*;
 mod record_batch_utility;
 pub use record_batch_utility::*;
 
-#[warn(missing_docs)]
 #[cfg(any(test, feature = "test"))]
 #[cfg(feature = "blitzar")]
 mod record_batch_test_accessor;
@@ -28,7 +26,6 @@ mod record_batch_test_accessor;
 #[cfg(feature = "blitzar")]
 pub use record_batch_test_accessor::RecordBatchTestAccessor;
 
-#[warn(missing_docs)]
 #[cfg(all(test, feature = "blitzar"))]
 mod record_batch_test_accessor_test;
 
@@ -37,30 +34,23 @@ mod test_accessor_utility;
 #[cfg(any(test, feature = "test"))]
 pub use test_accessor_utility::{make_random_test_accessor_data, RandomTestAccessorDescriptor};
 
-#[warn(missing_docs)]
 mod owned_column;
 pub use owned_column::*;
-#[warn(missing_docs)]
 mod owned_table;
 pub use owned_table::*;
 #[cfg(test)]
-#[warn(missing_docs)]
 mod owned_table_test;
 
-#[warn(missing_docs)]
 mod owned_and_arrow_conversions;
 pub use owned_and_arrow_conversions::*;
 #[cfg(test)]
-#[warn(missing_docs)]
 mod owned_and_arrow_conversions_test;
 
-#[warn(missing_docs)]
 #[cfg(any(test, feature = "test"))]
 mod test_accessor;
 #[cfg(any(test, feature = "test"))]
 pub use test_accessor::{TestAccessor, UnimplementedTestAccessor};
 
-#[warn(missing_docs)]
 #[cfg(any(test, feature = "test"))]
 mod owned_table_test_accessor;
 #[cfg(any(test, feature = "test"))]

--- a/crates/proofs/src/base/encode/mod.rs
+++ b/crates/proofs/src/base/encode/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 mod u256;
 pub(crate) use u256::U256;
 

--- a/crates/proofs/src/base/math/decimal.rs
+++ b/crates/proofs/src/base/math/decimal.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 use crate::{base::scalar::Scalar, sql::parse::ConversionError};
 use num_bigint::{
     BigInt,
@@ -10,6 +11,7 @@ use std::str::FromStr;
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Serialize, Copy)]
 /// limit-enforced precision
 pub struct Precision(u8);
+/// TODO: add docs
 pub const MAX_SUPPORTED_PRECISION: u8 = 75;
 
 impl Precision {

--- a/crates/proofs/src/base/math/log.rs
+++ b/crates/proofs/src/base/math/log.rs
@@ -1,15 +1,18 @@
 use num_traits::{PrimInt, Unsigned};
 use std::mem;
 
+/// TODO: add docs
 pub fn log2_down<T: PrimInt + Unsigned>(x: T) -> usize {
     mem::size_of::<T>() * 8 - (x.leading_zeros() as usize) - 1
 }
 
+/// TODO: add docs
 pub fn is_pow2<T: PrimInt + Unsigned>(x: T) -> bool {
     debug_assert!(x > T::zero());
     x & (x - T::one()) == T::zero()
 }
 
+/// TODO: add docs
 pub fn log2_up<T: PrimInt + Unsigned>(x: T) -> usize {
     let is_not_pow_2 = !is_pow2(x) as usize;
     log2_down(x) + is_not_pow_2

--- a/crates/proofs/src/base/math/mod.rs
+++ b/crates/proofs/src/base/math/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 pub mod decimal;
 #[cfg(test)]
 mod decimal_tests;

--- a/crates/proofs/src/base/mod.rs
+++ b/crates/proofs/src/base/mod.rs
@@ -1,11 +1,10 @@
+//! TODO: add docs
 pub mod bit;
-#[warn(missing_docs)]
 pub mod commitment;
 pub mod database;
 pub mod encode;
 pub mod math;
 pub mod polynomial;
-#[warn(missing_docs)]
 pub mod proof;
 pub mod ref_into;
 pub mod scalar;

--- a/crates/proofs/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proofs/src/base/polynomial/composite_polynomial.rs
@@ -111,6 +111,7 @@ impl<S: Scalar> CompositePolynomial<S> {
         level = "debug",
         skip_all
     )]
+    /// TODO: add docs
     pub fn annotate_trace(&self) {
         for i in 0..self.products.len() {
             tracing::info!(

--- a/crates/proofs/src/base/polynomial/mod.rs
+++ b/crates/proofs/src/base/polynomial/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 mod composite_polynomial;
 pub use composite_polynomial::{CompositePolynomial, CompositePolynomialInfo};
 #[cfg(test)]
@@ -8,13 +9,11 @@ mod interpolate;
 mod interpolate_test;
 pub use interpolate::interpolate_uni_poly;
 
-#[warn(missing_docs)]
 mod evaluation_vector;
 pub use evaluation_vector::compute_evaluation_vector;
 #[cfg(test)]
 mod evaluation_vector_test;
 
-#[warn(missing_docs)]
 mod lagrange_basis_evaluation;
 pub use lagrange_basis_evaluation::{
     compute_truncated_lagrange_basis_inner_product, compute_truncated_lagrange_basis_sum,
@@ -22,7 +21,6 @@ pub use lagrange_basis_evaluation::{
 #[cfg(test)]
 mod lagrange_basis_evaluation_test;
 
-#[warn(missing_docs)]
 mod multilinear_extension;
 pub use multilinear_extension::MultilinearExtension;
 #[cfg(test)]

--- a/crates/proofs/src/base/proof/mod.rs
+++ b/crates/proofs/src/base/proof/mod.rs
@@ -3,7 +3,6 @@
 mod error;
 pub use error::ProofError;
 
-#[warn(missing_docs)]
 /// Contains an extension trait for `merlin::Transcript`, which is used to construct a proof.
 mod transcript_protocol;
 #[cfg(test)]

--- a/crates/proofs/src/base/scalar/mod.rs
+++ b/crates/proofs/src/base/scalar/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 mod mont_scalar;
 #[cfg(test)]
 mod mont_scalar_test;
@@ -56,7 +57,10 @@ pub trait Scalar:
     /// The value (p - 1) / 2. This is "mid-point" of the field - the "six" on the clock.
     /// It is the largest signed value that can be represented in the field with the natural embedding.
     const MAX_SIGNED: Self;
+    /// TODO: add docs
     const ZERO: Self;
+    /// TODO: add docs
     const ONE: Self;
+    /// TODO: add docs
     const TWO: Self;
 }

--- a/crates/proofs/src/base/slice_ops/batch_inverse.rs
+++ b/crates/proofs/src/base/slice_ops/batch_inverse.rs
@@ -29,6 +29,7 @@ where
     batch_inversion_and_mul(v, F::one());
 }
 
+/// TODO: add docs
 pub fn batch_inversion_and_mul<F>(v: &mut [F], coeff: F)
 where
     F: One + Zero + MulAssign + Inv<Output = Option<F>> + Mul<Output = F> + Send + Sync + Copy,

--- a/crates/proofs/src/base/slice_ops/mod.rs
+++ b/crates/proofs/src/base/slice_ops/mod.rs
@@ -3,6 +3,7 @@
 //! For example, the inner product will not panic when the two input slices have different lengths.
 //! Instead, it will simply truncate the longer one, which is equivalent to multiply each extra element by zero before summing.
 
+/// TODO: add docs
 pub const MIN_RAYON_LEN: usize = 1 << 8;
 
 mod inner_product;

--- a/crates/proofs/src/lib.rs
+++ b/crates/proofs/src/lib.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 pub mod base;
 pub mod proof_primitive;
 pub mod sql;

--- a/crates/proofs/src/proof_primitive/dory/mod.rs
+++ b/crates/proofs/src/proof_primitive/dory/mod.rs
@@ -14,7 +14,6 @@
 //! This implementation only implements the computational integrity component of Dory.
 //! This can be extended in the future to achieve hiding, but that isn't needed for our initial use-case.
 
-#![warn(missing_docs)]
 // This is so that the naming in the code more closely matches the naming in the paper, since the paper used both capital and non-capital letters.
 #![allow(non_snake_case)]
 

--- a/crates/proofs/src/proof_primitive/mod.rs
+++ b/crates/proofs/src/proof_primitive/mod.rs
@@ -1,2 +1,3 @@
+//! TODO: add docs
 pub mod dory;
 pub mod sumcheck;

--- a/crates/proofs/src/proof_primitive/sumcheck/mod.rs
+++ b/crates/proofs/src/proof_primitive/sumcheck/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 mod proof;
 #[cfg(test)]
 mod proof_test;

--- a/crates/proofs/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proofs/src/proof_primitive/sumcheck/proof.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::vec::Vec;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+/// TODO: add docs
 pub struct SumcheckProof<S: Scalar> {
     pub(super) evaluations: Vec<Vec<S>>,
 }
@@ -26,6 +27,7 @@ impl<S: Scalar> SumcheckProof<S> {
         level = "info",
         skip_all
     )]
+    /// TODO: add docs
     pub fn create(
         transcript: &mut Transcript,
         evaluation_point: &mut [S],
@@ -58,6 +60,7 @@ impl<S: Scalar> SumcheckProof<S> {
         level = "debug",
         skip_all
     )]
+    /// TODO: add docs
     pub fn verify_without_evaluation(
         &self,
         transcript: &mut Transcript,

--- a/crates/proofs/src/proof_primitive/sumcheck/subclaim.rs
+++ b/crates/proofs/src/proof_primitive/sumcheck/subclaim.rs
@@ -6,8 +6,11 @@
 use crate::base::scalar::Scalar;
 use crate::base::{polynomial::interpolate_uni_poly, proof::ProofError};
 
+/// TODO: add docs
 pub struct Subclaim<S: Scalar> {
+    /// TODO: add docs
     pub evaluation_point: Vec<S>,
+    /// TODO: add docs
     pub expected_evaluation: S,
 }
 

--- a/crates/proofs/src/sql/ast/filter_expr.rs
+++ b/crates/proofs/src/sql/ast/filter_expr.rs
@@ -109,6 +109,7 @@ where
     }
 }
 
+/// TODO: add docs
 pub type FilterExpr<C> = OstensibleFilterExpr<C, HonestProver>;
 impl<C: Commitment> ProverEvaluate<C::Scalar> for FilterExpr<C> {
     fn result_evaluate<'a>(

--- a/crates/proofs/src/sql/ast/mod.rs
+++ b/crates/proofs/src/sql/ast/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 mod filter_result_expr;
 pub use filter_result_expr::FilterResultExpr;
 
@@ -65,11 +66,9 @@ mod test_expr;
 #[cfg(test)]
 pub mod test_utility;
 
-#[warn(missing_docs)]
 mod column_expr;
 pub use column_expr::ColumnExpr;
 
-#[warn(missing_docs)]
 mod dense_filter_expr;
 pub use dense_filter_expr::{DenseFilterExpr, OstensibleDenseFilterExpr};
 #[cfg(all(test, feature = "blitzar"))]
@@ -77,20 +76,17 @@ mod dense_filter_expr_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod dense_filter_expr_test_dishonest_prover;
 
-#[warn(missing_docs)]
 mod dense_filter_util;
 pub use dense_filter_util::{filter_column_by_index, filter_columns, fold_columns, fold_vals};
 #[cfg(test)]
 mod dense_filter_util_test;
 
-#[warn(missing_docs)]
 mod group_by_expr;
 pub use group_by_expr::GroupByExpr;
 
 #[cfg(all(test, feature = "blitzar"))]
 mod group_by_expr_test;
 
-#[warn(missing_docs)]
 mod group_by_util;
 use group_by_util::aggregate_columns;
 #[cfg(test)]

--- a/crates/proofs/src/sql/ast/table_expr.rs
+++ b/crates/proofs/src/sql/ast/table_expr.rs
@@ -4,5 +4,6 @@ use serde::{Deserialize, Serialize};
 /// Expression for an SQL table
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TableExpr {
+    /// TODO: add docs
     pub table_ref: TableRef,
 }

--- a/crates/proofs/src/sql/mod.rs
+++ b/crates/proofs/src/sql/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 pub mod ast;
 pub mod parse;
 pub mod proof;

--- a/crates/proofs/src/sql/parse/error.rs
+++ b/crates/proofs/src/sql/parse/error.rs
@@ -5,24 +5,34 @@ use thiserror::Error;
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ConversionError {
     #[error("Column '{0}' was not found in table '{1}'")]
+    /// TODO: add docs
     MissingColumn(Box<Identifier>, Box<ResourceId>),
     #[error("Left side has '{1}' type but right side has '{0}' type")]
+    /// TODO: add docs
     DataTypeMismatch(String, String),
     #[error("Multiple result columns with the same alias '{0}' have been found.")]
+    /// TODO: add docs
     DuplicateResultAlias(String),
     #[error("Invalid order by: alias '{0}' does not appear in the result expressions.")]
+    /// TODO: add docs
     InvalidOrderBy(String),
     #[error("Invalid group by: column '{0}' must appear in the group by expression.")]
+    /// TODO: add docs
     InvalidGroupByColumnRef(String),
     #[error("Invalid expression: {0}")]
+    /// TODO: add docs
     InvalidExpression(String),
     #[error("Error while parsing precision from query: {0}")]
+    /// TODO: add docs
     PrecisionParseError(String),
     #[error("Encountered parsing error: {0}")]
+    /// TODO: add docs
     ParseError(String),
     #[error("Unsupported operation: cannot round literal: {0}")]
+    /// TODO: add docs
     LiteralRoundDownError(String),
     #[error("Query not provable because: {0}")]
+    /// TODO: add docs
     Unprovable(String),
 }
 
@@ -33,6 +43,7 @@ impl From<String> for ConversionError {
 }
 
 impl ConversionError {
+    /// TODO: add docs
     pub fn non_numeric_expr_in_agg<S: Into<String>>(dtype: S, func: S) -> Self {
         ConversionError::InvalidExpression(format!(
             "cannot use expression of type '{}' with numeric aggregation function '{}'",
@@ -42,4 +53,5 @@ impl ConversionError {
     }
 }
 
+/// TODO: add docs
 pub type ConversionResult<T> = std::result::Result<T, ConversionError>;

--- a/crates/proofs/src/sql/parse/filter_expr_builder.rs
+++ b/crates/proofs/src/sql/parse/filter_expr_builder.rs
@@ -9,6 +9,7 @@ use crate::{
 use proofs_sql::{intermediate_ast::Expression, Identifier};
 use std::collections::{HashMap, HashSet};
 
+/// TODO: add docs
 pub struct FilterExprBuilder<C: Commitment> {
     table_expr: Option<TableExpr>,
     where_expr: Option<ProvableExprPlan<C>>,
@@ -18,6 +19,7 @@ pub struct FilterExprBuilder<C: Commitment> {
 
 // Public interface
 impl<C: Commitment> FilterExprBuilder<C> {
+    /// TODO: add docs
     pub fn new(column_mapping: HashMap<Identifier, ColumnRef>) -> Self {
         Self {
             table_expr: None,
@@ -27,11 +29,13 @@ impl<C: Commitment> FilterExprBuilder<C> {
         }
     }
 
+    /// TODO: add docs
     pub fn add_table_expr(mut self, table_ref: TableRef) -> Self {
         self.table_expr = Some(TableExpr { table_ref });
         self
     }
 
+    /// TODO: add docs
     pub fn add_where_expr(
         mut self,
         where_expr: Option<Box<Expression>>,
@@ -40,6 +44,7 @@ impl<C: Commitment> FilterExprBuilder<C> {
         Ok(self)
     }
 
+    /// TODO: add docs
     pub fn add_result_column_set(mut self, columns: HashSet<Identifier>) -> Self {
         // Sorting is required to make the relative order of the columns deterministic
         let mut columns = columns.into_iter().collect::<Vec<_>>();
@@ -54,6 +59,7 @@ impl<C: Commitment> FilterExprBuilder<C> {
         self
     }
 
+    /// TODO: add docs
     pub fn build(self) -> FilterExpr<C> {
         FilterExpr::new(
             self.filter_result_expr_list,

--- a/crates/proofs/src/sql/parse/mod.rs
+++ b/crates/proofs/src/sql/parse/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 mod error;
 mod where_expr_builder_tests;
 pub use error::{ConversionError, ConversionResult};
@@ -20,6 +21,5 @@ pub use query_context::QueryContext;
 mod query_context_builder;
 pub use query_context_builder::QueryContextBuilder;
 
-#[warn(missing_docs)]
 mod where_expr_builder;
 pub use where_expr_builder::WhereExprBuilder;

--- a/crates/proofs/src/sql/parse/query_context.rs
+++ b/crates/proofs/src/sql/parse/query_context.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 use crate::{
     base::{
         commitment::Commitment,
@@ -15,6 +16,7 @@ use proofs_sql::{
 use std::collections::{HashMap, HashSet};
 
 #[derive(Default, Debug)]
+/// TODO: add docs
 pub struct QueryContext {
     in_agg_scope: bool,
     agg_counter: usize,
@@ -34,37 +36,45 @@ pub struct QueryContext {
 }
 
 impl QueryContext {
+    /// TODO: add docs
     pub fn set_table_ref(&mut self, table: TableRef) {
         assert!(self.table.is_none());
         self.table = Some(table);
     }
 
+    /// TODO: add docs
     pub fn get_table_ref(&self) -> &TableRef {
         self.table
             .as_ref()
             .expect("Table should already have been set")
     }
 
+    /// TODO: add docs
     pub fn set_where_expr(&mut self, where_expr: Option<Box<Expression>>) {
         self.where_expr = where_expr;
     }
 
+    /// TODO: add docs
     pub fn get_where_expr(&self) -> &Option<Box<Expression>> {
         &self.where_expr
     }
 
+    /// TODO: add docs
     pub fn set_slice_expr(&mut self, slice_expr: Option<Slice>) {
         self.slice_expr = slice_expr;
     }
 
+    /// TODO: add docs
     pub fn toggle_result_scope(&mut self) {
         self.in_result_scope = !self.in_result_scope;
     }
 
+    /// TODO: add docs
     pub fn is_in_result_scope(&self) -> bool {
         self.in_result_scope
     }
 
+    /// TODO: add docs
     pub fn set_in_agg_scope(&mut self, in_agg_scope: bool) -> ConversionResult<()> {
         if !in_agg_scope {
             assert!(
@@ -95,6 +105,7 @@ impl QueryContext {
         self.in_agg_scope
     }
 
+    /// TODO: add docs
     pub fn push_column_ref(&mut self, column: Identifier, column_ref: ColumnRef) {
         self.col_ref_counter += 1;
         self.push_result_column_ref(column);
@@ -121,6 +132,7 @@ impl QueryContext {
         Ok(())
     }
 
+    /// TODO: add docs
     pub fn push_aliased_result_expr(&mut self, expr: AliasedResultExpr) -> ConversionResult<()> {
         assert!(&self.has_visited_group_by, "Group by must be visited first");
 
@@ -134,6 +146,7 @@ impl QueryContext {
         Ok(())
     }
 
+    /// TODO: add docs
     pub fn set_group_by_exprs(&mut self, exprs: Vec<Identifier>) {
         self.group_by_exprs = exprs;
 
@@ -146,10 +159,12 @@ impl QueryContext {
         self.has_visited_group_by = true;
     }
 
+    /// TODO: add docs
     pub fn set_order_by_exprs(&mut self, order_by_exprs: Vec<OrderBy>) {
         self.order_by_exprs = order_by_exprs;
     }
 
+    /// TODO: add docs
     pub fn get_any_result_column_ref(&self) -> Option<(Identifier, ColumnType)> {
         // For tests to work we need to make it deterministic by sorting the columns
         // In the long run we simply need to let * be *
@@ -162,6 +177,7 @@ impl QueryContext {
         })
     }
 
+    /// TODO: add docs
     pub fn is_in_group_by_exprs(&self, column: &Identifier) -> ConversionResult<bool> {
         // Non-aggregated result column references must be included in the group by statement.
         if self.group_by_exprs.is_empty() || self.is_in_agg_scope() || !self.is_in_result_scope() {
@@ -176,6 +192,7 @@ impl QueryContext {
             .ok_or(ConversionError::InvalidGroupByColumnRef(column.to_string()))
     }
 
+    /// TODO: add docs
     pub fn get_aliased_result_exprs(&self) -> ConversionResult<&[AliasedResultExpr]> {
         assert!(!self.res_aliased_exprs.is_empty(), "empty aliased exprs");
 
@@ -205,6 +222,7 @@ impl QueryContext {
         Ok(&self.res_aliased_exprs)
     }
 
+    /// TODO: add docs
     pub fn get_order_by_exprs(&self) -> ConversionResult<Vec<OrderBy>> {
         // Order by must reference only aliases in the result schema
         for by_expr in &self.order_by_exprs {
@@ -219,18 +237,22 @@ impl QueryContext {
         Ok(self.order_by_exprs.clone())
     }
 
+    /// TODO: add docs
     pub fn get_slice_expr(&self) -> &Option<Slice> {
         &self.slice_expr
     }
 
+    /// TODO: add docs
     pub fn get_group_by_exprs(&self) -> &[Identifier] {
         &self.group_by_exprs
     }
 
+    /// TODO: add docs
     pub fn get_result_column_set(&self) -> HashSet<Identifier> {
         self.result_column_set.clone()
     }
 
+    /// TODO: add docs
     pub fn get_column_mapping(&self) -> HashMap<Identifier, ColumnRef> {
         self.column_mapping.clone()
     }

--- a/crates/proofs/src/sql/parse/query_context_builder.rs
+++ b/crates/proofs/src/sql/parse/query_context_builder.rs
@@ -15,6 +15,7 @@ use proofs_sql::{
 };
 use std::ops::Deref;
 
+/// TODO: add docs
 pub struct QueryContextBuilder<'a> {
     context: QueryContext,
     schema_accessor: &'a dyn SchemaAccessor,
@@ -22,6 +23,7 @@ pub struct QueryContextBuilder<'a> {
 
 // Public interface
 impl<'a> QueryContextBuilder<'a> {
+    /// TODO: add docs
     pub fn new(schema_accessor: &'a dyn SchemaAccessor) -> Self {
         Self {
             context: QueryContext::default(),
@@ -29,6 +31,7 @@ impl<'a> QueryContextBuilder<'a> {
         }
     }
 
+    /// TODO: add docs
     pub fn visit_table_expr(
         mut self,
         table_expr: Vec<Box<TableExpression>>,
@@ -46,6 +49,7 @@ impl<'a> QueryContextBuilder<'a> {
         self
     }
 
+    /// TODO: add docs
     pub fn visit_where_expr(
         mut self,
         mut where_expr: Option<Box<Expression>>,
@@ -57,6 +61,7 @@ impl<'a> QueryContextBuilder<'a> {
         Ok(self)
     }
 
+    /// TODO: add docs
     pub fn visit_result_exprs(
         mut self,
         result_exprs: Vec<SelectResultExpr>,
@@ -73,16 +78,19 @@ impl<'a> QueryContextBuilder<'a> {
         Ok(self)
     }
 
+    /// TODO: add docs
     pub fn visit_order_by_exprs(mut self, order_by_exprs: Vec<OrderBy>) -> Self {
         self.context.set_order_by_exprs(order_by_exprs);
         self
     }
 
+    /// TODO: add docs
     pub fn visit_slice_expr(mut self, slice: Option<Slice>) -> Self {
         self.context.set_slice_expr(slice);
         self
     }
 
+    /// TODO: add docs
     pub fn visit_group_by_exprs(
         mut self,
         group_by_exprs: Vec<Identifier>,
@@ -94,6 +102,7 @@ impl<'a> QueryContextBuilder<'a> {
         Ok(self)
     }
 
+    /// TODO: add docs
     pub fn build(self) -> ConversionResult<QueryContext> {
         Ok(self.context)
     }

--- a/crates/proofs/src/sql/parse/query_expr.rs
+++ b/crates/proofs/src/sql/parse/query_expr.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(PartialEq, Serialize, Deserialize)]
+/// TODO: add docs
 pub struct QueryExpr<C: Commitment> {
     proof_expr: ProofPlan<C>,
     result: ResultExpr,
@@ -30,10 +31,12 @@ impl<C: Commitment> fmt::Debug for QueryExpr<C> {
 }
 
 impl<C: Commitment> QueryExpr<C> {
+    /// TODO: add docs
     pub fn new(proof_expr: ProofPlan<C>, result: ResultExpr) -> Self {
         Self { proof_expr, result }
     }
 
+    /// TODO: add docs
     pub fn try_new(
         ast: SelectStatement,
         default_schema: Identifier,

--- a/crates/proofs/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proofs/src/sql/proof/composite_polynomial_builder.rs
@@ -7,6 +7,7 @@ use num_traits::{One, Zero};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use std::{collections::HashMap, ffi::c_void, rc::Rc};
 
+/// TODO: add docs
 // Build up a composite polynomial from individual MLE expressions
 pub struct CompositePolynomialBuilder<S: Scalar> {
     num_sumcheck_variables: usize,
@@ -18,6 +19,7 @@ pub struct CompositePolynomialBuilder<S: Scalar> {
 }
 
 impl<S: Scalar> CompositePolynomialBuilder<S> {
+    /// TODO: add docs``
     pub fn new(num_sumcheck_variables: usize, fr: &[S]) -> Self {
         assert!(1 << num_sumcheck_variables >= fr.len());
         Self {

--- a/crates/proofs/src/sql/proof/count_builder.rs
+++ b/crates/proofs/src/sql/proof/count_builder.rs
@@ -11,6 +11,7 @@ pub struct CountBuilder<'a> {
 }
 
 impl<'a> CountBuilder<'a> {
+    /// TODO: add docs
     pub fn new(bit_distributions: &'a [BitDistribution]) -> Self {
         Self {
             bit_distributions,
@@ -34,27 +35,33 @@ impl<'a> CountBuilder<'a> {
         }
     }
 
+    /// TODO: add docs
     pub fn count_result_columns(&mut self, cnt: usize) {
         self.counts.result_columns += cnt;
     }
 
+    /// TODO: add docs
     pub fn count_subpolynomials(&mut self, cnt: usize) {
         self.counts.sumcheck_subpolynomials += cnt;
     }
 
+    /// TODO: add docs
     pub fn count_anchored_mles(&mut self, cnt: usize) {
         self.counts.anchored_mles += cnt;
     }
 
+    /// TODO: add docs
     pub fn count_intermediate_mles(&mut self, cnt: usize) {
         self.counts.intermediate_mles += cnt;
     }
 
+    /// TODO: add docs
     pub fn count_degree(&mut self, degree: usize) {
         self.counts.sumcheck_max_multiplicands =
             max(self.counts.sumcheck_max_multiplicands, degree);
     }
 
+    /// TODO: add docs
     pub fn counts(&self) -> Result<ProofCounts, ProofError> {
         if !self.bit_distributions.is_empty() {
             return Err(ProofError::VerificationError(

--- a/crates/proofs/src/sql/proof/mod.rs
+++ b/crates/proofs/src/sql/proof/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 mod count_builder;
 pub use count_builder::CountBuilder;
 
@@ -19,17 +20,14 @@ pub use verification_builder::VerificationBuilder;
 #[cfg(test)]
 mod verification_builder_test;
 
-#[warn(missing_docs)]
 mod provable_result_column;
 pub use provable_result_column::ProvableResultColumn;
 
-#[warn(missing_docs)]
 mod provable_query_result;
 pub use provable_query_result::ProvableQueryResult;
 #[cfg(test)]
 mod provable_query_result_test;
 
-#[warn(missing_docs)]
 mod sumcheck_mle_evaluations;
 pub use sumcheck_mle_evaluations::SumcheckMleEvaluations;
 #[cfg(test)]
@@ -49,11 +47,9 @@ pub use query_proof::QueryProof;
 #[cfg(all(test, feature = "blitzar"))]
 mod query_proof_test;
 
-#[warn(missing_docs)]
 mod query_result;
 pub use query_result::{QueryData, QueryError, QueryResult};
 
-#[warn(missing_docs)]
 mod sumcheck_subpolynomial;
 pub use sumcheck_subpolynomial::{
     SumcheckSubpolynomial, SumcheckSubpolynomialTerm, SumcheckSubpolynomialType,
@@ -79,12 +75,10 @@ pub use result_element_serialization::{
     decode_and_convert, decode_multiple_elements, ProvableResultElement,
 };
 
-#[warn(missing_docs)]
 mod indexes;
 pub use indexes::Indexes;
 #[cfg(test)]
 mod indexes_test;
 
-#[warn(missing_docs)]
 mod result_builder;
 pub use result_builder::ResultBuilder;

--- a/crates/proofs/src/sql/proof/proof_builder.rs
+++ b/crates/proofs/src/sql/proof/proof_builder.rs
@@ -30,6 +30,7 @@ pub struct ProofBuilder<'a, S: Scalar> {
 
 impl<'a, S: Scalar> ProofBuilder<'a, S> {
     #[tracing::instrument(name = "proofs.sql.proof.proof_builder.new", level = "debug", skip_all)]
+    /// TODO: add docs
     pub fn new(
         table_length: usize,
         num_sumcheck_variables: usize,
@@ -46,14 +47,17 @@ impl<'a, S: Scalar> ProofBuilder<'a, S> {
         }
     }
 
+    /// TODO: add docs
     pub fn table_length(&self) -> usize {
         self.table_length
     }
 
+    /// TODO: add docs
     pub fn num_sumcheck_variables(&self) -> usize {
         self.num_sumcheck_variables
     }
 
+    /// TODO: add docs
     pub fn num_sumcheck_subpolynomials(&self) -> usize {
         self.sumcheck_subpolynomials.len()
     }
@@ -183,6 +187,7 @@ impl<'a, S: Scalar> ProofBuilder<'a, S> {
         res
     }
 
+    /// TODO: add docs
     pub fn bit_distributions(&self) -> &[BitDistribution] {
         &self.bit_distributions
     }

--- a/crates/proofs/src/sql/proof/proof_counts.rs
+++ b/crates/proofs/src/sql/proof/proof_counts.rs
@@ -4,10 +4,15 @@ use std::fmt::Debug;
 /// Counters for different terms used within a proof
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct ProofCounts {
+    /// TODO: add docs
     pub sumcheck_max_multiplicands: usize,
+    /// TODO: add docs
     pub result_columns: usize,
+    /// TODO: add docs
     pub anchored_mles: usize,
+    /// TODO: add docs
     pub intermediate_mles: usize,
+    /// TODO: add docs
     pub sumcheck_subpolynomials: usize,
 
     /// The number of challenges used in the proof.
@@ -23,6 +28,7 @@ impl ProofCounts {
         level = "info",
         skip_all
     )]
+    /// TODO: add docs
     pub fn annotate_trace(&self) {
         tracing::info!(
             "sumcheck_max_multiplicands = {:?}",

--- a/crates/proofs/src/sql/proof/proof_exprs.rs
+++ b/crates/proofs/src/sql/proof/proof_exprs.rs
@@ -10,6 +10,7 @@ use bumpalo::Bump;
 use dyn_partial_eq::dyn_partial_eq;
 use std::{collections::HashSet, fmt::Debug};
 
+/// TODO: add docs
 pub trait ProofExpr<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scalar> {
     /// Count terms used within the Query's proof
     fn count(
@@ -18,10 +19,13 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
         accessor: &dyn MetadataAccessor,
     ) -> Result<(), ProofError>;
 
+    /// TODO: add docs
     fn get_length(&self, accessor: &dyn MetadataAccessor) -> usize;
 
+    /// TODO: add docs
     fn get_offset(&self, accessor: &dyn MetadataAccessor) -> usize;
 
+    /// TODO: add docs
     fn is_empty(&self, accessor: &dyn MetadataAccessor) -> bool {
         self.get_length(accessor) == 0
     }
@@ -41,6 +45,7 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
 }
 
 #[dyn_partial_eq]
+/// TODO: add docs
 pub trait TransformExpr: Debug + Send + Sync {
     /// Apply transformations to the resulting record batch
     fn transform_results(&self, result: RecordBatch) -> RecordBatch {
@@ -48,6 +53,7 @@ pub trait TransformExpr: Debug + Send + Sync {
     }
 }
 
+/// TODO: add docs
 pub trait ProverEvaluate<S: Scalar> {
     /// Evaluate the query and modify `ResultBuilder` to track the result of the query.
     fn result_evaluate<'a>(

--- a/crates/proofs/src/sql/proof/query_proof.rs
+++ b/crates/proofs/src/sql/proof/query_proof.rs
@@ -27,15 +27,21 @@ use std::cmp;
 /// all public so as to allow for easy manipulation for testing.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct QueryProof<CP: CommitmentEvaluationProof> {
+    /// TODO: add docs
     pub bit_distributions: Vec<BitDistribution>,
+    /// TODO: add docs
     pub commitments: Vec<CP::Commitment>,
+    /// TODO: add docs
     pub sumcheck_proof: SumcheckProof<CP::Scalar>,
+    /// TODO: add docs
     pub pre_result_mle_evaluations: Vec<CP::Scalar>,
+    /// TODO: add docs
     pub evaluation_proof: CP,
 }
 
 impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
     #[tracing::instrument(name = "proofs.sql.proof.query_proof.new", level = "info", skip_all)]
+    /// TODO: add docs
     pub fn new(
         expr: &(impl ProofExpr<CP::Commitment> + Serialize),
         accessor: &impl DataAccessor<CP::Scalar>,

--- a/crates/proofs/src/sql/proof/result_element_serialization.rs
+++ b/crates/proofs/src/sql/proof/result_element_serialization.rs
@@ -1,9 +1,13 @@
 use crate::base::encode::VarInt;
 
+/// TODO: add docs
 pub trait ProvableResultElement<'a> {
+    /// TODO: add docs
     fn required_bytes(&self) -> usize;
+    /// TODO: add docs
     fn encode(&self, out: &mut [u8]) -> usize;
 
+    /// TODO: add docs
     fn decode(data: &'a [u8]) -> Option<(Self, usize)>
     where
         Self: Sized;
@@ -89,6 +93,7 @@ impl ProvableResultElement<'_> for String {
     }
 }
 
+/// TODO: add docs
 pub fn decode_and_convert<'a, F, T>(data: &'a [u8]) -> Option<(T, usize)>
 where
     F: ProvableResultElement<'a>,

--- a/crates/proofs/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proofs/src/sql/proof/sumcheck_random_scalars.rs
@@ -2,12 +2,16 @@ use crate::base::{polynomial::compute_evaluation_vector, scalar::Scalar};
 
 /// Accessor for the random scalars used to form the sumcheck polynomial of a query proof
 pub struct SumcheckRandomScalars<'a, S: Scalar> {
+    /// TODO: add docs
     pub entrywise_point: &'a [S],
+    /// TODO: add docs
     pub subpolynomial_multipliers: &'a [S],
+    /// TODO: add docs
     pub table_length: usize,
 }
 
 impl<'a, S: Scalar> SumcheckRandomScalars<'a, S> {
+    /// TODO: add docs
     pub fn new(scalars: &'a [S], table_length: usize, num_sumcheck_variables: usize) -> Self {
         let (entrywise_point, subpolynomial_multipliers) = scalars.split_at(num_sumcheck_variables);
         Self {
@@ -17,6 +21,7 @@ impl<'a, S: Scalar> SumcheckRandomScalars<'a, S> {
         }
     }
 
+    /// TODO: add docs
     pub fn compute_entrywise_multipliers(&self) -> Vec<S> {
         let mut v = vec![Default::default(); self.table_length];
         compute_evaluation_vector(&mut v, self.entrywise_point);

--- a/crates/proofs/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proofs/src/sql/proof/verifiable_query_result.rs
@@ -67,7 +67,9 @@ use serde::{Deserialize, Serialize};
 /// all public so as to allow for easy manipulation for testing.
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct VerifiableQueryResult<CP: CommitmentEvaluationProof> {
+    /// TODO: add docs
     pub provable_result: Option<ProvableQueryResult>,
+    /// TODO: add docs
     pub proof: Option<QueryProof<CP>>,
 }
 

--- a/crates/proofs/src/sql/proof/verification_builder.rs
+++ b/crates/proofs/src/sql/proof/verification_builder.rs
@@ -4,6 +4,7 @@ use num_traits::Zero;
 
 /// Track components used to verify a query's proof
 pub struct VerificationBuilder<'a, C: Commitment> {
+    /// TODO: add docs
     pub mle_evaluations: SumcheckMleEvaluations<'a, C::Scalar>,
     generator_offset: usize,
     intermediate_commitments: &'a [C],
@@ -28,6 +29,7 @@ pub struct VerificationBuilder<'a, C: Commitment> {
 }
 
 impl<'a, C: Commitment> VerificationBuilder<'a, C> {
+    /// TODO: add docs
     pub fn new(
         generator_offset: usize,
         mle_evaluations: SumcheckMleEvaluations<'a, C::Scalar>,
@@ -59,10 +61,12 @@ impl<'a, C: Commitment> VerificationBuilder<'a, C> {
         }
     }
 
+    /// TODO: add docs
     pub fn table_length(&self) -> usize {
         self.mle_evaluations.table_length
     }
 
+    /// TODO: add docs
     pub fn generator_offset(&self) -> usize {
         self.generator_offset
     }

--- a/crates/proofs/src/sql/transform/data_frame_expr.rs
+++ b/crates/proofs/src/sql/transform/data_frame_expr.rs
@@ -6,5 +6,6 @@ use std::fmt::Debug;
 #[typetag::serde(tag = "type")]
 #[dyn_partial_eq]
 pub trait DataFrameExpr: Debug + Send + Sync {
+    /// TODO: add docs
     fn apply_transformation(&self, lazy_frame: LazyFrame, num_input_rows: usize) -> LazyFrame;
 }

--- a/crates/proofs/src/sql/transform/mod.rs
+++ b/crates/proofs/src/sql/transform/mod.rs
@@ -1,3 +1,4 @@
+//! TODO: add docs
 mod result_expr;
 pub use result_expr::ResultExpr;
 

--- a/crates/proofs/src/sql/transform/polars_arithmetic.rs
+++ b/crates/proofs/src/sql/transform/polars_arithmetic.rs
@@ -59,7 +59,9 @@ fn checked_div(series: &mut [Series]) -> PolarsResult<Option<Series>> {
     Ok(Some(num / den))
 }
 
+/// TODO: add docs
 pub trait SafeDivision {
+    /// TODO: add docs
     fn checked_div(self, rhs: Expr) -> Expr;
 }
 

--- a/crates/proofs/src/sql/transform/polars_conversions.rs
+++ b/crates/proofs/src/sql/transform/polars_conversions.rs
@@ -1,7 +1,9 @@
 use crate::base::database::{INT128_PRECISION, INT128_SCALE};
 use polars::prelude::{DataType, Expr, Literal, Series};
 
+/// TODO: add docs
 pub trait LiteralConversion {
+    /// TODO: add docs
     fn to_lit(&self) -> Expr;
 }
 

--- a/crates/proofs/src/sql/transform/select_expr.rs
+++ b/crates/proofs/src/sql/transform/select_expr.rs
@@ -11,6 +11,7 @@ pub struct SelectExpr {
 }
 
 impl SelectExpr {
+    /// TODO: add docs
     pub fn new(result_schema: Vec<Expr>) -> Self {
         assert!(!result_schema.is_empty());
         Self { result_schema }


### PR DESCRIPTION
# Rationale for this change

In order to enforce documentation, we should have the `missing_docs` lint enabled.

# What changes are included in this PR?

* The `missing_docs` lint is enabled.
* And existing missing docs have `TODO: add docs` added as the documentation.

# Are these changes tested?

NA
