### PR TITLE
test: replace InnerProduct types with Test types within test code

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -1,19 +1,16 @@
 use super::*;
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::test_scalar::TestScalar;
 use num_traits::{One, Zero};
 
 #[test]
 fn we_can_compute_the_bit_distribution_of_an_empty_slice() {
     let data: Vec<i64> = vec![];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 0);
     assert!(!dist.has_varying_sign_bit());
     assert!(!dist.sign_bit());
     assert!(dist.is_valid());
-    assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::zero()
-    );
+    assert_eq!(TestScalar::from(dist.constant_part()), TestScalar::zero());
 
     let mut cnt = 0;
     dist.for_each_abs_constant_bit(|_i: usize, _pos: usize| {
@@ -38,14 +35,14 @@ fn we_can_compute_the_bit_distribution_of_an_empty_slice() {
 fn we_can_compute_the_bit_distribution_of_a_slice_with_a_single_element() {
     let val = (1 << 2) | (1 << 10);
     let data: Vec<i64> = vec![val];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 0);
     assert!(!dist.has_varying_sign_bit());
     assert!(!dist.sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::from(val)
+        TestScalar::from(dist.constant_part()),
+        TestScalar::from(val)
     );
     assert_eq!(dist.most_significant_abs_bit(), 10);
 
@@ -73,14 +70,14 @@ fn we_can_compute_the_bit_distribution_of_a_slice_with_a_single_element() {
 #[test]
 fn we_can_compute_the_bit_distribution_of_a_slice_with_one_varying_bits() {
     let data: Vec<i64> = vec![(1 << 2) | (1 << 10), (1 << 2) | (1 << 10) | (1 << 21)];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 1);
     assert!(!dist.has_varying_sign_bit());
     assert!(!dist.sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::from((1 << 10) | (1 << 2))
+        TestScalar::from(dist.constant_part()),
+        TestScalar::from((1 << 10) | (1 << 2))
     );
     assert_eq!(dist.most_significant_abs_bit(), 21);
 
@@ -116,14 +113,14 @@ fn we_can_compute_the_bit_distribution_of_a_slice_with_multiple_varying_bits() {
         (1 << 3) | (1 << 10) | (1 << 21),
         (1 << 10) | (1 << 21) | (1 << 50),
     ];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 4);
     assert!(!dist.has_varying_sign_bit());
     assert!(!dist.sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::from(1 << 10)
+        TestScalar::from(dist.constant_part()),
+        TestScalar::from(1 << 10)
     );
     assert_eq!(dist.most_significant_abs_bit(), 50);
 
@@ -155,15 +152,12 @@ fn we_can_compute_the_bit_distribution_of_a_slice_with_multiple_varying_bits() {
 #[test]
 fn we_can_compute_the_bit_distribution_of_negative_values() {
     let data: Vec<i64> = vec![-1];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 0);
     assert!(!dist.has_varying_sign_bit());
     assert!(dist.sign_bit());
     assert!(dist.is_valid());
-    assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::one()
-    );
+    assert_eq!(TestScalar::from(dist.constant_part()), TestScalar::one());
     assert_eq!(dist.most_significant_abs_bit(), 0);
 
     let mut cnt = 0;
@@ -190,13 +184,10 @@ fn we_can_compute_the_bit_distribution_of_negative_values() {
 #[test]
 fn we_can_compute_the_bit_distribution_of_values_with_different_signs() {
     let data: Vec<i64> = vec![-1, 1];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 1);
     assert!(dist.has_varying_sign_bit());
-    assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::one()
-    );
+    assert_eq!(TestScalar::from(dist.constant_part()), TestScalar::one());
     assert_eq!(dist.most_significant_abs_bit(), 0);
 
     let mut cnt = 0;
@@ -225,14 +216,11 @@ fn we_can_compute_the_bit_distribution_of_values_with_different_signs() {
 #[test]
 fn we_can_compute_the_bit_distribution_of_values_with_different_signs_and_values() {
     let data: Vec<i64> = vec![4, -1, 1];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 3);
     assert!(dist.has_varying_sign_bit());
     assert!(dist.is_valid());
-    assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::zero()
-    );
+    assert_eq!(TestScalar::from(dist.constant_part()), TestScalar::zero());
     assert_eq!(dist.most_significant_abs_bit(), 2);
 
     let mut cnt = 0;
@@ -261,14 +249,14 @@ fn we_can_compute_the_bit_distribution_of_values_with_different_signs_and_values
 fn we_can_compute_the_bit_distribution_of_values_larger_than_64_bit_integers() {
     let mut val = [0; 4];
     val[3] = 1 << 11;
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::from_bigint(val)];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::from_bigint(val)];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 0);
     assert!(!dist.has_varying_sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::from_bigint(val)
+        TestScalar::from(dist.constant_part()),
+        TestScalar::from_bigint(val)
     );
     assert_eq!(dist.most_significant_abs_bit(), 64 * 3 + 11);
 

--- a/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
@@ -1,12 +1,12 @@
 use super::*;
-use crate::base::{bit::BitDistribution, scalar::Curve25519Scalar};
+use crate::base::{bit::BitDistribution, scalar::test_scalar::TestScalar};
 use bumpalo::Bump;
 use num_traits::{One, Zero};
 
 #[test]
 fn we_can_compute_the_bit_matrix_of_empty_data() {
-    let data: Vec<Curve25519Scalar> = vec![];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert!(matrix.is_empty());
@@ -14,8 +14,8 @@ fn we_can_compute_the_bit_matrix_of_empty_data() {
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_a_single_element() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::one()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::one()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert!(matrix.is_empty());
@@ -23,8 +23,8 @@ fn we_can_compute_the_bit_matrix_for_a_single_element() {
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_data_with_a_single_varying_bit() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::one(), Curve25519Scalar::zero()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::one(), TestScalar::zero()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 1);
@@ -34,8 +34,8 @@ fn we_can_compute_the_bit_matrix_for_data_with_a_single_varying_bit() {
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_data_with_a_varying_sign_bit() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::one(), -Curve25519Scalar::one()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::one(), -TestScalar::one()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 1);
@@ -45,8 +45,8 @@ fn we_can_compute_the_bit_matrix_for_data_with_a_varying_sign_bit() {
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_in_different_positions() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::from(2), Curve25519Scalar::one()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::from(2), TestScalar::one()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 2);
@@ -58,8 +58,8 @@ fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_in_different_positio
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_and_constant_bits() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::from(3), Curve25519Scalar::from(-1)];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::from(3), TestScalar::from(-1)];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 2);
@@ -73,9 +73,8 @@ fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_and_constant_bits() 
 fn we_can_compute_the_bit_matrix_for_data_entries_bigger_than_64_bit_integers() {
     let mut val = [0; 4];
     val[3] = 1 << 2;
-    let data: Vec<Curve25519Scalar> =
-        vec![Curve25519Scalar::from_bigint(val), Curve25519Scalar::one()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::from_bigint(val), TestScalar::one()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 2);

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -299,8 +299,9 @@ impl ColumnBounds {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::OwnedColumn, math::decimal::Precision, scalar::Curve25519Scalar};
-    use alloc::{string::String, vec};
+    use crate::base::{
+        database::OwnedColumn, math::decimal::Precision, scalar::test_scalar::TestScalar,
+    };
     use itertools::Itertools;
     use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
@@ -489,7 +490,7 @@ mod tests {
 
     #[test]
     fn we_can_construct_column_bounds_from_column() {
-        let varchar_column = OwnedColumn::<Curve25519Scalar>::VarChar(
+        let varchar_column = OwnedColumn::<TestScalar>::VarChar(
             ["Lorem", "ipsum", "dolor", "sit", "amet"]
                 .map(String::from)
                 .to_vec(),
@@ -498,7 +499,7 @@ mod tests {
         let varchar_column_bounds = ColumnBounds::from_column(&committable_varchar_column);
         assert_eq!(varchar_column_bounds, ColumnBounds::NoOrder);
 
-        let smallint_column = OwnedColumn::<Curve25519Scalar>::SmallInt([1, 2, 3, 1, 0].to_vec());
+        let smallint_column = OwnedColumn::<TestScalar>::SmallInt([1, 2, 3, 1, 0].to_vec());
         let committable_smallint_column = CommittableColumn::from(&smallint_column);
         let smallint_column_bounds = ColumnBounds::from_column(&committable_smallint_column);
         assert_eq!(
@@ -506,7 +507,7 @@ mod tests {
             ColumnBounds::SmallInt(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
         );
 
-        let int_column = OwnedColumn::<Curve25519Scalar>::Int([1, 2, 3, 1, 0].to_vec());
+        let int_column = OwnedColumn::<TestScalar>::Int([1, 2, 3, 1, 0].to_vec());
         let committable_int_column = CommittableColumn::from(&int_column);
         let int_column_bounds = ColumnBounds::from_column(&committable_int_column);
         assert_eq!(
@@ -514,7 +515,7 @@ mod tests {
             ColumnBounds::Int(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
         );
 
-        let bigint_column = OwnedColumn::<Curve25519Scalar>::BigInt([1, 2, 3, 1, 0].to_vec());
+        let bigint_column = OwnedColumn::<TestScalar>::BigInt([1, 2, 3, 1, 0].to_vec());
         let committable_bigint_column = CommittableColumn::from(&bigint_column);
         let bigint_column_bounds = ColumnBounds::from_column(&committable_bigint_column);
         assert_eq!(
@@ -522,7 +523,7 @@ mod tests {
             ColumnBounds::BigInt(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
         );
 
-        let int128_column = OwnedColumn::<Curve25519Scalar>::Int128([1, 2, 3, 1, 0].to_vec());
+        let int128_column = OwnedColumn::<TestScalar>::Int128([1, 2, 3, 1, 0].to_vec());
         let committable_int128_column = CommittableColumn::from(&int128_column);
         let int128_column_bounds = ColumnBounds::from_column(&committable_int128_column);
         assert_eq!(
@@ -530,20 +531,20 @@ mod tests {
             ColumnBounds::Int128(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
         );
 
-        let decimal75_column = OwnedColumn::<Curve25519Scalar>::Decimal75(
+        let decimal75_column = OwnedColumn::<TestScalar>::Decimal75(
             Precision::new(1).unwrap(),
             0,
             vec![
-                -Curve25519Scalar::from([1, 0, 0, 0]),
-                Curve25519Scalar::from([2, 0, 0, 0]),
-                Curve25519Scalar::from([3, 0, 0, 0]),
+                -TestScalar::from([1, 0, 0, 0]),
+                TestScalar::from([2, 0, 0, 0]),
+                TestScalar::from([3, 0, 0, 0]),
             ],
         );
         let committable_decimal75_column = CommittableColumn::from(&decimal75_column);
         let decimal75_column_bounds = ColumnBounds::from_column(&committable_decimal75_column);
         assert_eq!(decimal75_column_bounds, ColumnBounds::NoOrder);
 
-        let timestamp_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
+        let timestamp_column = OwnedColumn::<TestScalar>::TimestampTZ(
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
             vec![1_i64, 2, 3, 4],

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -175,7 +175,7 @@ mod tests {
     use super::*;
     use crate::base::{
         commitment::column_bounds::Bounds, database::OwnedColumn, math::decimal::Precision,
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar,
     };
     use alloc::string::String;
     use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
@@ -358,16 +358,16 @@ mod tests {
     #[test]
     fn we_can_construct_metadata_from_column() {
         let boolean_column =
-            OwnedColumn::<Curve25519Scalar>::Boolean([true, false, true, false, true].to_vec());
+            OwnedColumn::<TestScalar>::Boolean([true, false, true, false, true].to_vec());
         let committable_boolean_column = CommittableColumn::from(&boolean_column);
         let boolean_metadata = ColumnCommitmentMetadata::from_column(&committable_boolean_column);
         assert_eq!(boolean_metadata.column_type(), &ColumnType::Boolean);
         assert_eq!(boolean_metadata.bounds(), &ColumnBounds::NoOrder);
 
-        let decimal_column = OwnedColumn::<Curve25519Scalar>::Decimal75(
+        let decimal_column = OwnedColumn::<TestScalar>::Decimal75(
             Precision::new(10).unwrap(),
             0,
-            [1, 2, 3, 4, 5].map(Curve25519Scalar::from).to_vec(),
+            [1, 2, 3, 4, 5].map(TestScalar::from).to_vec(),
         );
         let committable_decimal_column = CommittableColumn::from(&decimal_column);
         let decimal_metadata = ColumnCommitmentMetadata::from_column(&committable_decimal_column);
@@ -377,12 +377,11 @@ mod tests {
         );
         assert_eq!(decimal_metadata.bounds(), &ColumnBounds::NoOrder);
 
-        let timestamp_column: OwnedColumn<Curve25519Scalar> =
-            OwnedColumn::<Curve25519Scalar>::TimestampTZ(
-                PoSQLTimeUnit::Second,
-                PoSQLTimeZone::Utc,
-                [1i64, 2, 3, 4, 5].to_vec(),
-            );
+        let timestamp_column: OwnedColumn<TestScalar> = OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::Utc,
+            [1i64, 2, 3, 4, 5].to_vec(),
+        );
         let committable_timestamp_column = CommittableColumn::from(&timestamp_column);
         let timestamp_metadata =
             ColumnCommitmentMetadata::from_column(&committable_timestamp_column);
@@ -397,7 +396,7 @@ mod tests {
             panic!("Bounds constructed from nonempty TimestampTZ column should be ColumnBounds::BigInt(Bounds::Sharp(_))");
         }
 
-        let varchar_column = OwnedColumn::<Curve25519Scalar>::VarChar(
+        let varchar_column = OwnedColumn::<TestScalar>::VarChar(
             ["Lorem", "ipsum", "dolor", "sit", "amet"]
                 .map(String::from)
                 .to_vec(),
@@ -407,7 +406,7 @@ mod tests {
         assert_eq!(varchar_metadata.column_type(), &ColumnType::VarChar);
         assert_eq!(varchar_metadata.bounds(), &ColumnBounds::NoOrder);
 
-        let bigint_column = OwnedColumn::<Curve25519Scalar>::BigInt([1, 2, 3, 1, 0].to_vec());
+        let bigint_column = OwnedColumn::<TestScalar>::BigInt([1, 2, 3, 1, 0].to_vec());
         let committable_bigint_column = CommittableColumn::from(&bigint_column);
         let bigint_metadata = ColumnCommitmentMetadata::from_column(&committable_bigint_column);
         assert_eq!(bigint_metadata.column_type(), &ColumnType::BigInt);
@@ -418,7 +417,7 @@ mod tests {
             panic!("Bounds constructed from nonempty BigInt column should be ColumnBounds::BigInt(Bounds::Sharp(_))");
         }
 
-        let int_column = OwnedColumn::<Curve25519Scalar>::Int([1, 2, 3, 1, 0].to_vec());
+        let int_column = OwnedColumn::<TestScalar>::Int([1, 2, 3, 1, 0].to_vec());
         let committable_int_column = CommittableColumn::from(&int_column);
         let int_metadata = ColumnCommitmentMetadata::from_column(&committable_int_column);
         assert_eq!(int_metadata.column_type(), &ColumnType::Int);
@@ -429,7 +428,7 @@ mod tests {
             panic!("Bounds constructed from nonempty BigInt column should be ColumnBounds::Int(Bounds::Sharp(_))");
         }
 
-        let smallint_column = OwnedColumn::<Curve25519Scalar>::SmallInt([1, 2, 3, 1, 0].to_vec());
+        let smallint_column = OwnedColumn::<TestScalar>::SmallInt([1, 2, 3, 1, 0].to_vec());
         let committable_smallint_column = CommittableColumn::from(&smallint_column);
         let smallint_metadata = ColumnCommitmentMetadata::from_column(&committable_smallint_column);
         assert_eq!(smallint_metadata.column_type(), &ColumnType::SmallInt);
@@ -440,7 +439,7 @@ mod tests {
             panic!("Bounds constructed from nonempty BigInt column should be ColumnBounds::SmallInt(Bounds::Sharp(_))");
         }
 
-        let int128_column = OwnedColumn::<Curve25519Scalar>::Int128([].to_vec());
+        let int128_column = OwnedColumn::<TestScalar>::Int128([].to_vec());
         let committable_int128_column = CommittableColumn::from(&int128_column);
         let int128_metadata = ColumnCommitmentMetadata::from_column(&committable_int128_column);
         assert_eq!(int128_metadata.column_type(), &ColumnType::Int128);
@@ -449,8 +448,7 @@ mod tests {
             &ColumnBounds::Int128(Bounds::Empty)
         );
 
-        let scalar_column =
-            OwnedColumn::Scalar([1, 2, 3, 4, 5].map(Curve25519Scalar::from).to_vec());
+        let scalar_column = OwnedColumn::Scalar([1, 2, 3, 4, 5].map(TestScalar::from).to_vec());
         let committable_scalar_column = CommittableColumn::from(&scalar_column);
         let scalar_metadata = ColumnCommitmentMetadata::from_column(&committable_scalar_column);
         assert_eq!(scalar_metadata.column_type(), &ColumnType::Scalar);

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -140,14 +140,12 @@ mod tests {
     use crate::base::{
         commitment::{column_bounds::Bounds, ColumnBounds},
         database::{owned_table_utility::*, ColumnType, OwnedTable},
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar,
     };
     use alloc::vec::Vec;
     use itertools::Itertools;
 
-    fn metadata_map_from_owned_table(
-        table: OwnedTable<Curve25519Scalar>,
-    ) -> ColumnCommitmentMetadataMap {
+    fn metadata_map_from_owned_table(table: OwnedTable<TestScalar>) -> ColumnCommitmentMetadataMap {
         let (identifiers, columns): (Vec<&Identifier>, Vec<CommittableColumn>) = table
             .inner_table()
             .into_iter()
@@ -164,7 +162,7 @@ mod tests {
         assert_eq!(empty_metadata_map.len(), 0);
 
         // With columns
-        let table: OwnedTable<Curve25519Scalar> = owned_table([
+        let table: OwnedTable<TestScalar> = owned_table([
             bigint("bigint_column", [1, 5, -5, 0]),
             int128("int128_column", [100, 200, 300, 400]),
             varchar("varchar_column", ["Lorem", "ipsum", "dolor", "sit"]),

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -347,18 +347,17 @@ impl<C> FromIterator<(Identifier, ColumnCommitmentMetadata, C)> for ColumnCommit
 mod tests {
     use super::*;
     use crate::base::{
-        commitment::{column_bounds::Bounds, ColumnBounds},
+        commitment::{column_bounds::Bounds, naive_commitment::NaiveCommitment, ColumnBounds},
         database::{owned_table_utility::*, ColumnType, OwnedColumn, OwnedTable},
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar,
     };
-    use curve25519_dalek::RistrettoPoint;
 
     #[test]
     fn we_can_construct_column_commitments_from_columns_and_identifiers() {
         // empty case
         let column_commitments =
-            ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset::<
-                &OwnedColumn<Curve25519Scalar>,
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset::<
+                &OwnedColumn<TestScalar>,
             >([], 0, &())
             .unwrap();
         assert_eq!(column_commitments.len(), 0);
@@ -370,7 +369,7 @@ mod tests {
         let bigint_id: Identifier = "bigint_column".parse().unwrap();
         let varchar_id: Identifier = "varchar_column".parse().unwrap();
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
-        let owned_table = owned_table::<Curve25519Scalar>([
+        let owned_table = owned_table::<TestScalar>([
             bigint(bigint_id, [1, 5, -5, 0]),
             // "int128_column" => [100i128, 200, 300, 400], TODO: enable this column once blitzar
             // supports it
@@ -378,16 +377,17 @@ mod tests {
             scalar(scalar_id, [1000, 2000, -1000, 0]),
         ]);
 
-        let column_commitments = ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
-            owned_table.inner_table(),
-            0,
-            &(),
-        )
-        .unwrap();
+        let column_commitments =
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
+                owned_table.inner_table(),
+                0,
+                &(),
+            )
+            .unwrap();
 
         assert_eq!(column_commitments.len(), 3);
 
-        let expected_commitments = Vec::<RistrettoPoint>::from_columns_with_offset(
+        let expected_commitments = Vec::<NaiveCommitment>::from_columns_with_offset(
             owned_table.inner_table().values(),
             0,
             &(),
@@ -444,7 +444,7 @@ mod tests {
         let bigint_id: Identifier = "bigint_column".parse().unwrap();
         let varchar_id: Identifier = "varchar_column".parse().unwrap();
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
-        let owned_table = owned_table::<Curve25519Scalar>([
+        let owned_table = owned_table::<TestScalar>([
             bigint(bigint_id, [1, 5, -5, 0]),
             // "int128_column" => [100i128, 200, 300, 400], TODO: enable this column once blitzar
             // supports it
@@ -453,7 +453,7 @@ mod tests {
         ]);
 
         let column_commitments_from_columns =
-            ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
                 owned_table.inner_table(),
                 0,
                 &(),
@@ -474,24 +474,25 @@ mod tests {
         let duplicate_identifier_b = "duplicate_identifier_b".parse().unwrap();
         let unique_identifier = "unique_identifier".parse().unwrap();
 
-        let empty_column = OwnedColumn::<Curve25519Scalar>::BigInt(vec![]);
+        let empty_column = OwnedColumn::<TestScalar>::BigInt(vec![]);
 
-        let from_columns_result = ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
-            [
-                (&duplicate_identifier_b, &empty_column),
-                (&duplicate_identifier_b, &empty_column),
-                (&unique_identifier, &empty_column),
-            ],
-            0,
-            &(),
-        );
+        let from_columns_result =
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
+                [
+                    (&duplicate_identifier_b, &empty_column),
+                    (&duplicate_identifier_b, &empty_column),
+                    (&unique_identifier, &empty_column),
+                ],
+                0,
+                &(),
+            );
         assert!(matches!(
             from_columns_result,
             Err(DuplicateIdentifiers { .. })
         ));
 
         let mut existing_column_commitments =
-            ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
                 [
                     (&duplicate_identifier_a, &empty_column),
                     (&unique_identifier, &empty_column),
@@ -542,19 +543,20 @@ mod tests {
         let bigint_id: Identifier = "bigint_column".parse().unwrap();
         let varchar_id: Identifier = "varchar_column".parse().unwrap();
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
-        let owned_table = owned_table::<Curve25519Scalar>([
+        let owned_table = owned_table::<TestScalar>([
             bigint(bigint_id, [1, 5, -5, 0]),
             varchar(varchar_id, ["Lorem", "ipsum", "dolor", "sit"]),
             scalar(scalar_id, [1000, 2000, -1000, 0]),
         ]);
-        let column_commitments = ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
-            owned_table.inner_table(),
-            0,
-            &(),
-        )
-        .unwrap();
+        let column_commitments =
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
+                owned_table.inner_table(),
+                0,
+                &(),
+            )
+            .unwrap();
 
-        let expected_commitments = Vec::<RistrettoPoint>::from_columns_with_offset(
+        let expected_commitments = Vec::<NaiveCommitment>::from_columns_with_offset(
             owned_table.inner_table().values(),
             0,
             &(),
@@ -589,21 +591,21 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let initial_columns: OwnedTable<Curve25519Scalar> = owned_table([
+        let initial_columns: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[..2].to_vec()),
             varchar(varchar_id, varchar_data[..2].to_vec()),
             scalar(scalar_id, scalar_data[..2].to_vec()),
         ]);
 
         let mut column_commitments =
-            ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
                 initial_columns.inner_table(),
                 0,
                 &(),
             )
             .unwrap();
 
-        let append_columns: OwnedTable<Curve25519Scalar> = owned_table([
+        let append_columns: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[2..].to_vec()),
             varchar(varchar_id, varchar_data[2..].to_vec()),
             scalar(scalar_id, scalar_data[2..].to_vec()),
@@ -613,7 +615,7 @@ mod tests {
             .try_append_rows_with_offset(append_columns.inner_table(), 2, &())
             .unwrap();
 
-        let total_columns: OwnedTable<Curve25519Scalar> = owned_table([
+        let total_columns: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
             scalar(scalar_id, scalar_data),
@@ -628,19 +630,19 @@ mod tests {
 
     #[test]
     fn we_cannot_append_rows_to_mismatched_column_commitments() {
-        let base_table: OwnedTable<Curve25519Scalar> = owned_table([
+        let base_table: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [1, 2, 3, 4]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
         let mut base_commitments =
-            ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
                 base_table.inner_table(),
                 0,
                 &(),
             )
             .unwrap();
 
-        let table_diff_type: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_diff_type: OwnedTable<TestScalar> = owned_table([
             varchar("column_a", ["5", "6", "7", "8"]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
@@ -651,7 +653,7 @@ mod tests {
             })
         ));
 
-        let table_diff_id: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_diff_id: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [5, 6, 7, 8]),
             varchar("b", ["amet", "ipsum", "dolor", "sit"]),
         ]);
@@ -666,7 +668,7 @@ mod tests {
             })
         ));
 
-        let table_diff_len: OwnedTable<Curve25519Scalar> =
+        let table_diff_len: OwnedTable<TestScalar> =
             owned_table([bigint("column_a", [5, 6, 7, 8])]);
         assert!(matches!(
             base_commitments.try_append_rows_with_offset(table_diff_len.inner_table(), 4, &()),
@@ -687,24 +689,24 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let initial_columns: OwnedTable<Curve25519Scalar> = owned_table([
+        let initial_columns: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
         ]);
         let mut column_commitments =
-            ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
                 initial_columns.inner_table(),
                 0,
                 &(),
             )
             .unwrap();
 
-        let new_columns = owned_table::<Curve25519Scalar>([scalar(scalar_id, scalar_data)]);
+        let new_columns = owned_table::<TestScalar>([scalar(scalar_id, scalar_data)]);
         column_commitments
             .try_extend_columns_with_offset(new_columns.inner_table(), 0, &())
             .unwrap();
 
-        let expected_columns = owned_table::<Curve25519Scalar>([
+        let expected_columns = owned_table::<TestScalar>([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
             scalar(scalar_id, scalar_data),
@@ -727,21 +729,21 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let columns_a: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_a: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[..2].to_vec()),
             varchar(varchar_id, varchar_data[..2].to_vec()),
             scalar(scalar_id, scalar_data[..2].to_vec()),
         ]);
 
         let column_commitments_a =
-            ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
                 columns_a.inner_table(),
                 0,
                 &(),
             )
             .unwrap();
 
-        let columns_b: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_b: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[2..].to_vec()),
             varchar(varchar_id, varchar_data[2..].to_vec()),
             scalar(scalar_id, scalar_data[2..].to_vec()),
@@ -750,7 +752,7 @@ mod tests {
             ColumnCommitments::try_from_columns_with_offset(columns_b.inner_table(), 2, &())
                 .unwrap();
 
-        let columns_sum: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_sum: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
             scalar(scalar_id, scalar_data),
@@ -767,18 +769,18 @@ mod tests {
 
     #[test]
     fn we_cannot_add_mismatched_column_commitments() {
-        let base_table: OwnedTable<Curve25519Scalar> = owned_table([
+        let base_table: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [1, 2, 3, 4]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
-        let base_commitments = ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
+        let base_commitments = ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
             base_table.inner_table(),
             0,
             &(),
         )
         .unwrap();
 
-        let table_diff_type: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_diff_type: OwnedTable<TestScalar> = owned_table([
             varchar("column_a", ["5", "6", "7", "8"]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
@@ -790,7 +792,7 @@ mod tests {
             Err(ColumnCommitmentsMismatch::ColumnCommitmentMetadata { .. })
         ));
 
-        let table_diff_id: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_diff_id: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [5, 6, 7, 8]),
             varchar("b", ["amet", "ipsum", "dolor", "sit"]),
         ]);
@@ -802,7 +804,7 @@ mod tests {
             Err(ColumnCommitmentsMismatch::Identifier { .. })
         ));
 
-        let table_diff_len: OwnedTable<Curve25519Scalar> =
+        let table_diff_len: OwnedTable<TestScalar> =
             owned_table([bigint("column_a", [5, 6, 7, 8])]);
         let commitments_diff_len =
             ColumnCommitments::try_from_columns_with_offset(table_diff_len.inner_table(), 4, &())
@@ -824,21 +826,21 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let columns_subtrahend: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_subtrahend: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[..2].to_vec()),
             varchar(varchar_id, varchar_data[..2].to_vec()),
             scalar(scalar_id, scalar_data[..2].to_vec()),
         ]);
 
         let column_commitments_subtrahend =
-            ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
                 columns_subtrahend.inner_table(),
                 0,
                 &(),
             )
             .unwrap();
 
-        let columns_minuend: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_minuend: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
             scalar(scalar_id, scalar_data),
@@ -851,7 +853,7 @@ mod tests {
             .try_sub(column_commitments_subtrahend)
             .unwrap();
 
-        let expected_difference_columns: OwnedTable<Curve25519Scalar> = owned_table([
+        let expected_difference_columns: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[2..].to_vec()),
             varchar(varchar_id, varchar_data[2..].to_vec()),
             scalar(scalar_id, scalar_data[2..].to_vec()),
@@ -894,19 +896,19 @@ mod tests {
 
     #[test]
     fn we_cannot_sub_mismatched_column_commitments() {
-        let minuend_table: OwnedTable<Curve25519Scalar> = owned_table([
+        let minuend_table: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [1, 2, 3, 4]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
         let minuend_commitments =
-            ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
+            ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
                 minuend_table.inner_table(),
                 0,
                 &(),
             )
             .unwrap();
 
-        let table_diff_type: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_diff_type: OwnedTable<TestScalar> = owned_table([
             varchar("column_a", ["1", "2"]),
             varchar("column_b", ["Lorem", "ipsum"]),
         ]);
@@ -918,7 +920,7 @@ mod tests {
             Err(ColumnCommitmentsMismatch::ColumnCommitmentMetadata { .. })
         ));
 
-        let table_diff_id: OwnedTable<Curve25519Scalar> =
+        let table_diff_id: OwnedTable<TestScalar> =
             owned_table([bigint("column_a", [1, 2]), varchar("b", ["Lorem", "ipsum"])]);
         let commitments_diff_id =
             ColumnCommitments::try_from_columns_with_offset(table_diff_id.inner_table(), 4, &())
@@ -928,8 +930,7 @@ mod tests {
             Err(ColumnCommitmentsMismatch::Identifier { .. })
         ));
 
-        let table_diff_len: OwnedTable<Curve25519Scalar> =
-            owned_table([bigint("column_a", [1, 2])]);
+        let table_diff_len: OwnedTable<TestScalar> = owned_table([bigint("column_a", [1, 2])]);
         let commitments_diff_len =
             ColumnCommitments::try_from_columns_with_offset(table_diff_len.inner_table(), 4, &())
                 .unwrap();

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -208,16 +208,16 @@ impl<'a, 'b> From<&'a CommittableColumn<'b>> for Sequence<'a> {
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;
-    use crate::{base::scalar::Curve25519Scalar, proof_primitive::dory::DoryScalar};
+    use crate::{base::scalar::test_scalar::TestScalar, proof_primitive::dory::DoryScalar};
     use blitzar::compute::compute_curve25519_commitments;
     use curve25519_dalek::ristretto::CompressedRistretto;
 
     #[test]
     fn we_can_convert_from_owned_decimal75_column_to_committable_column() {
         let decimals = vec![
-            Curve25519Scalar::from(-1),
-            Curve25519Scalar::from(1),
-            Curve25519Scalar::from(2),
+            TestScalar::from(-1),
+            TestScalar::from(1),
+            TestScalar::from(2),
         ];
         let decimal_column = OwnedColumn::Decimal75(Precision::new(75).unwrap(), -1, decimals);
 
@@ -226,7 +226,7 @@ mod tests {
             Precision::new(75).unwrap(),
             -1,
             [-1, 1, 2]
-                .map(<Curve25519Scalar>::from)
+                .map(<TestScalar>::from)
                 .map(<[u64; 4]>::from)
                 .into(),
         );
@@ -356,7 +356,7 @@ mod tests {
         let bigint_committable_column = CommittableColumn::VarChar(
             ["12", "34", "56"]
                 .map(Into::<String>::into)
-                .map(Into::<Curve25519Scalar>::into)
+                .map(Into::<TestScalar>::into)
                 .map(Into::<[u64; 4]>::into)
                 .into(),
         );
@@ -375,7 +375,7 @@ mod tests {
 
         let bigint_committable_column = CommittableColumn::Scalar(
             [12, 34, 56]
-                .map(<Curve25519Scalar>::from)
+                .map(<TestScalar>::from)
                 .map(<[u64; 4]>::from)
                 .into(),
         );
@@ -413,12 +413,11 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_timestamp_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::TimestampTZ(
-                PoSQLTimeUnit::Second,
-                PoSQLTimeZone::Utc,
-                &[],
-            ));
+        let from_borrowed_column = CommittableColumn::from(&Column::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::Utc,
+            &[],
+        ));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[])
@@ -426,12 +425,11 @@ mod tests {
 
         // non-empty case
         let timestamps = [1625072400, 1625076000, 1625083200];
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::TimestampTZ(
-                PoSQLTimeUnit::Second,
-                PoSQLTimeZone::Utc,
-                &timestamps,
-            ));
+        let from_borrowed_column = CommittableColumn::from(&Column::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::Utc,
+            &timestamps,
+        ));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &timestamps)
@@ -441,12 +439,11 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_bigint_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::BigInt(&[]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<TestScalar>::BigInt(&[]));
         assert_eq!(from_borrowed_column, CommittableColumn::BigInt(&[]));
 
         let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::BigInt(&[12, 34, 56]));
+            CommittableColumn::from(&Column::<TestScalar>::BigInt(&[12, 34, 56]));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::BigInt(&[12, 34, 56])
@@ -456,12 +453,11 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_smallint_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::SmallInt(&[]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<TestScalar>::SmallInt(&[]));
         assert_eq!(from_borrowed_column, CommittableColumn::SmallInt(&[]));
 
         let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::SmallInt(&[12, 34, 56]));
+            CommittableColumn::from(&Column::<TestScalar>::SmallInt(&[12, 34, 56]));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::SmallInt(&[12, 34, 56])
@@ -471,21 +467,21 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_int_column() {
         // empty case
-        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Int(&[]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<TestScalar>::Int(&[]));
         assert_eq!(from_borrowed_column, CommittableColumn::Int(&[]));
 
         let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Int(&[12, 34, 56]));
+            CommittableColumn::from(&Column::<TestScalar>::Int(&[12, 34, 56]));
         assert_eq!(from_borrowed_column, CommittableColumn::Int(&[12, 34, 56]));
     }
 
     #[test]
     fn we_can_convert_from_borrowing_decimal_column() {
-        // Define a non-empty array of Curve25519Scalars
+        // Define a non-empty array of TestScalars
         let binding = vec![
-            Curve25519Scalar::from(-1),
-            Curve25519Scalar::from(34),
-            Curve25519Scalar::from(56),
+            TestScalar::from(-1),
+            TestScalar::from(34),
+            TestScalar::from(56),
         ];
 
         let precision = Precision::new(75).unwrap();
@@ -506,12 +502,11 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_int128_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Int128(&[]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<TestScalar>::Int128(&[]));
         assert_eq!(from_borrowed_column, CommittableColumn::Int128(&[]));
 
         let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Int128(&[12, 34, 56]));
+            CommittableColumn::from(&Column::<TestScalar>::Int128(&[12, 34, 56]));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::Int128(&[12, 34, 56])
@@ -522,11 +517,11 @@ mod tests {
     fn we_can_convert_from_borrowing_varchar_column() {
         // empty case
         let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::VarChar((&[], &[])));
+            CommittableColumn::from(&Column::<TestScalar>::VarChar((&[], &[])));
         assert_eq!(from_borrowed_column, CommittableColumn::VarChar(Vec::new()));
 
         let varchar_data = ["12", "34", "56"];
-        let scalars = varchar_data.map(Curve25519Scalar::from);
+        let scalars = varchar_data.map(TestScalar::from);
         let from_borrowed_column =
             CommittableColumn::from(&Column::VarChar((&varchar_data, &scalars)));
         assert_eq!(
@@ -538,11 +533,10 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_scalar_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Scalar(&[]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<TestScalar>::Scalar(&[]));
         assert_eq!(from_borrowed_column, CommittableColumn::Scalar(Vec::new()));
 
-        let scalars = [12, 34, 56].map(Curve25519Scalar::from);
+        let scalars = [12, 34, 56].map(TestScalar::from);
         let from_borrowed_column = CommittableColumn::from(&Column::Scalar(&scalars));
         assert_eq!(
             from_borrowed_column,
@@ -553,12 +547,11 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_boolean_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Boolean(&[]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<TestScalar>::Boolean(&[]));
         assert_eq!(from_borrowed_column, CommittableColumn::Boolean(&[]));
 
         let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Boolean(&[true, false, true]));
+            CommittableColumn::from(&Column::<TestScalar>::Boolean(&[true, false, true]));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::Boolean(&[true, false, true])
@@ -568,11 +561,11 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_bigint_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::BigInt(Vec::new());
+        let owned_column = OwnedColumn::<TestScalar>::BigInt(Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::BigInt(&[]));
 
-        let owned_column = OwnedColumn::<Curve25519Scalar>::BigInt(vec![12, 34, 56]);
+        let owned_column = OwnedColumn::<TestScalar>::BigInt(vec![12, 34, 56]);
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::BigInt(&[12, 34, 56]));
     }
@@ -595,7 +588,7 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_timestamp_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
+        let owned_column = OwnedColumn::<TestScalar>::TimestampTZ(
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
             Vec::new(),
@@ -608,7 +601,7 @@ mod tests {
 
         // non-empty case
         let timestamps = vec![1625072400, 1625076000, 1625083200];
-        let owned_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
+        let owned_column = OwnedColumn::<TestScalar>::TimestampTZ(
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
             timestamps.clone(),
@@ -635,11 +628,11 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_int128_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::Int128(Vec::new());
+        let owned_column = OwnedColumn::<TestScalar>::Int128(Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Int128(&[]));
 
-        let owned_column = OwnedColumn::<Curve25519Scalar>::Int128(vec![12, 34, 56]);
+        let owned_column = OwnedColumn::<TestScalar>::Int128(vec![12, 34, 56]);
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Int128(&[12, 34, 56]));
     }
@@ -647,32 +640,27 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_varchar_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(Vec::new());
+        let owned_column = OwnedColumn::<TestScalar>::VarChar(Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::VarChar(Vec::new()));
 
         let strings = ["12", "34", "56"].map(String::from);
-        let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(strings.to_vec());
+        let owned_column = OwnedColumn::<TestScalar>::VarChar(strings.to_vec());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
-            CommittableColumn::VarChar(
-                strings
-                    .map(Curve25519Scalar::from)
-                    .map(<[u64; 4]>::from)
-                    .into()
-            )
+            CommittableColumn::VarChar(strings.map(TestScalar::from).map(<[u64; 4]>::from).into())
         );
     }
 
     #[test]
     fn we_can_convert_from_owned_scalar_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::Scalar(Vec::new());
+        let owned_column = OwnedColumn::<TestScalar>::Scalar(Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Scalar(Vec::new()));
 
-        let scalars = [12, 34, 56].map(Curve25519Scalar::from);
+        let scalars = [12, 34, 56].map(TestScalar::from);
         let owned_column = OwnedColumn::Scalar(scalars.to_vec());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
@@ -802,9 +790,9 @@ mod tests {
 
         // nonempty case
         let values = [
-            Curve25519Scalar::from(12),
-            Curve25519Scalar::from(34),
-            Curve25519Scalar::from(56),
+            TestScalar::from(12),
+            TestScalar::from(34),
+            TestScalar::from(56),
         ]
         .map(<[u64; 4]>::from);
         let committable_column =
@@ -858,11 +846,11 @@ mod tests {
 
         // nonempty case
         let values = ["12", "34", "56"].map(String::from);
-        let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(values.to_vec());
+        let owned_column = OwnedColumn::<TestScalar>::VarChar(values.to_vec());
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);
-        let scalars = values.map(Curve25519Scalar::from).map(<[u64; 4]>::from);
+        let scalars = values.map(TestScalar::from).map(<[u64; 4]>::from);
         let sequence_expected = Sequence::from(scalars.as_slice());
         let mut commitment_buffer = [CompressedRistretto::default(); 2];
         compute_curve25519_commitments(
@@ -883,12 +871,12 @@ mod tests {
         assert_eq!(commitment_buffer[0], CompressedRistretto::default());
 
         // nonempty case
-        let values = [12, 34, 56].map(Curve25519Scalar::from);
+        let values = [12, 34, 56].map(TestScalar::from);
         let owned_column = OwnedColumn::Scalar(values.to_vec());
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);
-        let scalars = values.map(Curve25519Scalar::from).map(<[u64; 4]>::from);
+        let scalars = values.map(TestScalar::from).map(<[u64; 4]>::from);
         let sequence_expected = Sequence::from(scalars.as_slice());
         let mut commitment_buffer = [CompressedRistretto::default(); 2];
         compute_curve25519_commitments(

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -125,38 +125,37 @@ mod tests {
     use super::*;
     use crate::{
         base::{
-            commitment::{Bounds, ColumnBounds},
+            commitment::{naive_commitment::NaiveCommitment, Bounds, ColumnBounds},
             database::{
                 owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableTestAccessor,
                 TestAccessor,
             },
-            scalar::Curve25519Scalar,
+            scalar::test_scalar::TestScalar,
         },
         proof_primitive::dory::{
             test_rng, DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup, ProverSetup,
             PublicParameters,
         },
     };
-    use curve25519_dalek::RistrettoPoint;
 
     #[test]
     fn we_can_get_length_and_offset_of_tables() {
-        let table_a: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_a: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [1, 2, 3, 4]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
 
-        let table_b: OwnedTable<Curve25519Scalar> = owned_table([scalar("column_c", [1, 2])]);
+        let table_b: OwnedTable<TestScalar> = owned_table([scalar("column_c", [1, 2])]);
 
         let offset_commitment =
-            TableCommitment::<RistrettoPoint>::from_owned_table_with_offset(&table_a, 2, &());
+            TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_a, 2, &());
         let offset_table_id = "off.table".parse().unwrap();
 
         let no_offset_commitment = TableCommitment::from_owned_table_with_offset(&table_b, 0, &());
         let no_offset_id = "no.off".parse().unwrap();
 
         let no_columns_commitment = TableCommitment::try_from_columns_with_offset(
-            Vec::<(&Identifier, &OwnedColumn<Curve25519Scalar>)>::new(),
+            Vec::<(&Identifier, &OwnedColumn<TestScalar>)>::new(),
             0,
             &(),
         )
@@ -166,7 +165,7 @@ mod tests {
         let no_rows_commitment = TableCommitment::try_from_columns_with_offset(
             [(
                 &"column_c".parse().unwrap(),
-                &OwnedColumn::<Curve25519Scalar>::BigInt(vec![]),
+                &OwnedColumn::<TestScalar>::BigInt(vec![]),
             )],
             3,
             &(),
@@ -199,14 +198,14 @@ mod tests {
         let column_a_id: Identifier = "column_a".parse().unwrap();
         let column_b_id: Identifier = "column_b".parse().unwrap();
 
-        let table_a: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_a: OwnedTable<TestScalar> = owned_table([
             bigint(column_a_id, [1, 2, 3, 4]),
             varchar(column_b_id, ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
-        let table_b: OwnedTable<Curve25519Scalar> = owned_table([scalar(column_a_id, [1, 2])]);
+        let table_b: OwnedTable<TestScalar> = owned_table([scalar(column_a_id, [1, 2])]);
 
         let table_a_commitment =
-            TableCommitment::<RistrettoPoint>::from_owned_table_with_offset(&table_a, 2, &());
+            TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_a, 2, &());
         let table_a_id = "table.a".parse().unwrap();
 
         let table_b_commitment = TableCommitment::from_owned_table_with_offset(&table_b, 0, &());
@@ -248,21 +247,21 @@ mod tests {
         let column_a_id: Identifier = "column_a".parse().unwrap();
         let column_b_id: Identifier = "column_b".parse().unwrap();
 
-        let table_a: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_a: OwnedTable<TestScalar> = owned_table([
             bigint(column_a_id, [1, 2, 3, 4]),
             varchar(column_b_id, ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
-        let table_b: OwnedTable<Curve25519Scalar> = owned_table([scalar(column_a_id, [1, 2])]);
+        let table_b: OwnedTable<TestScalar> = owned_table([scalar(column_a_id, [1, 2])]);
 
         let table_a_commitment =
-            TableCommitment::<RistrettoPoint>::from_owned_table_with_offset(&table_a, 2, &());
+            TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_a, 2, &());
         let table_a_id = "table.a".parse().unwrap();
 
         let table_b_commitment = TableCommitment::from_owned_table_with_offset(&table_b, 0, &());
         let table_b_id = "table.b".parse().unwrap();
 
         let no_columns_commitment = TableCommitment::try_from_columns_with_offset(
-            Vec::<(&Identifier, &OwnedColumn<Curve25519Scalar>)>::new(),
+            Vec::<(&Identifier, &OwnedColumn<TestScalar>)>::new(),
             0,
             &(),
         )

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -490,19 +490,19 @@ mod tests {
     use super::*;
     use crate::{
         base::{
+            commitment::naive_commitment::NaiveCommitment,
             database::{owned_table_utility::*, OwnedColumn},
             map::IndexMap,
-            scalar::Curve25519Scalar,
+            scalar::test_scalar::TestScalar,
         },
         record_batch,
     };
-    use curve25519_dalek::RistrettoPoint;
 
     #[test]
     #[allow(clippy::reversed_empty_ranges)]
     fn we_cannot_construct_table_commitment_with_negative_range() {
         let try_new_result =
-            TableCommitment::<RistrettoPoint>::try_new(ColumnCommitments::default(), 1..0);
+            TableCommitment::<NaiveCommitment>::try_new(ColumnCommitments::default(), 1..0);
 
         assert!(matches!(try_new_result, Err(NegativeRange)));
     }
@@ -510,10 +510,10 @@ mod tests {
     #[test]
     fn we_can_construct_table_commitment_from_columns_and_identifiers() {
         // no-columns case
-        let mut empty_columns_iter: IndexMap<Identifier, OwnedColumn<Curve25519Scalar>> =
+        let mut empty_columns_iter: IndexMap<Identifier, OwnedColumn<TestScalar>> =
             IndexMap::default();
         let empty_table_commitment =
-            TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
                 &empty_columns_iter,
                 0,
                 &(),
@@ -530,7 +530,7 @@ mod tests {
         // no-rows case
         empty_columns_iter.insert("column_a".parse().unwrap(), OwnedColumn::BigInt(vec![]));
         let empty_table_commitment =
-            TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
                 &empty_columns_iter,
                 1,
                 &(),
@@ -545,14 +545,14 @@ mod tests {
         assert_eq!(empty_table_commitment.num_rows(), 0);
 
         // nonempty case
-        let owned_table = owned_table::<Curve25519Scalar>([
+        let owned_table = owned_table::<TestScalar>([
             bigint("bigint_id", [1, 5, -5, 0]),
             // "int128_column" => [100i128, 200, 300, 400], TODO: enable this column once blitzar
             // supports it
             varchar("varchar_id", ["Lorem", "ipsum", "dolor", "sit"]),
             scalar("scalar_id", [1000, 2000, -1000, 0]),
         ]);
-        let table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+        let table_commitment = TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
             owned_table.inner_table(),
             2,
             &(),
@@ -579,9 +579,9 @@ mod tests {
         let duplicate_identifier_b = "duplicate_identifier_b".parse().unwrap();
         let unique_identifier = "unique_identifier".parse().unwrap();
 
-        let empty_column = OwnedColumn::<Curve25519Scalar>::BigInt(vec![]);
+        let empty_column = OwnedColumn::<TestScalar>::BigInt(vec![]);
 
-        let from_columns_result = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+        let from_columns_result = TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
             [
                 (&duplicate_identifier_a, &empty_column),
                 (&unique_identifier, &empty_column),
@@ -595,15 +595,16 @@ mod tests {
             Err(TableCommitmentFromColumnsError::DuplicateIdentifiers { .. })
         ));
 
-        let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
-            [
-                (&duplicate_identifier_a, &empty_column),
-                (&unique_identifier, &empty_column),
-            ],
-            0,
-            &(),
-        )
-        .unwrap();
+        let mut table_commitment =
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+                [
+                    (&duplicate_identifier_a, &empty_column),
+                    (&unique_identifier, &empty_column),
+                ],
+                0,
+                &(),
+            )
+            .unwrap();
         let column_commitments = table_commitment.column_commitments().clone();
 
         let extend_columns_result =
@@ -636,10 +637,10 @@ mod tests {
         let column_id_b = "column_b".parse().unwrap();
         let column_id_c = "column_c".parse().unwrap();
 
-        let one_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1]);
-        let two_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1, 2]);
+        let one_row_column = OwnedColumn::<TestScalar>::BigInt(vec![1]);
+        let two_row_column = OwnedColumn::<TestScalar>::BigInt(vec![1, 2]);
 
-        let from_columns_result = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+        let from_columns_result = TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
             [
                 (&column_id_a, &one_row_column),
                 (&column_id_b, &two_row_column),
@@ -652,12 +653,13 @@ mod tests {
             Err(TableCommitmentFromColumnsError::MixedLengthColumns { .. })
         ));
 
-        let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
-            [(&column_id_a, &one_row_column)],
-            0,
-            &(),
-        )
-        .unwrap();
+        let mut table_commitment =
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+                [(&column_id_a, &one_row_column)],
+                0,
+                &(),
+            )
+            .unwrap();
         let column_commitments = table_commitment.column_commitments().clone();
 
         let extend_columns_result =
@@ -695,21 +697,22 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let initial_columns: OwnedTable<Curve25519Scalar> = owned_table([
+        let initial_columns: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[..2].to_vec()),
             varchar(varchar_id, varchar_data[..2].to_vec()),
             scalar(scalar_id, scalar_data[..2].to_vec()),
         ]);
 
-        let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
-            initial_columns.inner_table(),
-            0,
-            &(),
-        )
-        .unwrap();
+        let mut table_commitment =
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+                initial_columns.inner_table(),
+                0,
+                &(),
+            )
+            .unwrap();
         let mut table_commitment_clone = table_commitment.clone();
 
-        let append_columns: OwnedTable<Curve25519Scalar> = owned_table([
+        let append_columns: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[2..].to_vec()),
             varchar(varchar_id, varchar_data[2..].to_vec()),
             scalar(scalar_id, scalar_data[2..].to_vec()),
@@ -719,7 +722,7 @@ mod tests {
             .try_append_rows(append_columns.inner_table(), &())
             .unwrap();
 
-        let total_columns: OwnedTable<Curve25519Scalar> = owned_table([
+        let total_columns: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
             scalar(scalar_id, scalar_data),
@@ -740,19 +743,20 @@ mod tests {
 
     #[test]
     fn we_cannot_append_mismatched_columns_to_table_commitment() {
-        let base_table: OwnedTable<Curve25519Scalar> = owned_table([
+        let base_table: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [1, 2, 3, 4]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
-        let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
-            base_table.inner_table(),
-            0,
-            &(),
-        )
-        .unwrap();
+        let mut table_commitment =
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+                base_table.inner_table(),
+                0,
+                &(),
+            )
+            .unwrap();
         let column_commitments = table_commitment.column_commitments().clone();
 
-        let table_diff_type: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_diff_type: OwnedTable<TestScalar> = owned_table([
             varchar("column_a", ["5", "6", "7", "8"]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
@@ -775,14 +779,15 @@ mod tests {
         let column_id_a = "column_a".parse().unwrap();
         let column_id_b = "column_b".parse().unwrap();
 
-        let column_data = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1, 2, 3]);
+        let column_data = OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3]);
 
-        let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
-            [(&column_id_a, &column_data), (&column_id_b, &column_data)],
-            0,
-            &(),
-        )
-        .unwrap();
+        let mut table_commitment =
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+                [(&column_id_a, &column_data), (&column_id_b, &column_data)],
+                0,
+                &(),
+            )
+            .unwrap();
         let column_commitments = table_commitment.column_commitments().clone();
 
         let append_column_result = table_commitment.try_append_rows(
@@ -809,20 +814,21 @@ mod tests {
     fn we_cannot_append_columns_of_mixed_length_to_table_commitment() {
         let column_id_a: Identifier = "column_a".parse().unwrap();
         let column_id_b: Identifier = "column_b".parse().unwrap();
-        let base_table: OwnedTable<Curve25519Scalar> = owned_table([
+        let base_table: OwnedTable<TestScalar> = owned_table([
             bigint(column_id_a, [1, 2, 3, 4]),
             varchar(column_id_b, ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
 
-        let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
-            base_table.inner_table(),
-            0,
-            &(),
-        )
-        .unwrap();
+        let mut table_commitment =
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+                base_table.inner_table(),
+                0,
+                &(),
+            )
+            .unwrap();
         let column_commitments = table_commitment.column_commitments().clone();
 
-        let column_a_append_data = OwnedColumn::<Curve25519Scalar>::BigInt(vec![5, 6, 7]);
+        let column_a_append_data = OwnedColumn::<TestScalar>::BigInt(vec![5, 6, 7]);
         let column_b_append_data =
             OwnedColumn::VarChar(["amet", "consectetur"].map(String::from).to_vec());
 
@@ -854,23 +860,24 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let initial_columns: OwnedTable<Curve25519Scalar> = owned_table([
+        let initial_columns: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
         ]);
-        let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
-            initial_columns.inner_table(),
-            2,
-            &(),
-        )
-        .unwrap();
+        let mut table_commitment =
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+                initial_columns.inner_table(),
+                2,
+                &(),
+            )
+            .unwrap();
 
-        let new_columns = owned_table::<Curve25519Scalar>([scalar(scalar_id, scalar_data)]);
+        let new_columns = owned_table::<TestScalar>([scalar(scalar_id, scalar_data)]);
         table_commitment
             .try_extend_columns(new_columns.inner_table(), &())
             .unwrap();
 
-        let expected_columns = owned_table::<Curve25519Scalar>([
+        let expected_columns = owned_table::<TestScalar>([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
             scalar(scalar_id, scalar_data),
@@ -893,20 +900,20 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let columns_a: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_a: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[..2].to_vec()),
             varchar(varchar_id, varchar_data[..2].to_vec()),
             scalar(scalar_id, scalar_data[..2].to_vec()),
         ]);
 
-        let table_commitment_a = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+        let table_commitment_a = TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
             columns_a.inner_table(),
             0,
             &(),
         )
         .unwrap();
 
-        let columns_b: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_b: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[2..].to_vec()),
             varchar(varchar_id, varchar_data[2..].to_vec()),
             scalar(scalar_id, scalar_data[2..].to_vec()),
@@ -914,7 +921,7 @@ mod tests {
         let table_commitment_b =
             TableCommitment::try_from_columns_with_offset(columns_b.inner_table(), 2, &()).unwrap();
 
-        let columns_sum: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_sum: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
             scalar(scalar_id, scalar_data),
@@ -939,18 +946,18 @@ mod tests {
 
     #[test]
     fn we_cannot_add_mismatched_table_commitments() {
-        let base_table: OwnedTable<Curve25519Scalar> = owned_table([
+        let base_table: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [1, 2, 3, 4]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
-        let table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+        let table_commitment = TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
             base_table.inner_table(),
             0,
             &(),
         )
         .unwrap();
 
-        let table_diff_type: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_diff_type: OwnedTable<TestScalar> = owned_table([
             varchar("column_a", ["5", "6", "7", "8"]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
@@ -965,11 +972,11 @@ mod tests {
 
     #[test]
     fn we_cannot_add_noncontiguous_table_commitments() {
-        let base_table: OwnedTable<Curve25519Scalar> = owned_table([
+        let base_table: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [1, 2, 3, 4]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
-        let table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+        let table_commitment = TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
             base_table.inner_table(),
             5,
             &(),
@@ -1038,19 +1045,20 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let columns_low: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_low: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[..2].to_vec()),
             varchar(varchar_id, varchar_data[..2].to_vec()),
             scalar(scalar_id, scalar_data[..2].to_vec()),
         ]);
-        let table_commitment_low = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
-            columns_low.inner_table(),
-            0,
-            &(),
-        )
-        .unwrap();
+        let table_commitment_low =
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+                columns_low.inner_table(),
+                0,
+                &(),
+            )
+            .unwrap();
 
-        let columns_high: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_high: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[2..].to_vec()),
             varchar(varchar_id, varchar_data[2..].to_vec()),
             scalar(scalar_id, scalar_data[2..].to_vec()),
@@ -1059,7 +1067,7 @@ mod tests {
             TableCommitment::try_from_columns_with_offset(columns_high.inner_table(), 2, &())
                 .unwrap();
 
-        let columns_all: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_all: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
             scalar(scalar_id, scalar_data),
@@ -1092,18 +1100,18 @@ mod tests {
 
     #[test]
     fn we_cannot_sub_mismatched_table_commitments() {
-        let base_table: OwnedTable<Curve25519Scalar> = owned_table([
+        let base_table: OwnedTable<TestScalar> = owned_table([
             bigint("column_a", [1, 2, 3, 4]),
             varchar("column_b", ["Lorem", "ipsum", "dolor", "sit"]),
         ]);
-        let table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+        let table_commitment = TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
             base_table.inner_table(),
             0,
             &(),
         )
         .unwrap();
 
-        let table_diff_type: OwnedTable<Curve25519Scalar> = owned_table([
+        let table_diff_type: OwnedTable<TestScalar> = owned_table([
             varchar("column_a", ["1", "2"]),
             varchar("column_b", ["Lorem", "ipsum"]),
         ]);
@@ -1127,20 +1135,20 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let columns_minuend: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_minuend: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[..].to_vec()),
             varchar(varchar_id, varchar_data[..].to_vec()),
             scalar(scalar_id, scalar_data[..].to_vec()),
         ]);
 
-        let columns_subtrahend: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_subtrahend: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[..2].to_vec()),
             varchar(varchar_id, varchar_data[..2].to_vec()),
             scalar(scalar_id, scalar_data[..2].to_vec()),
         ]);
 
         let minuend_table_commitment =
-            TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
                 columns_minuend.inner_table(),
                 4,
                 &(),
@@ -1199,19 +1207,20 @@ mod tests {
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
         let scalar_data = [1000, 2000, 3000, -1000, 0];
 
-        let columns_low: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_low: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[..2].to_vec()),
             varchar(varchar_id, varchar_data[..2].to_vec()),
             scalar(scalar_id, scalar_data[..2].to_vec()),
         ]);
-        let table_commitment_low = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
-            columns_low.inner_table(),
-            0,
-            &(),
-        )
-        .unwrap();
+        let table_commitment_low =
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+                columns_low.inner_table(),
+                0,
+                &(),
+            )
+            .unwrap();
 
-        let columns_high: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_high: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data[2..].to_vec()),
             varchar(varchar_id, varchar_data[2..].to_vec()),
             scalar(scalar_id, scalar_data[2..].to_vec()),
@@ -1220,7 +1229,7 @@ mod tests {
             TableCommitment::try_from_columns_with_offset(columns_high.inner_table(), 2, &())
                 .unwrap();
 
-        let columns_all: OwnedTable<Curve25519Scalar> = owned_table([
+        let columns_all: OwnedTable<TestScalar> = owned_table([
             bigint(bigint_id, bigint_data),
             varchar(varchar_id, varchar_data),
             scalar(scalar_id, scalar_data),
@@ -1258,20 +1267,20 @@ mod tests {
         let columns = [
             (
                 &"a".parse().unwrap(),
-                &Column::<Curve25519Scalar>::BigInt(&[1, 2, 3]),
+                &Column::<TestScalar>::BigInt(&[1, 2, 3]),
             ),
             (
                 &"b".parse().unwrap(),
-                &Column::<Curve25519Scalar>::VarChar((&["1", "2", "3"], &b_scals)),
+                &Column::<TestScalar>::VarChar((&["1", "2", "3"], &b_scals)),
             ),
         ];
 
         let mut expected_commitment =
-            TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(columns, 0, &())
+            TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(columns, 0, &())
                 .unwrap();
 
         let mut commitment =
-            TableCommitment::<RistrettoPoint>::try_from_record_batch(&batch, &()).unwrap();
+            TableCommitment::<NaiveCommitment>::try_from_record_batch(&batch, &()).unwrap();
 
         assert_eq!(commitment, expected_commitment);
 
@@ -1285,11 +1294,11 @@ mod tests {
         let columns2 = [
             (
                 &"a".parse().unwrap(),
-                &Column::<Curve25519Scalar>::BigInt(&[4, 5, 6]),
+                &Column::<TestScalar>::BigInt(&[4, 5, 6]),
             ),
             (
                 &"b".parse().unwrap(),
-                &Column::<Curve25519Scalar>::VarChar((&["4", "5", "6"], &b_scals2)),
+                &Column::<TestScalar>::VarChar((&["4", "5", "6"], &b_scals2)),
             ),
         ];
 

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -175,17 +175,16 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
 mod tests {
     use super::*;
     use crate::base::{
+        commitment::naive_commitment::NaiveCommitment,
         database::{Column, OwnedColumn},
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar,
     };
-    use blitzar::{compute::compute_curve25519_commitments, sequence::Sequence};
-    use curve25519_dalek::{ristretto::CompressedRistretto, RistrettoPoint};
 
     #[test]
     fn we_can_convert_from_columns() {
         // empty case
-        let commitments = Vec::<RistrettoPoint>::from_columns_with_offset(
-            &Vec::<Column<Curve25519Scalar>>::new(),
+        let commitments = Vec::<NaiveCommitment>::from_columns_with_offset(
+            &Vec::<Column<TestScalar>>::new(),
             0,
             &(),
         );
@@ -197,28 +196,24 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a.to_vec()),
             OwnedColumn::VarChar(column_b.to_vec()),
         ];
 
-        let commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
+        let commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
 
-        let mut expected_commitments = vec![CompressedRistretto::default(); 2];
-        compute_curve25519_commitments(
-            &mut expected_commitments,
-            &[
-                Sequence::from(column_a.as_slice()),
-                Sequence::from(
-                    column_b
-                        .map(Curve25519Scalar::from)
-                        .map(<[u64; 4]>::from)
-                        .as_slice(),
-                ),
-            ],
-            0,
-        );
+        let committable_columns = [
+            CommittableColumn::BigInt(&column_a),
+            CommittableColumn::VarChar(
+                column_b
+                    .iter()
+                    .map(TestScalar::from)
+                    .map(<[u64; 4]>::from)
+                    .collect(),
+            ),
+        ];
         let expected_commitments =
-            Vec::from_iter(expected_commitments.iter().map(|c| c.decompress().unwrap()));
+            NaiveCommitment::compute_commitments(&committable_columns, 0, &());
 
         assert_eq!(commitments, expected_commitments);
     }
@@ -229,14 +224,14 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[..3].to_vec()),
             OwnedColumn::VarChar(column_b[..3].to_vec()),
         ];
 
-        let mut commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
+        let mut commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[3..].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[3..].to_vec()),
             OwnedColumn::VarChar(column_b[3..].to_vec()),
         ];
 
@@ -244,22 +239,18 @@ mod tests {
             .try_append_rows_with_offset(&new_columns, 3, &())
             .unwrap();
 
-        let mut expected_commitments = vec![CompressedRistretto::default(); 2];
-        compute_curve25519_commitments(
-            &mut expected_commitments,
-            &[
-                Sequence::from(column_a.as_slice()),
-                Sequence::from(
-                    column_b
-                        .map(Curve25519Scalar::from)
-                        .map(<[u64; 4]>::from)
-                        .as_slice(),
-                ),
-            ],
-            0,
-        );
+        let committable_columns = [
+            CommittableColumn::BigInt(&column_a),
+            CommittableColumn::VarChar(
+                column_b
+                    .iter()
+                    .map(TestScalar::from)
+                    .map(<[u64; 4]>::from)
+                    .collect(),
+            ),
+        ];
         let expected_commitments =
-            Vec::from_iter(expected_commitments.iter().map(|c| c.decompress().unwrap()));
+            NaiveCommitment::compute_commitments(&committable_columns, 0, &());
 
         assert_eq!(commitments, expected_commitments);
     }
@@ -270,28 +261,26 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[..3].to_vec()),
             OwnedColumn::VarChar(column_b[..3].to_vec()),
         ];
 
-        let mut commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
+        let mut commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
 
-        let new_columns = Vec::<Column<Curve25519Scalar>>::new();
+        let new_columns = Vec::<Column<TestScalar>>::new();
         assert!(matches!(
             commitments.try_append_rows_with_offset(&new_columns, 3, &()),
             Err(NumColumnsMismatch)
         ));
 
-        let new_columns = vec![OwnedColumn::<Curve25519Scalar>::BigInt(
-            column_a[3..].to_vec(),
-        )];
+        let new_columns = vec![OwnedColumn::<TestScalar>::BigInt(column_a[3..].to_vec())];
         assert!(matches!(
             commitments.try_append_rows_with_offset(&new_columns, 3, &()),
             Err(NumColumnsMismatch)
         ));
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[3..].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[3..].to_vec()),
             OwnedColumn::VarChar(column_b[3..].to_vec()),
             OwnedColumn::BigInt(column_a[3..].to_vec()),
         ];
@@ -309,42 +298,51 @@ mod tests {
         let column_d = [78i64, 90, 1112];
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a.to_vec()),
             OwnedColumn::VarChar(column_b.to_vec()),
         ];
 
-        let mut commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
+        let mut commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::VarChar(column_c.to_vec()),
+            OwnedColumn::<TestScalar>::VarChar(column_c.to_vec()),
             OwnedColumn::BigInt(column_d.to_vec()),
         ];
 
         commitments.extend_columns_with_offset(&new_columns, 0, &());
 
-        let mut expected_commitments = vec![CompressedRistretto::default(); 4];
-        compute_curve25519_commitments(
-            &mut expected_commitments,
-            &[
-                Sequence::from(column_a.as_slice()),
-                Sequence::from(
-                    column_b
-                        .map(Curve25519Scalar::from)
-                        .map(<[u64; 4]>::from)
-                        .as_slice(),
-                ),
-                Sequence::from(
-                    column_c
-                        .map(Curve25519Scalar::from)
-                        .map(<[u64; 4]>::from)
-                        .as_slice(),
-                ),
-                Sequence::from(column_d.as_slice()),
-            ],
-            0,
-        );
+        let committable_columns = [
+            CommittableColumn::VarChar(
+                column_a
+                    .iter()
+                    .map(Into::<TestScalar>::into)
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+            CommittableColumn::VarChar(
+                column_b
+                    .iter()
+                    .map(Into::<TestScalar>::into)
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+            CommittableColumn::VarChar(
+                column_c
+                    .iter()
+                    .map(Into::<TestScalar>::into)
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+            CommittableColumn::VarChar(
+                column_d
+                    .iter()
+                    .map(Into::<TestScalar>::into)
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+        ];
         let expected_commitments =
-            Vec::from_iter(expected_commitments.iter().map(|c| c.decompress().unwrap()));
+            NaiveCommitment::compute_commitments(&committable_columns, 0, &());
 
         assert_eq!(commitments, expected_commitments);
     }
@@ -355,37 +353,33 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[..3].to_vec()),
             OwnedColumn::VarChar(column_b[..3].to_vec()),
         ];
 
-        let commitments_a = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
+        let commitments_a = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[3..].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[3..].to_vec()),
             OwnedColumn::VarChar(column_b[3..].to_vec()),
         ];
 
-        let commitments_b = Vec::<RistrettoPoint>::from_columns_with_offset(&new_columns, 3, &());
+        let commitments_b = Vec::<NaiveCommitment>::from_columns_with_offset(&new_columns, 3, &());
 
         let commitments = commitments_a.try_add(commitments_b).unwrap();
 
-        let mut expected_commitments = vec![CompressedRistretto::default(); 2];
-        compute_curve25519_commitments(
-            &mut expected_commitments,
-            &[
-                Sequence::from(column_a.as_slice()),
-                Sequence::from(
-                    column_b
-                        .map(Curve25519Scalar::from)
-                        .map(<[u64; 4]>::from)
-                        .as_slice(),
-                ),
-            ],
-            0,
-        );
+        let committable_columns = [
+            CommittableColumn::BigInt(&column_a),
+            CommittableColumn::VarChar(
+                column_b
+                    .iter()
+                    .map(Into::<TestScalar>::into)
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+        ];
         let expected_commitments =
-            Vec::from_iter(expected_commitments.iter().map(|c| c.decompress().unwrap()));
+            NaiveCommitment::compute_commitments(&committable_columns, 0, &());
 
         assert_eq!(commitments, expected_commitments);
     }
@@ -396,34 +390,35 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[..3].to_vec()),
             OwnedColumn::VarChar(column_b[..3].to_vec()),
         ];
 
-        let commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
+        let commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
 
-        let new_columns = Vec::<Column<Curve25519Scalar>>::new();
-        let new_commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&new_columns, 3, &());
+        let new_columns = Vec::<Column<TestScalar>>::new();
+        let new_commitments =
+            Vec::<NaiveCommitment>::from_columns_with_offset(&new_columns, 3, &());
         assert!(matches!(
             commitments.clone().try_add(new_commitments),
             Err(NumColumnsMismatch)
         ));
 
-        let new_columns = vec![OwnedColumn::<Curve25519Scalar>::BigInt(
-            column_a[3..].to_vec(),
-        )];
-        let new_commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&new_columns, 3, &());
+        let new_columns = vec![OwnedColumn::<TestScalar>::BigInt(column_a[3..].to_vec())];
+        let new_commitments =
+            Vec::<NaiveCommitment>::from_columns_with_offset(&new_columns, 3, &());
         assert!(matches!(
             commitments.clone().try_add(new_commitments),
             Err(NumColumnsMismatch)
         ));
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[3..].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[3..].to_vec()),
             OwnedColumn::VarChar(column_b[3..].to_vec()),
             OwnedColumn::BigInt(column_a[3..].to_vec()),
         ];
-        let new_commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&new_columns, 3, &());
+        let new_commitments =
+            Vec::<NaiveCommitment>::from_columns_with_offset(&new_columns, 3, &());
         assert!(matches!(
             commitments.try_add(new_commitments),
             Err(NumColumnsMismatch)
@@ -434,34 +429,37 @@ mod tests {
     fn we_can_sub_commitment_collections() {
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
+        let front_emptied_column_a = [0i64, 0, 0, 78, 90];
+        let front_emptied_column_b = ["", "", "", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[..3].to_vec()),
             OwnedColumn::VarChar(column_b[..3].to_vec()),
         ];
 
-        let commitments_a = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
+        let commitments_a = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
 
         let full_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a.to_vec()),
             OwnedColumn::VarChar(column_b.to_vec()),
         ];
 
-        let commitments_b = Vec::<RistrettoPoint>::from_columns_with_offset(&full_columns, 0, &());
+        let commitments_b = Vec::<NaiveCommitment>::from_columns_with_offset(&full_columns, 0, &());
 
         let commitments = commitments_b.try_sub(commitments_a).unwrap();
 
-        let mut expected_commitments = vec![CompressedRistretto::default(); 2];
-        compute_curve25519_commitments(
-            &mut expected_commitments,
-            &[
-                Sequence::from(&column_a[3..]),
-                Sequence::from(&column_b.map(Curve25519Scalar::from).map(<[u64; 4]>::from)[3..]),
-            ],
-            3,
-        );
+        let committable_columns = [
+            CommittableColumn::BigInt(&front_emptied_column_a),
+            CommittableColumn::VarChar(
+                front_emptied_column_b
+                    .iter()
+                    .map(Into::<TestScalar>::into)
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+        ];
         let expected_commitments =
-            Vec::from_iter(expected_commitments.iter().map(|c| c.decompress().unwrap()));
+            NaiveCommitment::compute_commitments(&committable_columns, 0, &());
 
         assert_eq!(commitments, expected_commitments);
     }
@@ -472,35 +470,35 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a[..3].to_vec()),
             OwnedColumn::VarChar(column_b[..3].to_vec()),
         ];
 
-        let commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
+        let commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
 
-        let full_columns = Vec::<Column<Curve25519Scalar>>::new();
+        let full_columns = Vec::<Column<TestScalar>>::new();
         let full_commitments =
-            Vec::<RistrettoPoint>::from_columns_with_offset(&full_columns, 0, &());
+            Vec::<NaiveCommitment>::from_columns_with_offset(&full_columns, 0, &());
         assert!(matches!(
             full_commitments.clone().try_sub(commitments.clone()),
             Err(NumColumnsMismatch)
         ));
 
-        let full_columns = vec![OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec())];
+        let full_columns = vec![OwnedColumn::<TestScalar>::BigInt(column_a.to_vec())];
         let full_commitments =
-            Vec::<RistrettoPoint>::from_columns_with_offset(&full_columns, 0, &());
+            Vec::<NaiveCommitment>::from_columns_with_offset(&full_columns, 0, &());
         assert!(matches!(
             full_commitments.try_sub(commitments.clone()),
             Err(NumColumnsMismatch)
         ));
 
         let full_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec()),
+            OwnedColumn::<TestScalar>::BigInt(column_a.to_vec()),
             OwnedColumn::VarChar(column_b.to_vec()),
             OwnedColumn::BigInt(column_a.to_vec()),
         ];
         let full_commitments =
-            Vec::<RistrettoPoint>::from_columns_with_offset(&full_columns, 0, &());
+            Vec::<NaiveCommitment>::from_columns_with_offset(&full_columns, 0, &());
         assert!(matches!(
             full_commitments.try_sub(commitments),
             Err(NumColumnsMismatch)

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -39,7 +39,7 @@ pub enum Column<'a, S: Scalar> {
     /// i128 columns
     Int128(&'a [i128]),
     /// Decimal columns with a max width of 252 bits
-    ///  - the backing store maps to the type [crate::base::scalar::Curve25519Scalar]
+    ///  - the backing store maps to the type [crate::base::scalar::test_scalar::TestScalar]
     Decimal75(Precision, i8, &'a [S]),
     /// Scalar columns
     Scalar(&'a [S]),
@@ -231,7 +231,7 @@ pub enum ColumnType {
     /// Mapped to i64
     #[serde(alias = "TIMESTAMP", alias = "timestamp")]
     TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone),
-    /// Mapped to Curve25519Scalar
+    /// Mapped to TestScalar
     #[serde(alias = "SCALAR", alias = "scalar")]
     Scalar,
 }
@@ -518,7 +518,7 @@ impl From<&ColumnField> for Field {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{base::scalar::Curve25519Scalar, proof_primitive::dory::DoryScalar};
+    use crate::{base::scalar::test_scalar::TestScalar, proof_primitive::dory::DoryScalar};
     use alloc::{
         string::{String, ToString},
         vec,
@@ -803,9 +803,9 @@ mod tests {
         let scale = 2;
 
         let scals = [
-            Curve25519Scalar::from(1),
-            Curve25519Scalar::from(2),
-            Curve25519Scalar::from(3),
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
         ];
 
         // Test non-empty columns
@@ -813,15 +813,15 @@ mod tests {
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::SmallInt(&[1, 2, 3]);
+        let column = Column::<TestScalar>::SmallInt(&[1, 2, 3]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::Int(&[1, 2, 3]);
+        let column = Column::<TestScalar>::Int(&[1, 2, 3]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::BigInt(&[1, 2, 3]);
+        let column = Column::<TestScalar>::BigInt(&[1, 2, 3]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
@@ -838,9 +838,9 @@ mod tests {
         assert!(!column.is_empty());
 
         let decimal_data = [
-            Curve25519Scalar::from(1),
-            Curve25519Scalar::from(2),
-            Curve25519Scalar::from(3),
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
         ];
 
         let precision = Precision::new(precision).unwrap();
@@ -853,15 +853,15 @@ mod tests {
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::SmallInt(&[]);
+        let column = Column::<TestScalar>::SmallInt(&[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::Int(&[]);
+        let column = Column::<TestScalar>::Int(&[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::BigInt(&[]);
+        let column = Column::<TestScalar>::BigInt(&[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
@@ -869,7 +869,7 @@ mod tests {
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::Int128(&[]);
+        let column = Column::<TestScalar>::Int128(&[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
@@ -877,7 +877,7 @@ mod tests {
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column: Column<'_, Curve25519Scalar> = Column::Decimal75(precision, scale, &[]);
+        let column: Column<'_, TestScalar> = Column::Decimal75(precision, scale, &[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
     }
@@ -886,16 +886,16 @@ mod tests {
     fn we_can_convert_owned_columns_to_columns_round_trip() {
         let alloc = Bump::new();
         // Integers
-        let owned_col: OwnedColumn<Curve25519Scalar> = OwnedColumn::Int128(vec![1, 2, 3, 4, 5]);
-        let col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
+        let owned_col: OwnedColumn<TestScalar> = OwnedColumn::Int128(vec![1, 2, 3, 4, 5]);
+        let col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, Column::Int128(&[1, 2, 3, 4, 5]));
         let new_owned_col = (&col).into();
         assert_eq!(owned_col, new_owned_col);
 
         // Booleans
-        let owned_col: OwnedColumn<Curve25519Scalar> =
+        let owned_col: OwnedColumn<TestScalar> =
             OwnedColumn::Boolean(vec![true, false, true, false, true]);
-        let col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
+        let col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, Column::Boolean(&[true, false, true, false, true]));
         let new_owned_col = (&col).into();
         assert_eq!(owned_col, new_owned_col);
@@ -908,20 +908,19 @@ mod tests {
             "Spațiu și Timp",
             "Spazju u Ħin",
         ];
-        let scalars = strs.iter().map(Curve25519Scalar::from).collect::<Vec<_>>();
+        let scalars = strs.iter().map(TestScalar::from).collect::<Vec<_>>();
         let owned_col =
             OwnedColumn::VarChar(strs.iter().map(|s| s.to_string()).collect::<Vec<String>>());
-        let col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
+        let col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, Column::VarChar((&strs, &scalars)));
         let new_owned_col = (&col).into();
         assert_eq!(owned_col, new_owned_col);
 
         // Decimals
-        let scalars: Vec<Curve25519Scalar> =
-            [1, 2, 3, 4, 5].iter().map(Curve25519Scalar::from).collect();
-        let owned_col: OwnedColumn<Curve25519Scalar> =
+        let scalars: Vec<TestScalar> = [1, 2, 3, 4, 5].iter().map(TestScalar::from).collect();
+        let owned_col: OwnedColumn<TestScalar> =
             OwnedColumn::Decimal75(Precision::new(75).unwrap(), 127, scalars.clone());
-        let col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
+        let col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(
             col,
             Column::Decimal75(Precision::new(75).unwrap(), 127, &scalars)
@@ -936,15 +935,15 @@ mod tests {
         assert_eq!(column.column_type().byte_size(), 1);
         assert_eq!(column.column_type().bit_size(), 8);
 
-        let column = Column::<Curve25519Scalar>::SmallInt(&[1, 2, 3, 4]);
+        let column = Column::<TestScalar>::SmallInt(&[1, 2, 3, 4]);
         assert_eq!(column.column_type().byte_size(), 2);
         assert_eq!(column.column_type().bit_size(), 16);
 
-        let column = Column::<Curve25519Scalar>::Int(&[1, 2, 3]);
+        let column = Column::<TestScalar>::Int(&[1, 2, 3]);
         assert_eq!(column.column_type().byte_size(), 4);
         assert_eq!(column.column_type().bit_size(), 32);
 
-        let column = Column::<Curve25519Scalar>::BigInt(&[1]);
+        let column = Column::<TestScalar>::BigInt(&[1]);
         assert_eq!(column.column_type().byte_size(), 8);
         assert_eq!(column.column_type().bit_size(), 64);
 
@@ -953,9 +952,9 @@ mod tests {
         assert_eq!(column.column_type().bit_size(), 128);
 
         let scals = [
-            Curve25519Scalar::from(1),
-            Curve25519Scalar::from(2),
-            Curve25519Scalar::from(3),
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
         ];
 
         let column = Column::VarChar((&["a", "b", "c", "d", "e"], &scals));
@@ -969,9 +968,9 @@ mod tests {
         let precision = 10;
         let scale = 2;
         let decimal_data = [
-            Curve25519Scalar::from(1),
-            Curve25519Scalar::from(2),
-            Curve25519Scalar::from(3),
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
         ];
 
         let precision = Precision::new(precision).unwrap();

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -894,7 +894,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::base::scalar::Curve25519Scalar;
+    use crate::base::scalar::test_scalar::TestScalar;
 
     #[test]
     fn we_can_add_numeric_types() {
@@ -1387,7 +1387,7 @@ mod test {
         let lhs = [1_i16, -2, 3];
         let rhs = [100_i16, 5, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::SmallInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
@@ -1399,7 +1399,7 @@ mod test {
         let lhs = [400_i64, -82, -200];
         let rhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::BigInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
@@ -1410,11 +1410,11 @@ mod test {
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = [4_i16, -80, 230]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -8, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 3);
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
@@ -1425,11 +1425,11 @@ mod test {
         // lhs is decimal with negative scale and rhs is decimal with nonnegative scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, 150000, -20000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 2);
@@ -1440,11 +1440,11 @@ mod test {
         // lhs is decimal with nonnegative scale and rhs is decimal with negative scale
         let lhs = [71_i64, 150000, -20000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 2);
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
@@ -1455,11 +1455,11 @@ mod test {
         // lhs and rhs are both decimals with negative scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, 150000, -20000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -50);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), -46);
@@ -1470,11 +1470,11 @@ mod test {
         // lhs and rhs are decimals with extreme differences in scale
         let lhs = [4_i16, 0, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, 0, -20000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -50);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 26);
@@ -1508,7 +1508,7 @@ mod test {
         let lhs = [1_i16, -2, 3];
         let rhs = [100_i16, 5, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::SmallInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
@@ -1520,7 +1520,7 @@ mod test {
         let lhs = [400_i64, -82, -199];
         let rhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::BigInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
@@ -1531,11 +1531,11 @@ mod test {
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = [4_i16, -80, 230]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -8, 22]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 3);
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
@@ -1546,11 +1546,11 @@ mod test {
         // lhs is decimal with negative scale and rhs is decimal with nonnegative scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, 150000, -30000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 2);
@@ -1561,11 +1561,11 @@ mod test {
         // lhs is decimal with nonnegative scale and rhs is decimal with negative scale
         let lhs = [71_i64, 150000, -19000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 2);
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
@@ -1576,11 +1576,11 @@ mod test {
         // lhs and rhs are both decimals with negative scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71000_i64, 150000, -21000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -50);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), -46);
@@ -1591,11 +1591,11 @@ mod test {
         // lhs and rhs are decimals with extreme differences in scale
         let lhs = [1_i16, 1, 1, 0, 0, 0, -1, -1, -1]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [1_i64, 0, -1, 1, 0, -1, 1, 0, -1]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -50);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 26);
@@ -1629,7 +1629,7 @@ mod test {
         let lhs = [1_i16, -2, 3];
         let rhs = [100_i16, 5, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::SmallInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
@@ -1641,7 +1641,7 @@ mod test {
         let lhs = [400_i64, -82, 199];
         let rhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::BigInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
@@ -1652,11 +1652,11 @@ mod test {
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = [4_i16, -80, 230]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -8, -22]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 3);
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
@@ -1667,11 +1667,11 @@ mod test {
         // lhs is decimal with negative scale and rhs is decimal with nonnegative scale
         let lhs = [-4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, 150000, -30000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 2);
@@ -1682,11 +1682,11 @@ mod test {
         // lhs is decimal with nonnegative scale and rhs is decimal with negative scale
         let lhs = [71_i64, 150000, -19000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 2);
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
@@ -1697,11 +1697,11 @@ mod test {
         // lhs and rhs are both decimals with negative scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71000_i64, 150000, -21000]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -50);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), -46);
@@ -1712,11 +1712,11 @@ mod test {
         // lhs and rhs are decimals with extreme differences in scale
         let lhs = [1_i16, 1, 1, 0, 0, 0, -1, -1, -1]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [1_i64, 0, -1, 1, 0, -1, 1, 0, -1]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -50);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 26);
@@ -1770,16 +1770,16 @@ mod test {
         let lhs = [1_i16, -2, 3];
         let rhs = [4_i16, 5, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::SmallInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_add_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(104),
-            Curve25519Scalar::from(-195),
-            Curve25519Scalar::from(298),
+            TestScalar::from(104),
+            TestScalar::from(-195),
+            TestScalar::from(298),
         ];
         let expected = (Precision::new(11).unwrap(), 2, expected_scalars);
         assert_eq!(expected, actual);
@@ -1787,17 +1787,17 @@ mod test {
         // lhs is decimal with negative scale and rhs is integer
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23];
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
         let right_column_type = ColumnType::BigInt;
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_add_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(471),
-            Curve25519Scalar::from(1418),
-            Curve25519Scalar::from(-177),
+            TestScalar::from(471),
+            TestScalar::from(1418),
+            TestScalar::from(-177),
         ];
         let expected = (Precision::new(20).unwrap(), 0, expected_scalars);
         assert_eq!(expected, actual);
@@ -1805,20 +1805,20 @@ mod test {
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(12).unwrap(), 2);
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 3);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_add_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(111),
-            Curve25519Scalar::from(68),
-            Curve25519Scalar::from(3),
+            TestScalar::from(111),
+            TestScalar::from(68),
+            TestScalar::from(3),
         ];
         let expected = (Precision::new(14).unwrap(), 3, expected_scalars);
         assert_eq!(expected, actual);
@@ -1827,20 +1827,20 @@ mod test {
         // and with result having maximum precision
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(69).unwrap(), -2);
         let right_column_type = ColumnType::Decimal75(Precision::new(50).unwrap(), 3);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_add_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(400071),
-            Curve25519Scalar::from(1499918),
-            Curve25519Scalar::from(-199977),
+            TestScalar::from(400071),
+            TestScalar::from(1499918),
+            TestScalar::from(-199977),
         ];
         let expected = (Precision::new(75).unwrap(), 3, expected_scalars);
         assert_eq!(expected, actual);
@@ -1849,20 +1849,20 @@ mod test {
         // and with result having maximum precision and minimum scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(74).unwrap(), -128);
         let right_column_type = ColumnType::Decimal75(Precision::new(74).unwrap(), -128);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_add_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(75),
-            Curve25519Scalar::from(-67),
-            Curve25519Scalar::from(21),
+            TestScalar::from(75),
+            TestScalar::from(-67),
+            TestScalar::from(21),
         ];
         let expected = (Precision::new(75).unwrap(), -128, expected_scalars);
         assert_eq!(expected, actual);
@@ -1932,16 +1932,16 @@ mod test {
         let lhs = [1_i16, -2, 3];
         let rhs = [4_i16, 5, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::SmallInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_subtract_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(96),
-            Curve25519Scalar::from(-205),
-            Curve25519Scalar::from(302),
+            TestScalar::from(96),
+            TestScalar::from(-205),
+            TestScalar::from(302),
         ];
         let expected = (Precision::new(11).unwrap(), 2, expected_scalars);
         assert_eq!(expected, actual);
@@ -1949,17 +1949,17 @@ mod test {
         // lhs is decimal with negative scale and rhs is integer
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23];
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
         let right_column_type = ColumnType::BigInt;
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_subtract_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(329),
-            Curve25519Scalar::from(1582),
-            Curve25519Scalar::from(-223),
+            TestScalar::from(329),
+            TestScalar::from(1582),
+            TestScalar::from(-223),
         ];
         let expected = (Precision::new(20).unwrap(), 0, expected_scalars);
         assert_eq!(expected, actual);
@@ -1967,20 +1967,20 @@ mod test {
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(12).unwrap(), 2);
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 3);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_subtract_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(-31),
-            Curve25519Scalar::from(232),
-            Curve25519Scalar::from(-43),
+            TestScalar::from(-31),
+            TestScalar::from(232),
+            TestScalar::from(-43),
         ];
         let expected = (Precision::new(14).unwrap(), 3, expected_scalars);
         assert_eq!(expected, actual);
@@ -1989,20 +1989,20 @@ mod test {
         // and with result having maximum precision
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(69).unwrap(), -2);
         let right_column_type = ColumnType::Decimal75(Precision::new(50).unwrap(), 3);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_subtract_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(399929),
-            Curve25519Scalar::from(1500082),
-            Curve25519Scalar::from(-200023),
+            TestScalar::from(399929),
+            TestScalar::from(1500082),
+            TestScalar::from(-200023),
         ];
         let expected = (Precision::new(75).unwrap(), 3, expected_scalars);
         assert_eq!(expected, actual);
@@ -2011,20 +2011,20 @@ mod test {
         // and with result having maximum precision and minimum scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(74).unwrap(), -128);
         let right_column_type = ColumnType::Decimal75(Precision::new(74).unwrap(), -128);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_subtract_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(-67),
-            Curve25519Scalar::from(97),
-            Curve25519Scalar::from(-25),
+            TestScalar::from(-67),
+            TestScalar::from(97),
+            TestScalar::from(-25),
         ];
         let expected = (Precision::new(75).unwrap(), -128, expected_scalars);
         assert_eq!(expected, actual);
@@ -2075,16 +2075,16 @@ mod test {
         let lhs = [1_i16, -2, 3];
         let rhs = [4_i16, 5, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::SmallInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_multiply_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(4),
-            Curve25519Scalar::from(-10),
-            Curve25519Scalar::from(-6),
+            TestScalar::from(4),
+            TestScalar::from(-10),
+            TestScalar::from(-6),
         ];
         let expected = (Precision::new(16).unwrap(), 2, expected_scalars);
         assert_eq!(expected, actual);
@@ -2092,17 +2092,17 @@ mod test {
         // lhs is decimal with negative scale and rhs is integer
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23];
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
         let right_column_type = ColumnType::BigInt;
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_multiply_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(284),
-            Curve25519Scalar::from(-1230),
-            Curve25519Scalar::from(-46),
+            TestScalar::from(284),
+            TestScalar::from(-1230),
+            TestScalar::from(-46),
         ];
         let expected = (Precision::new(30).unwrap(), -2, expected_scalars);
         assert_eq!(expected, actual);
@@ -2111,20 +2111,20 @@ mod test {
         // and with result having maximum precision and maximum scale
         let lhs = [4_i16, 25, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(42).unwrap(), 72);
         let right_column_type = ColumnType::Decimal75(Precision::new(32).unwrap(), 55);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_multiply_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(284),
-            Curve25519Scalar::from(-2050),
-            Curve25519Scalar::from(-46),
+            TestScalar::from(284),
+            TestScalar::from(-2050),
+            TestScalar::from(-46),
         ];
         let expected = (Precision::new(75).unwrap(), 127, expected_scalars);
         assert_eq!(expected, actual);
@@ -2133,20 +2133,20 @@ mod test {
         // and with result having maximum precision
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(69).unwrap(), -2);
         let right_column_type = ColumnType::Decimal75(Precision::new(5).unwrap(), 3);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_multiply_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(284),
-            Curve25519Scalar::from(-1230),
-            Curve25519Scalar::from(-46),
+            TestScalar::from(284),
+            TestScalar::from(-1230),
+            TestScalar::from(-46),
         ];
         let expected = (Precision::new(75).unwrap(), 1, expected_scalars);
         assert_eq!(expected, actual);
@@ -2155,20 +2155,20 @@ mod test {
         // and with result having maximum precision and minimum scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(34).unwrap(), -64);
         let right_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), -64);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_multiply_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(284),
-            Curve25519Scalar::from(-1230),
-            Curve25519Scalar::from(-46),
+            TestScalar::from(284),
+            TestScalar::from(-1230),
+            TestScalar::from(-46),
         ];
         let expected = (Precision::new(75).unwrap(), -128, expected_scalars);
         assert_eq!(expected, actual);
@@ -2238,16 +2238,16 @@ mod test {
         let lhs = [0_i16, 2, 3];
         let rhs = [4_i16, 5, 2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::SmallInt;
         let right_column_type = ColumnType::Decimal75(Precision::new(3).unwrap(), 2);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_divide_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(0_i64),
-            Curve25519Scalar::from(40000000_i64),
-            Curve25519Scalar::from(150000000_i64),
+            TestScalar::from(0_i64),
+            TestScalar::from(40000000_i64),
+            TestScalar::from(150000000_i64),
         ];
         let expected = (Precision::new(13).unwrap(), 6, expected_scalars);
         assert_eq!(expected, actual);
@@ -2255,17 +2255,17 @@ mod test {
         // lhs is decimal with negative scale and rhs is integer
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23];
         let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
         let right_column_type = ColumnType::SmallInt;
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_divide_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(5633802),
-            Curve25519Scalar::from(-18292682),
-            Curve25519Scalar::from(-8695652),
+            TestScalar::from(5633802),
+            TestScalar::from(-18292682),
+            TestScalar::from(-8695652),
         ];
         let expected = (Precision::new(18).unwrap(), 6, expected_scalars);
         assert_eq!(expected, actual);
@@ -2273,20 +2273,20 @@ mod test {
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = [4_i16, 2, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [3_i64, -5, 7]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(4).unwrap(), 2);
         let right_column_type = ColumnType::Decimal75(Precision::new(3).unwrap(), 2);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_divide_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(1333333),
-            Curve25519Scalar::from(-400000),
-            Curve25519Scalar::from(-285714),
+            TestScalar::from(1333333),
+            TestScalar::from(-400000),
+            TestScalar::from(-285714),
         ];
         let expected = (Precision::new(10).unwrap(), 6, expected_scalars);
         assert_eq!(expected, actual);
@@ -2294,20 +2294,20 @@ mod test {
         // lhs and rhs are both decimals one of which has negative scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(2).unwrap(), -2);
         let right_column_type = ColumnType::Decimal75(Precision::new(3).unwrap(), 3);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_divide_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(5633802816_i128),
-            Curve25519Scalar::from(-18292682926_i128),
-            Curve25519Scalar::from(-8695652173_i128),
+            TestScalar::from(5633802816_i128),
+            TestScalar::from(-18292682926_i128),
+            TestScalar::from(-8695652173_i128),
         ];
         let expected = (Precision::new(13).unwrap(), 6, expected_scalars);
         assert_eq!(expected, actual);
@@ -2315,20 +2315,20 @@ mod test {
         // lhs and rhs are both decimals with negative scale
         let lhs = [4_i16, 15, -2]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let rhs = [71_i64, -82, 23]
             .into_iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let left_column_type = ColumnType::Decimal75(Precision::new(2).unwrap(), -3);
         let right_column_type = ColumnType::Decimal75(Precision::new(3).unwrap(), -2);
-        let actual: (Precision, i8, Vec<Curve25519Scalar>) =
+        let actual: (Precision, i8, Vec<TestScalar>) =
             try_divide_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
         let expected_scalars = vec![
-            Curve25519Scalar::from(563380),
-            Curve25519Scalar::from(-1829268),
-            Curve25519Scalar::from(-869565),
+            TestScalar::from(563380),
+            TestScalar::from(-1829268),
+            TestScalar::from(-869565),
         ];
         let expected = (Precision::new(9).unwrap(), 6, expected_scalars);
         assert_eq!(expected, actual);

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
@@ -4,7 +4,7 @@ use crate::base::{
         OwnedTable,
     },
     math::decimal::Precision,
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
 };
 use proof_of_sql_parser::{
     intermediate_ast::Literal,
@@ -15,7 +15,7 @@ use proof_of_sql_parser::{
 
 #[test]
 fn we_can_evaluate_a_simple_literal() {
-    let table: OwnedTable<Curve25519Scalar> =
+    let table: OwnedTable<TestScalar> =
         owned_table([varchar("languages", ["en", "es", "pt", "fr", "ht"])]);
 
     // "Space and Time" in Hebrew
@@ -54,7 +54,7 @@ fn we_can_evaluate_a_simple_literal() {
 
 #[test]
 fn we_can_evaluate_a_simple_column() {
-    let table: OwnedTable<Curve25519Scalar> = owned_table([
+    let table: OwnedTable<TestScalar> = owned_table([
         bigint("bigints", [i64::MIN, -1, 0, 1, i64::MAX]),
         varchar("language", ["en", "es", "pt", "fr", "ht"]),
         varchar("john", ["John", "Juan", "João", "Jean", "Jean"]),
@@ -77,7 +77,7 @@ fn we_can_evaluate_a_simple_column() {
 
 #[test]
 fn we_can_not_evaluate_a_nonexisting_column() {
-    let table: OwnedTable<Curve25519Scalar> =
+    let table: OwnedTable<TestScalar> =
         owned_table([varchar("cats", ["Chloe", "Margaret", "Prudence", "Lucy"])]);
     // "not_a_column" is not a column in the table
     let expr = col("not_a_column");
@@ -89,7 +89,7 @@ fn we_can_not_evaluate_a_nonexisting_column() {
 
 #[test]
 fn we_can_evaluate_a_logical_expression() {
-    let table: OwnedTable<Curve25519Scalar> = owned_table([
+    let table: OwnedTable<TestScalar> = owned_table([
         varchar("en", ["Elizabeth", "John", "cat", "dog", "Munich"]),
         varchar("pl", ["Elżbieta", "Jan", "kot", "pies", "Monachium"]),
         varchar("cz", ["Alžběta", "Jan", "kočka", "pes", "Mnichov"]),
@@ -108,14 +108,14 @@ fn we_can_evaluate_a_logical_expression() {
     // Which Czech and Slovak words agree?
     let expr = equal(col("cz"), col("sk"));
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column: OwnedColumn<Curve25519Scalar> =
+    let expected_column: OwnedColumn<TestScalar> =
         OwnedColumn::Boolean(vec![false, false, false, true, false]);
     assert_eq!(actual_column, expected_column);
 
     // Find words shared among Slovak, Croatian and Slovenian
     let expr = and(equal(col("sk"), col("hr")), equal(col("hr"), col("sl")));
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column: OwnedColumn<Curve25519Scalar> =
+    let expected_column: OwnedColumn<TestScalar> =
         OwnedColumn::Boolean(vec![false, false, true, false, false]);
     assert_eq!(actual_column, expected_column);
 
@@ -125,7 +125,7 @@ fn we_can_evaluate_a_logical_expression() {
         not(equal(col("pl"), col("sl"))),
     );
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column: OwnedColumn<Curve25519Scalar> =
+    let expected_column: OwnedColumn<TestScalar> =
         OwnedColumn::Boolean(vec![false, true, false, false, false]);
     assert_eq!(actual_column, expected_column);
 
@@ -135,14 +135,14 @@ fn we_can_evaluate_a_logical_expression() {
         and(equal(col("hr"), col("sl")), equal(col("hr"), col("sk"))),
     );
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column: OwnedColumn<Curve25519Scalar> =
+    let expected_column: OwnedColumn<TestScalar> =
         OwnedColumn::Boolean(vec![true, true, true, false, true]);
     assert_eq!(actual_column, expected_column);
 }
 
 #[test]
 fn we_can_evaluate_an_arithmetic_expression() {
-    let table: OwnedTable<Curve25519Scalar> = owned_table([
+    let table: OwnedTable<TestScalar> = owned_table([
         smallint("smallints", [-2_i16, -1, 0, 1, 2]),
         int("ints", [-4_i32, -2, 0, 2, 4]),
         bigint("bigints", [-8_i64, -4, 0, 4, 8]),
@@ -197,7 +197,7 @@ fn we_can_evaluate_an_arithmetic_expression() {
 
 #[test]
 fn we_cannot_evaluate_expressions_if_column_operation_errors_out() {
-    let table: OwnedTable<Curve25519Scalar> = owned_table([
+    let table: OwnedTable<TestScalar> = owned_table([
         bigint("bigints", [i64::MIN, -1, 0, 1, i64::MAX]),
         varchar("language", ["en", "es", "pt", "fr", "ht"]),
         varchar("sarah", ["Sarah", "Sara", "Sara", "Sarah", "Sarah"]),

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,15 +1,14 @@
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
 
 #[test]
 fn we_can_filter_columns() {
     let selection = vec![true, false, true, false, true];
-    let str_scalars: [Curve25519Scalar; 5] =
-        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let str_scalars: [TestScalar; 5] = ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![
@@ -40,8 +39,7 @@ fn we_can_filter_columns() {
 #[test]
 fn we_can_filter_columns_with_empty_result() {
     let selection = vec![false, false, false, false, false];
-    let str_scalars: [Curve25519Scalar; 5] =
-        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let str_scalars: [TestScalar; 5] = ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![
@@ -69,7 +67,7 @@ fn we_can_filter_columns_with_empty_result() {
 fn we_can_filter_empty_columns() {
     let selection = vec![];
     let columns = vec![
-        Column::<Curve25519Scalar>::BigInt(&[]),
+        Column::<TestScalar>::BigInt(&[]),
         Column::Int128(&[]),
         Column::VarChar((&[], &[])),
         Column::Scalar(&[]),

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -229,9 +229,9 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
 /// let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
 /// let counts = &[3, 3, 4];
 /// let expected = &[
-///     Curve25519Scalar::from(112 + 111 + 101),
-///     Curve25519Scalar::from(110 + 102 + 103),
-///     Curve25519Scalar::from(106 + 114 + 113 + 109),
+///     TestScalar::from(112 + 111 + 101),
+///     TestScalar::from(110 + 102 + 103),
+///     TestScalar::from(106 + 114 + 113 + 109),
 /// ];
 /// let alloc = Bump::new();
 /// let result = sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
@@ -270,9 +270,9 @@ where
 /// let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
 /// let counts = &[3, 3, 4];
 /// let expected = &[
-///     Some(Curve25519Scalar::from(max(112, 111, 101))),
-///     Some(Curve25519Scalar::from(max(110, 102, 103))),
-///     Some(Curve25519Scalar::from(max(106, 114, 113, 109))),
+///     Some(TestScalar::from(max(112, 111, 101))),
+///     Some(TestScalar::from(max(110, 102, 103))),
+///     Some(TestScalar::from(max(106, 114, 113, 109))),
 /// ];
 /// let alloc = Bump::new();
 /// let result = max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
@@ -313,9 +313,9 @@ where
 /// let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
 /// let counts = &[3, 3, 4];
 /// let expected = &[
-///     Some(Curve25519Scalar::from(min(112, 111, 101))),
-///     Some(Curve25519Scalar::from(min(110, 102, 103))),
-///     Some(Curve25519Scalar::from(min(106, 114, 113, 109))),
+///     Some(TestScalar::from(min(112, 111, 101))),
+///     Some(TestScalar::from(min(110, 102, 103))),
+///     Some(TestScalar::from(min(106, 114, 113, 109))),
 /// ];
 /// let alloc = Bump::new();
 /// let result = min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         database::{group_by_util::*, Column, OwnedColumn},
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
 };
@@ -10,7 +10,7 @@ use core::cmp::Ordering;
 
 #[test]
 fn we_can_aggregate_empty_columns() {
-    let column_a = Column::BigInt::<Curve25519Scalar>(&[]);
+    let column_a = Column::BigInt::<TestScalar>(&[]);
     let column_b = Column::VarChar((&[], &[]));
     let column_c = Column::Int128(&[]);
     let column_d = Column::Scalar(&[]);
@@ -33,7 +33,7 @@ fn we_can_aggregate_columns_with_empty_group_by_and_no_rows_selected() {
     let slice_c = &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111];
     let slice_d = &[200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211];
     let selection = &[false; 12];
-    let scals_d: Vec<Curve25519Scalar> = slice_d.iter().map(|s| s.into()).collect();
+    let scals_d: Vec<TestScalar> = slice_d.iter().map(|s| s.into()).collect();
     let column_c = Column::Int128(slice_c);
     let column_d = Column::Scalar(&scals_d);
     let group_by = &[];
@@ -69,7 +69,7 @@ fn we_can_aggregate_columns_with_empty_group_by() {
     let selection = &[
         false, true, true, true, true, true, true, true, true, true, true, true,
     ];
-    let scals_d: Vec<Curve25519Scalar> = slice_d.iter().map(|s| s.into()).collect();
+    let scals_d: Vec<TestScalar> = slice_d.iter().map(|s| s.into()).collect();
     let column_c = Column::Int128(slice_c);
     let column_d = Column::Scalar(&scals_d);
     let group_by = &[];
@@ -88,20 +88,20 @@ fn we_can_aggregate_columns_with_empty_group_by() {
     .expect("Aggregation should succeed");
     let expected_group_by_result = &[];
     let expected_sum_result = &[
-        &[Curve25519Scalar::from(
+        &[TestScalar::from(
             101 + 102 + 103 + 104 + 105 + 106 + 107 + 108 + 109 + 110 + 111,
         )],
-        &[Curve25519Scalar::from(
+        &[TestScalar::from(
             201 + 202 + 203 + 204 + 205 + 206 + 207 + 208 + 209 + 210 + 211,
         )],
     ];
     let expected_max_result = &[
-        &[Some(Curve25519Scalar::from(111))],
-        &[Some(Curve25519Scalar::from(211))],
+        &[Some(TestScalar::from(111))],
+        &[Some(TestScalar::from(211))],
     ];
     let expected_min_result = &[
-        &[Some(Curve25519Scalar::from(101))],
-        &[Some(Curve25519Scalar::from(201))],
+        &[Some(TestScalar::from(101))],
+        &[Some(TestScalar::from(201))],
     ];
     let expected_count_result = &[11];
     assert_eq!(aggregate_result.group_by_columns, expected_group_by_result);
@@ -122,8 +122,8 @@ fn we_can_aggregate_columns() {
     let selection = &[
         false, true, true, true, true, true, true, true, true, true, true, true,
     ];
-    let scals_b: Vec<Curve25519Scalar> = slice_b.iter().map(|s| s.into()).collect();
-    let scals_d: Vec<Curve25519Scalar> = slice_d.iter().map(|s| s.into()).collect();
+    let scals_b: Vec<TestScalar> = slice_b.iter().map(|s| s.into()).collect();
+    let scals_d: Vec<TestScalar> = slice_d.iter().map(|s| s.into()).collect();
     let column_a = Column::BigInt(slice_a);
     let column_b = Column::VarChar((slice_b, &scals_b));
     let column_c = Column::Int128(slice_c);
@@ -143,12 +143,12 @@ fn we_can_aggregate_columns() {
     )
     .expect("Aggregation should succeed");
     let scals_res = [
-        Curve25519Scalar::from("Cat"),
-        Curve25519Scalar::from("Dog"),
-        Curve25519Scalar::from("Cat"),
-        Curve25519Scalar::from("Dog"),
-        Curve25519Scalar::from("Cat"),
-        Curve25519Scalar::from("Dog"),
+        TestScalar::from("Cat"),
+        TestScalar::from("Dog"),
+        TestScalar::from("Cat"),
+        TestScalar::from("Dog"),
+        TestScalar::from("Cat"),
+        TestScalar::from("Dog"),
     ];
     let expected_group_by_result = &[
         Column::BigInt(&[1, 1, 2, 2, 3, 3]),
@@ -156,56 +156,56 @@ fn we_can_aggregate_columns() {
     ];
     let expected_sum_result = &[
         &[
-            Curve25519Scalar::from(105),
-            Curve25519Scalar::from(106),
-            Curve25519Scalar::from(103 + 107),
-            Curve25519Scalar::from(104 + 108),
-            Curve25519Scalar::from(101 + 109 + 111),
-            Curve25519Scalar::from(102 + 110),
+            TestScalar::from(105),
+            TestScalar::from(106),
+            TestScalar::from(103 + 107),
+            TestScalar::from(104 + 108),
+            TestScalar::from(101 + 109 + 111),
+            TestScalar::from(102 + 110),
         ],
         &[
-            Curve25519Scalar::from(205),
-            Curve25519Scalar::from(206),
-            Curve25519Scalar::from(203 + 207),
-            Curve25519Scalar::from(204 + 208),
-            Curve25519Scalar::from(201 + 209 + 211),
-            Curve25519Scalar::from(202 + 210),
+            TestScalar::from(205),
+            TestScalar::from(206),
+            TestScalar::from(203 + 207),
+            TestScalar::from(204 + 208),
+            TestScalar::from(201 + 209 + 211),
+            TestScalar::from(202 + 210),
         ],
     ];
     let expected_max_result = &[
         &[
-            Some(Curve25519Scalar::from(105)),
-            Some(Curve25519Scalar::from(106)),
-            Some(Curve25519Scalar::from(107)),
-            Some(Curve25519Scalar::from(108)),
-            Some(Curve25519Scalar::from(111)),
-            Some(Curve25519Scalar::from(110)),
+            Some(TestScalar::from(105)),
+            Some(TestScalar::from(106)),
+            Some(TestScalar::from(107)),
+            Some(TestScalar::from(108)),
+            Some(TestScalar::from(111)),
+            Some(TestScalar::from(110)),
         ],
         &[
-            Some(Curve25519Scalar::from(205)),
-            Some(Curve25519Scalar::from(206)),
-            Some(Curve25519Scalar::from(207)),
-            Some(Curve25519Scalar::from(208)),
-            Some(Curve25519Scalar::from(211)),
-            Some(Curve25519Scalar::from(210)),
+            Some(TestScalar::from(205)),
+            Some(TestScalar::from(206)),
+            Some(TestScalar::from(207)),
+            Some(TestScalar::from(208)),
+            Some(TestScalar::from(211)),
+            Some(TestScalar::from(210)),
         ],
     ];
     let expected_min_result = &[
         &[
-            Some(Curve25519Scalar::from(105)),
-            Some(Curve25519Scalar::from(106)),
-            Some(Curve25519Scalar::from(103)),
-            Some(Curve25519Scalar::from(104)),
-            Some(Curve25519Scalar::from(101)),
-            Some(Curve25519Scalar::from(102)),
+            Some(TestScalar::from(105)),
+            Some(TestScalar::from(106)),
+            Some(TestScalar::from(103)),
+            Some(TestScalar::from(104)),
+            Some(TestScalar::from(101)),
+            Some(TestScalar::from(102)),
         ],
         &[
-            Some(Curve25519Scalar::from(205)),
-            Some(Curve25519Scalar::from(206)),
-            Some(Curve25519Scalar::from(203)),
-            Some(Curve25519Scalar::from(204)),
-            Some(Curve25519Scalar::from(201)),
-            Some(Curve25519Scalar::from(202)),
+            Some(TestScalar::from(205)),
+            Some(TestScalar::from(206)),
+            Some(TestScalar::from(203)),
+            Some(TestScalar::from(204)),
+            Some(TestScalar::from(201)),
+            Some(TestScalar::from(202)),
         ],
     ];
     let expected_count_result = &[1, 1, 2, 2, 3, 2];
@@ -218,7 +218,7 @@ fn we_can_aggregate_columns() {
 
 #[test]
 fn we_can_compare_indexes_by_columns_with_no_columns() {
-    let columns: &[Column<Curve25519Scalar>; 0] = &[];
+    let columns: &[Column<TestScalar>; 0] = &[];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Equal);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Equal);
     assert_eq!(compare_indexes_by_columns(columns, 3, 2), Ordering::Equal);
@@ -258,7 +258,7 @@ fn we_can_compare_indexes_by_columns_for_mixed_columns() {
     let slice_a = &["55", "44", "66", "66", "66", "77", "66", "66", "66", "66"];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];
     let slice_c = &[11, 55, 11, 44, 77, 11, 22, 55, 11, 22];
-    let scals_a: Vec<Curve25519Scalar> = slice_a.iter().map(|s| s.into()).collect();
+    let scals_a: Vec<TestScalar> = slice_a.iter().map(|s| s.into()).collect();
     let column_a = Column::VarChar((slice_a, &scals_a));
     let column_b = Column::Int128(slice_b);
     let column_c = Column::BigInt(slice_c);
@@ -368,7 +368,7 @@ fn we_can_compare_indexes_by_columns_for_scalar_columns() {
     let slice_a = &[55, 44, 66, 66, 66, 77, 66, 66, 66, 66];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];
     let slice_c = &[11, 55, 11, 44, 77, 11, 22, 55, 11, 22];
-    let scals_a: Vec<Curve25519Scalar> = slice_a.iter().map(|s| s.into()).collect();
+    let scals_a: Vec<TestScalar> = slice_a.iter().map(|s| s.into()).collect();
     let column_a = Column::Scalar(&scals_a);
     let column_b = Column::Int128(slice_b);
     let column_c = Column::BigInt(slice_c);
@@ -426,9 +426,9 @@ fn we_can_sum_aggregate_slice_by_counts_with_all_empty_groups() {
     ];
     let indexes = &[];
     let counts = &[0, 0, 0];
-    let expected = &[Curve25519Scalar::from(0); 3];
+    let expected = &[TestScalar::from(0); 3];
     let alloc = Bump::new();
-    let result: &[Curve25519Scalar] =
+    let result: &[TestScalar] =
         sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -441,12 +441,12 @@ fn we_can_sum_aggregate_slice_by_counts_with_some_empty_group() {
     let indexes = &[12, 11, 1, 10, 2, 3, 4];
     let counts = &[3, 4, 0];
     let expected = &[
-        Curve25519Scalar::from(112 + 111 + 101),
-        Curve25519Scalar::from(110 + 102 + 103 + 104),
-        Curve25519Scalar::from(0),
+        TestScalar::from(112 + 111 + 101),
+        TestScalar::from(110 + 102 + 103 + 104),
+        TestScalar::from(0),
     ];
     let alloc = Bump::new();
-    let result: &[Curve25519Scalar] =
+    let result: &[TestScalar] =
         sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -459,12 +459,12 @@ fn we_can_sum_aggregate_slice_by_counts_without_empty_groups() {
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4];
     let expected = &[
-        Curve25519Scalar::from(112 + 111 + 101),
-        Curve25519Scalar::from(110 + 102 + 103),
-        Curve25519Scalar::from(106 + 114 + 113 + 109),
+        TestScalar::from(112 + 111 + 101),
+        TestScalar::from(110 + 102 + 103),
+        TestScalar::from(106 + 114 + 113 + 109),
     ];
     let alloc = Bump::new();
-    let result: &[Curve25519Scalar] =
+    let result: &[TestScalar] =
         sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -493,16 +493,16 @@ fn we_can_sum_aggregate_columns_by_counts() {
     let slice_c = &[
         100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
     ];
-    let scals_c: Vec<Curve25519Scalar> = slice_c.iter().map(|s| s.into()).collect();
-    let column_a = Column::BigInt::<Curve25519Scalar>(slice_a);
-    let columns_b = Column::Int128::<Curve25519Scalar>(slice_b);
+    let scals_c: Vec<TestScalar> = slice_c.iter().map(|s| s.into()).collect();
+    let column_a = Column::BigInt::<TestScalar>(slice_a);
+    let columns_b = Column::Int128::<TestScalar>(slice_b);
     let columns_c = Column::Scalar(&scals_c);
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4];
     let expected = &[
-        Curve25519Scalar::from(112 + 111 + 101),
-        Curve25519Scalar::from(110 + 102 + 103),
-        Curve25519Scalar::from(106 + 114 + 113 + 109),
+        TestScalar::from(112 + 111 + 101),
+        TestScalar::from(110 + 102 + 103),
+        TestScalar::from(106 + 114 + 113 + 109),
     ];
     let alloc = Bump::new();
     let result = sum_aggregate_column_by_index_counts(&alloc, &column_a, counts, indexes);
@@ -547,7 +547,7 @@ fn we_can_max_aggregate_slice_by_counts_with_all_empty_groups() {
     let counts = &[0, 0, 0];
     let expected = &[None; 3];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -560,12 +560,12 @@ fn we_can_max_aggregate_slice_by_counts_with_some_empty_group() {
     let indexes = &[12, 11, 1, 10, 2, 3, 4];
     let counts = &[3, 4, 0];
     let expected = &[
-        Some(Curve25519Scalar::from(112)),
-        Some(Curve25519Scalar::from(110)),
+        Some(TestScalar::from(112)),
+        Some(TestScalar::from(110)),
         None,
     ];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -578,12 +578,12 @@ fn we_can_max_aggregate_slice_by_counts_without_empty_groups() {
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4];
     let expected = &[
-        Some(Curve25519Scalar::from(112)),
-        Some(Curve25519Scalar::from(110)),
-        Some(Curve25519Scalar::from(114)),
+        Some(TestScalar::from(112)),
+        Some(TestScalar::from(110)),
+        Some(TestScalar::from(114)),
     ];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -612,16 +612,16 @@ fn we_can_max_aggregate_columns_by_counts() {
     let slice_c = &[
         100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
     ];
-    let scals_c: Vec<Curve25519Scalar> = slice_c.iter().map(|s| s.into()).collect();
-    let column_a = Column::BigInt::<Curve25519Scalar>(slice_a);
-    let columns_b = Column::Int128::<Curve25519Scalar>(slice_b);
+    let scals_c: Vec<TestScalar> = slice_c.iter().map(|s| s.into()).collect();
+    let column_a = Column::BigInt::<TestScalar>(slice_a);
+    let columns_b = Column::Int128::<TestScalar>(slice_b);
     let columns_c = Column::Scalar(&scals_c);
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4, 0];
     let expected = &[
-        Some(Curve25519Scalar::from(112)),
-        Some(Curve25519Scalar::from(110)),
-        Some(Curve25519Scalar::from(114)),
+        Some(TestScalar::from(112)),
+        Some(TestScalar::from(110)),
+        Some(TestScalar::from(114)),
         None,
     ];
     let alloc = Bump::new();
@@ -667,7 +667,7 @@ fn we_can_min_aggregate_slice_by_counts_with_all_empty_groups() {
     let counts = &[0, 0, 0];
     let expected = &[None; 3];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -680,12 +680,12 @@ fn we_can_min_aggregate_slice_by_counts_with_some_empty_group() {
     let indexes = &[12, 11, 1, 10, 2, 3, 4];
     let counts = &[3, 4, 0];
     let expected = &[
-        Some(Curve25519Scalar::from(101)),
-        Some(Curve25519Scalar::from(102)),
+        Some(TestScalar::from(101)),
+        Some(TestScalar::from(102)),
         None,
     ];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -698,12 +698,12 @@ fn we_can_min_aggregate_slice_by_counts_without_empty_groups() {
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4];
     let expected = &[
-        Some(Curve25519Scalar::from(101)),
-        Some(Curve25519Scalar::from(102)),
-        Some(Curve25519Scalar::from(106)),
+        Some(TestScalar::from(101)),
+        Some(TestScalar::from(102)),
+        Some(TestScalar::from(106)),
     ];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -732,16 +732,16 @@ fn we_can_min_aggregate_columns_by_counts() {
     let slice_c = &[
         100, -101, 102, -103, 104, -105, 106, -107, 108, -109, 110, -111, 112, -113, 114, -115,
     ];
-    let scals_c: Vec<Curve25519Scalar> = slice_c.iter().map(|s| s.into()).collect();
-    let column_a = Column::BigInt::<Curve25519Scalar>(slice_a);
-    let columns_b = Column::Int128::<Curve25519Scalar>(slice_b);
+    let scals_c: Vec<TestScalar> = slice_c.iter().map(|s| s.into()).collect();
+    let column_a = Column::BigInt::<TestScalar>(slice_a);
+    let columns_b = Column::Int128::<TestScalar>(slice_b);
     let columns_c = Column::Scalar(&scals_c);
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4, 0];
     let expected = &[
-        Some(Curve25519Scalar::from(-111)),
-        Some(Curve25519Scalar::from(-103)),
-        Some(Curve25519Scalar::from(-113)),
+        Some(TestScalar::from(-111)),
+        Some(TestScalar::from(-103)),
+        Some(TestScalar::from(-113)),
         None,
     ];
     let alloc = Bump::new();

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -27,7 +27,7 @@ pub enum LiteralValue<S: Scalar> {
     /// i128 literals
     Int128(i128),
     /// Decimal literals with a max width of 252 bits
-    ///  - the backing store maps to the type [crate::base::scalar::Curve25519Scalar]
+    ///  - the backing store maps to the type [crate::base::scalar::test_scalar::TestScalar]
     Decimal75(Precision, i8, S),
     /// Scalar literals
     Scalar(S),

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{
         database::{owned_table_utility::*, OwnedArrowConversionError},
         map::IndexMap,
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar,
     },
     record_batch,
 };
@@ -15,7 +15,7 @@ use arrow::{
 };
 
 fn we_can_convert_between_owned_column_and_array_ref_impl(
-    owned_column: OwnedColumn<Curve25519Scalar>,
+    owned_column: OwnedColumn<TestScalar>,
     array_ref: ArrayRef,
 ) {
     let ic_to_ar = ArrayRef::from(owned_column.clone());
@@ -26,19 +26,19 @@ fn we_can_convert_between_owned_column_and_array_ref_impl(
 }
 fn we_can_convert_between_boolean_owned_column_and_array_ref_impl(data: Vec<bool>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Boolean(data.clone()),
+        OwnedColumn::<TestScalar>::Boolean(data.clone()),
         Arc::new(BooleanArray::from(data)),
     );
 }
 fn we_can_convert_between_bigint_owned_column_and_array_ref_impl(data: Vec<i64>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::BigInt(data.clone()),
+        OwnedColumn::<TestScalar>::BigInt(data.clone()),
         Arc::new(Int64Array::from(data)),
     );
 }
 fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Int128(data.clone()),
+        OwnedColumn::<TestScalar>::Int128(data.clone()),
         Arc::new(
             Decimal128Array::from(data)
                 .with_precision_and_scale(38, 0)
@@ -48,7 +48,7 @@ fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>
 }
 fn we_can_convert_between_varchar_owned_column_and_array_ref_impl(data: Vec<String>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::VarChar(data.clone()),
+        OwnedColumn::<TestScalar>::VarChar(data.clone()),
         Arc::new(StringArray::from(data)),
     );
 }
@@ -75,13 +75,13 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
 ) {
     let array_ref: ArrayRef = Arc::new(Float32Array::from(vec![0.0]));
     assert!(matches!(
-        OwnedColumn::<Curve25519Scalar>::try_from(array_ref),
+        OwnedColumn::<TestScalar>::try_from(array_ref),
         Err(OwnedArrowConversionError::UnsupportedType { .. })
     ));
 }
 
 fn we_can_convert_between_owned_table_and_record_batch_impl(
-    owned_table: OwnedTable<Curve25519Scalar>,
+    owned_table: OwnedTable<TestScalar>,
     record_batch: RecordBatch,
 ) {
     let it_to_rb = RecordBatch::try_from(owned_table.clone()).unwrap();
@@ -93,7 +93,7 @@ fn we_can_convert_between_owned_table_and_record_batch_impl(
 #[test]
 fn we_can_convert_between_owned_table_and_record_batch() {
     we_can_convert_between_owned_table_and_record_batch_impl(
-        OwnedTable::<Curve25519Scalar>::try_new(IndexMap::default()).unwrap(),
+        OwnedTable::<TestScalar>::try_new(IndexMap::default()).unwrap(),
         RecordBatch::new_empty(Arc::new(Schema::empty())),
     );
     we_can_convert_between_owned_table_and_record_batch_impl(
@@ -136,7 +136,7 @@ fn we_cannot_convert_a_record_batch_if_it_has_repeated_column_names() {
         "A" => [0_i128; 0],
     );
     assert!(matches!(
-        OwnedTable::<Curve25519Scalar>::try_from(record_batch),
+        OwnedTable::<TestScalar>::try_from(record_batch),
         Err(OwnedArrowConversionError::DuplicateIdentifiers)
     ));
 }
@@ -144,6 +144,6 @@ fn we_cannot_convert_a_record_batch_if_it_has_repeated_column_names() {
 #[test]
 #[should_panic]
 fn we_panic_when_converting_an_owned_table_with_a_scalar_column() {
-    let owned_table = owned_table::<Curve25519Scalar>([scalar("a", [0; 0])]);
+    let owned_table = owned_table::<TestScalar>([scalar("a", [0; 0])]);
     let _ = RecordBatch::try_from(owned_table);
 }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -335,20 +335,20 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::base::{math::decimal::Precision, scalar::Curve25519Scalar};
+    use crate::base::{math::decimal::Precision, scalar::test_scalar::TestScalar};
     use alloc::vec;
     use bumpalo::Bump;
     use proof_of_sql_parser::intermediate_ast::OrderByDirection;
 
     #[test]
     fn we_can_slice_a_column() {
-        let col: OwnedColumn<Curve25519Scalar> = OwnedColumn::Int128(vec![1, 2, 3, 4, 5]);
+        let col: OwnedColumn<TestScalar> = OwnedColumn::Int128(vec![1, 2, 3, 4, 5]);
         assert_eq!(col.slice(1, 4), OwnedColumn::Int128(vec![2, 3, 4]));
     }
 
     #[test]
     fn we_can_permute_a_column() {
-        let col: OwnedColumn<Curve25519Scalar> = OwnedColumn::Int128(vec![1, 2, 3, 4, 5]);
+        let col: OwnedColumn<TestScalar> = OwnedColumn::Int128(vec![1, 2, 3, 4, 5]);
         let permutation = Permutation::try_new(vec![1, 3, 4, 0, 2]).unwrap();
         assert_eq!(
             col.try_permute(&permutation).unwrap(),
@@ -358,19 +358,19 @@ mod test {
 
     #[test]
     fn we_can_compare_columns() {
-        let col1: OwnedColumn<Curve25519Scalar> = OwnedColumn::SmallInt(vec![1, 1, 2, 1, 1]);
-        let col2: OwnedColumn<Curve25519Scalar> = OwnedColumn::VarChar(
+        let col1: OwnedColumn<TestScalar> = OwnedColumn::SmallInt(vec![1, 1, 2, 1, 1]);
+        let col2: OwnedColumn<TestScalar> = OwnedColumn::VarChar(
             ["b", "b", "a", "b", "a"]
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
         );
-        let col3: OwnedColumn<Curve25519Scalar> = OwnedColumn::Decimal75(
+        let col3: OwnedColumn<TestScalar> = OwnedColumn::Decimal75(
             Precision::new(70).unwrap(),
             20,
             [1, 2, 2, 1, 2]
                 .iter()
-                .map(|&i| Curve25519Scalar::from(i))
+                .map(|&i| TestScalar::from(i))
                 .collect(),
         );
         let order_by_pairs = vec![
@@ -404,20 +404,20 @@ mod test {
     fn we_can_convert_columns_to_owned_columns_round_trip() {
         let alloc = Bump::new();
         // Integers
-        let col: Column<'_, Curve25519Scalar> = Column::Int128(&[1, 2, 3, 4, 5]);
-        let owned_col: OwnedColumn<Curve25519Scalar> = (&col).into();
+        let col: Column<'_, TestScalar> = Column::Int128(&[1, 2, 3, 4, 5]);
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
         assert_eq!(owned_col, OwnedColumn::Int128(vec![1, 2, 3, 4, 5]));
-        let new_col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
+        let new_col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, new_col);
 
         // Booleans
-        let col: Column<'_, Curve25519Scalar> = Column::Boolean(&[true, false, true, false, true]);
-        let owned_col: OwnedColumn<Curve25519Scalar> = (&col).into();
+        let col: Column<'_, TestScalar> = Column::Boolean(&[true, false, true, false, true]);
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
         assert_eq!(
             owned_col,
             OwnedColumn::Boolean(vec![true, false, true, false, true])
         );
-        let new_col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
+        let new_col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, new_col);
 
         // Strings
@@ -429,27 +429,26 @@ mod test {
             "ቦታ እና ጊዜ",
             "სივრცე და დრო",
         ];
-        let scalars = strs.iter().map(Curve25519Scalar::from).collect::<Vec<_>>();
-        let col: Column<'_, Curve25519Scalar> = Column::VarChar((&strs, &scalars));
-        let owned_col: OwnedColumn<Curve25519Scalar> = (&col).into();
+        let scalars = strs.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let col: Column<'_, TestScalar> = Column::VarChar((&strs, &scalars));
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
         assert_eq!(
             owned_col,
             OwnedColumn::VarChar(strs.iter().map(|s| s.to_string()).collect::<Vec<String>>())
         );
-        let new_col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
+        let new_col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, new_col);
 
         // Decimals
-        let scalars: Vec<Curve25519Scalar> =
-            [1, 2, 3, 4, 5].iter().map(Curve25519Scalar::from).collect();
-        let col: Column<'_, Curve25519Scalar> =
+        let scalars: Vec<TestScalar> = [1, 2, 3, 4, 5].iter().map(TestScalar::from).collect();
+        let col: Column<'_, TestScalar> =
             Column::Decimal75(Precision::new(75).unwrap(), -128, &scalars);
-        let owned_col: OwnedColumn<Curve25519Scalar> = (&col).into();
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
         assert_eq!(
             owned_col,
             OwnedColumn::Decimal75(Precision::new(75).unwrap(), -128, scalars.clone())
         );
-        let new_col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
+        let new_col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, new_col);
     }
 
@@ -458,7 +457,7 @@ mod test {
         // Int
         let scalars = [1, 2, 3, 4, 5]
             .iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let column_type = ColumnType::Int128;
         let owned_col = OwnedColumn::try_from_scalars(&scalars, column_type).unwrap();
@@ -467,7 +466,7 @@ mod test {
         // Boolean
         let scalars = [true, false, true, false, true]
             .iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let column_type = ColumnType::Boolean;
         let owned_col = OwnedColumn::try_from_scalars(&scalars, column_type).unwrap();
@@ -479,7 +478,7 @@ mod test {
         // Decimal
         let scalars = [1, 2, 3, 4, 5]
             .iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let column_type = ColumnType::Decimal75(Precision::new(75).unwrap(), -128);
         let owned_col = OwnedColumn::try_from_scalars(&scalars, column_type).unwrap();
@@ -493,7 +492,7 @@ mod test {
     fn we_cannot_convert_scalars_to_owned_columns_if_varchar() {
         let scalars = ["a", "b", "c", "d", "e"]
             .iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let column_type = ColumnType::VarChar;
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
@@ -505,7 +504,7 @@ mod test {
         // Int
         let scalars = [i128::MAX, i128::MAX, i128::MAX, i128::MAX, i128::MAX]
             .iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let column_type = ColumnType::BigInt;
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
@@ -517,7 +516,7 @@ mod test {
         // Boolean
         let scalars = [i128::MAX, i128::MAX, i128::MAX, i128::MAX, i128::MAX]
             .iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect::<Vec<_>>();
         let column_type = ColumnType::Boolean;
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
@@ -532,7 +531,7 @@ mod test {
         // Int
         let option_scalars = [Some(1), Some(2), Some(3), Some(4), Some(5)]
             .iter()
-            .map(|s| s.map(Curve25519Scalar::from))
+            .map(|s| s.map(TestScalar::from))
             .collect::<Vec<_>>();
         let column_type = ColumnType::Int128;
         let owned_col = OwnedColumn::try_from_option_scalars(&option_scalars, column_type).unwrap();
@@ -541,7 +540,7 @@ mod test {
         // Boolean
         let option_scalars = [Some(true), Some(false), Some(true), Some(false), Some(true)]
             .iter()
-            .map(|s| s.map(Curve25519Scalar::from))
+            .map(|s| s.map(TestScalar::from))
             .collect::<Vec<_>>();
         let column_type = ColumnType::Boolean;
         let owned_col = OwnedColumn::try_from_option_scalars(&option_scalars, column_type).unwrap();
@@ -553,11 +552,11 @@ mod test {
         // Decimal
         let option_scalars = [Some(1), Some(2), Some(3), Some(4), Some(5)]
             .iter()
-            .map(|s| s.map(Curve25519Scalar::from))
+            .map(|s| s.map(TestScalar::from))
             .collect::<Vec<_>>();
         let scalars = [1, 2, 3, 4, 5]
             .iter()
-            .map(|&i| Curve25519Scalar::from(i))
+            .map(|&i| TestScalar::from(i))
             .collect::<Vec<_>>();
         let column_type = ColumnType::Decimal75(Precision::new(75).unwrap(), 127);
         let owned_col = OwnedColumn::try_from_option_scalars(&option_scalars, column_type).unwrap();
@@ -571,7 +570,7 @@ mod test {
     fn we_cannot_convert_option_scalars_to_owned_columns_if_varchar() {
         let option_scalars = ["a", "b", "c", "d", "e"]
             .iter()
-            .map(|s| Some(Curve25519Scalar::from(*s)))
+            .map(|s| Some(TestScalar::from(*s)))
             .collect::<Vec<_>>();
         let column_type = ColumnType::VarChar;
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
@@ -589,7 +588,7 @@ mod test {
             Some(i128::MAX),
         ]
         .iter()
-        .map(|s| s.map(Curve25519Scalar::from))
+        .map(|s| s.map(TestScalar::from))
         .collect::<Vec<_>>();
         let column_type = ColumnType::BigInt;
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
@@ -607,7 +606,7 @@ mod test {
             Some(i128::MAX),
         ]
         .iter()
-        .map(|s| s.map(Curve25519Scalar::from))
+        .map(|s| s.map(TestScalar::from))
         .collect::<Vec<_>>();
         let column_type = ColumnType::Boolean;
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
@@ -622,7 +621,7 @@ mod test {
         // Int
         let option_scalars = [Some(1), Some(2), None, Some(4), Some(5)]
             .iter()
-            .map(|s| s.map(Curve25519Scalar::from))
+            .map(|s| s.map(TestScalar::from))
             .collect::<Vec<_>>();
         let column_type = ColumnType::Int128;
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
@@ -631,7 +630,7 @@ mod test {
         // Boolean
         let option_scalars = [Some(true), Some(false), None, Some(false), Some(true)]
             .iter()
-            .map(|s| s.map(Curve25519Scalar::from))
+            .map(|s| s.map(TestScalar::from))
             .collect::<Vec<_>>();
         let column_type = ColumnType::Boolean;
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -1045,12 +1045,12 @@ impl<S: Scalar> Div for OwnedColumn<S> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::base::{math::decimal::Precision, scalar::Curve25519Scalar};
+    use crate::base::{math::decimal::Precision, scalar::test_scalar::TestScalar};
 
     #[test]
     fn we_cannot_do_binary_operation_on_columns_with_different_lengths() {
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false]);
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]);
+        let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false]);
 
         let result = lhs.element_wise_and(&rhs);
         assert!(matches!(
@@ -1076,8 +1076,8 @@ mod test {
             Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2]);
+        let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![1, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]);
         let result = lhs.clone() + rhs.clone();
         assert!(matches!(
             result,
@@ -1105,8 +1105,8 @@ mod test {
 
     #[test]
     fn we_cannot_do_logical_operation_on_nonboolean_columns() {
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![1, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::Int(vec![1, 2, 3]);
         let result = lhs.element_wise_and(&rhs);
         assert!(matches!(
             result,
@@ -1128,12 +1128,12 @@ mod test {
 
     #[test]
     fn we_can_do_logical_operation_on_boolean_columns() {
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true, false]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, true, false, false]);
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true, false]);
+        let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true, true, false, false]);
         let result = lhs.element_wise_and(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![
                 true, false, false, false
             ]))
         );
@@ -1141,7 +1141,7 @@ mod test {
         let result = lhs.element_wise_or(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![
                 true, true, true, false
             ]))
         );
@@ -1149,7 +1149,7 @@ mod test {
         let result = lhs.element_wise_not();
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![
                 false, true, false, true
             ]))
         );
@@ -1158,24 +1158,22 @@ mod test {
     #[test]
     fn we_can_do_eq_operation() {
         // Integers
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 3, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![1, 3, 2]);
+        let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![1, 2, 3]);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, false, false
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, false]))
         );
 
         // Strings
-        let lhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+        let lhs = OwnedColumn::<TestScalar>::VarChar(
             ["Space", "and", "Time"]
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
         );
-        let rhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+        let rhs = OwnedColumn::<TestScalar>::VarChar(
             ["Space", "and", "time"]
                 .iter()
                 .map(|s| s.to_string())
@@ -1184,162 +1182,129 @@ mod test {
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]))
         );
 
         // Booleans
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, true, false]);
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]);
+        let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, false, false
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, false]))
         );
 
         // Decimals
-        let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
-        let rhs_scalars = [1, 2, -3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 3, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs_scalars = [10, 2, 30].iter().map(TestScalar::from).collect();
+        let rhs_scalars = [1, 2, -3].iter().map(TestScalar::from).collect();
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 3, lhs_scalars);
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, false, false
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, false]))
         );
 
         // Decimals and integers
-        let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, -2, 3]);
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 1, lhs_scalars);
+        let lhs_scalars = [10, 2, 30].iter().map(TestScalar::from).collect();
+        let rhs = OwnedColumn::<TestScalar>::Int(vec![1, -2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 1, lhs_scalars);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]))
         );
     }
 
     #[test]
     fn we_can_do_le_operation_on_numeric_and_boolean_columns() {
         // Booleans
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, true, false]);
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]);
+        let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]))
         );
 
         // Integers
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 3, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![1, 3, 2]);
+        let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![1, 2, 3]);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]))
         );
 
         // Decimals
-        let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
-        let rhs_scalars = [1, 24, -3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 3, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs_scalars = [10, 2, 30].iter().map(TestScalar::from).collect();
+        let rhs_scalars = [1, 24, -3].iter().map(TestScalar::from).collect();
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 3, lhs_scalars);
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]))
         );
 
         // Decimals and integers
-        let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, -20, 3]);
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), -1, lhs_scalars);
+        let lhs_scalars = [10, -2, -30].iter().map(TestScalar::from).collect();
+        let rhs = OwnedColumn::<TestScalar>::Int(vec![1, -20, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), -1, lhs_scalars);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                false, true, true
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![false, true, true]))
         );
     }
 
     #[test]
     fn we_can_do_ge_operation_on_numeric_and_boolean_columns() {
         // Booleans
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, true, false]);
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]);
+        let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]))
         );
 
         // Integers
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 3, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![1, 3, 2]);
+        let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![1, 2, 3]);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]))
         );
 
         // Decimals
-        let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
-        let rhs_scalars = [1, 24, -3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 3, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs_scalars = [10, 2, 30].iter().map(TestScalar::from).collect();
+        let rhs_scalars = [1, 24, -3].iter().map(TestScalar::from).collect();
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 3, lhs_scalars);
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]))
         );
 
         // Decimals and integers
-        let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
-        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, -20, 3]);
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), -1, lhs_scalars);
+        let lhs_scalars = [10, -2, -30].iter().map(TestScalar::from).collect();
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1_i64, -20, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), -1, lhs_scalars);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]))
         );
     }
 
     #[test]
     fn we_cannot_do_comparison_on_columns_with_incompatible_types() {
         // Strings can't be compared with other types
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![1, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::VarChar(
             ["Space", "and", "Time"]
                 .iter()
                 .map(|s| s.to_string())
@@ -1364,8 +1329,8 @@ mod test {
         ));
 
         // Booleans can't be compared with other types
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]);
+        let rhs = OwnedColumn::<TestScalar>::Int(vec![1, 2, 3]);
         let result = lhs.element_wise_le(&rhs);
         assert!(matches!(
             result,
@@ -1373,13 +1338,13 @@ mod test {
         ));
 
         // Strings can not be <= or >= to each other
-        let lhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+        let lhs = OwnedColumn::<TestScalar>::VarChar(
             ["Space", "and", "Time"]
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
         );
-        let rhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+        let rhs = OwnedColumn::<TestScalar>::VarChar(
             ["Space", "and", "time"]
                 .iter()
                 .map(|s| s.to_string())
@@ -1400,16 +1365,16 @@ mod test {
 
     #[test]
     fn we_cannot_do_arithmetic_on_nonnumeric_columns() {
-        let lhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+        let lhs = OwnedColumn::<TestScalar>::VarChar(
             ["Space", "and", "Time"]
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
         );
-        let rhs = OwnedColumn::<Curve25519Scalar>::Scalar(vec![
-            Curve25519Scalar::from(1),
-            Curve25519Scalar::from(2),
-            Curve25519Scalar::from(3),
+        let rhs = OwnedColumn::<TestScalar>::Scalar(vec![
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
         ]);
         let result = lhs.clone() + rhs.clone();
         assert!(matches!(
@@ -1439,274 +1404,218 @@ mod test {
     #[test]
     fn we_can_add_integer_columns() {
         // lhs and rhs have the same precision
-        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1_i16, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1_i16, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![1_i16, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![1_i16, 2, 3]);
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::SmallInt(vec![2_i16, 4, 6]))
+            Ok(OwnedColumn::<TestScalar>::SmallInt(vec![2_i16, 4, 6]))
         );
 
         // lhs and rhs have different precisions
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int128(vec![1_i128, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1_i32, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Int128(vec![1_i128, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::Int(vec![1_i32, 2, 3]);
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(vec![2_i128, 4, 6]))
+            Ok(OwnedColumn::<TestScalar>::Int128(vec![2_i128, 4, 6]))
         );
     }
 
     #[test]
     fn we_can_try_add_decimal_columns() {
         // lhs and rhs have the same precision and scale
-        let lhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs_scalars = [1, 2, 3].iter().map(TestScalar::from).collect();
+        let rhs_scalars = [1, 2, 3].iter().map(TestScalar::from).collect();
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs + rhs).unwrap();
-        let expected_scalars = [2, 4, 6].iter().map(Curve25519Scalar::from).collect();
+        let expected_scalars = [2, 4, 6].iter().map(TestScalar::from).collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(6).unwrap(),
-                2,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(6).unwrap(), 2, expected_scalars)
         );
 
         // lhs and rhs have different precisions and scales
-        let lhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(51).unwrap(), 3, rhs_scalars);
+        let lhs_scalars = [1, 2, 3].iter().map(TestScalar::from).collect();
+        let rhs_scalars = [1, 2, 3].iter().map(TestScalar::from).collect();
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(51).unwrap(), 3, rhs_scalars);
         let result = (lhs + rhs).unwrap();
-        let expected_scalars = [11, 22, 33].iter().map(Curve25519Scalar::from).collect();
+        let expected_scalars = [11, 22, 33].iter().map(TestScalar::from).collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(52).unwrap(),
-                3,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(52).unwrap(), 3, expected_scalars)
         );
 
         // lhs is integer and rhs is decimal
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
-        let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![1, 2, 3]);
+        let rhs_scalars = [1, 2, 3].iter().map(TestScalar::from).collect();
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs + rhs).unwrap();
-        let expected_scalars = [101, 202, 303].iter().map(Curve25519Scalar::from).collect();
+        let expected_scalars = [101, 202, 303].iter().map(TestScalar::from).collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(13).unwrap(),
-                2,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(13).unwrap(), 2, expected_scalars)
         );
     }
 
     #[test]
     fn we_can_try_subtract_integer_columns() {
         // lhs and rhs have the same precision
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![4_i32, 5, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1_i32, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![4_i32, 5, 2]);
+        let rhs = OwnedColumn::<TestScalar>::Int(vec![1_i32, 2, 3]);
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int(vec![3_i32, 3, -1]))
+            Ok(OwnedColumn::<TestScalar>::Int(vec![3_i32, 3, -1]))
         );
 
         // lhs and rhs have different precisions
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![3_i32, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, 2, 5]);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![3_i32, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1_i64, 2, 5]);
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(vec![2_i64, 0, -2]))
+            Ok(OwnedColumn::<TestScalar>::BigInt(vec![2_i64, 0, -2]))
         );
     }
 
     #[test]
     fn we_can_try_subtract_decimal_columns() {
         // lhs and rhs have the same precision and scale
-        let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
-        let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs_scalars = [4, 5, 2].iter().map(TestScalar::from).collect();
+        let rhs_scalars = [1, 2, 3].iter().map(TestScalar::from).collect();
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs - rhs).unwrap();
-        let expected_scalars = [3, 3, -1].iter().map(Curve25519Scalar::from).collect();
+        let expected_scalars = [3, 3, -1].iter().map(TestScalar::from).collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(6).unwrap(),
-                2,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(6).unwrap(), 2, expected_scalars)
         );
 
         // lhs and rhs have different precisions and scales
-        let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
-        let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(25).unwrap(), 2, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(51).unwrap(), 3, rhs_scalars);
+        let lhs_scalars = [4, 5, 2].iter().map(TestScalar::from).collect();
+        let rhs_scalars = [1, 2, 3].iter().map(TestScalar::from).collect();
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(25).unwrap(), 2, lhs_scalars);
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(51).unwrap(), 3, rhs_scalars);
         let result = (lhs - rhs).unwrap();
-        let expected_scalars = [39, 48, 17].iter().map(Curve25519Scalar::from).collect();
+        let expected_scalars = [39, 48, 17].iter().map(TestScalar::from).collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(52).unwrap(),
-                3,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(52).unwrap(), 3, expected_scalars)
         );
 
         // lhs is integer and rhs is decimal
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![4, 5, 2]);
-        let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![4, 5, 2]);
+        let rhs_scalars = [1, 2, 3].iter().map(TestScalar::from).collect();
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs - rhs).unwrap();
-        let expected_scalars = [399, 498, 197].iter().map(Curve25519Scalar::from).collect();
+        let expected_scalars = [399, 498, 197].iter().map(TestScalar::from).collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(13).unwrap(),
-                2,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(13).unwrap(), 2, expected_scalars)
         );
     }
 
     #[test]
     fn we_can_try_multiply_integer_columns() {
         // lhs and rhs have the same precision
-        let lhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 5, -2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![4_i64, 5, -2]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1_i64, 2, 3]);
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 10, -6]))
+            Ok(OwnedColumn::<TestScalar>::BigInt(vec![4_i64, 10, -6]))
         );
 
         // lhs and rhs have different precisions
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![3_i32, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(vec![1_i128, 2, 5]);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![3_i32, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::Int128(vec![1_i128, 2, 5]);
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(vec![3_i128, 4, 15]))
+            Ok(OwnedColumn::<TestScalar>::Int128(vec![3_i128, 4, 15]))
         );
     }
 
     #[test]
     fn we_can_try_multiply_decimal_columns() {
         // lhs and rhs are both decimals
-        let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
-        let rhs_scalars = [-1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs_scalars = [4, 5, 2].iter().map(TestScalar::from).collect();
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+        let rhs_scalars = [-1, 2, 3].iter().map(TestScalar::from).collect();
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs * rhs).unwrap();
-        let expected_scalars = [-4, 10, 6].iter().map(Curve25519Scalar::from).collect();
+        let expected_scalars = [-4, 10, 6].iter().map(TestScalar::from).collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(11).unwrap(),
-                4,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(11).unwrap(), 4, expected_scalars)
         );
 
         // lhs is integer and rhs is decimal
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![4, 5, 2]);
-        let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![4, 5, 2]);
+        let rhs_scalars = [1, 2, 3].iter().map(TestScalar::from).collect();
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs * rhs).unwrap();
-        let expected_scalars = [4, 10, 6].iter().map(Curve25519Scalar::from).collect();
+        let expected_scalars = [4, 10, 6].iter().map(TestScalar::from).collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(16).unwrap(),
-                2,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(16).unwrap(), 2, expected_scalars)
         );
     }
 
     #[test]
     fn we_can_try_divide_integer_columns() {
         // lhs and rhs have the same precision
-        let lhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 5, -2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, 2, 3]);
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![4_i64, 5, -2]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1_i64, 2, 3]);
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 2, 0]))
+            Ok(OwnedColumn::<TestScalar>::BigInt(vec![4_i64, 2, 0]))
         );
 
         // lhs and rhs have different precisions
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![3_i32, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(vec![1_i128, 2, 5]);
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![3_i32, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::Int128(vec![1_i128, 2, 5]);
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(vec![3_i128, 1, 0]))
+            Ok(OwnedColumn::<TestScalar>::Int128(vec![3_i128, 1, 0]))
         );
     }
 
     #[test]
     fn we_can_try_divide_decimal_columns() {
         // lhs and rhs are both decimals
-        let lhs_scalars = [4, 5, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
-        let rhs_scalars = [-1, 2, 4].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs_scalars = [4, 5, 3].iter().map(TestScalar::from).collect();
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+        let rhs_scalars = [-1, 2, 4].iter().map(TestScalar::from).collect();
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs / rhs).unwrap();
         let expected_scalars = [-400000000_i128, 250000000, 75000000]
             .iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(13).unwrap(),
-                8,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(13).unwrap(), 8, expected_scalars)
         );
 
         // lhs is integer and rhs is decimal
-        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![4, 5, 3]);
-        let rhs_scalars = [-1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(3).unwrap(), 2, rhs_scalars);
+        let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![4, 5, 3]);
+        let rhs_scalars = [-1, 2, 3].iter().map(TestScalar::from).collect();
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(Precision::new(3).unwrap(), 2, rhs_scalars);
         let result = (lhs / rhs).unwrap();
         let expected_scalars = [-400000000, 250000000, 100000000]
             .iter()
-            .map(Curve25519Scalar::from)
+            .map(TestScalar::from)
             .collect();
         assert_eq!(
             result,
-            OwnedColumn::<Curve25519Scalar>::Decimal75(
-                Precision::new(13).unwrap(),
-                6,
-                expected_scalars
-            )
+            OwnedColumn::<TestScalar>::Decimal75(Precision::new(13).unwrap(), 6, expected_scalars)
         );
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -2,7 +2,7 @@ use crate::{
     base::{
         database::{owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableError},
         map::IndexMap,
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
 };
@@ -13,7 +13,7 @@ use proof_of_sql_parser::{
 
 #[test]
 fn we_can_create_an_owned_table_with_no_columns() {
-    let table = OwnedTable::<Curve25519Scalar>::try_new(IndexMap::default()).unwrap();
+    let table = OwnedTable::<TestScalar>::try_new(IndexMap::default()).unwrap();
     assert_eq!(table.num_columns(), 0);
 }
 #[test]
@@ -121,7 +121,7 @@ fn we_can_create_an_owned_table_with_data() {
 }
 #[test]
 fn we_get_inequality_between_tables_with_differing_column_order() {
-    let owned_table_a: OwnedTable<Curve25519Scalar> = owned_table([
+    let owned_table_a: OwnedTable<TestScalar> = owned_table([
         bigint("a", [0; 0]),
         int128("b", [0; 0]),
         varchar("c", ["0"; 0]),
@@ -133,7 +133,7 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
             [0; 0],
         ),
     ]);
-    let owned_table_b: OwnedTable<Curve25519Scalar> = owned_table([
+    let owned_table_b: OwnedTable<TestScalar> = owned_table([
         boolean("d", [false; 0]),
         int128("b", [0; 0]),
         bigint("a", [0; 0]),
@@ -178,7 +178,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
 #[test]
 fn we_cannot_create_an_owned_table_with_differing_column_lengths() {
     assert!(matches!(
-        OwnedTable::<Curve25519Scalar>::try_from_iter([
+        OwnedTable::<TestScalar>::try_from_iter([
             ("a".parse().unwrap(), OwnedColumn::BigInt(vec![0])),
             ("b".parse().unwrap(), OwnedColumn::BigInt(vec![])),
         ]),

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -3,17 +3,18 @@ use super::{
     OwnedTableTestAccessor, SchemaAccessor, TestAccessor,
 };
 use crate::base::{
-    commitment::{Commitment, CommittableColumn},
+    commitment::{
+        naive_commitment::NaiveCommitment, test_evaluation_proof::TestEvaluationProof, Commitment,
+        CommittableColumn,
+    },
     database::owned_table_utility::*,
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
 };
-use blitzar::proof::InnerProductProof;
-use curve25519_dalek::ristretto::RistrettoPoint;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
 #[test]
 fn we_can_query_the_length_of_a_table() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
@@ -31,7 +32,7 @@ fn we_can_query_the_length_of_a_table() {
 
 #[test]
 fn we_can_access_the_columns_of_a_table() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
@@ -94,10 +95,10 @@ fn we_can_access_the_columns_of_a_table() {
         Column::Scalar(col) => assert_eq!(
             col.to_vec(),
             vec![
-                Curve25519Scalar::from(1),
-                Curve25519Scalar::from(2),
-                Curve25519Scalar::from(3),
-                Curve25519Scalar::from(4)
+                TestScalar::from(1),
+                TestScalar::from(2),
+                TestScalar::from(3),
+                TestScalar::from(4)
             ]
         ),
         _ => panic!("Invalid column type"),
@@ -122,7 +123,7 @@ fn we_can_access_the_columns_of_a_table() {
 
 #[test]
 fn we_can_access_the_commitments_of_table_columns() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
@@ -132,7 +133,7 @@ fn we_can_access_the_commitments_of_table_columns() {
     let column = ColumnRef::new(table_ref_1, "b".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
         accessor.get_commitment(column),
-        RistrettoPoint::compute_commitments(
+        NaiveCommitment::compute_commitments(
             &[CommittableColumn::from(&[4i64, 5, 6][..])],
             0_usize,
             &()
@@ -145,7 +146,7 @@ fn we_can_access_the_commitments_of_table_columns() {
     let column = ColumnRef::new(table_ref_1, "a".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
         accessor.get_commitment(column),
-        RistrettoPoint::compute_commitments(
+        NaiveCommitment::compute_commitments(
             &[CommittableColumn::from(&[1i64, 2, 3][..])],
             0_usize,
             &()
@@ -155,7 +156,7 @@ fn we_can_access_the_commitments_of_table_columns() {
     let column = ColumnRef::new(table_ref_2, "b".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
         accessor.get_commitment(column),
-        RistrettoPoint::compute_commitments(
+        NaiveCommitment::compute_commitments(
             &[CommittableColumn::from(&[4i64, 5, 6, 5][..])],
             0_usize,
             &()
@@ -165,7 +166,7 @@ fn we_can_access_the_commitments_of_table_columns() {
 
 #[test]
 fn we_can_access_the_type_of_table_columns() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
@@ -206,7 +207,7 @@ fn we_can_access_the_type_of_table_columns() {
 
 #[test]
 fn we_can_access_schema_and_column_names() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
 
     let data1 = owned_table([bigint("a", [1, 2, 3]), varchar("b", ["x", "y", "z"])]);
@@ -224,14 +225,14 @@ fn we_can_access_schema_and_column_names() {
 
 #[test]
 fn we_can_correctly_update_offsets() {
-    let mut accessor1 = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor1 = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref = "sxt.test".parse().unwrap();
 
     let data = owned_table([bigint("a", [1, 2, 3]), bigint("b", [123, 5, 123])]);
     accessor1.add_table(table_ref, data.clone(), 0_usize);
 
     let offset = 123;
-    let mut accessor2 = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor2 = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor2.add_table(table_ref, data, offset);
 
     let column = ColumnRef::new(table_ref, "a".parse().unwrap(), ColumnType::BigInt);

--- a/crates/proof-of-sql/src/base/database/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/scalar_and_i256_conversions.rs
@@ -56,7 +56,7 @@ mod tests {
     use super::{convert_i256_to_scalar, convert_scalar_to_i256};
     use crate::base::{
         database::scalar_and_i256_conversions::{MAX_SUPPORTED_I256, MIN_SUPPORTED_I256},
-        scalar::{Curve25519Scalar, Scalar},
+        scalar::{test_scalar::TestScalar, Curve25519Scalar, Scalar},
     };
     use arrow::datatypes::i256;
     use num_traits::Zero;
@@ -66,7 +66,7 @@ mod tests {
     fn random_i256<R: RngCore + ?Sized>(rng: &mut R) -> i256 {
         use rand::Rng;
         let max_signed_as_parts: (u128, i128) =
-            convert_scalar_to_i256(&Curve25519Scalar::MAX_SIGNED).to_parts();
+            convert_scalar_to_i256(&TestScalar::MAX_SIGNED).to_parts();
 
         // Generate a random high part
         let high: i128 = rng.gen_range(-max_signed_as_parts.1..=max_signed_as_parts.1);
@@ -81,7 +81,7 @@ mod tests {
         i256::from_parts(low, high)
     }
 
-    impl TryFrom<i256> for Curve25519Scalar {
+    impl TryFrom<i256> for TestScalar {
         type Error = ();
 
         // Must fit inside 252 bits and so requires fallible
@@ -89,109 +89,109 @@ mod tests {
             convert_i256_to_scalar(&value).ok_or(())
         }
     }
+
     impl From<Curve25519Scalar> for i256 {
         fn from(value: Curve25519Scalar) -> Self {
             convert_scalar_to_i256(&value)
         }
     }
 
+    impl From<TestScalar> for i256 {
+        fn from(value: TestScalar) -> Self {
+            convert_scalar_to_i256(&value)
+        }
+    }
+
     #[test]
-    fn test_curve25519scalar_to_i256_conversion() {
-        let positive_scalar = Curve25519Scalar::from(12345);
+    fn test_testscalar_to_i256_conversion() {
+        let positive_scalar = TestScalar::from(12345);
         let expected_i256 = i256::from(12345);
         assert_eq!(i256::from(positive_scalar), expected_i256);
 
-        let negative_scalar = Curve25519Scalar::from(-12345);
+        let negative_scalar = TestScalar::from(-12345);
         let expected_i256 = i256::from(-12345);
         assert_eq!(i256::from(negative_scalar), expected_i256);
 
-        let max_scalar = Curve25519Scalar::MAX_SIGNED;
-        let expected_max = i256::from(Curve25519Scalar::MAX_SIGNED);
+        let max_scalar = TestScalar::MAX_SIGNED;
+        let expected_max = i256::from(TestScalar::MAX_SIGNED);
         assert_eq!(i256::from(max_scalar), expected_max);
 
-        let min_scalar = Curve25519Scalar::from(0);
-        let expected_min = i256::from(Curve25519Scalar::from(0));
+        let min_scalar = TestScalar::from(0);
+        let expected_min = i256::from(TestScalar::from(0));
         assert_eq!(i256::from(min_scalar), expected_min);
     }
 
     #[test]
-    fn test_curve25519scalar_i256_overflow_and_underflow() {
+    fn test_testscalar_i256_overflow_and_underflow() {
         // 2^256 overflows
-        assert!(Curve25519Scalar::try_from(i256::MAX).is_err());
+        assert!(TestScalar::try_from(i256::MAX).is_err());
 
         // MAX_SIGNED + 1 overflows
-        assert!(Curve25519Scalar::try_from(MAX_SUPPORTED_I256 + i256::from(1)).is_err());
+        assert!(TestScalar::try_from(MAX_SUPPORTED_I256 + i256::from(1)).is_err());
 
         // -2^255 underflows
-        assert!(i256::MIN < -(i256::from(Curve25519Scalar::MAX_SIGNED)));
-        assert!(Curve25519Scalar::try_from(i256::MIN).is_err());
+        assert!(i256::MIN < -(i256::from(TestScalar::MAX_SIGNED)));
+        assert!(TestScalar::try_from(i256::MIN).is_err());
 
         // -MAX-SIGNED - 1 underflows
-        assert!(Curve25519Scalar::try_from(MIN_SUPPORTED_I256 - i256::from(1)).is_err());
+        assert!(TestScalar::try_from(MIN_SUPPORTED_I256 - i256::from(1)).is_err());
     }
 
     #[test]
-    fn test_i256_curve25519scalar_negative() {
-        // Test conversion from i256(-1) to Curve25519Scalar
-        let neg_one_i256_curve25519scalar = Curve25519Scalar::try_from(i256::from(-1));
-        assert!(neg_one_i256_curve25519scalar.is_ok());
-        let neg_one_curve25519scalar = Curve25519Scalar::from(-1);
-        assert_eq!(
-            neg_one_i256_curve25519scalar.unwrap(),
-            neg_one_curve25519scalar
-        );
+    fn test_i256_testscalar_negative() {
+        // Test conversion from i256(-1) to TestScalar
+        let neg_one_i256_testscalar = TestScalar::try_from(i256::from(-1));
+        assert!(neg_one_i256_testscalar.is_ok());
+        let neg_one_testscalar = TestScalar::from(-1);
+        assert_eq!(neg_one_i256_testscalar.unwrap(), neg_one_testscalar);
     }
 
     #[test]
-    fn test_i256_curve25519scalar_zero() {
-        // Test conversion from i256(0) to Curve25519Scalar
-        let zero_i256_curve25519scalar = Curve25519Scalar::try_from(i256::from(0));
-        assert!(zero_i256_curve25519scalar.is_ok());
-        let zero_curve25519scalar = Curve25519Scalar::zero();
-        assert_eq!(zero_i256_curve25519scalar.unwrap(), zero_curve25519scalar);
+    fn test_i256_testscalar_zero() {
+        // Test conversion from i256(0) to TestScalar
+        let zero_i256_testscalar = TestScalar::try_from(i256::from(0));
+        assert!(zero_i256_testscalar.is_ok());
+        let zero_testscalar = TestScalar::zero();
+        assert_eq!(zero_i256_testscalar.unwrap(), zero_testscalar);
     }
 
     #[test]
-    fn test_i256_curve25519scalar_positive() {
-        // Test conversion from i256(42) to Curve25519Scalar
-        let forty_two_i256_curve25519scalar = Curve25519Scalar::try_from(i256::from(42));
-        let forty_two_curve25519scalar = Curve25519Scalar::from(42);
-        assert_eq!(
-            forty_two_i256_curve25519scalar.unwrap(),
-            forty_two_curve25519scalar
-        );
+    fn test_i256_testscalar_positive() {
+        // Test conversion from i256(42) to TestScalar
+        let forty_two_i256_testscalar = TestScalar::try_from(i256::from(42));
+        let forty_two_testscalar = TestScalar::from(42);
+        assert_eq!(forty_two_i256_testscalar.unwrap(), forty_two_testscalar);
     }
 
     #[test]
-    fn test_i256_curve25519scalar_max_signed() {
+    fn test_i256_testscalar_max_signed() {
         let max_signed = MAX_SUPPORTED_I256;
         // max signed value
-        let max_signed_scalar = Curve25519Scalar::MAX_SIGNED;
-        // Test conversion from i256 to Curve25519Scalar
-        let i256_curve25519scalar = Curve25519Scalar::try_from(max_signed);
-        assert!(i256_curve25519scalar.is_ok());
-        assert_eq!(i256_curve25519scalar.unwrap(), max_signed_scalar);
+        let max_signed_scalar = TestScalar::MAX_SIGNED;
+        // Test conversion from i256 to TestScalar
+        let i256_testscalar = TestScalar::try_from(max_signed);
+        assert!(i256_testscalar.is_ok());
+        assert_eq!(i256_testscalar.unwrap(), max_signed_scalar);
     }
 
     #[test]
-    fn test_i256_curve25519scalar_min_signed() {
+    fn test_i256_testscalar_min_signed() {
         let min_signed = MIN_SUPPORTED_I256;
-        let i256_curve25519scalar = Curve25519Scalar::try_from(min_signed);
+        let i256_testscalar = TestScalar::try_from(min_signed);
         // -MAX_SIGNED is ok
-        assert!(i256_curve25519scalar.is_ok());
+        assert!(i256_testscalar.is_ok());
         assert_eq!(
-            i256_curve25519scalar.unwrap(),
-            Curve25519Scalar::MAX_SIGNED + Curve25519Scalar::from(1)
+            i256_testscalar.unwrap(),
+            TestScalar::MAX_SIGNED + TestScalar::from(1)
         );
     }
 
     #[test]
-    fn test_i256_curve25519scalar_random() {
+    fn test_i256_testscalar_random() {
         let mut rng = rand::thread_rng();
         for _ in 0..1000 {
             let i256_value = random_i256(&mut rng);
-            let curve25519_scalar =
-                Curve25519Scalar::try_from(i256_value).expect("Conversion failed");
+            let curve25519_scalar = TestScalar::try_from(i256_value).expect("Conversion failed");
             let back_to_i256 = i256::from(curve25519_scalar);
             assert_eq!(i256_value, back_to_i256, "Round-trip conversion failed");
         }

--- a/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
@@ -2,15 +2,15 @@ use super::scalar_varint::{
     read_scalar_varint, read_scalar_varints, scalar_varint_size, scalar_varints_size,
     write_scalar_varint, write_scalar_varints,
 };
-use crate::base::{encode::U256, scalar::Curve25519Scalar};
+use crate::base::{encode::U256, scalar::test_scalar::TestScalar};
 use alloc::vec;
 
 #[test]
 fn small_scalars_are_encoded_as_positive_varints_and_consume_few_bytes() {
-    assert!(scalar_varint_size(&Curve25519Scalar::from(0_u64)) == 1);
-    assert!(scalar_varint_size(&Curve25519Scalar::from(1_u64)) == 1);
-    assert!(scalar_varint_size(&Curve25519Scalar::from(2_u64)) == 1);
-    assert!(scalar_varint_size(&Curve25519Scalar::from(1000_u64)) == 2);
+    assert!(scalar_varint_size(&TestScalar::from(0_u64)) == 1);
+    assert!(scalar_varint_size(&TestScalar::from(1_u64)) == 1);
+    assert!(scalar_varint_size(&TestScalar::from(2_u64)) == 1);
+    assert!(scalar_varint_size(&TestScalar::from(1000_u64)) == 2);
 }
 
 #[test]
@@ -18,12 +18,12 @@ fn big_scalars_with_small_additive_inverses_are_encoded_as_negative_varints_and_
 {
     // x = p - 1 (p is the ristretto group order)
     // y = -x = 1
-    let val = -Curve25519Scalar::from(1_u64);
+    let val = -TestScalar::from(1_u64);
     assert!(scalar_varint_size(&val) == 1);
 
     // x = p - 1000 (p is the ristretto group order)
     // y = -x = 1000
-    let val = -Curve25519Scalar::from(1000_u64);
+    let val = -TestScalar::from(1000_u64);
     assert!(scalar_varint_size(&val) == 2);
 }
 
@@ -32,7 +32,7 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_posi
 ) {
     // x = (p - 1) / 10 (p is the ristretto group order)
     // y = -x = (p + 1) / 10
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x9bafe5c976b25c7bd59b704f6fb22eca,
         0x1999999999999999999999999999999,
     ))
@@ -45,7 +45,7 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
 ) {
     // x = (p + 1) / 10 (p is the ristretto group order)
     // y = -x = (p - 1) / 10
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x9bafe5c976b25c7bd59b704f6fb22ecb,
         0x1999999999999999999999999999999,
     ))
@@ -58,7 +58,7 @@ fn the_maximum_positive_and_negative_encoded_scalars_consume_the_maximum_amount_
     // maximum negative encoded scalar
     // x = (p + 1) / 2 (p is the ristretto group order)
     // y = -x = (p - 1) / 2
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0xa6f7cef517bce6b2c09318d2e7ae9f7,
         0x8000000000000000000000000000000,
     ))
@@ -68,7 +68,7 @@ fn the_maximum_positive_and_negative_encoded_scalars_consume_the_maximum_amount_
     // maximum positive encoded scalar
     // x = (p - 1) / 2 (p is the ristretto group order)
     // y = -x = (p + 1) / 2
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0xa6f7cef517bce6b2c09318d2e7ae9f6,
         0x8000000000000000000000000000000,
     ))
@@ -80,23 +80,23 @@ fn the_maximum_positive_and_negative_encoded_scalars_consume_the_maximum_amount_
 #[test]
 fn scalar_slices_consumes_the_correct_amount_of_bytes() {
     // x = (p - 1)
-    let val1 = -Curve25519Scalar::from(1_u64);
+    let val1 = -TestScalar::from(1_u64);
 
     // x = (p + 1) / 2
-    let val2: Curve25519Scalar = (&U256::from_words(
+    let val2: TestScalar = (&U256::from_words(
         0xa6f7cef517bce6b2c09318d2e7ae9f7,
         0x8000000000000000000000000000000,
     ))
         .into();
 
-    assert!(scalar_varints_size(&[Curve25519Scalar::from(1000_u64)]) == 2);
+    assert!(scalar_varints_size(&[TestScalar::from(1000_u64)]) == 2);
 
     assert!(
         scalar_varints_size(&[
-            Curve25519Scalar::from(1000_u64),
-            Curve25519Scalar::from(0_u64),
+            TestScalar::from(1000_u64),
+            TestScalar::from(0_u64),
             val1,
-            Curve25519Scalar::from(2_u64),
+            TestScalar::from(2_u64),
             val2
         ]) == 42
     );
@@ -107,19 +107,19 @@ fn small_scalars_are_correctly_encoded_and_decoded_as_positive_varints() {
     let mut buf = [0_u8; 38];
 
     // x = 0, which is encoded as 2 * 0 = 0
-    assert!(write_scalar_varint(&mut buf[..], &Curve25519Scalar::from(0_u64)) == 1);
+    assert!(write_scalar_varint(&mut buf[..], &TestScalar::from(0_u64)) == 1);
     assert!(buf[0] == 0);
-    assert!(read_scalar_varint(&buf[..]).unwrap() == (Curve25519Scalar::from(0_u64), 1));
+    assert!(read_scalar_varint(&buf[..]).unwrap() == (TestScalar::from(0_u64), 1));
 
     // x = 1, which is encoded as 2 * 1 = 2
-    assert!(write_scalar_varint(&mut buf[..], &Curve25519Scalar::from(1_u64)) == 1);
+    assert!(write_scalar_varint(&mut buf[..], &TestScalar::from(1_u64)) == 1);
     assert!(buf[0] == 2);
-    assert!(read_scalar_varint(&buf[..]).unwrap() == (Curve25519Scalar::from(1_u64), 1));
+    assert!(read_scalar_varint(&buf[..]).unwrap() == (TestScalar::from(1_u64), 1));
 
     // x = 2, which is encoded as 2 * x = 4
-    assert!(write_scalar_varint(&mut buf[..], &Curve25519Scalar::from(2_u64)) == 1);
+    assert!(write_scalar_varint(&mut buf[..], &TestScalar::from(2_u64)) == 1);
     assert!(buf[0] == 4);
-    assert!(read_scalar_varint(&buf[..]).unwrap() == (Curve25519Scalar::from(2_u64), 1));
+    assert!(read_scalar_varint(&buf[..]).unwrap() == (TestScalar::from(2_u64), 1));
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn big_scalars_with_small_additive_inverses_are_correctly_encoded_and_decoded_as
     // x = p - 1 (p is the ristretto group order)
     // y = -x = 1
     // which is encoded as -y, or as 2 * y - 1 = 1
-    let val = -Curve25519Scalar::from(1u64);
+    let val = -TestScalar::from(1u64);
     assert!(write_scalar_varint(&mut buf[..], &val) == 1);
     assert!(buf[0] == 1);
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 1));
@@ -138,7 +138,7 @@ fn big_scalars_with_small_additive_inverses_are_correctly_encoded_and_decoded_as
     // x = p - 2 (p is the ristretto group order)
     // y = -x = 2
     // which is encoded as -y, or as 2 * y - 1 = 3
-    let val = -Curve25519Scalar::from(2u64);
+    let val = -TestScalar::from(2u64);
     assert!(write_scalar_varint(&mut buf[..], &val) == 1);
     assert!(buf[0] == 3);
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 1));
@@ -151,7 +151,7 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_correctly_encod
 
     // (p - 1) / 2 (p is the ristretto group order)
     // y = -x = (p + 1) / 2 (which is bigger than x)
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0xa6f7cef517bce6b2c09318d2e7ae9f6,
         0x8000000000000000000000000000000,
     ))
@@ -160,7 +160,7 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_correctly_encod
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 37));
 
     // using a smaller buffer will fail
-    assert!((read_scalar_varint(&buf[..10]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..10]) as Option<(TestScalar, _)>).is_none());
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_correctly_e
 
     // x = (p + 1) / 2 (p is the group order)
     // y = -x = (p - 1) / 2 (which is smaller than x)
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0xa6f7cef517bce6b2c09318d2e7ae9f7,
         0x8000000000000000000000000000000,
     ))
@@ -180,7 +180,7 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_correctly_e
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 37));
 
     // using a smaller buffer will fail
-    assert!((read_scalar_varint(&buf[..10]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..10]) as Option<(TestScalar, _)>).is_none());
 }
 
 #[test]
@@ -195,7 +195,7 @@ fn valid_varint_encoded_input_that_map_to_curve25519_scalars_smaller_than_the_p_
     // buf represents the number 2^252 - 1
     // removing the varint encoding, we would have y = ((2^252 - 1) // 2 + 1) % p
     // since we want x, we would have x = -y
-    let expected_x = -Curve25519Scalar::from(&U256::from_words(
+    let expected_x = -TestScalar::from(&U256::from_words(
         0x00000000000000000000000000000000,
         0x8000000000000000000000000000000,
     ));
@@ -216,7 +216,7 @@ fn valid_varint_encoded_input_that_map_to_curve25519_scalars_bigger_than_the_p_f
     // at this point, buf represents the number 2^256 - 2,
     // which has 256 bit-length, where 255 bits are set to 1
     // also, `expected_val` is simply x = ((2^256 - 2) >> 1) % p
-    let expected_val: Curve25519Scalar = (&U256::from_words(
+    let expected_val: TestScalar = (&U256::from_words(
         0x6de72ae98b3ab623977f4a4775473484,
         0xfffffffffffffffffffffffffffffff,
     ))
@@ -240,7 +240,7 @@ fn varint_encoded_values_that_never_ends_will_make_the_read_scalar_to_error_out(
     let buf = [0b11111111_u8; 5];
 
     // varint numbers that do not terminate will fail out
-    assert!((read_scalar_varint(&buf[..]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..]) as Option<(TestScalar, _)>).is_none());
 }
 
 #[test]
@@ -251,21 +251,20 @@ fn valid_varint_encoded_input_that_has_length_bigger_than_259_bits_will_make_the
     // a varint with 260 bit-length will fail (260 bits = 37 * 7 + 1 as
     //  each byte can hold only 7 bits in the varint encoding)
     buf[37] = 0b00000001_u8;
-    assert!((read_scalar_varint(&buf[..37]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..37]) as Option<(TestScalar, _)>).is_none());
 
     // a varint with 266 bit-length will fail (266 bits = 38 * 7 as
     //  each byte can hold only 7 bits in the varint encoding)
     buf[37] = 0b01111111_u8;
-    assert!((read_scalar_varint(&buf[..38]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..38]) as Option<(TestScalar, _)>).is_none());
 }
 
-fn write_read_and_compare_encoding(expected_scals: &[Curve25519Scalar]) {
+fn write_read_and_compare_encoding(expected_scals: &[TestScalar]) {
     let mut buf_vec = vec![0_u8; 37 * expected_scals.len()];
     let total_bytes_read = write_scalar_varints(&mut buf_vec[..], expected_scals);
 
     let buf = &buf_vec[0..total_bytes_read];
-    let mut scals =
-        vec![Curve25519Scalar::from_le_bytes_mod_order(&[0_u8; 32]); expected_scals.len()];
+    let mut scals = vec![TestScalar::from_le_bytes_mod_order(&[0_u8; 32]); expected_scals.len()];
     read_scalar_varints(&mut scals[..], buf).unwrap();
 
     for (scal, expected_scal) in scals.iter().zip(expected_scals.iter()) {
@@ -275,30 +274,27 @@ fn write_read_and_compare_encoding(expected_scals: &[Curve25519Scalar]) {
 
 #[test]
 fn scalar_slices_are_correctly_encoded_and_decoded() {
-    write_read_and_compare_encoding(&[Curve25519Scalar::from(0_u128)]);
+    write_read_and_compare_encoding(&[TestScalar::from(0_u128)]);
+    write_read_and_compare_encoding(&[TestScalar::from(1_u64), TestScalar::from(4_u32)]);
     write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(4_u32),
-    ]);
-    write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(u128::MAX),
-        Curve25519Scalar::from(0_u128),
-        Curve25519Scalar::from(5_u16),
-        Curve25519Scalar::from(u128::MAX),
+        TestScalar::from(1_u64),
+        TestScalar::from(u128::MAX),
+        TestScalar::from(0_u128),
+        TestScalar::from(5_u16),
+        TestScalar::from(u128::MAX),
     ]);
 
     // x = p - 1 (where p is the ristretto group_order)
-    let val = -Curve25519Scalar::from(1_u64);
+    let val = -TestScalar::from(1_u64);
 
     write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(u128::MAX),
-        Curve25519Scalar::from(0_u64),
+        TestScalar::from(u128::MAX),
+        TestScalar::from(0_u64),
         val,
-        Curve25519Scalar::from(5_u16),
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from(u128::MAX),
+        TestScalar::from(5_u16),
+        TestScalar::from(1_u64),
+        TestScalar::from(0_u64),
+        TestScalar::from(u128::MAX),
     ]);
 
     // some random scalar
@@ -309,14 +305,14 @@ fn scalar_slices_are_correctly_encoded_and_decoded() {
     ];
 
     write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(u128::MAX),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from_le_bytes_mod_order(&bytes),
-        Curve25519Scalar::from(5_u16),
-        Curve25519Scalar::from_le_bytes_mod_order(&bytes),
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from(u128::MAX),
+        TestScalar::from(u128::MAX),
+        TestScalar::from(0_u64),
+        TestScalar::from_le_bytes_mod_order(&bytes),
+        TestScalar::from(5_u16),
+        TestScalar::from_le_bytes_mod_order(&bytes),
+        TestScalar::from(1_u64),
+        TestScalar::from(0_u64),
+        TestScalar::from(u128::MAX),
     ]);
 
     // some random scalar
@@ -327,13 +323,13 @@ fn scalar_slices_are_correctly_encoded_and_decoded() {
     ];
 
     write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(u128::MAX),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from_le_bytes_mod_order(&bytes),
-        Curve25519Scalar::from(5_u16),
-        Curve25519Scalar::from_le_bytes_mod_order(&bytes),
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from(u128::MAX),
+        TestScalar::from(u128::MAX),
+        TestScalar::from(0_u64),
+        TestScalar::from_le_bytes_mod_order(&bytes),
+        TestScalar::from(5_u16),
+        TestScalar::from_le_bytes_mod_order(&bytes),
+        TestScalar::from(1_u64),
+        TestScalar::from(0_u64),
+        TestScalar::from(u128::MAX),
     ]);
 }

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -1,5 +1,5 @@
 use super::VarInt;
-use crate::base::scalar::{Curve25519Scalar, Scalar};
+use crate::base::scalar::{test_scalar::TestScalar, Scalar};
 use alloc::{vec, vec::Vec};
 use core::{
     fmt::Debug,
@@ -372,19 +372,19 @@ fn we_can_encode_and_decode_small_u128_values() {
 
 #[test]
 fn we_can_encode_and_decode_small_curve25519_scalar_values() {
-    test_small_signed_values_encode_and_decode_properly::<Curve25519Scalar>(Curve25519Scalar::ONE);
+    test_small_signed_values_encode_and_decode_properly::<TestScalar>(TestScalar::ONE);
 }
 
 #[test]
 fn we_can_encode_and_decode_i128_and_curve25519_scalar_the_same() {
     let mut rng = rand::thread_rng();
-    test_encode_and_decode_types_align::<i128, Curve25519Scalar>(
+    test_encode_and_decode_types_align::<i128, TestScalar>(
         &rng.gen::<[_; 32]>(),
         &[
-            Curve25519Scalar::from(i128::MAX) + Curve25519Scalar::one(),
-            Curve25519Scalar::from(i128::MIN) - Curve25519Scalar::one(),
-            Curve25519Scalar::from(i128::MAX) * Curve25519Scalar::from(1000),
-            Curve25519Scalar::from(i128::MIN) * Curve25519Scalar::from(1000),
+            TestScalar::from(i128::MAX) + TestScalar::one(),
+            TestScalar::from(i128::MIN) - TestScalar::one(),
+            TestScalar::from(i128::MAX) * TestScalar::from(1000),
+            TestScalar::from(i128::MIN) * TestScalar::from(1000),
         ],
         100,
     );

--- a/crates/proof-of-sql/src/base/encode/zigzag_test.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag_test.rs
@@ -1,32 +1,32 @@
 use crate::base::{
     encode::{ZigZag, U256},
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
 };
 
 #[test]
 fn small_scalars_are_encoded_as_positive_zigzag_values() {
     // x = 0
     // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
-    assert!(Curve25519Scalar::from(0_u64).zigzag() == U256::from_words(0, 0));
+    assert!(TestScalar::from(0_u64).zigzag() == U256::from_words(0, 0));
 
     // x = 1
     // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
-    assert!(Curve25519Scalar::from(1_u8).zigzag() == U256::from_words(2, 0));
+    assert!(TestScalar::from(1_u8).zigzag() == U256::from_words(2, 0));
 
     // x = 2
     // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
-    assert!(Curve25519Scalar::from(2_u32).zigzag() == U256::from_words(4, 0));
+    assert!(TestScalar::from(2_u32).zigzag() == U256::from_words(4, 0));
 
     // x = u128::MAX
     // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
     assert!(
-        Curve25519Scalar::from(u128::MAX).zigzag()
+        TestScalar::from(u128::MAX).zigzag()
             == U256::from_words(0xfffffffffffffffffffffffffffffffe, 0x1)
     );
 
     for x in 1..1000_u128 {
         // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
-        assert!(Curve25519Scalar::from(x).zigzag() == U256::from_words(2 * x, 0));
+        assert!(TestScalar::from(x).zigzag() == U256::from_words(2 * x, 0));
     }
 }
 
@@ -35,16 +35,16 @@ fn big_scalars_with_small_additive_inverses_are_encoded_as_negative_zigzag_value
     // x = p - 1 (p = 2^252 + 27742317777372353535851937790883648493 is the ristretto group order)
     // the additive inverse of x is y = 1. Since y < x, the ZigZag encodes -y, which is
     // encoded as 2 * y - 1 = 1
-    assert!((-Curve25519Scalar::from(1_u32)).zigzag() == U256::from_words(1, 0));
+    assert!((-TestScalar::from(1_u32)).zigzag() == U256::from_words(1, 0));
 
     // x = p - 2 (p = 2^252 + 27742317777372353535851937790883648493 is the ristretto group order)
     // the additive inverse of x is y = 2. Since y < x, the ZigZag encodes -y, which is
     // encoded as 2 * y - 1 = 3
-    assert!((-Curve25519Scalar::from(2_u32)).zigzag() == U256::from_words(3, 0));
+    assert!((-TestScalar::from(2_u32)).zigzag() == U256::from_words(3, 0));
 
     for y in 1..1000_u128 {
         // since x > y, where x + y = 0, the ZigZag value is encoded as 2 * y - 1
-        assert!((-Curve25519Scalar::from(y)).zigzag() == U256::from_words(2 * y - 1, 0));
+        assert!((-TestScalar::from(y)).zigzag() == U256::from_words(2 * y - 1, 0));
     }
 }
 
@@ -52,7 +52,7 @@ fn big_scalars_with_small_additive_inverses_are_encoded_as_negative_zigzag_value
 fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_positive_zigzag_values()
 {
     // x = (p - 1) / 2 (p is the ristretto group order)
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0xa6f7cef517bce6b2c09318d2e7ae9f6,
         0x8000000000000000000000000000000,
     ))
@@ -71,7 +71,7 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_posi
 fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_negative_zigzag_values(
 ) {
     // x = (p + 1) / 2 (p is the ristretto group order)
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0xa6f7cef517bce6b2c09318d2e7ae9f7,
         0x8000000000000000000000000000000,
     ))
@@ -89,7 +89,7 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
 
     // x = - U256 { low: 0, high: 0x1_u128 }
     // since x > y, where x + y = 0, the ZigZag value is encoded as 2 * y - 1
-    let val: Curve25519Scalar = (&U256 {
+    let val: TestScalar = (&U256 {
         low: 0x0_u128,
         high: 0x1_u128,
     })

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -230,7 +230,7 @@ pub(crate) fn scale_scalar<S: Scalar>(s: S, scale: i8) -> DecimalResult<S> {
 mod scale_adjust_test {
 
     use super::*;
-    use crate::base::scalar::Curve25519Scalar;
+    use crate::base::scalar::test_scalar::TestScalar;
     use num_bigint::BigInt;
 
     #[test]
@@ -241,7 +241,7 @@ mod scale_adjust_test {
 
         let target_scale = 5;
 
-        assert!(try_into_to_scalar::<Curve25519Scalar>(
+        assert!(try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(decimal.value().digits() as u8).unwrap(),
             target_scale
@@ -265,13 +265,13 @@ mod scale_adjust_test {
         let decimal = "120.00".parse().unwrap();
         let target_scale = -1;
         let expected = [12, 0, 0, 0];
-        let result = try_into_to_scalar::<Curve25519Scalar>(
+        let result = try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(MAX_SUPPORTED_PRECISION).unwrap(),
             target_scale,
         )
         .unwrap();
-        assert_eq!(result, Curve25519Scalar::from(expected));
+        assert_eq!(result, TestScalar::from(expected));
     }
 
     #[test]
@@ -280,14 +280,14 @@ mod scale_adjust_test {
         let target_scale = -2;
         let expected_limbs = [123, 0, 0, 0];
 
-        let limbs = try_into_to_scalar::<Curve25519Scalar>(
+        let limbs = try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(decimal.value().digits() as u8).unwrap(),
             target_scale,
         )
         .unwrap();
 
-        assert_eq!(limbs, Curve25519Scalar::from(expected_limbs));
+        assert_eq!(limbs, TestScalar::from(expected_limbs));
     }
 
     #[test]
@@ -295,13 +295,13 @@ mod scale_adjust_test {
         let decimal = "-123.45".parse().unwrap();
         let target_scale = 2;
         let expected_limbs = [12345, 0, 0, 0];
-        let limbs = try_into_to_scalar::<Curve25519Scalar>(
+        let limbs = try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(decimal.value().digits() as u8).unwrap(),
             target_scale,
         )
         .unwrap();
-        assert_eq!(limbs, -Curve25519Scalar::from(expected_limbs));
+        assert_eq!(limbs, -TestScalar::from(expected_limbs));
     }
 
     #[test]
@@ -311,7 +311,7 @@ mod scale_adjust_test {
             .parse()
             .unwrap();
         let target_scale = 6; // now precision exceeds maximum
-        assert!(try_into_to_scalar::<Curve25519Scalar>(
+        assert!(try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(decimal.value().digits() as u8,).unwrap(),
             target_scale
@@ -324,7 +324,7 @@ mod scale_adjust_test {
                 .parse()
                 .unwrap();
         let target_scale = 1;
-        assert!(try_into_to_scalar::<Curve25519Scalar>(
+        assert!(try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(MAX_SUPPORTED_PRECISION).unwrap(),
             target_scale
@@ -337,7 +337,7 @@ mod scale_adjust_test {
                 .parse()
                 .unwrap();
         let target_scale = 1;
-        assert!(try_into_to_scalar::<Curve25519Scalar>(
+        assert!(try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(MAX_SUPPORTED_PRECISION).unwrap(),
             target_scale
@@ -350,7 +350,7 @@ mod scale_adjust_test {
                 .parse()
                 .unwrap();
         let target_scale = MAX_SUPPORTED_PRECISION as i8;
-        assert!(try_into_to_scalar::<Curve25519Scalar>(
+        assert!(try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(decimal.value().digits() as u8,).unwrap(),
             target_scale
@@ -360,7 +360,7 @@ mod scale_adjust_test {
         // this is ok because it can be scaled to 75 precision
         let decimal = "0.1".parse().unwrap();
         let target_scale = MAX_SUPPORTED_PRECISION as i8;
-        assert!(try_into_to_scalar::<Curve25519Scalar>(
+        assert!(try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(MAX_SUPPORTED_PRECISION).unwrap(),
             target_scale
@@ -370,7 +370,7 @@ mod scale_adjust_test {
         // this exceeds max precision
         let decimal = "1.0".parse().unwrap();
         let target_scale = 75;
-        assert!(try_into_to_scalar::<Curve25519Scalar>(
+        assert!(try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(decimal.value().digits() as u8,).unwrap(),
             target_scale
@@ -380,7 +380,7 @@ mod scale_adjust_test {
         // but this is ok
         let decimal = "1.0".parse().unwrap();
         let target_scale = 74;
-        assert!(try_into_to_scalar::<Curve25519Scalar>(
+        assert!(try_into_to_scalar::<TestScalar>(
             &decimal,
             Precision::new(MAX_SUPPORTED_PRECISION).unwrap(),
             target_scale

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -1,38 +1,38 @@
 use super::CompositePolynomial;
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::test_scalar::TestScalar;
 use alloc::rc::Rc;
 
 #[test]
 fn test_composite_polynomial_evaluation() {
-    let a: Vec<Curve25519Scalar> = vec![
-        -Curve25519Scalar::from(7u32),
-        Curve25519Scalar::from(2u32),
-        -Curve25519Scalar::from(6u32),
-        Curve25519Scalar::from(17u32),
+    let a: Vec<TestScalar> = vec![
+        -TestScalar::from(7u32),
+        TestScalar::from(2u32),
+        -TestScalar::from(6u32),
+        TestScalar::from(17u32),
     ];
-    let b: Vec<Curve25519Scalar> = vec![
-        Curve25519Scalar::from(2u32),
-        -Curve25519Scalar::from(8u32),
-        Curve25519Scalar::from(4u32),
-        Curve25519Scalar::from(1u32),
+    let b: Vec<TestScalar> = vec![
+        TestScalar::from(2u32),
+        -TestScalar::from(8u32),
+        TestScalar::from(4u32),
+        TestScalar::from(1u32),
     ];
-    let c: Vec<Curve25519Scalar> = vec![
-        Curve25519Scalar::from(1u32),
-        Curve25519Scalar::from(3u32),
-        -Curve25519Scalar::from(5u32),
-        -Curve25519Scalar::from(9u32),
+    let c: Vec<TestScalar> = vec![
+        TestScalar::from(1u32),
+        TestScalar::from(3u32),
+        -TestScalar::from(5u32),
+        -TestScalar::from(9u32),
     ];
     let mut prod = CompositePolynomial::new(2);
-    prod.add_product([Rc::new(a), Rc::new(b)], Curve25519Scalar::from(3u32));
-    prod.add_product([Rc::new(c)], Curve25519Scalar::from(2u32));
-    let prod00 = prod.evaluate(&[Curve25519Scalar::from(0u32), Curve25519Scalar::from(0u32)]);
-    let prod10 = prod.evaluate(&[Curve25519Scalar::from(1u32), Curve25519Scalar::from(0u32)]);
-    let prod01 = prod.evaluate(&[Curve25519Scalar::from(0u32), Curve25519Scalar::from(1u32)]);
-    let prod11 = prod.evaluate(&[Curve25519Scalar::from(1u32), Curve25519Scalar::from(1u32)]);
-    let calc00 = -Curve25519Scalar::from(40u32);
-    let calc10 = -Curve25519Scalar::from(42u32);
-    let calc01 = -Curve25519Scalar::from(82u32);
-    let calc11 = Curve25519Scalar::from(33u32);
+    prod.add_product([Rc::new(a), Rc::new(b)], TestScalar::from(3u32));
+    prod.add_product([Rc::new(c)], TestScalar::from(2u32));
+    let prod00 = prod.evaluate(&[TestScalar::from(0u32), TestScalar::from(0u32)]);
+    let prod10 = prod.evaluate(&[TestScalar::from(1u32), TestScalar::from(0u32)]);
+    let prod01 = prod.evaluate(&[TestScalar::from(0u32), TestScalar::from(1u32)]);
+    let prod11 = prod.evaluate(&[TestScalar::from(1u32), TestScalar::from(1u32)]);
+    let calc00 = -TestScalar::from(40u32);
+    let calc10 = -TestScalar::from(42u32);
+    let calc01 = -TestScalar::from(82u32);
+    let calc11 = TestScalar::from(33u32);
     assert_eq!(prod00, calc00);
     assert_eq!(prod10, calc10);
     assert_eq!(prod01, calc01);

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
@@ -1,65 +1,57 @@
 use super::compute_evaluation_vector;
-use crate::base::{scalar::Curve25519Scalar, slice_ops};
+use crate::base::{scalar::test_scalar::TestScalar, slice_ops};
 use ark_poly::MultilinearExtension;
 use num_traits::{One, Zero};
 
 #[test]
 fn we_compute_the_correct_evaluation_vector_for_a_small_example() {
-    let mut v = [Curve25519Scalar::zero(); 2];
-    compute_evaluation_vector(&mut v, &[Curve25519Scalar::from(3u64)]);
+    let mut v = [TestScalar::zero(); 2];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64)]);
     let expected_v = [
-        Curve25519Scalar::one() - Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(3u64),
+        TestScalar::one() - TestScalar::from(3u64),
+        TestScalar::from(3u64),
     ];
     assert_eq!(v, expected_v);
 
-    let mut v = [Curve25519Scalar::zero(); 4];
-    compute_evaluation_vector(
-        &mut v,
-        &[Curve25519Scalar::from(3u64), Curve25519Scalar::from(4u64)],
-    );
+    let mut v = [TestScalar::zero(); 4];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64), TestScalar::from(4u64)]);
     let expected_v = [
-        (Curve25519Scalar::one() - Curve25519Scalar::from(4u64))
-            * (Curve25519Scalar::one() - Curve25519Scalar::from(3u64)),
-        (Curve25519Scalar::one() - Curve25519Scalar::from(4u64)) * Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(4u64) * (Curve25519Scalar::one() - Curve25519Scalar::from(3u64)),
-        Curve25519Scalar::from(4u64) * Curve25519Scalar::from(3u64),
+        (TestScalar::one() - TestScalar::from(4u64)) * (TestScalar::one() - TestScalar::from(3u64)),
+        (TestScalar::one() - TestScalar::from(4u64)) * TestScalar::from(3u64),
+        TestScalar::from(4u64) * (TestScalar::one() - TestScalar::from(3u64)),
+        TestScalar::from(4u64) * TestScalar::from(3u64),
     ];
     assert_eq!(v, expected_v);
 }
 
 #[test]
 fn we_compute_the_evaluation_vectors_not_a_power_of_2() {
-    let mut v = [Curve25519Scalar::zero(); 1];
-    compute_evaluation_vector(&mut v, &[Curve25519Scalar::from(3u64)]);
-    let expected_v = [Curve25519Scalar::one() - Curve25519Scalar::from(3u64)];
+    let mut v = [TestScalar::zero(); 1];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64)]);
+    let expected_v = [TestScalar::one() - TestScalar::from(3u64)];
     assert_eq!(v, expected_v);
 
-    let mut v = [Curve25519Scalar::zero(); 3];
-    compute_evaluation_vector(
-        &mut v,
-        &[Curve25519Scalar::from(3u64), Curve25519Scalar::from(4u64)],
-    );
+    let mut v = [TestScalar::zero(); 3];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64), TestScalar::from(4u64)]);
     let expected_v = [
-        (Curve25519Scalar::one() - Curve25519Scalar::from(4u64))
-            * (Curve25519Scalar::one() - Curve25519Scalar::from(3u64)),
-        (Curve25519Scalar::one() - Curve25519Scalar::from(4u64)) * Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(4u64) * (Curve25519Scalar::one() - Curve25519Scalar::from(3u64)),
+        (TestScalar::one() - TestScalar::from(4u64)) * (TestScalar::one() - TestScalar::from(3u64)),
+        (TestScalar::one() - TestScalar::from(4u64)) * TestScalar::from(3u64),
+        TestScalar::from(4u64) * (TestScalar::one() - TestScalar::from(3u64)),
     ];
     assert_eq!(v, expected_v);
 }
 #[test]
 fn we_compute_the_evaluation_vectors_of_any_length() {
-    let mut full_vec = [Curve25519Scalar::zero(); 16];
+    let mut full_vec = [TestScalar::zero(); 16];
     let evaluation_point = [
-        Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(5u64),
-        Curve25519Scalar::from(7u64),
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
+        TestScalar::from(5u64),
+        TestScalar::from(7u64),
     ];
     compute_evaluation_vector(&mut full_vec, &evaluation_point);
     for i in 0..16 {
-        let mut v = vec![Curve25519Scalar::zero(); i];
+        let mut v = vec![TestScalar::zero(); i];
         compute_evaluation_vector(&mut v, &evaluation_point);
         assert_eq!(v, &full_vec[..i]);
     }
@@ -67,40 +59,37 @@ fn we_compute_the_evaluation_vectors_of_any_length() {
 
 #[test]
 fn we_compute_the_evaluation_vector_for_an_empty_point() {
-    let mut v = [Curve25519Scalar::zero(); 1];
+    let mut v = [TestScalar::zero(); 1];
     compute_evaluation_vector(&mut v, &[]);
-    let expected_v = [Curve25519Scalar::one()];
+    let expected_v = [TestScalar::one()];
     assert_eq!(v, expected_v);
 }
 
 #[test]
 fn we_get_the_same_result_using_evaluation_vector_as_direct_evaluation() {
     let xs = [
-        Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(7u64),
-        Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(9u64),
-        Curve25519Scalar::from(21u64),
-        Curve25519Scalar::from(10u64),
-        Curve25519Scalar::from(5u64),
-        Curve25519Scalar::from(92u64),
+        TestScalar::from(3u64),
+        TestScalar::from(7u64),
+        TestScalar::from(2u64),
+        TestScalar::from(9u64),
+        TestScalar::from(21u64),
+        TestScalar::from(10u64),
+        TestScalar::from(5u64),
+        TestScalar::from(92u64),
     ];
     let point = [
-        Curve25519Scalar::from(81u64),
-        Curve25519Scalar::from(33u64),
-        Curve25519Scalar::from(22u64),
+        TestScalar::from(81u64),
+        TestScalar::from(33u64),
+        TestScalar::from(22u64),
     ];
-    let mut v = [Curve25519Scalar::zero(); 8];
+    let mut v = [TestScalar::zero(); 8];
     compute_evaluation_vector(&mut v, &point);
     let eval = slice_ops::inner_product(&xs, &v);
 
     let poly = ark_poly::DenseMultilinearExtension::from_evaluations_slice(
         3,
-        &Curve25519Scalar::unwrap_slice(&xs),
+        &TestScalar::unwrap_slice(&xs),
     );
-    let expected_eval = Curve25519Scalar::new(
-        poly.evaluate(&Curve25519Scalar::unwrap_slice(&point))
-            .unwrap(),
-    );
+    let expected_eval = TestScalar::new(poly.evaluate(&TestScalar::unwrap_slice(&point)).unwrap());
     assert_eq!(eval, expected_eval);
 }

--- a/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
@@ -4,7 +4,7 @@
  * See third_party/license/arkworks.LICENSE
  */
 use super::interpolate::*;
-use crate::base::scalar::{Curve25519Scalar, Curve25519Scalar as S};
+use crate::base::scalar::test_scalar::{TestScalar, TestScalar as S};
 use ark_std::UniformRand;
 use core::iter;
 use num_traits::{Inv, Zero};
@@ -16,20 +16,20 @@ fn test_interpolate_uni_poly_for_random_polynomials() {
     let num_points = vec![0, 1, 2, 3, 4, 5, 10, 20, 32, 33, 64, 65];
 
     for n in num_points {
-        let poly = iter::repeat_with(|| Curve25519Scalar::rand(&mut prng))
+        let poly = iter::repeat_with(|| TestScalar::rand(&mut prng))
             .take(n)
             .collect::<Vec<_>>();
         let evals = (0..n)
             .map(|i| {
-                let x: Curve25519Scalar = (i as u64).into();
+                let x: TestScalar = (i as u64).into();
                 poly.iter().fold(Zero::zero(), |acc, &c| acc * x + c)
             })
             .collect::<Vec<_>>();
-        let query = Curve25519Scalar::rand(&mut prng);
+        let query = TestScalar::rand(&mut prng);
         let value = interpolate_uni_poly(&evals, query);
         let expected_value = poly
             .iter()
-            .fold(Curve25519Scalar::zero(), |acc, &c| acc * query + c);
+            .fold(TestScalar::zero(), |acc, &c| acc * query + c);
         assert_eq!(value, expected_value);
     }
 }
@@ -38,58 +38,58 @@ fn test_interpolate_uni_poly_for_random_polynomials() {
 fn interpolate_uni_poly_gives_zero_for_no_evaluations() {
     let evaluations = vec![];
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(10)),
-        Curve25519Scalar::from(0)
+        interpolate_uni_poly(&evaluations, TestScalar::from(10)),
+        TestScalar::from(0)
     );
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(100)),
-        Curve25519Scalar::from(0)
+        interpolate_uni_poly(&evaluations, TestScalar::from(100)),
+        TestScalar::from(0)
     );
 }
 
 #[test]
 fn interpolate_uni_poly_gives_constant_for_degree_0_polynomial() {
-    let evaluations = vec![Curve25519Scalar::from(77)];
+    let evaluations = vec![TestScalar::from(77)];
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(10)),
-        Curve25519Scalar::from(77)
+        interpolate_uni_poly(&evaluations, TestScalar::from(10)),
+        TestScalar::from(77)
     );
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(100)),
-        Curve25519Scalar::from(77)
+        interpolate_uni_poly(&evaluations, TestScalar::from(100)),
+        TestScalar::from(77)
     );
 }
 
 #[test]
 fn interpolate_uni_poly_gives_correct_result_for_linear_polynomial() {
     let evaluations = vec![
-        Curve25519Scalar::from(2),
-        Curve25519Scalar::from(3),
-        Curve25519Scalar::from(4),
+        TestScalar::from(2),
+        TestScalar::from(3),
+        TestScalar::from(4),
     ];
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(10)),
-        Curve25519Scalar::from(12)
+        interpolate_uni_poly(&evaluations, TestScalar::from(10)),
+        TestScalar::from(12)
     );
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(100)),
-        Curve25519Scalar::from(102)
+        interpolate_uni_poly(&evaluations, TestScalar::from(100)),
+        TestScalar::from(102)
     );
 }
 
 #[test]
 fn interpolate_uni_poly_gives_correct_value_for_known_evaluation() {
     let evaluations = vec![
-        Curve25519Scalar::from(777),
-        Curve25519Scalar::from(123),
-        Curve25519Scalar::from(2357),
-        Curve25519Scalar::from(1),
-        Curve25519Scalar::from(2),
-        Curve25519Scalar::from(3),
+        TestScalar::from(777),
+        TestScalar::from(123),
+        TestScalar::from(2357),
+        TestScalar::from(1),
+        TestScalar::from(2),
+        TestScalar::from(3),
     ];
     for i in 0..evaluations.len() {
         assert_eq!(
-            interpolate_uni_poly(&evaluations, Curve25519Scalar::from(i as u32)),
+            interpolate_uni_poly(&evaluations, TestScalar::from(i as u32)),
             evaluations[i]
         );
     }

--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
@@ -3,7 +3,7 @@ use crate::base::{
         compute_evaluation_vector, compute_truncated_lagrange_basis_inner_product,
         compute_truncated_lagrange_basis_sum,
     },
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
 };
 use ark_std::UniformRand;
 use core::iter;
@@ -11,144 +11,144 @@ use num_traits::Zero;
 
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_0_variables() {
-    let point: Vec<Curve25519Scalar> = vec![];
+    let point: Vec<TestScalar> = vec![];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        Curve25519Scalar::from(1u8)
+        TestScalar::from(1u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_1_variables() {
-    let point: Vec<Curve25519Scalar> = vec![Curve25519Scalar::from(2u8)];
+    let point: Vec<TestScalar> = vec![TestScalar::from(2u8)];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(2, &point),
-        Curve25519Scalar::from(1u8) // This is (1-2) + (2)
+        TestScalar::from(1u8) // This is (1-2) + (2)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        -Curve25519Scalar::from(1u8) // This is (1-2)
+        -TestScalar::from(1u8) // This is (1-2)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_2_variables() {
-    let point = vec![Curve25519Scalar::from(2u8), Curve25519Scalar::from(5u8)];
+    let point = vec![TestScalar::from(2u8), TestScalar::from(5u8)];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(4, &point),
-        Curve25519Scalar::from(1u8) // This is (1-2)(1-5)+(2)(1-5)+(1-2)(5)+(2)(5)
+        TestScalar::from(1u8) // This is (1-2)(1-5)+(2)(1-5)+(1-2)(5)+(2)(5)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(3, &point),
-        -Curve25519Scalar::from(9u8) // This is (1-2)(1-5)+(2)(1-5)+(1-2)(5)
+        -TestScalar::from(9u8) // This is (1-2)(1-5)+(2)(1-5)+(1-2)(5)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(2, &point),
-        -Curve25519Scalar::from(4u8) // This is (1-2)(1-5)+(2)(1-5)
+        -TestScalar::from(4u8) // This is (1-2)(1-5)+(2)(1-5)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        Curve25519Scalar::from(4u8) // This is (1-2)(1-5)
+        TestScalar::from(4u8) // This is (1-2)(1-5)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_3_variables() {
     let point = vec![
-        Curve25519Scalar::from(2u8),
-        Curve25519Scalar::from(5u8),
-        Curve25519Scalar::from(7u8),
+        TestScalar::from(2u8),
+        TestScalar::from(5u8),
+        TestScalar::from(7u8),
     ];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(8, &point),
-        Curve25519Scalar::from(1u8)
+        TestScalar::from(1u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(7, &point),
-        -Curve25519Scalar::from(69u8)
+        -TestScalar::from(69u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(6, &point),
-        -Curve25519Scalar::from(34u8)
+        -TestScalar::from(34u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(5, &point),
-        Curve25519Scalar::from(22u8)
+        TestScalar::from(22u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(4, &point),
-        -Curve25519Scalar::from(6u8)
+        -TestScalar::from(6u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(3, &point),
-        Curve25519Scalar::from(54u8)
+        TestScalar::from(54u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(2, &point),
-        Curve25519Scalar::from(24u8)
+        TestScalar::from(24u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        -Curve25519Scalar::from(24u8)
+        -TestScalar::from(24u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_3_variables_using_dalek_scalar() {
     let point = vec![
-        Curve25519Scalar::from(2u8),
-        Curve25519Scalar::from(5u8),
-        Curve25519Scalar::from(7u8),
+        TestScalar::from(2u8),
+        TestScalar::from(5u8),
+        TestScalar::from(7u8),
     ];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(8, &point),
-        Curve25519Scalar::from(1u8)
+        TestScalar::from(1u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(7, &point),
-        -Curve25519Scalar::from(69u8)
+        -TestScalar::from(69u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(6, &point),
-        -Curve25519Scalar::from(34u8)
+        -TestScalar::from(34u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(5, &point),
-        Curve25519Scalar::from(22u8)
+        TestScalar::from(22u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(4, &point),
-        -Curve25519Scalar::from(6u8)
+        -TestScalar::from(6u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(3, &point),
-        Curve25519Scalar::from(54u8)
+        TestScalar::from(54u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(2, &point),
-        Curve25519Scalar::from(24u8)
+        TestScalar::from(24u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        -Curve25519Scalar::from(24u8)
+        -TestScalar::from(24u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 
@@ -168,82 +168,82 @@ fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_3_variables_us
 
 #[test]
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_0_variables() {
-    let a: Vec<Curve25519Scalar> = vec![];
+    let a: Vec<TestScalar> = vec![];
     let b = vec![];
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(1, &a, &b),
-        Curve25519Scalar::from(1u32)
+        TestScalar::from(1u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(0, &a, &b),
-        Curve25519Scalar::from(0u32)
+        TestScalar::from(0u32)
     );
 }
 #[test]
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_1_variables() {
-    let a = vec![Curve25519Scalar::from(2u8)];
-    let b = vec![Curve25519Scalar::from(3u8)];
+    let a = vec![TestScalar::from(2u8)];
+    let b = vec![TestScalar::from(3u8)];
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(2, &a, &b),
-        Curve25519Scalar::from(8u32) // This is (2-1)(3-1) + (2)(3)
+        TestScalar::from(8u32) // This is (2-1)(3-1) + (2)(3)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(1, &a, &b),
-        Curve25519Scalar::from(2u32) // This is (2-1)(3-1)
+        TestScalar::from(2u32) // This is (2-1)(3-1)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(0, &a, &b),
-        Curve25519Scalar::from(0u32)
+        TestScalar::from(0u32)
     );
 }
 
 #[test]
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_3_variables() {
     let a = vec![
-        Curve25519Scalar::from(2u8),
-        Curve25519Scalar::from(5u8),
-        Curve25519Scalar::from(7u8),
+        TestScalar::from(2u8),
+        TestScalar::from(5u8),
+        TestScalar::from(7u8),
     ];
     let b = vec![
-        Curve25519Scalar::from(3u8),
-        Curve25519Scalar::from(11u8),
-        Curve25519Scalar::from(13u8),
+        TestScalar::from(3u8),
+        TestScalar::from(11u8),
+        TestScalar::from(13u8),
     ];
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(8, &a, &b),
-        Curve25519Scalar::from(123880u32)
+        TestScalar::from(123880u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(7, &a, &b),
-        Curve25519Scalar::from(93850u32)
+        TestScalar::from(93850u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(6, &a, &b),
-        Curve25519Scalar::from(83840u32)
+        TestScalar::from(83840u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(5, &a, &b),
-        Curve25519Scalar::from(62000u32)
+        TestScalar::from(62000u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(4, &a, &b),
-        Curve25519Scalar::from(54720u32)
+        TestScalar::from(54720u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(3, &a, &b),
-        Curve25519Scalar::from(30960u32)
+        TestScalar::from(30960u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(2, &a, &b),
-        Curve25519Scalar::from(23040u32)
+        TestScalar::from(23040u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(1, &a, &b),
-        Curve25519Scalar::from(5760u32)
+        TestScalar::from(5760u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(0, &a, &b),
-        Curve25519Scalar::from(0u32)
+        TestScalar::from(0u32)
     );
 }
 
@@ -251,50 +251,50 @@ fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_3_va
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_3_variables_using_dalek_scalar(
 ) {
     let a = vec![
-        Curve25519Scalar::from(2u8),
-        Curve25519Scalar::from(5u8),
-        Curve25519Scalar::from(7u8),
+        TestScalar::from(2u8),
+        TestScalar::from(5u8),
+        TestScalar::from(7u8),
     ];
     let b = vec![
-        Curve25519Scalar::from(3u8),
-        Curve25519Scalar::from(11u8),
-        Curve25519Scalar::from(13u8),
+        TestScalar::from(3u8),
+        TestScalar::from(11u8),
+        TestScalar::from(13u8),
     ];
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(8, &a, &b),
-        Curve25519Scalar::from(123880u32)
+        TestScalar::from(123880u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(7, &a, &b),
-        Curve25519Scalar::from(93850u32)
+        TestScalar::from(93850u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(6, &a, &b),
-        Curve25519Scalar::from(83840u32)
+        TestScalar::from(83840u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(5, &a, &b),
-        Curve25519Scalar::from(62000u32)
+        TestScalar::from(62000u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(4, &a, &b),
-        Curve25519Scalar::from(54720u32)
+        TestScalar::from(54720u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(3, &a, &b),
-        Curve25519Scalar::from(30960u32)
+        TestScalar::from(30960u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(2, &a, &b),
-        Curve25519Scalar::from(23040u32)
+        TestScalar::from(23040u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(1, &a, &b),
-        Curve25519Scalar::from(5760u32)
+        TestScalar::from(5760u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(0, &a, &b),
-        Curve25519Scalar::from(0u32)
+        TestScalar::from(0u32)
     );
 }
 
@@ -351,10 +351,10 @@ fn compute_truncated_lagrange_basis_sum_matches_sum_of_result_from_compute_evalu
     for _ in 0..20 {
         let variables = dist.sample(&mut rng);
         let length = Uniform::new((1 << (variables - 1)) + 1, 1 << variables).sample(&mut rng);
-        let point: Vec<_> = iter::repeat_with(|| Curve25519Scalar::rand(&mut rng))
+        let point: Vec<_> = iter::repeat_with(|| TestScalar::rand(&mut rng))
             .take(variables)
             .collect();
-        let mut eval_vec = vec![Curve25519Scalar::zero(); length];
+        let mut eval_vec = vec![TestScalar::zero(); length];
         compute_evaluation_vector(&mut eval_vec, &point);
         // ---------------- This is the actual test --------------------
         assert_eq!(
@@ -379,14 +379,14 @@ fn compute_truncated_lagrange_basis_inner_product_matches_inner_product_of_resul
     for _ in 0..20 {
         let variables = dist.sample(&mut rng);
         let length = Uniform::new((1 << (variables - 1)) + 1, 1 << variables).sample(&mut rng);
-        let a: Vec<_> = iter::repeat_with(|| Curve25519Scalar::rand(&mut rng))
+        let a: Vec<_> = iter::repeat_with(|| TestScalar::rand(&mut rng))
             .take(variables)
             .collect();
-        let b: Vec<_> = iter::repeat_with(|| Curve25519Scalar::rand(&mut rng))
+        let b: Vec<_> = iter::repeat_with(|| TestScalar::rand(&mut rng))
             .take(variables)
             .collect();
-        let mut eval_vec_a = vec![Curve25519Scalar::zero(); length];
-        let mut eval_vec_b = vec![Curve25519Scalar::zero(); length];
+        let mut eval_vec_a = vec![TestScalar::zero(); length];
+        let mut eval_vec_b = vec![TestScalar::zero(); length];
         compute_evaluation_vector(&mut eval_vec_a, &a);
         compute_evaluation_vector(&mut eval_vec_b, &b);
         // ---------------- This is the actual test --------------------

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,10 +1,10 @@
 use super::MultilinearExtension;
-use crate::base::{database::Column, scalar::Curve25519Scalar};
+use crate::base::{database::Column, scalar::test_scalar::TestScalar};
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_i64_slice() {
     let slice: &[i64] = &[2, 3, 4, 5, 6];
-    let evaluation_vec: Vec<Curve25519Scalar> =
+    let evaluation_vec: Vec<TestScalar> =
         vec![101.into(), 102.into(), 103.into(), 104.into(), 105.into()];
     assert_eq!(
         slice.inner_product(&evaluation_vec),
@@ -17,7 +17,7 @@ fn we_can_use_multilinear_extension_methods_for_i64_slice() {
         vec![121.into(), 132.into(), 143.into(), 154.into(), 165.into()]
     );
     assert_eq!(
-        *MultilinearExtension::<Curve25519Scalar>::to_sumcheck_term(&slice, 3),
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&slice, 3),
         vec![
             2.into(),
             3.into(),
@@ -30,15 +30,15 @@ fn we_can_use_multilinear_extension_methods_for_i64_slice() {
         ]
     );
     assert_ne!(
-        MultilinearExtension::<Curve25519Scalar>::id(&slice),
-        MultilinearExtension::<Curve25519Scalar>::id(&&evaluation_vec)
+        MultilinearExtension::<TestScalar>::id(&slice),
+        MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
 }
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_column() {
     let slice = Column::BigInt(&[2, 3, 4, 5, 6]);
-    let evaluation_vec: Vec<Curve25519Scalar> =
+    let evaluation_vec: Vec<TestScalar> =
         vec![101.into(), 102.into(), 103.into(), 104.into(), 105.into()];
     assert_eq!(
         slice.inner_product(&evaluation_vec),
@@ -51,7 +51,7 @@ fn we_can_use_multilinear_extension_methods_for_column() {
         vec![121.into(), 132.into(), 143.into(), 154.into(), 165.into()]
     );
     assert_eq!(
-        *MultilinearExtension::<Curve25519Scalar>::to_sumcheck_term(&slice, 3),
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&slice, 3),
         vec![
             2.into(),
             3.into(),
@@ -64,15 +64,15 @@ fn we_can_use_multilinear_extension_methods_for_column() {
         ]
     );
     assert_ne!(
-        MultilinearExtension::<Curve25519Scalar>::id(&slice),
-        MultilinearExtension::<Curve25519Scalar>::id(&&evaluation_vec)
+        MultilinearExtension::<TestScalar>::id(&slice),
+        MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
 }
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_i64_vec() {
     let slice: &Vec<i64> = &vec![2, 3, 4, 5, 6];
-    let evaluation_vec: Vec<Curve25519Scalar> =
+    let evaluation_vec: Vec<TestScalar> =
         vec![101.into(), 102.into(), 103.into(), 104.into(), 105.into()];
     assert_eq!(
         slice.inner_product(&evaluation_vec),
@@ -85,7 +85,7 @@ fn we_can_use_multilinear_extension_methods_for_i64_vec() {
         vec![121.into(), 132.into(), 143.into(), 154.into(), 165.into()]
     );
     assert_eq!(
-        *MultilinearExtension::<Curve25519Scalar>::to_sumcheck_term(&slice, 3),
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&slice, 3),
         vec![
             2.into(),
             3.into(),
@@ -98,7 +98,7 @@ fn we_can_use_multilinear_extension_methods_for_i64_vec() {
         ]
     );
     assert_ne!(
-        MultilinearExtension::<Curve25519Scalar>::id(&slice),
-        MultilinearExtension::<Curve25519Scalar>::id(&&evaluation_vec)
+        MultilinearExtension::<TestScalar>::id(&slice),
+        MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
 }

--- a/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
@@ -1,5 +1,5 @@
 use super::{transcript_core::TranscriptCore, Keccak256Transcript as T, Transcript};
-use crate::base::scalar::Curve25519Scalar as S;
+use crate::base::scalar::test_scalar::TestScalar as S;
 use zerocopy::AsBytes;
 #[test]
 fn we_can_add_values_to_the_transcript_in_big_endian_form() {

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
@@ -1,6 +1,6 @@
 use crate::base::{
     map::IndexSet,
-    scalar::{Curve25519Scalar, Scalar},
+    scalar::{test_scalar::TestScalar, Scalar},
 };
 use alloc::{format, string::ToString, vec::Vec};
 use byte_slice_cast::AsByteSlice;
@@ -15,43 +15,40 @@ use rand_core::SeedableRng;
 
 #[test]
 fn the_zero_integer_maps_to_the_zero_scalar() {
-    assert_eq!(Curve25519Scalar::from(0_u32), Curve25519Scalar::zero());
-    assert_eq!(Curve25519Scalar::from(0_u64), Curve25519Scalar::zero());
-    assert_eq!(Curve25519Scalar::from(0_u128), Curve25519Scalar::zero());
-    assert_eq!(Curve25519Scalar::from(0_i32), Curve25519Scalar::zero());
-    assert_eq!(Curve25519Scalar::from(0_i64), Curve25519Scalar::zero());
-    assert_eq!(Curve25519Scalar::from(0_i128), Curve25519Scalar::zero());
+    assert_eq!(TestScalar::from(0_u32), TestScalar::zero());
+    assert_eq!(TestScalar::from(0_u64), TestScalar::zero());
+    assert_eq!(TestScalar::from(0_u128), TestScalar::zero());
+    assert_eq!(TestScalar::from(0_i32), TestScalar::zero());
+    assert_eq!(TestScalar::from(0_i64), TestScalar::zero());
+    assert_eq!(TestScalar::from(0_i128), TestScalar::zero());
 }
 
 #[test]
 fn bools_map_to_curve25519_scalar_properly() {
-    assert_eq!(Curve25519Scalar::from(true), Curve25519Scalar::one());
-    assert_eq!(Curve25519Scalar::from(false), Curve25519Scalar::zero());
+    assert_eq!(TestScalar::from(true), TestScalar::one());
+    assert_eq!(TestScalar::from(false), TestScalar::zero());
 }
 
 #[test]
 fn the_one_integer_maps_to_the_zero_scalar() {
-    assert_eq!(Curve25519Scalar::from(1_u32), Curve25519Scalar::one());
-    assert_eq!(Curve25519Scalar::from(1_u64), Curve25519Scalar::one());
-    assert_eq!(Curve25519Scalar::from(1_u128), Curve25519Scalar::one());
-    assert_eq!(Curve25519Scalar::from(1_i32), Curve25519Scalar::one());
-    assert_eq!(Curve25519Scalar::from(1_i64), Curve25519Scalar::one());
-    assert_eq!(Curve25519Scalar::from(1_i128), Curve25519Scalar::one());
+    assert_eq!(TestScalar::from(1_u32), TestScalar::one());
+    assert_eq!(TestScalar::from(1_u64), TestScalar::one());
+    assert_eq!(TestScalar::from(1_u128), TestScalar::one());
+    assert_eq!(TestScalar::from(1_i32), TestScalar::one());
+    assert_eq!(TestScalar::from(1_i64), TestScalar::one());
+    assert_eq!(TestScalar::from(1_i128), TestScalar::one());
 }
 
 #[test]
 fn the_zero_scalar_is_the_additive_identity() {
     let mut rng = StdRng::seed_from_u64(0u64);
     for _ in 0..1000 {
-        let a = Curve25519Scalar::from(rng.gen::<i128>());
-        let b = Curve25519Scalar::from(rng.gen::<i128>());
+        let a = TestScalar::from(rng.gen::<i128>());
+        let b = TestScalar::from(rng.gen::<i128>());
         assert_eq!(a + b, b + a);
-        assert_eq!(a + Curve25519Scalar::zero(), a);
-        assert_eq!(b + Curve25519Scalar::zero(), b);
-        assert_eq!(
-            Curve25519Scalar::zero() + Curve25519Scalar::zero(),
-            Curve25519Scalar::zero()
-        );
+        assert_eq!(a + TestScalar::zero(), a);
+        assert_eq!(b + TestScalar::zero(), b);
+        assert_eq!(TestScalar::zero() + TestScalar::zero(), TestScalar::zero());
     }
 }
 
@@ -59,24 +56,21 @@ fn the_zero_scalar_is_the_additive_identity() {
 fn the_one_scalar_is_the_multiplicative_identity() {
     let mut rng = StdRng::seed_from_u64(0u64);
     for _ in 0..1000 {
-        let a = Curve25519Scalar::from(rng.gen::<i128>());
-        let b = Curve25519Scalar::from(rng.gen::<i128>());
+        let a = TestScalar::from(rng.gen::<i128>());
+        let b = TestScalar::from(rng.gen::<i128>());
         assert_eq!(a * b, b * a);
-        assert_eq!(a * Curve25519Scalar::one(), a);
-        assert_eq!(b * Curve25519Scalar::one(), b);
-        assert_eq!(
-            Curve25519Scalar::one() * Curve25519Scalar::one(),
-            Curve25519Scalar::one()
-        );
+        assert_eq!(a * TestScalar::one(), a);
+        assert_eq!(b * TestScalar::one(), b);
+        assert_eq!(TestScalar::one() * TestScalar::one(), TestScalar::one());
     }
 }
 
 #[test]
 fn scalar_comparison_works() {
-    let zero = Curve25519Scalar::ZERO;
-    let one = Curve25519Scalar::ONE;
-    let two = Curve25519Scalar::TWO;
-    let max = Curve25519Scalar::MAX_SIGNED;
+    let zero = TestScalar::ZERO;
+    let one = TestScalar::ONE;
+    let two = TestScalar::TWO;
+    let max = TestScalar::MAX_SIGNED;
     let min = max + one;
     assert_eq!(max.signed_cmp(&one), Ordering::Greater);
     assert_eq!(one.signed_cmp(&zero), Ordering::Greater);
@@ -87,36 +81,30 @@ fn scalar_comparison_works() {
 
 #[test]
 fn the_empty_string_will_be_mapped_to_the_zero_scalar() {
-    assert_eq!(Curve25519Scalar::from(""), Curve25519Scalar::zero());
-    assert_eq!(
-        Curve25519Scalar::from(<&str>::default()),
-        Curve25519Scalar::zero()
-    );
+    assert_eq!(TestScalar::from(""), TestScalar::zero());
+    assert_eq!(TestScalar::from(<&str>::default()), TestScalar::zero());
 }
 
 #[test]
 fn two_different_strings_map_to_different_scalars() {
     let s = "abc12";
-    assert_ne!(Curve25519Scalar::from(s), Curve25519Scalar::zero());
-    assert_ne!(Curve25519Scalar::from(s), Curve25519Scalar::from("abc123"));
+    assert_ne!(TestScalar::from(s), TestScalar::zero());
+    assert_ne!(TestScalar::from(s), TestScalar::from("abc123"));
 }
 
 #[test]
 fn the_empty_buffer_will_be_mapped_to_the_zero_scalar() {
     let buf = Vec::<u8>::default();
-    assert_eq!(Curve25519Scalar::from(&buf[..]), Curve25519Scalar::zero());
+    assert_eq!(TestScalar::from(&buf[..]), TestScalar::zero());
 }
 
 #[test]
 fn byte_arrays_with_the_same_content_but_different_types_map_to_different_scalars() {
     let array = [1_u8, 2_u8, 34_u8];
+    assert_ne!(TestScalar::from(array.as_byte_slice()), TestScalar::zero());
     assert_ne!(
-        Curve25519Scalar::from(array.as_byte_slice()),
-        Curve25519Scalar::zero()
-    );
-    assert_ne!(
-        Curve25519Scalar::from(array.as_byte_slice()),
-        Curve25519Scalar::from([1_u32, 2_u32, 34_u32].as_byte_slice())
+        TestScalar::from(array.as_byte_slice()),
+        TestScalar::from([1_u32, 2_u32, 34_u32].as_byte_slice())
     );
 }
 
@@ -133,7 +121,7 @@ fn strings_of_arbitrary_size_map_to_different_scalars() {
             i,
             "testing string to scalar".repeat(dist.sample(&mut rng))
         );
-        assert!(prev_scalars.insert(Curve25519Scalar::from(s.as_str())));
+        assert!(prev_scalars.insert(TestScalar::from(s.as_str())));
     }
 }
 
@@ -147,7 +135,7 @@ fn byte_arrays_of_arbitrary_size_map_to_different_scalars() {
         let v = (0..dist.sample(&mut rng))
             .map(|_v| (dist.sample(&mut rng) % 255) as u8)
             .collect::<Vec<u8>>();
-        assert!(prev_scalars.insert(Curve25519Scalar::from(&v[..])));
+        assert!(prev_scalars.insert(TestScalar::from(&v[..])));
     }
 }
 
@@ -162,7 +150,7 @@ fn the_string_hash_implementation_uses_the_full_range_of_bits() {
         let mut bset = IndexSet::default();
 
         loop {
-            let s: Curve25519Scalar = dist.sample(&mut rng).to_string().as_str().into();
+            let s: TestScalar = dist.sample(&mut rng).to_string().as_str().into();
             let bytes = s.to_bytes_le(); //Note: this is the only spot that these tests are different from the to_curve25519_scalar tests.
 
             let is_ith_bit_set = bytes[i / 8] & (1 << (i % 8)) != 0;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -19,13 +19,14 @@ fn test_dalek_interop_m1() {
     assert_eq!(mxp, Curve25519Scalar::from(-123i64));
     assert_eq!(curve25519_dalek::scalar::Scalar::from(mxp), mx);
 }
+use crate::base::scalar::test_scalar::TestScalar;
 
 #[test]
 fn test_add() {
-    let one = Curve25519Scalar::from(1u64);
-    let two = Curve25519Scalar::from(2u64);
+    let one = TestScalar::from(1u64);
+    let two = TestScalar::from(2u64);
     let sum = one + two;
-    let expected_sum = Curve25519Scalar::from(3u64);
+    let expected_sum = TestScalar::from(3u64);
     assert_eq!(sum, expected_sum);
 }
 
@@ -34,9 +35,9 @@ fn test_mod() {
     let pm1: ark_ff::BigInt<4> = ark_ff::BigInt!(
         "7237005577332262213973186563042994240857116359379907606001950938285454250988"
     );
-    let x = Curve25519Scalar::from(pm1.0);
-    let one = Curve25519Scalar::from(1u64);
-    let zero = Curve25519Scalar::from(0u64);
+    let x = TestScalar::from(pm1.0);
+    let one = TestScalar::from(1u64);
+    let zero = TestScalar::from(0u64);
     let xp1 = x + one;
     assert_eq!(xp1, zero);
 }

--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
@@ -1,9 +1,9 @@
-use crate::base::{scalar::Curve25519Scalar, slice_ops};
+use crate::base::{scalar::test_scalar::TestScalar, slice_ops};
 use num_traits::{Inv, Zero};
 
 #[test]
 fn we_can_pseudo_invert_empty_arrays() {
-    let input: Vec<Curve25519Scalar> = Vec::new();
+    let input: Vec<TestScalar> = Vec::new();
     let mut res = Vec::new();
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
@@ -12,8 +12,8 @@ fn we_can_pseudo_invert_empty_arrays() {
 
 #[test]
 fn we_can_pseudo_invert_arrays_of_length_1_with_non_zero() {
-    let input = [Curve25519Scalar::from(2_u32)];
-    let mut res = vec![Curve25519Scalar::from(0_u32)];
+    let input = [TestScalar::from(2_u32)];
+    let mut res = vec![TestScalar::from(0_u32)];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
@@ -23,8 +23,8 @@ fn we_can_pseudo_invert_arrays_of_length_1_with_non_zero() {
 
 #[test]
 fn we_can_pseudo_invert_arrays_of_length_1_with_zero() {
-    let input = [Curve25519Scalar::from(0_u32)];
-    let mut res = vec![Curve25519Scalar::from(0_u32)];
+    let input = [TestScalar::from(0_u32)];
+    let mut res = vec![TestScalar::from(0_u32)];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
@@ -34,24 +34,24 @@ fn we_can_pseudo_invert_arrays_of_length_1_with_zero() {
 #[test]
 fn we_can_pseudo_invert_arrays_of_length_bigger_than_1_with_zeros_and_non_zeros() {
     let input = vec![
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(2_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(2_u32),
         (-33_i32).into(),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(45_u32),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(47_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(45_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(47_u32),
     ];
-    let mut res = vec![Curve25519Scalar::from(0_u32); input.len()];
+    let mut res = vec![TestScalar::from(0_u32); input.len()];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
 
     for (input_val, res_val) in input.iter().zip(res) {
-        if *input_val != Curve25519Scalar::zero() {
+        if *input_val != TestScalar::zero() {
             assert!(input_val.inv().unwrap() == res_val);
         } else {
-            assert!(Curve25519Scalar::zero() == res_val);
+            assert!(TestScalar::zero() == res_val);
         }
     }
 }
@@ -60,29 +60,29 @@ fn we_can_pseudo_invert_arrays_of_length_bigger_than_1_with_zeros_and_non_zeros(
 fn we_can_pseudo_invert_arrays_with_nonzero_count_bigger_than_min_chunking_size_with_zeros_and_non_zeros(
 ) {
     let input: Vec<_> = vec![
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(2_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(2_u32),
         (-33_i32).into(),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(45_u32),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(47_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(45_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(47_u32),
     ]
     .into_iter()
     .cycle()
     .take(slice_ops::MIN_RAYON_LEN * 10)
     .collect();
 
-    let mut res = vec![Curve25519Scalar::from(0_u32); input.len()];
+    let mut res = vec![TestScalar::from(0_u32); input.len()];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
 
     for (input_val, res_val) in input.iter().zip(res) {
-        if *input_val != Curve25519Scalar::zero() {
+        if *input_val != TestScalar::zero() {
             assert!(input_val.inv().unwrap() == res_val);
         } else {
-            assert!(Curve25519Scalar::zero() == res_val);
+            assert!(TestScalar::zero() == res_val);
         }
     }
 }
@@ -91,29 +91,29 @@ fn we_can_pseudo_invert_arrays_with_nonzero_count_bigger_than_min_chunking_size_
 fn we_can_pseudo_invert_arrays_with_nonzero_count_smaller_than_min_chunking_size_with_zeros_and_non_zeros(
 ) {
     let input: Vec<_> = vec![
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(2_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(2_u32),
         (-33_i32).into(),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(45_u32),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(47_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(45_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(47_u32),
     ]
     .into_iter()
     .cycle()
     .take(slice_ops::MIN_RAYON_LEN - 1)
     .collect();
 
-    let mut res = vec![Curve25519Scalar::from(0_u32); input.len()];
+    let mut res = vec![TestScalar::from(0_u32); input.len()];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
 
     for (input_val, res_val) in input.iter().zip(res) {
-        if *input_val != Curve25519Scalar::zero() {
+        if *input_val != TestScalar::zero() {
             assert!(input_val.inv().unwrap() == res_val);
         } else {
-            assert!(Curve25519Scalar::zero() == res_val);
+            assert!(TestScalar::zero() == res_val);
         }
     }
 }

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::test_scalar::TestScalar;
 
 #[test]
 fn test_inner_product() {
@@ -19,39 +19,39 @@ fn test_inner_product_different_lengths() {
 /// test inner producr with scalar
 #[test]
 fn test_inner_product_scalar() {
-    let a = vec![Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
-    let b = vec![Curve25519Scalar::from(2u64), Curve25519Scalar::from(3u64)];
-    assert_eq!(Curve25519Scalar::from(8u64), inner_product(&a, &b));
+    let a = vec![TestScalar::from(1u64), TestScalar::from(2u64)];
+    let b = vec![TestScalar::from(2u64), TestScalar::from(3u64)];
+    assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
 
 /// test uneven inner product with scalars
 #[test]
 fn test_inner_product_scalar_uneven() {
-    let a = vec![Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
+    let a = vec![TestScalar::from(1u64), TestScalar::from(2u64)];
     let b = vec![
-        Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(4u64),
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
+        TestScalar::from(4u64),
     ];
-    assert_eq!(Curve25519Scalar::from(8u64), inner_product(&a, &b));
+    assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
 
-/// test inner product with curve25519scalar
+/// test inner product with TestScalar
 #[test]
-fn test_inner_product_curve25519scalar() {
-    let a = vec![Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
-    let b = vec![Curve25519Scalar::from(2u64), Curve25519Scalar::from(3u64)];
-    assert_eq!(Curve25519Scalar::from(8u64), inner_product(&a, &b));
+fn test_inner_product_testscalar() {
+    let a = vec![TestScalar::from(1u64), TestScalar::from(2u64)];
+    let b = vec![TestScalar::from(2u64), TestScalar::from(3u64)];
+    assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
 
-/// test uneven inner product with curve25519scalars
+/// test uneven inner product with TestScalars
 #[test]
-fn test_inner_product_curve25519scalar_uneven() {
-    let a = vec![Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
+fn test_inner_product_testscalar_uneven() {
+    let a = vec![TestScalar::from(1u64), TestScalar::from(2u64)];
     let b = vec![
-        Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(4u64),
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
+        TestScalar::from(4u64),
     ];
-    assert_eq!(Curve25519Scalar::from(8u64), inner_product(&a, &b));
+    assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }

--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::test_scalar::TestScalar;
 
 #[test]
 fn test_mul_add_assign() {
@@ -29,33 +29,33 @@ fn test_mul_add_assign_uneven_panic() {
     mul_add_assign(&mut a, 10, &b);
 }
 
-/// test mul_add_assign with curve25519scalar
+/// test mul_add_assign with TestScalar
 #[test]
-fn test_mul_add_assign_curve25519scalar() {
-    let mut a = vec![Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
-    let b = vec![Curve25519Scalar::from(2u64), Curve25519Scalar::from(3u64)];
-    mul_add_assign(&mut a, Curve25519Scalar::from(10u64), &b);
+fn test_mul_add_assign_testscalar() {
+    let mut a = vec![TestScalar::from(1u64), TestScalar::from(2u64)];
+    let b = vec![TestScalar::from(2u64), TestScalar::from(3u64)];
+    mul_add_assign(&mut a, TestScalar::from(10u64), &b);
     let c = vec![
-        Curve25519Scalar::from(1u64) + Curve25519Scalar::from(10u64) * Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(2u64) + Curve25519Scalar::from(10u64) * Curve25519Scalar::from(3u64),
+        TestScalar::from(1u64) + TestScalar::from(10u64) * TestScalar::from(2u64),
+        TestScalar::from(2u64) + TestScalar::from(10u64) * TestScalar::from(3u64),
     ];
     assert_eq!(a, c);
 }
 
-/// test mul_add_assign with uneven curve25519scalars
+/// test mul_add_assign with uneven TestScalars
 #[test]
-fn test_mul_add_assign_curve25519scalar_uneven() {
+fn test_mul_add_assign_testscalar_uneven() {
     let mut a = vec![
-        Curve25519Scalar::from(1u64),
-        Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(3u64),
+        TestScalar::from(1u64),
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
     ];
-    let b = vec![Curve25519Scalar::from(2u64), Curve25519Scalar::from(3u64)];
-    mul_add_assign(&mut a, Curve25519Scalar::from(10u64), &b);
+    let b = vec![TestScalar::from(2u64), TestScalar::from(3u64)];
+    mul_add_assign(&mut a, TestScalar::from(10u64), &b);
     let c = vec![
-        Curve25519Scalar::from(1u64) + Curve25519Scalar::from(10u64) * Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(2u64) + Curve25519Scalar::from(10u64) * Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(3u64),
+        TestScalar::from(1u64) + TestScalar::from(10u64) * TestScalar::from(2u64),
+        TestScalar::from(2u64) + TestScalar::from(10u64) * TestScalar::from(3u64),
+        TestScalar::from(3u64),
     ];
     assert_eq!(a, c);
 }

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::{test_scalar::TestScalar, Curve25519Scalar};
 use curve25519_dalek::scalar::Scalar;
 
 #[test]
@@ -39,25 +39,25 @@ fn test_slice_cast_with_random() {
     assert_eq!(a, b);
 }
 
-/// random test casting from integer to curve25519scalar
+/// random test casting from integer to TestScalar
 #[test]
 fn test_slice_cast_with_random_from_integer_to_curve25519scalar() {
     use rand::Rng;
     let mut rng = rand::thread_rng();
     let a: Vec<u32> = (0..100).map(|_| rng.gen()).collect();
-    let b: Vec<Curve25519Scalar> = a.iter().map(|&x| Curve25519Scalar::from(x)).collect();
-    let a: Vec<Curve25519Scalar> = slice_cast_with(&a, |&x| Curve25519Scalar::from(x));
+    let b: Vec<TestScalar> = a.iter().map(|&x| TestScalar::from(x)).collect();
+    let a: Vec<TestScalar> = slice_cast_with(&a, |&x| TestScalar::from(x));
     assert_eq!(a, b);
 }
 
-/// random test auto casting from integer to curve25519scalar
+/// random test auto casting from integer to TestScalar
 #[test]
 fn test_slice_cast_random_from_integer_to_curve25519scalar() {
     use rand::Rng;
     let mut rng = rand::thread_rng();
     let a: Vec<u32> = (0..100).map(|_| rng.gen()).collect();
-    let b: Vec<Curve25519Scalar> = a.iter().map(|&x| Curve25519Scalar::from(x)).collect();
-    let a: Vec<Curve25519Scalar> = slice_cast(&a);
+    let b: Vec<TestScalar> = a.iter().map(|&x| TestScalar::from(x)).collect();
+    let a: Vec<TestScalar> = slice_cast(&a);
     assert_eq!(a, b);
 }
 
@@ -87,7 +87,7 @@ fn test_slice_cast_mut_random() {
     use rand::Rng;
     let mut rng = rand::thread_rng();
     let a: Vec<u32> = (0..100).map(|_| rng.gen()).collect();
-    let mut b: Vec<Curve25519Scalar> = vec![Curve25519Scalar::default(); 100];
+    let mut b: Vec<TestScalar> = vec![TestScalar::default(); 100];
     slice_cast_mut(&a, &mut b);
     assert_eq!(b, slice_cast(&a));
 }


### PR DESCRIPTION
# Rationale for this change

The types InnerProductProof, RistrettoPoint, and Curve25519Scalar are used in many tests within the base directory. We want to use our test types TestEvaluationProof, NaiveCommitment, and TestScalar instead.

# What changes are included in this PR?

The InnerProduct types are replaced within tests that are held within the base directory.

# Are these changes tested?

This PR refactors many tests.
