### PR TITLE
feat!: Initial Support for `FixedSizeBinary`

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -32,6 +32,7 @@ impl From<&ColumnType> for DataType {
                 };
                 DataType::Timestamp(arrow_timeunit, arrow_timezone)
             }
+            ColumnType::FixedSizeBinary(bw) => DataType::FixedSizeBinary(bw.width()),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -22,9 +22,9 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, StringArray, TimestampMicrosecondArray, TimestampMillisecondArray,
-        TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Int16Array,
+        Int32Array, Int64Array, Int8Array, StringArray, TimestampMicrosecondArray,
+        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
     error::ArrowError,
@@ -111,6 +111,9 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
                 PoSQLTimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(col)),
                 PoSQLTimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::from(col)),
             },
+            OwnedColumn::FixedSizeBinary(bw, col) => {
+                Arc::new(FixedSizeBinaryArray::new(bw.width(), col.into(), None))
+            }
         }
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -238,7 +238,8 @@ impl ColumnBounds {
             CommittableColumn::Boolean(_)
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
-            | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
+            | CommittableColumn::VarChar(_)
+            | CommittableColumn::FixedSizeBinary(_, _) => ColumnBounds::NoOrder,
         }
     }
 

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -153,6 +153,10 @@ impl Commitment for NaiveCommitment {
                     CommittableColumn::TimestampTZ(_, _, i64_vec) => {
                         i64_vec.iter().map(core::convert::Into::into).collect()
                     }
+                    CommittableColumn::FixedSizeBinary(bw, bytes) => bytes
+                        .chunks(bw.width_as_usize())
+                        .map(TestScalar::from)
+                        .collect(),
                 };
                 vectors.append(&mut existing_scalars);
                 NaiveCommitment(vectors)

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -1,5 +1,9 @@
-use super::{slice_operation::apply_slice_to_indexes, Column, ColumnOperationResult, ColumnType};
+use super::{
+    slice_operation::apply_slice_to_indexes, Column, ColumnOperationError, ColumnOperationResult,
+    ColumnType,
+};
 use crate::base::scalar::Scalar;
+use alloc::vec::Vec;
 use bumpalo::Bump;
 
 /// Apply a `Column` to a vector of indexes, returning a new `Column` with the
@@ -7,7 +11,7 @@ use bumpalo::Bump;
 ///
 /// # Panics
 /// Panics if any of the indexes are out of bounds.
-#[allow(dead_code)]
+#[allow(clippy::too_many_lines)]
 pub(crate) fn apply_column_to_indexes<'a, S>(
     column: &Column<'a, S>,
     alloc: &'a Bump,
@@ -104,13 +108,40 @@ where
                 alloc.alloc_slice_copy(&raw_values) as &[_],
             ))
         }
+        ColumnType::FixedSizeBinary(width) => {
+            let col = column
+                .as_fixed_size_binary()
+                .expect("Column types should match")
+                .1;
+
+            let bw = width.width_as_usize();
+            let num_rows = col.len() / bw;
+            let mut new_bytes = Vec::with_capacity(indexes.len() * bw);
+
+            for &i in indexes {
+                if i >= num_rows {
+                    return Err(ColumnOperationError::IndexOutOfBounds {
+                        index: i,
+                        len: num_rows,
+                    });
+                }
+                let start = i * bw;
+                let end = start + bw;
+                new_bytes.extend_from_slice(&col[start..end]);
+            }
+            let allocated = alloc.alloc_slice_copy(&new_bytes);
+            Ok(Column::FixedSizeBinary(width, allocated))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::ColumnOperationError, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        database::ColumnOperationError, math::non_negative_i32::NonNegativeI32,
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn test_apply_index_op() {
@@ -148,6 +179,109 @@ mod tests {
         let bump = Bump::new();
         let column: Column<TestScalar> = Column::Int(&[1, 2, 3, 4, 5]);
         let indexes = [1, 3, 1, 2, 5];
+        let result = apply_column_to_indexes(&column, &bump, &indexes);
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::IndexOutOfBounds { .. })
+        ));
+    }
+
+    #[test]
+    fn test_apply_index_op_fixed_size_binary_min_max() {
+        let bump = Bump::new();
+
+        let row0 = i32::MIN.to_le_bytes();
+        let row1 = 123_i32.to_le_bytes();
+        let row2 = i32::MAX.to_le_bytes();
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&row0);
+        bytes.extend_from_slice(&row1);
+        bytes.extend_from_slice(&row2);
+
+        let width = NonNegativeI32::new(4).unwrap();
+        let column: Column<TestScalar> = Column::FixedSizeBinary(width, &bytes);
+
+        let indexes = [0, 2, 1];
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+
+        let mut expected_bytes = Vec::new();
+        expected_bytes.extend_from_slice(&row0);
+        expected_bytes.extend_from_slice(&row2);
+        expected_bytes.extend_from_slice(&row1);
+        let expected = Column::FixedSizeBinary(width, &expected_bytes);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_apply_index_op_fixed_size_binary_out_of_bounds_min_max() {
+        let bump = Bump::new();
+
+        let row0 = i32::MIN.to_le_bytes();
+        let row1 = i32::MAX.to_le_bytes();
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&row0);
+        bytes.extend_from_slice(&row1);
+
+        let width = NonNegativeI32::new(4).unwrap();
+        let column: Column<TestScalar> = Column::FixedSizeBinary(width, &bytes);
+
+        let indexes = [0, 2];
+        let result = apply_column_to_indexes(&column, &bump, &indexes);
+
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::IndexOutOfBounds { index: 2, len: 2 })
+        ));
+    }
+
+    #[test]
+    fn test_apply_index_op_fixed_size_binary() {
+        let bump = Bump::new();
+
+        let bytes: &[u8] = &[
+            1, 0, 0, 0, // row0 => i32 = 1
+            2, 0, 0, 0, // row1 => i32 = 2
+            3, 0, 0, 0, // row2 => i32 = 3
+            4, 0, 0, 0, // row3 => i32 = 4
+            5, 0, 0, 0, // row4 => i32 = 5
+        ];
+
+        let width = NonNegativeI32::new(4).unwrap();
+        let column: Column<TestScalar> = Column::FixedSizeBinary(width, bytes);
+
+        // We want to select row1, row3, row0 => indexes = [1, 3, 0]
+        // That should produce a new column with bytes for rows 1,3,0 in that order.
+        // row1 => [2, 0, 0, 0]
+        // row3 => [4, 0, 0, 0]
+        // row0 => [1, 0, 0, 0]
+        let indexes = [1, 3, 0];
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+
+        let expected_bytes: &[u8] = &[
+            2, 0, 0, 0, // from row1
+            4, 0, 0, 0, // from row3
+            1, 0, 0, 0, // from row0
+        ];
+        let expected = Column::FixedSizeBinary(width, expected_bytes);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_apply_index_op_fixed_size_binary_out_of_bounds() {
+        let bump = Bump::new();
+
+        let bytes: &[u8] = &[
+            1, 0, 0, 0, // row0 => i32=1
+            2, 0, 0, 0, // row1 => i32=2
+        ];
+        let width = NonNegativeI32::new(4).unwrap();
+        let column: Column<TestScalar> = Column::FixedSizeBinary(width, bytes);
+
+        // We only have 2 rows -> valid indexes are {0,1} -> index=2 is out-of-bounds
+        let indexes = [1, 2];
         let result = apply_column_to_indexes(&column, &bump, &indexes);
         assert!(matches!(
             result,

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -5,8 +5,7 @@ use super::{
 use crate::base::scalar::Scalar;
 use alloc::vec::Vec;
 use bumpalo::Bump;
-use core::iter;
-use core::iter::Iterator;
+use core::{iter, iter::Iterator};
 
 pub trait RepetitionOp {
     fn op<T: Clone>(column: &[T], n: usize) -> impl Iterator<Item = T>;
@@ -161,7 +160,7 @@ impl RepetitionOp for ElementwiseRepeatOp {
                 .chunks_exact(width)
                 .flat_map(|row| iter::repeat(row).take(n))
                 .flatten()
-                .cloned(),
+                .copied(),
         );
         out
     }

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -5,8 +5,8 @@ use super::{
 use crate::base::scalar::Scalar;
 use alloc::vec::Vec;
 use bumpalo::Bump;
+use core::iter;
 use core::iter::Iterator;
-use std::iter;
 
 pub trait RepetitionOp {
     fn op<T: Clone>(column: &[T], n: usize) -> impl Iterator<Item = T>;

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -3,14 +3,18 @@ use super::{
     Column, ColumnType,
 };
 use crate::base::scalar::Scalar;
+use alloc::vec::Vec;
 use bumpalo::Bump;
 use core::iter::Iterator;
 
-#[allow(dead_code)]
 pub trait RepetitionOp {
     fn op<T: Clone>(column: &[T], n: usize) -> impl Iterator<Item = T>;
 
+    // Special case for fixed-size binary columns.
+    fn op_fixed_size_binary(col_bytes: &[u8], width: usize, n: usize) -> Vec<u8>;
+
     /// Run a column repetition operation on a `Column`.
+    #[allow(clippy::too_many_lines)]
     fn column_op<'a, S>(column: &Column<'a, S>, alloc: &'a Bump, n: usize) -> Column<'a, S>
     where
         S: Scalar,
@@ -111,6 +115,18 @@ pub trait RepetitionOp {
                     }) as &[_],
                 )
             }
+            ColumnType::FixedSizeBinary(width) => {
+                // get the existing bytes
+                let col_bytes = column.as_fixed_size_binary().expect("Column types match").1;
+                let bw = width.width_as_usize();
+
+                // call the new trait method, which is specialized
+                let repeated_bytes = Self::op_fixed_size_binary(col_bytes, bw, n);
+
+                // copy the repeated result into Bump
+                let allocated = alloc.alloc_slice_copy(&repeated_bytes);
+                Column::FixedSizeBinary(width, allocated)
+            }
         }
     }
 }
@@ -120,6 +136,20 @@ impl RepetitionOp for ColumnRepeatOp {
     fn op<T: Clone>(column: &[T], n: usize) -> impl Iterator<Item = T> {
         repeat_slice(column, n)
     }
+
+    fn op_fixed_size_binary(col_bytes: &[u8], width: usize, n: usize) -> Vec<u8> {
+        let num_rows = col_bytes.len() / width;
+        let mut out = Vec::with_capacity(col_bytes.len() * n);
+
+        for _ in 0..n {
+            for row_idx in 0..num_rows {
+                let start = row_idx * width;
+                let end = start + width;
+                out.extend_from_slice(&col_bytes[start..end]);
+            }
+        }
+        out
+    }
 }
 
 pub struct ElementwiseRepeatOp {}
@@ -127,12 +157,27 @@ impl RepetitionOp for ElementwiseRepeatOp {
     fn op<T: Clone>(column: &[T], n: usize) -> impl Iterator<Item = T> {
         repeat_elementwise(column, n)
     }
+
+    fn op_fixed_size_binary(col_bytes: &[u8], width: usize, n: usize) -> Vec<u8> {
+        let num_rows = col_bytes.len() / width;
+        let mut out = Vec::with_capacity(col_bytes.len() * n);
+
+        for row_idx in 0..num_rows {
+            let start = row_idx * width;
+            let end = start + width;
+            let chunk = &col_bytes[start..end];
+            for _ in 0..n {
+                out.extend_from_slice(chunk);
+            }
+        }
+        out
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::{math::non_negative_i32::NonNegativeI32, scalar::test_scalar::TestScalar};
 
     #[test]
     fn test_column_repetition_op() {
@@ -180,5 +225,82 @@ mod tests {
             result,
             Column::VarChar((&doubled_strings, &doubled_scalars))
         );
+    }
+
+    #[test]
+    fn test_column_repetition_op_fixedsizebinary() {
+        let bump = Bump::new();
+
+        // define a 3-row column: row0 => i32=1, row1 => i32=2, row2 => i32=3
+        // in little-endian, each row is 4 bytes
+        let row0 = 1_i32.to_le_bytes();
+        let row1 = 2_i32.to_le_bytes();
+        let row2 = 3_i32.to_le_bytes();
+
+        // concatenate into a single buffer
+        let mut bytes = Vec::with_capacity(3 * 4);
+        bytes.extend_from_slice(&row0);
+        bytes.extend_from_slice(&row1);
+        bytes.extend_from_slice(&row2);
+
+        // construct the column
+        let width = NonNegativeI32::new(4).unwrap();
+        let column: Column<TestScalar> = Column::FixedSizeBinary(width, &bytes);
+
+        // apply ColumnRepeatOp with n=2 => we repeat the entire column in sequence:
+        // result => row0, row1, row2, row0, row1, row2
+        let repeated = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+
+        // build the expected 6-row sequence
+        let mut expected_bytes = Vec::with_capacity(6 * 4);
+        // original 3 rows
+        expected_bytes.extend_from_slice(&row0);
+        expected_bytes.extend_from_slice(&row1);
+        expected_bytes.extend_from_slice(&row2);
+        // repeated again
+        expected_bytes.extend_from_slice(&row0);
+        expected_bytes.extend_from_slice(&row1);
+        expected_bytes.extend_from_slice(&row2);
+
+        let expected = Column::FixedSizeBinary(width, &expected_bytes);
+        assert_eq!(repeated, expected);
+    }
+
+    #[test]
+    fn test_elementwise_repetition_op_fixedsizebinary() {
+        let bump = Bump::new();
+
+        // define 3 rows, each 4 bytes in little-endian i32 format.
+        //   row0 => i32=1
+        //   row1 => i32=2
+        //   row2 => i32=3
+        let row0 = 1_i32.to_le_bytes();
+        let row1 = 2_i32.to_le_bytes();
+        let row2 = 3_i32.to_le_bytes();
+
+        // concatenate into a single buffer of 12 bytes (3 rows × 4 bytes each).
+        let mut bytes = Vec::with_capacity(3 * 4);
+        bytes.extend_from_slice(&row0);
+        bytes.extend_from_slice(&row1);
+        bytes.extend_from_slice(&row2);
+
+        let width = NonNegativeI32::new(4).unwrap();
+        let column: Column<TestScalar> = Column::FixedSizeBinary(width, &bytes);
+
+        // call "ElementwiseRepeatOp" with n=2 => each row duplicated in place
+        // so we expect row0,row0, row1,row1, row2,row2.
+        let repeated = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+
+        // build the expected 6-row buffer (6 × 4 = 24 bytes)
+        let mut expected_bytes = Vec::with_capacity(6 * 4);
+        expected_bytes.extend_from_slice(&row0); // row0 repeated
+        expected_bytes.extend_from_slice(&row0);
+        expected_bytes.extend_from_slice(&row1); // row1 repeated
+        expected_bytes.extend_from_slice(&row1);
+        expected_bytes.extend_from_slice(&row2); // row2 repeated
+        expected_bytes.extend_from_slice(&row2);
+
+        let expected = Column::FixedSizeBinary(width, &expected_bytes);
+        assert_eq!(repeated, expected);
     }
 }

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -78,5 +78,21 @@ pub fn filter_column_by_index<'a, S: Scalar>(
             *tz,
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
         ),
+        Column::FixedSizeBinary(byte_width, col) => {
+            let bw = byte_width.width_as_usize();
+            let required_len = indexes.len() * bw;
+
+            let allocated_bytes = alloc.alloc_slice_fill_default::<u8>(required_len);
+
+            let mut out_pos = 0;
+            for &idx in indexes {
+                let start = idx * bw;
+                let end = start + bw;
+                allocated_bytes[out_pos..(out_pos + bw)].copy_from_slice(&col[start..end]);
+                out_pos += bw;
+            }
+
+            Column::FixedSizeBinary(*byte_width, allocated_bytes)
+        }
     }
 }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -165,7 +165,10 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         }
         Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         // The following should never be reached because the `SUM` function can only be applied to numeric types.
-        Column::VarChar(_) | Column::TimestampTZ(_, _, _) | Column::Boolean(_) => {
+        Column::VarChar(_)
+        | Column::TimestampTZ(_, _, _)
+        | Column::Boolean(_)
+        | Column::FixedSizeBinary(_, _) => {
             unreachable!("SUM can not be applied to non-numeric types")
         }
     }
@@ -202,6 +205,9 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
         Column::VarChar(_) => {
             unreachable!("MAX can not be applied to varchar")
         }
+        Column::FixedSizeBinary(_, _) => {
+            unreachable!("MAX can not be applied to fixed size binary")
+        }
     }
 }
 
@@ -235,6 +241,9 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
         // The following should never be reached because the `MIN` function can't be applied to varchar.
         Column::VarChar(_) => {
             unreachable!("MIN can not be applied to varchar")
+        }
+        Column::FixedSizeBinary(_, _) => {
+            unreachable!("MIN can not be applied to fixed size binary")
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -111,6 +111,10 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                 Column::VarChar((col, scals))
             }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col),
+            OwnedColumn::FixedSizeBinary(bw, col) => {
+                let col: &mut [u8] = self.alloc.alloc_slice_copy(col);
+                Column::FixedSizeBinary(*bw, col)
+            }
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/slice_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_operation.rs
@@ -242,20 +242,17 @@ pub(super) fn repeat_elementwise<S: Clone>(slice: &[S], n: usize) -> impl Iterat
         .flat_map(move |s| core::iter::repeat(s).take(n).cloned())
 }
 
-fn repeat_elementwise_fixed_size_binary(col_bytes: &[u8], width: usize, n: usize) -> Vec<u8> {
-    let num_rows = col_bytes.len() / width;
-    let mut out = Vec::with_capacity(num_rows * width * n);
-
-    // For each row, copy it `n` times before moving on
-    for row_idx in 0..num_rows {
-        let start = row_idx * width;
-        let end = start + width;
-        let chunk = &col_bytes[start..end];
-        for _ in 0..n {
-            out.extend_from_slice(chunk);
-        }
-    }
-    out
+fn repeat_elementwise_fixed_size_binary_no_prealloc(
+    col_bytes: &[u8],
+    width: usize,
+    n: usize,
+) -> Vec<u8> {
+    col_bytes
+        .chunks_exact(width)
+        .flat_map(|row| std::iter::repeat(row).take(n))
+        .flatten() // turns iterator of &[u8] into iterator of &u8
+        .copied() // copies each &u8 into a real u8
+        .collect()
 }
 
 /// Apply a slice to a slice of indexes.

--- a/crates/proof-of-sql/src/base/database/slice_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_operation.rs
@@ -242,6 +242,22 @@ pub(super) fn repeat_elementwise<S: Clone>(slice: &[S], n: usize) -> impl Iterat
         .flat_map(move |s| core::iter::repeat(s).take(n).cloned())
 }
 
+fn repeat_elementwise_fixed_size_binary(col_bytes: &[u8], width: usize, n: usize) -> Vec<u8> {
+    let num_rows = col_bytes.len() / width;
+    let mut out = Vec::with_capacity(num_rows * width * n);
+
+    // For each row, copy it `n` times before moving on
+    for row_idx in 0..num_rows {
+        let start = row_idx * width;
+        let end = start + width;
+        let chunk = &col_bytes[start..end];
+        for _ in 0..n {
+            out.extend_from_slice(chunk);
+        }
+    }
+    out
+}
+
 /// Apply a slice to a slice of indexes.
 ///
 /// e.g. `apply_slice_to_indexes(&[1, 2, 3], &[0, 0, 1, 0]).unwrap()` -> `vec![1, 1, 2, 1]`

--- a/crates/proof-of-sql/src/base/database/slice_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_operation.rs
@@ -249,7 +249,7 @@ fn repeat_elementwise_fixed_size_binary_no_prealloc(
 ) -> Vec<u8> {
     col_bytes
         .chunks_exact(width)
-        .flat_map(|row| std::iter::repeat(row).take(n))
+        .flat_map(|row| core::iter::repeat(row).take(n))
         .flatten() // turns iterator of &[u8] into iterator of &u8
         .copied() // copies each &u8 into a real u8
         .collect()

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -190,8 +190,7 @@ pub fn column_union<'a, S: Scalar>(
             assert_eq!(
                 flattened.len(),
                 total_bytes,
-                "Expected total of {} bytes",
-                total_bytes
+                "Expected total of {total_bytes} bytes"
             );
             let allocated = alloc.alloc_slice_copy(&flattened);
             Column::FixedSizeBinary(width, allocated)

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -177,24 +177,24 @@ pub fn column_union<'a, S: Scalar>(
         ColumnType::FixedSizeBinary(width) => {
             let bw = width.width_as_usize();
             let total_bytes = len * bw;
-
-            // Allocate a new contiguous slice of the correct total size in the bump arena
-            let new_slice = alloc.alloc_slice_fill_with(total_bytes, |_| 0u8);
-
-            // Copy the data from each column into the newly allocated slice
-            let mut position = 0;
-            for col in columns {
-                let (col_width, col_data) = col
-                    .as_fixed_size_binary()
-                    .expect("column_type check above should guarantee same type");
-
-                assert_eq!(col_width, width, "Inconsistent FixedSizeBinary width");
-
-                new_slice[position..position + col_data.len()].copy_from_slice(col_data);
-                position += col_data.len();
-            }
-
-            Column::FixedSizeBinary(width, new_slice)
+            let flattened: Vec<u8> = columns
+                .iter()
+                .flat_map(|col| {
+                    let (col_width, col_data) = col
+                        .as_fixed_size_binary()
+                        .expect("column_type check above should guarantee same type");
+                    assert_eq!(col_width, width, "Inconsistent FixedSizeBinary width");
+                    col_data.iter().copied()
+                })
+                .collect();
+            assert_eq!(
+                flattened.len(),
+                total_bytes,
+                "Expected total of {} bytes",
+                total_bytes
+            );
+            let allocated = alloc.alloc_slice_copy(&flattened);
+            Column::FixedSizeBinary(width, allocated)
         }
     })
 }

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -174,6 +174,28 @@ pub fn column_union<'a, S: Scalar>(
                 }) as &[_],
             )
         }
+        ColumnType::FixedSizeBinary(width) => {
+            let bw = width.width_as_usize();
+            let total_bytes = len * bw;
+
+            // Allocate a new contiguous slice of the correct total size in the bump arena
+            let new_slice = alloc.alloc_slice_fill_with(total_bytes, |_| 0u8);
+
+            // Copy the data from each column into the newly allocated slice
+            let mut position = 0;
+            for col in columns {
+                let (col_width, col_data) = col
+                    .as_fixed_size_binary()
+                    .expect("column_type check above should guarantee same type");
+
+                assert_eq!(col_width, width, "Inconsistent FixedSizeBinary width");
+
+                new_slice[position..position + col_data.len()].copy_from_slice(col_data);
+                position += col_data.len();
+            }
+
+            Column::FixedSizeBinary(width, new_slice)
+        }
     })
 }
 

--- a/crates/proof-of-sql/src/base/math/mod.rs
+++ b/crates/proof-of-sql/src/base/math/mod.rs
@@ -6,6 +6,8 @@ mod decimal_tests;
 /// Module containing [I256] type.
 pub mod i256;
 mod log;
+/// Module containing [`NonNegativeI32`] type.
+pub mod non_negative_i32;
 pub(crate) use log::log2_up;
 /// TODO: add docs
 pub(crate) mod permutation;

--- a/crates/proof-of-sql/src/base/math/non_negative_i32.rs
+++ b/crates/proof-of-sql/src/base/math/non_negative_i32.rs
@@ -1,0 +1,48 @@
+use alloc::fmt::Display;
+use serde::{Deserialize, Serialize};
+
+/// Type-safe non-negative integer, exists for the sole purpose
+/// of preventing negative values from being used as fixed-size
+/// binary slice widths, due to arrow's unfortunate use of i32 as width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct NonNegativeI32(i32);
+
+/// Error type for `NonNegativeI32::new`.
+#[derive(Debug)]
+pub enum WidthError {
+    /// The width was negative.
+    NegativeWidth(i32),
+}
+
+impl NonNegativeI32 {
+    /// Returns an error if `x` is negative. Otherwise returns the wrapped value.
+    pub fn new(x: i32) -> Result<Self, WidthError> {
+        if x < 0 {
+            Err(WidthError::NegativeWidth(x))
+        } else {
+            Ok(Self(x))
+        }
+    }
+
+    /// Returns the wrapped value.
+    #[must_use]
+    pub fn width(&self) -> i32 {
+        self.0
+    }
+
+    /// Returns the wrapped value.
+    #[allow(
+        clippy::cast_sign_loss,
+        reason = "i32 is guaranteed to be non-negative by constructor"
+    )]
+    #[must_use]
+    pub fn width_as_usize(&self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl Display for NonNegativeI32 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -100,22 +100,19 @@ impl Permutation {
                 slice_length: slice.len(),
             });
         }
-
-        let num_chunks = slice.len() / chunk_size;
+        let num_chunks = slice.len();
         if self.size() != num_chunks {
             return Err(PermutationError::PermutationSizeMismatch {
                 permutation_size: self.size(),
                 slice_length: num_chunks,
             });
         }
-
-        let mut result = Vec::with_capacity(slice.len());
-        for &i in &self.permutation {
-            let start = i * chunk_size;
-            let end = start + chunk_size;
-            result.extend_from_slice(&slice[start..end]);
-        }
-
+        let result = self
+            .permutation
+            .iter()
+            .flat_map(|&i| slice[i * chunk_size..(i + 1) * chunk_size].iter())
+            .cloned()
+            .collect();
         Ok(result)
     }
 }

--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -84,6 +84,40 @@ impl Permutation {
             })
         }
     }
+
+    /// Apply the permutation to chunks of the given size within the slice
+    pub fn try_chunked_apply<T>(
+        &self,
+        slice: &[T],
+        chunk_size: usize,
+    ) -> Result<Vec<T>, PermutationError>
+    where
+        T: Clone,
+    {
+        if slice.len() % chunk_size != 0 {
+            return Err(PermutationError::PermutationSizeMismatch {
+                permutation_size: self.size(),
+                slice_length: slice.len(),
+            });
+        }
+
+        let num_chunks = slice.len() / chunk_size;
+        if self.size() != num_chunks {
+            return Err(PermutationError::PermutationSizeMismatch {
+                permutation_size: self.size(),
+                slice_length: num_chunks,
+            });
+        }
+
+        let mut result = Vec::with_capacity(slice.len());
+        for &i in &self.permutation {
+            let start = i * chunk_size;
+            let end = start + chunk_size;
+            result.extend_from_slice(&slice[start..end]);
+        }
+
+        Ok(result)
+    }
 }
 
 #[cfg(test)]

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -102,7 +102,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
                 c.inner_product(evaluation_vec)
             }
-            Column::Uint8(c) => c.inner_product(evaluation_vec),
+            Column::Uint8(c) | Column::FixedSizeBinary(_, c) => c.inner_product(evaluation_vec),
             Column::TinyInt(c) => c.inner_product(evaluation_vec),
             Column::SmallInt(c) => c.inner_product(evaluation_vec),
             Column::Int(c) => c.inner_product(evaluation_vec),
@@ -117,7 +117,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
                 c.mul_add(res, multiplier);
             }
-            Column::Uint8(c) => c.mul_add(res, multiplier),
+            Column::Uint8(c) | Column::FixedSizeBinary(_, c) => c.mul_add(res, multiplier),
             Column::TinyInt(c) => c.mul_add(res, multiplier),
             Column::SmallInt(c) => c.mul_add(res, multiplier),
             Column::Int(c) => c.mul_add(res, multiplier),
@@ -132,7 +132,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
                 c.to_sumcheck_term(num_vars)
             }
-            Column::Uint8(c) => c.to_sumcheck_term(num_vars),
+            Column::Uint8(c) | Column::FixedSizeBinary(_, c) => c.to_sumcheck_term(num_vars),
             Column::TinyInt(c) => c.to_sumcheck_term(num_vars),
             Column::SmallInt(c) => c.to_sumcheck_term(num_vars),
             Column::Int(c) => c.to_sumcheck_term(num_vars),
@@ -147,7 +147,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
                 MultilinearExtension::<S>::id(c)
             }
-            Column::Uint8(c) => MultilinearExtension::<S>::id(c),
+            Column::Uint8(c) | Column::FixedSizeBinary(_, c) => MultilinearExtension::<S>::id(c),
             Column::TinyInt(c) => MultilinearExtension::<S>::id(c),
             Column::SmallInt(c) => MultilinearExtension::<S>::id(c),
             Column::Int(c) => MultilinearExtension::<S>::id(c),

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -32,7 +32,8 @@ pub trait Scalar:
     + for<'a> core::convert::From<&'a i64> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a i128> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a u8> // Required for `Column` to implement `MultilinearExtension`
-    + for<'a> core::convert::From<&'a u64> // Required for `Column` to implement `MultilinearExtension`
+    + for<'a> core::convert::From<&'a u64> // Required for `Column` to implement `MultilinearExtension`\
+    + for<'a> core::convert::From<&'a [u8]>
     + core::convert::TryInto <bool>
     + core::convert::TryInto<u8>
     + core::convert::TryInto <i8>

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -88,6 +88,9 @@ fn compute_dory_commitment(
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
+        CommittableColumn::FixedSizeBinary(_, column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -134,6 +134,9 @@ impl Commitment for HyperKZGCommitment {
                 CommittableColumn::Decimal75(_, _, vals)
                 | CommittableColumn::Scalar(vals)
                 | CommittableColumn::VarChar(vals) => compute_commitments_impl(setup, offset, vals),
+                CommittableColumn::FixedSizeBinary(_, items) => {
+                    compute_commitments_impl(setup, offset, items)
+                }
             })
             .collect()
     }

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -32,7 +32,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
     fn num_bytes(&self, length: u64) -> usize {
         match self {
             Column::Boolean(col) => col.num_bytes(length),
-            Column::Uint8(col) => col.num_bytes(length),
+            Column::Uint8(col) | Column::FixedSizeBinary(_, col) => col.num_bytes(length),
             Column::TinyInt(col) => col.num_bytes(length),
             Column::SmallInt(col) => col.num_bytes(length),
             Column::Int(col) => col.num_bytes(length),
@@ -46,7 +46,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
     fn write(&self, out: &mut [u8], length: u64) -> usize {
         match self {
             Column::Boolean(col) => col.write(out, length),
-            Column::Uint8(col) => col.write(out, length),
+            Column::Uint8(col) | Column::FixedSizeBinary(_, col) => col.write(out, length),
             Column::TinyInt(col) => col.write(out, length),
             Column::SmallInt(col) => col.write(out, length),
             Column::Int(col) => col.write(out, length),

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -179,6 +179,7 @@ fn make_empty_query_result<S: Scalar>(result_fields: &[ColumnField]) -> QueryRes
                         ColumnType::Scalar => OwnedColumn::Scalar(vec![]),
                         ColumnType::VarChar => OwnedColumn::VarChar(vec![]),
                         ColumnType::TimestampTZ(tu, tz) => OwnedColumn::TimestampTZ(tu, tz, vec![]),
+                        ColumnType::FixedSizeBinary(bw) => OwnedColumn::FixedSizeBinary(bw, vec![]),
                     },
                 )
             })

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -126,6 +126,7 @@ fn append_single_row_to_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedColum
         OwnedColumn::VarChar(col) => col.push(String::new()),
         OwnedColumn::Int128(col) => col.push(0),
         OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col.push(S::ZERO),
+        OwnedColumn::FixedSizeBinary(_, items) => items.push(0),
     }
     column
 }
@@ -162,6 +163,7 @@ pub fn tamper_first_row_of_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedCo
         OwnedColumn::VarChar(col) => col[0].push('1'),
         OwnedColumn::Int128(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col[0] += S::ONE,
+        OwnedColumn::FixedSizeBinary(_, items) => items[0] = items[0].wrapping_add(1),
     }
     column
 }


### PR DESCRIPTION
# Rationale for this change
This PR adds support for `FixedSizeBinary` 

> This PR is not meant to close #229 but serves as initial support. We should use this as a stepping stone and, after discussions arising from the code, decide how to build on this and address the issue in a follow-up PR.
# What changes are included in this PR?
- Added support for `FixedSizeBinary` in various parts of the codebase. The proposed representation is `FixedSizeBinary(i32, Vec<u8>)`, with conversion implementations `from (i32, Vec<u8>)` and `(i32, &[u8])`.
- Updated documentation to reflect the new changes (`docs/SQLSyntaxSpecification.md`)
- Modified the implementation of `impl<T: MontConfig<4>> From<&[u8]> for MontScalar<T> {`:
	- Previously, this was only used for strings and hashed the value regardless.
	- Now, if the byte slice is empty, the result is the zero scalar. If the byte slice has length 31 or less, the bytes are directly converted to a scalar. If the byte slice has length 32, the bytes are hashed using blake3 and the result is converted to a scalar.
	- String handling was updated to keep it hashed all the time.
# Are these changes tested?
Yes, new tests were added.
However, there are some "FIXME" comments in places where I wasn't sure if the implementation is correct. These are open for discussion and review.
# Additional Notes
- I have not added literal support yet.
- I have attempted to add support in every required place in the code, but please let me know if I missed any areas!
