### PR TITLE
feat: Add generic hyrax scheme

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_commitment.rs
@@ -1,0 +1,230 @@
+use super::{
+    hyrax_configuration::HyraxConfiguration, hyrax_public_setup::HyraxPublicSetup,
+    hyrax_scalar::HyraxScalarWrapper,
+};
+use crate::{
+    base::{
+        commitment::{Commitment, CommittableColumn},
+        if_rayon,
+    },
+    proof_primitive::dynamic_matrix_utils::matrix_structure::row_and_column_from_index,
+};
+use alloc::{vec, vec::Vec};
+use ark_std::iterable::Iterable;
+use core::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
+use itertools::{EitherOrBoth, Itertools};
+#[cfg(feature = "rayon")]
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use serde::{Deserialize, Serialize};
+
+/// The Hyrax commitment scheme:
+/// A column of data is converted to a matrix, which is crossed with a vector of generators to produce a vector of commits, which is the commitment.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+pub struct HyraxCommitment<C: HyraxConfiguration> {
+    /// The result of matrix cross the generators
+    pub row_commits: Vec<C::CompressedGroup>,
+}
+
+impl<'a, C: HyraxConfiguration> HyraxCommitment<C>
+where
+    for<'b> C::OperableGroup: 'b,
+{
+    /// The algorithm for computing a hyrax commitment is as follows:
+    /// Transform the committable column into a dynamic matrix (similar to dynamic dory)
+    /// Multiply the dynamic matrix by the generators from the setup.
+    /// The resulting vector of group elements is the commitment.
+    /// There is a need (for sp1 development) for commitments to be deserialized to a decompressed type rather than a compressed type,
+    /// so the vector is converted to a vector of compressed group elements.
+    fn compute_hyrax_commitment(
+        committable_column: &CommittableColumn,
+        offset: usize,
+        setup: &HyraxPublicSetup<'a, C::OperableGroup>,
+    ) -> Self {
+        let scalar_column: Vec<C::OperableScalar> = match committable_column {
+            CommittableColumn::Boolean(vec) => vec.iter().map(Into::into).collect(),
+            CommittableColumn::TinyInt(vec) => vec.iter().map(Into::into).collect(),
+            CommittableColumn::SmallInt(vec) => vec.iter().map(Into::into).collect(),
+            CommittableColumn::Int(vec) => vec.iter().map(Into::into).collect(),
+            CommittableColumn::BigInt(vec) | CommittableColumn::TimestampTZ(_, _, vec) => {
+                vec.iter().map(Into::into).collect()
+            }
+            CommittableColumn::Int128(vec) => vec.iter().map(Into::into).collect(),
+            CommittableColumn::Decimal75(_, _, vec) => vec.iter().map(Into::into).collect(),
+            CommittableColumn::Scalar(vec) | CommittableColumn::VarChar(vec) => {
+                vec.iter().map(Into::into).collect()
+            }
+            CommittableColumn::RangeCheckWord(vec) => vec.iter().map(Into::into).collect(),
+        };
+        let table_size = offset + committable_column.len();
+        let empty_row_commits =
+            vec![C::OperableGroup::default(); row_and_column_from_index(table_size - 1).0 + 1];
+        let decompressed_row_commits = if_rayon!(
+            (offset..table_size).into_par_iter(),
+            (offset..table_size).into_iter()
+        )
+        .map(|index| {
+            let (row, column) = row_and_column_from_index(index);
+            (
+                row,
+                setup.generators[column] * scalar_column[index - offset],
+            )
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .fold(empty_row_commits, |mut acc, (row, ep)| {
+            acc[row] += ep;
+            acc
+        });
+        let row_commits: Vec<C::CompressedGroup> = if_rayon!(
+            decompressed_row_commits.par_iter(),
+            decompressed_row_commits.iter()
+        )
+        .map(C::from_operable_to_compressed)
+        .collect();
+        Self { row_commits }
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if decompression is unsuccessful.
+    fn add_row_commits(
+        row_commits_a: &[C::CompressedGroup],
+        row_commits_b: &[C::CompressedGroup],
+    ) -> Vec<C::CompressedGroup> {
+        row_commits_a
+            .iter()
+            .zip_longest(row_commits_b)
+            .map(|both| match both {
+                EitherOrBoth::Both(a, b) => C::from_operable_to_compressed(
+                    &(C::from_compressed_to_operable(a) + C::from_compressed_to_operable(b)),
+                ),
+                EitherOrBoth::Left(a) => *a,
+                EitherOrBoth::Right(b) => *b,
+            })
+            .collect()
+    }
+
+    fn sub_row_commits(
+        row_commits_a: &[C::CompressedGroup],
+        row_commits_b: &[C::CompressedGroup],
+    ) -> Vec<C::CompressedGroup> {
+        row_commits_a
+            .iter()
+            .zip_longest(row_commits_b)
+            .map(|both| match both {
+                EitherOrBoth::Both(a, b) => C::from_operable_to_compressed(
+                    &(C::from_compressed_to_operable(a) - C::from_compressed_to_operable(b)),
+                ),
+                EitherOrBoth::Left(a) => *a,
+                EitherOrBoth::Right(b) => {
+                    C::from_operable_to_compressed(&-C::from_compressed_to_operable(b))
+                }
+            })
+            .collect()
+    }
+}
+
+impl<C: HyraxConfiguration> Sub for HyraxCommitment<C>
+where
+    for<'a> C::OperableGroup: 'a,
+{
+    type Output = HyraxCommitment<C>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            row_commits: Self::sub_row_commits(&self.row_commits, &rhs.row_commits),
+        }
+    }
+}
+
+impl<C: HyraxConfiguration> SubAssign for HyraxCommitment<C>
+where
+    for<'a> C::OperableGroup: 'a,
+{
+    fn sub_assign(&mut self, rhs: Self) {
+        self.row_commits = Self::sub_row_commits(&self.row_commits, &rhs.row_commits);
+    }
+}
+
+impl<C: HyraxConfiguration> Neg for HyraxCommitment<C> {
+    type Output = HyraxCommitment<C>;
+
+    fn neg(self) -> Self::Output {
+        HyraxCommitment {
+            row_commits: self
+                .row_commits
+                .iter()
+                .map(|rc| C::from_operable_to_compressed(&-C::from_compressed_to_operable(rc)))
+                .collect(),
+        }
+    }
+}
+
+impl<C: HyraxConfiguration> AddAssign for HyraxCommitment<C>
+where
+    for<'a> C::OperableGroup: 'a,
+{
+    fn add_assign(&mut self, rhs: Self) {
+        self.row_commits = Self::add_row_commits(&self.row_commits, &rhs.row_commits);
+    }
+}
+
+impl<C: HyraxConfiguration> Add for HyraxCommitment<C>
+where
+    for<'a> C::OperableGroup: 'a,
+{
+    type Output = HyraxCommitment<C>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            row_commits: Self::add_row_commits(&self.row_commits, &rhs.row_commits),
+        }
+    }
+}
+
+impl<C: HyraxConfiguration> Mul<HyraxCommitment<C>> for HyraxScalarWrapper<C::OperableScalar> {
+    type Output = HyraxCommitment<C>;
+
+    fn mul(self, rhs: HyraxCommitment<C>) -> Self::Output {
+        self * &rhs
+    }
+}
+
+impl<C: HyraxConfiguration> Mul<&HyraxCommitment<C>> for HyraxScalarWrapper<C::OperableScalar> {
+    type Output = HyraxCommitment<C>;
+
+    fn mul(self, rhs: &HyraxCommitment<C>) -> Self::Output {
+        HyraxCommitment {
+            row_commits: rhs
+                .row_commits
+                .iter()
+                .map(|rc| {
+                    C::from_operable_to_compressed(&(C::from_compressed_to_operable(rc) * self.0))
+                })
+                .collect(),
+        }
+    }
+}
+
+impl<C: HyraxConfiguration> Commitment for HyraxCommitment<C>
+where
+    for<'a> C::OperableGroup: 'a,
+{
+    type Scalar = HyraxScalarWrapper<C::OperableScalar>;
+
+    type PublicSetup<'a> = HyraxPublicSetup<'a, C::OperableGroup>;
+    fn compute_commitments(
+        committable_columns: &[CommittableColumn],
+        offset: usize,
+        setup: &Self::PublicSetup<'_>,
+    ) -> Vec<Self> {
+        committable_columns
+            .iter()
+            .map(|cc| Self::compute_hyrax_commitment(cc, offset, setup))
+            .collect()
+    }
+
+    fn append_to_transcript(&self, transcript: &mut impl crate::base::proof::Transcript) {
+        transcript.extend_as_le(self.row_commits.iter().map(|rc| C::compressed_to_bytes(rc)));
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_commitment_evaluation_proof.rs
@@ -1,0 +1,142 @@
+use super::{
+    hyrax_commitment::HyraxCommitment, hyrax_configuration::HyraxConfiguration,
+    hyrax_error::HyraxError, hyrax_public_setup::HyraxPublicSetup,
+    hyrax_scalar::HyraxScalarWrapper,
+};
+use crate::{
+    base::{commitment::CommitmentEvaluationProof, if_rayon, proof::Transcript, scalar::Scalar},
+    proof_primitive::dynamic_matrix_utils::{
+        matrix_structure::{matrix_size, row_and_column_from_index},
+        standard_basis_helper::compute_dynamic_vecs,
+    },
+};
+use alloc::{vec, vec::Vec};
+#[cfg(feature = "rayon")]
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
+use serde::{Deserialize, Serialize};
+
+/// The Hyrax evaluation proof scheme
+#[derive(Serialize, Deserialize)]
+pub struct HyraxCommitmentEvaluationProof<C: HyraxConfiguration> {
+    /// Represents the matrix cross the high vector.
+    /// Verified against the product with the low vector.
+    /// Verified against the commitment and high vector using the generators.
+    witness: Vec<C::OperableScalar>,
+    challenge: [u8; 32],
+}
+
+impl<C: HyraxConfiguration> CommitmentEvaluationProof for HyraxCommitmentEvaluationProof<C>
+where
+    for<'b> C::OperableGroup: 'b,
+{
+    type Scalar = HyraxScalarWrapper<C::OperableScalar>;
+
+    type Commitment = HyraxCommitment<C>;
+
+    type Error = HyraxError;
+    type ProverPublicSetup<'a> = HyraxPublicSetup<'a, C::OperableGroup>;
+    type VerifierPublicSetup<'a> = HyraxPublicSetup<'a, C::OperableGroup>;
+
+    /// Creates a `HyraxCommitmentEvaluationProof`
+    ///
+    /// Given a column of data and a random `b_point`, the resulting proof is effectively the witness:
+    /// the product of the `high_vec` (which is derved from `b_point`) and the column of data (transformed to a dynamic matrix).
+    fn new(
+        transcript: &mut impl Transcript,
+        a: &[Self::Scalar],
+        b_point: &[Self::Scalar],
+        generators_offset: u64,
+        _setup: &Self::ProverPublicSetup<'_>,
+    ) -> Self {
+        if generators_offset != 0 {
+            return Self {
+                witness: Vec::new(),
+                challenge: [0u8; 32],
+            };
+        }
+        let challenge = transcript.challenge_as_le();
+        let (_, high_vec) = compute_dynamic_vecs(b_point);
+        let empty_column_scalars = vec![C::OperableScalar::ZERO; matrix_size(a.len(), 0).0];
+        let witness: Vec<_> = if_rayon!((0..a.len()).into_par_iter(), (0..a.len()).into_iter())
+            .map(|index| {
+                let (row, column) = row_and_column_from_index(index);
+                (column, a[index].0 * high_vec[row].0)
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .fold(
+                empty_column_scalars,
+                |mut acc: Vec<C::OperableScalar>, (column, scalar)| {
+                    acc[column] += scalar;
+                    acc
+                },
+            )
+            .into_iter()
+            .collect();
+        transcript.extend_scalars_as_be(witness.iter());
+        Self { witness, challenge }
+    }
+
+    /// Verifies a batched hyrax proof
+    ///
+    /// Given a proof, commitment, inner product, and random `b_point`, the proof is verified against the commitment and `b_point` as follows:
+    /// - The product of the witness and the the `lo_vec` (which is derved from `b_point`) should equal the inner product. `hi_vec` and `lo_vec` are
+    ///   defined so that LMH is equal to M evaluated at `b_point`, which is why this constraint must hold (remember witness = MH).
+    /// - The product of the vector of group elements in the commitment with the high vector should be equal to the product of the witness and the generators.
+    ///   This must hold because commitment = GM, witness = MH, and (GM)H = G(MH).
+    fn verify_batched_proof(
+        &self,
+        transcript: &mut impl Transcript,
+        commit_batch: &[Self::Commitment],
+        batching_factors: &[Self::Scalar],
+        evaluations: &[Self::Scalar],
+        b_point: &[Self::Scalar],
+        generators_offset: u64,
+        _table_length: usize,
+        setup: &Self::VerifierPublicSetup<'_>,
+    ) -> Result<(), Self::Error> {
+        if generators_offset != 0 {
+            return Err(HyraxError::InvalidGeneratorsOffset {
+                offset: generators_offset,
+            });
+        }
+        if transcript.challenge_as_le() != self.challenge {
+            return Err(HyraxError::VerificationError);
+        }
+        let (lo_vec, high_vec) = compute_dynamic_vecs(b_point);
+        let expected_product = if_rayon!(self.witness.par_iter(), self.witness.iter())
+            .zip(lo_vec)
+            .map(|(s, l)| *s * l.0)
+            .sum::<C::OperableScalar>();
+        let product: Self::Scalar = evaluations
+            .iter()
+            .zip(batching_factors)
+            .map(|(&e, &f)| e * f)
+            .sum();
+        if product.0 != expected_product {
+            return Err(HyraxError::VerificationError);
+        }
+        let generators_by_witness = if_rayon!(setup.generators.par_iter(), setup.generators.iter())
+            .zip(self.witness.clone())
+            .map(|(g, w)| *g * w)
+            .sum::<C::OperableGroup>();
+        let row_commits_by_high = if_rayon!(commit_batch.par_iter(), commit_batch.iter())
+            .zip(batching_factors)
+            .map(|(hc, bf)| {
+                let row_commits_iter = if_rayon!(hc.row_commits.par_iter(), hc.row_commits.iter());
+                row_commits_iter
+                    .zip(high_vec.clone())
+                    .map(|(rc, hs)| C::from_compressed_to_operable(rc) * (hs.0 * bf.0))
+                    .sum::<C::OperableGroup>()
+            })
+            .sum::<C::OperableGroup>();
+
+        if generators_by_witness != row_commits_by_high {
+            return Err(HyraxError::VerificationError);
+        }
+        transcript.extend_scalars_as_be(self.witness.iter());
+        Ok(())
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_configuration.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_configuration.rs
@@ -23,8 +23,8 @@ pub trait HyraxConfiguration: Debug + Eq + Clone + Default + Send + Sync {
         + Sync;
     /// The scalar that will be used.
     type OperableScalar: HyraxScalar + for<'a> Deserialize<'a>;
-    /// The compressed representation of the operabe group. Note that decompression occurs primarily in verification,
-    /// whereas compression occurs mostly in proof and commitment generation. This is an important deatil for example in the sp1 implementation,
+    /// The compressed representation of the operable group. Note that decompression occurs primarily in verification,
+    /// whereas compression occurs mostly in commitment generation. This is an important detail for example in the sp1 implementation,
     /// where it is most important to emphasize efficient verification.
     type CompressedGroup: Serialize
         + for<'a> Deserialize<'a>

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_configuration.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_configuration.rs
@@ -1,0 +1,47 @@
+use super::hyrax_scalar::HyraxScalar;
+use core::{
+    fmt::Debug,
+    iter::Sum,
+    ops::{Add, AddAssign, Mul, Neg, Sub},
+};
+use serde::{Deserialize, Serialize};
+
+pub trait HyraxConfiguration: Debug + Eq + Clone + Default + Send + Sync {
+    /// The group that will be used to perform any mathematical operations.
+    type OperableGroup: Default
+        + Clone
+        + Copy
+        + Mul<Self::OperableScalar, Output = Self::OperableGroup>
+        + AddAssign
+        + Sub<Output = Self::OperableGroup>
+        + Add<Output = Self::OperableGroup>
+        + Eq
+        + Debug
+        + Neg<Output = Self::OperableGroup>
+        + Sum
+        + Send
+        + Sync;
+    /// The scalar that will be used.
+    type OperableScalar: HyraxScalar + for<'a> Deserialize<'a>;
+    /// The compressed representation of the operabe group. Note that decompression occurs primarily in verification,
+    /// whereas compression occurs mostly in proof and commitment generation. This is an important deatil for example in the sp1 implementation,
+    /// where it is most important to emphasize efficient verification.
+    type CompressedGroup: Serialize
+        + for<'a> Deserialize<'a>
+        + Debug
+        + Eq
+        + Clone
+        + Default
+        + Send
+        + Sync
+        + Copy;
+
+    fn from_operable_to_compressed(operable_element: &Self::OperableGroup)
+        -> Self::CompressedGroup;
+
+    fn from_compressed_to_operable(
+        compressed_element: &Self::CompressedGroup,
+    ) -> Self::OperableGroup;
+
+    fn compressed_to_bytes(compressed_element: &Self::CompressedGroup) -> [u8; 32];
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_error.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_error.rs
@@ -1,0 +1,11 @@
+use snafu::Snafu;
+
+#[derive(Snafu, Debug)]
+pub enum HyraxError {
+    /// Hyrax does not currently support an offset for the generators.
+    #[snafu(display("invalid generators offset: {offset}"))]
+    InvalidGeneratorsOffset { offset: u64 },
+    /// This error occurs when the proof fails to verify.
+    #[snafu(display("verification error"))]
+    VerificationError,
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_public_setup.rs
@@ -1,0 +1,9 @@
+/// The proof and verification setup for the Hyrax scheme
+#[derive(Clone, Copy)]
+pub struct HyraxPublicSetup<'a, G>
+where
+    for<'b> G: 'b,
+{
+    /// The generators used to generate `HyraxCommitment`s.
+    pub generators: &'a [G],
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_scalar.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/base/hyrax_scalar.rs
@@ -1,0 +1,201 @@
+use crate::base::{
+    encode::VarInt,
+    scalar::{Scalar, ScalarConversionError},
+};
+use alloc::string::String;
+use ark_ff::{One, UniformRand};
+use ark_serialize::CanonicalSerialize;
+use core::ops::{Mul, MulAssign};
+use derive_more::{Add, AddAssign, Display, Neg, Product, Sub, SubAssign, Sum};
+use num_bigint::BigInt;
+use num_traits::{Inv, Zero};
+use serde::{Deserialize, Serialize};
+
+pub trait HyraxScalar:
+    for<'a> core::convert::From<&'a [u64; 4]> + Serialize + Scalar + Mul<Self, Output = Self>
+{
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    CanonicalSerialize,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Eq,
+    Default,
+    Neg,
+    AddAssign,
+    Sub,
+    SubAssign,
+    Add,
+    Display,
+    Sum,
+    Product,
+)]
+
+/// A wrapper type for Scalars that implement `HyraxScalar`.
+#[serde(bound = "S: for<'a> Deserialize<'a>")]
+pub struct HyraxScalarWrapper<S: HyraxScalar>(pub S);
+
+impl<S: HyraxScalar> Scalar for HyraxScalarWrapper<S> {
+    const MAX_SIGNED: Self = Self(S::MAX_SIGNED);
+
+    const ZERO: Self = Self(S::ZERO);
+
+    const ONE: Self = Self(S::ONE);
+
+    const TWO: Self = Self(S::TWO);
+
+    const TEN: Self = Self(S::TEN);
+}
+
+impl<S: HyraxScalar> TryFrom<BigInt> for HyraxScalarWrapper<S> {
+    type Error = ScalarConversionError;
+
+    fn try_from(value: BigInt) -> Result<Self, Self::Error> {
+        value.try_into().map(Self)
+    }
+}
+
+impl<S: HyraxScalar> VarInt for HyraxScalarWrapper<S> {
+    fn required_space(self) -> usize {
+        self.0.required_space()
+    }
+
+    fn decode_var(src: &[u8]) -> Option<(Self, usize)> {
+        S::decode_var(src).map(|(s, u)| (Self(s), u))
+    }
+
+    fn encode_var(self, src: &mut [u8]) -> usize {
+        S::encode_var(self.0, src)
+    }
+}
+
+impl<S: HyraxScalar> Inv for HyraxScalarWrapper<S> {
+    type Output = Option<Self>;
+
+    fn inv(self) -> Self::Output {
+        S::inv(self.0).map(|s| Self(s))
+    }
+}
+
+impl<S: HyraxScalar> Zero for HyraxScalarWrapper<S> {
+    fn zero() -> Self {
+        Self(S::zero())
+    }
+
+    fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+}
+
+impl<S: HyraxScalar> One for HyraxScalarWrapper<S> {
+    fn one() -> Self {
+        Self(S::one())
+    }
+}
+
+impl<S: HyraxScalar> Mul for HyraxScalarWrapper<S> {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self(self.0 * rhs.0)
+    }
+}
+
+impl<S: HyraxScalar> MulAssign for HyraxScalarWrapper<S> {
+    fn mul_assign(&mut self, rhs: Self) {
+        self.0 *= rhs.0;
+    }
+}
+
+impl<S: HyraxScalar> UniformRand for HyraxScalarWrapper<S> {
+    fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
+        Self(S::rand(rng))
+    }
+}
+
+impl<S: HyraxScalar> From<&HyraxScalarWrapper<S>> for HyraxScalarWrapper<S> {
+    fn from(value: &HyraxScalarWrapper<S>) -> Self {
+        Self(value.0)
+    }
+}
+
+impl<'a, S: HyraxScalar> From<&'a HyraxScalarWrapper<S>> for [u64; 4] {
+    fn from(value: &'a HyraxScalarWrapper<S>) -> [u64; 4] {
+        value.0.into()
+    }
+}
+
+macro_rules! impl_from_type {
+    ($from_type:ty) => {
+        impl<S: HyraxScalar> From<$from_type> for HyraxScalarWrapper<S> {
+            fn from(value: $from_type) -> Self {
+                Self(value.into())
+            }
+        }
+    };
+}
+
+macro_rules! impl_from_wrapper {
+    ($from_type:ty) => {
+        impl<S: HyraxScalar> From<HyraxScalarWrapper<S>> for $from_type {
+            fn from(value: HyraxScalarWrapper<S>) -> $from_type {
+                value.0.into()
+            }
+        }
+    };
+}
+
+macro_rules! impl_from_with_lifetime {
+    ($from_type:ty) => {
+        impl<'a, S: HyraxScalar> From<$from_type> for HyraxScalarWrapper<S> {
+            fn from(value: $from_type) -> Self {
+                Self(value.into())
+            }
+        }
+    };
+}
+
+macro_rules! impl_try_into {
+    ($from_type:ty) => {
+        impl<S: HyraxScalar> TryInto<$from_type> for HyraxScalarWrapper<S> {
+            type Error = <S as TryInto<$from_type>>::Error;
+
+            fn try_into(self) -> Result<$from_type, Self::Error> {
+                self.0.try_into()
+            }
+        }
+    };
+}
+
+impl_from_type!(bool);
+impl_from_type!(i8);
+impl_from_type!(i16);
+impl_from_type!(i32);
+impl_from_type!(i64);
+impl_from_type!(i128);
+impl_from_type!(String);
+impl_from_type!(&String);
+impl_from_type!([u64; 4]);
+impl_from_with_lifetime!(&'a u8);
+impl_from_with_lifetime!(&'a i128);
+impl_from_with_lifetime!(&'a i64);
+impl_from_with_lifetime!(&'a i32);
+impl_from_with_lifetime!(&'a i16);
+impl_from_with_lifetime!(&'a i8);
+impl_from_with_lifetime!(&'a bool);
+impl_from_with_lifetime!(&'a str);
+impl_from_wrapper!(BigInt);
+impl_from_wrapper!([u64; 4]);
+impl_try_into!(i128);
+impl_try_into!(i64);
+impl_try_into!(i32);
+impl_try_into!(i16);
+impl_try_into!(i8);
+impl_try_into!(bool);

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/base/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/base/mod.rs
@@ -1,0 +1,12 @@
+/// The commitment scheme for hyrax
+pub mod hyrax_commitment;
+/// The verification scheme for hyrax
+pub mod hyrax_commitment_evaluation_proof;
+/// Effectively defines the implementation of the scalar, commitment, and evaluation proof by providing the scalar and group.
+pub mod hyrax_configuration;
+/// Errors that can occur in hyrax
+pub mod hyrax_error;
+/// The group generators
+pub mod hyrax_public_setup;
+/// A wrapper for the scalar. This might not need to be a wrapper. The purpose of this is to allow the implementation of certain traits on a generic type.
+pub mod hyrax_scalar;

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/mod.rs
@@ -1,0 +1,2 @@
+/// The hyrax scheme in generic form.
+pub(super) mod base;

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/mod.rs
@@ -1,2 +1,5 @@
 /// The hyrax scheme in generic form.
 pub(super) mod base;
+/// A configuration with ristretto point as the group and curve 25519 scalar. For now, this will only be used for testing purposes.
+#[cfg(test)]
+pub mod ristretto;

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/mod.rs
@@ -1,2 +1,10 @@
+/// A hyrax commitment using the ristretto configuration
+pub mod ristretto_hyrax_commitment;
+/// A hyrax commitment evaluation proof using the ristretto configuration
+pub mod ristretto_hyrax_commitment_evaluation_proof;
 /// A hyrax configuration using `RistrettoPoint` and `Curve25519Scalar`
 pub mod ristretto_hyrax_configuration;
+/// A hyrax public setup using `RistrettoPoint`, which is the group of the ristretto configuration
+pub mod ristretto_hyrax_public_setup;
+/// A hyrax `Curve25519Scalar` wrapper which is compatible with the ristretto configuration
+pub mod ristretto_hyrax_scalar;

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/mod.rs
@@ -1,0 +1,2 @@
+/// A hyrax configuration using `RistrettoPoint` and `Curve25519Scalar`
+pub mod ristretto_hyrax_configuration;

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_commitment.rs
@@ -1,0 +1,73 @@
+use super::ristretto_hyrax_configuration::RistrettoHyraxConfiguration;
+use crate::{
+    base::{
+        commitment::ColumnCommitments,
+        database::{
+            owned_table_utility::{bigint, owned_table, varchar},
+            OwnedTable,
+        },
+        scalar::test_scalar::TestScalar,
+    },
+    proof_primitive::hyrax::{
+        base::hyrax_commitment::HyraxCommitment,
+        ristretto::ristretto_hyrax_public_setup::RistrettoHyraxPublicSetup,
+    },
+};
+use core::iter;
+use curve25519_dalek::RistrettoPoint;
+use proof_of_sql_parser::Identifier;
+use rand::SeedableRng;
+
+pub type RistrettoHyraxCommitment = HyraxCommitment<RistrettoHyraxConfiguration>;
+
+#[test]
+fn we_can_append_rows_to_column_commitments() {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(100);
+    let generators = iter::repeat_with(|| RistrettoPoint::random(&mut rng))
+        .take(1000)
+        .collect::<Vec<_>>();
+    let public_setup = RistrettoHyraxPublicSetup {
+        generators: &generators,
+    };
+    let bigint_id: Identifier = "bigint_column".parse().unwrap();
+    let bigint_data = [1i64, 5, -5, 0, 10];
+
+    let varchar_id: Identifier = "varchar_column".parse().unwrap();
+    let varchar_data = ["Lorem", "ipsum", "dolor", "sit", "amet"];
+
+    let initial_columns: OwnedTable<TestScalar> = owned_table([
+        bigint(bigint_id, bigint_data[..2].to_vec()),
+        varchar(varchar_id, varchar_data[..2].to_vec()),
+    ]);
+
+    let mut column_commitments =
+        ColumnCommitments::<RistrettoHyraxCommitment>::try_from_columns_with_offset(
+            initial_columns.inner_table(),
+            0,
+            &public_setup,
+        )
+        .unwrap();
+
+    let append_columns: OwnedTable<TestScalar> = owned_table([
+        bigint(bigint_id, bigint_data[2..].to_vec()),
+        varchar(varchar_id, varchar_data[2..].to_vec()),
+    ]);
+
+    column_commitments
+        .try_append_rows_with_offset(append_columns.inner_table(), 2, &public_setup)
+        .unwrap();
+
+    let total_columns: OwnedTable<TestScalar> = owned_table([
+        bigint(bigint_id, bigint_data),
+        varchar(varchar_id, varchar_data),
+    ]);
+
+    let expected_column_commitments = ColumnCommitments::try_from_columns_with_offset(
+        total_columns.inner_table(),
+        0,
+        &public_setup,
+    )
+    .unwrap();
+
+    assert_eq!(column_commitments, expected_column_commitments);
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_commitment_evaluation_proof.rs
@@ -1,0 +1,64 @@
+use super::{
+    ristretto_hyrax_configuration::RistrettoHyraxConfiguration,
+    ristretto_hyrax_public_setup::RistrettoHyraxPublicSetup,
+};
+use crate::{
+    base::commitment::commitment_evaluation_proof_test::{
+        test_commitment_evaluation_proof_with_length_1, test_random_commitment_evaluation_proof,
+        test_simple_commitment_evaluation_proof,
+    },
+    proof_primitive::hyrax::base::hyrax_commitment_evaluation_proof::HyraxCommitmentEvaluationProof,
+};
+use core::iter;
+use curve25519_dalek::RistrettoPoint;
+use rand::SeedableRng;
+
+pub type RistrettoHyraxCommitmentEvaluationProof =
+    HyraxCommitmentEvaluationProof<RistrettoHyraxConfiguration>;
+
+#[test]
+fn we_can_test_simple_test_hyrax_commitment_evaluation_proof() {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(100);
+    let generators = iter::repeat_with(|| RistrettoPoint::random(&mut rng))
+        .take(10)
+        .collect::<Vec<_>>();
+    let public_setup = RistrettoHyraxPublicSetup {
+        generators: &generators,
+    };
+    test_simple_commitment_evaluation_proof::<RistrettoHyraxCommitmentEvaluationProof>(
+        &public_setup,
+        &public_setup,
+    );
+}
+
+#[test]
+fn we_can_test_simple_test_hyrax_commitment_evaluation_proof_with_length_1() {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(100);
+    let generators = iter::repeat_with(|| RistrettoPoint::random(&mut rng))
+        .take(10)
+        .collect::<Vec<_>>();
+    let public_setup = RistrettoHyraxPublicSetup {
+        generators: &generators,
+    };
+    test_commitment_evaluation_proof_with_length_1::<RistrettoHyraxCommitmentEvaluationProof>(
+        &public_setup,
+        &public_setup,
+    );
+}
+
+#[test]
+fn we_can_test_random_test_hyrax_commitment_evaluation_proofs() {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(100);
+    let generators = iter::repeat_with(|| RistrettoPoint::random(&mut rng))
+        .take(1000)
+        .collect::<Vec<_>>();
+    let public_setup = RistrettoHyraxPublicSetup {
+        generators: &generators,
+    };
+    test_random_commitment_evaluation_proof::<RistrettoHyraxCommitmentEvaluationProof>(
+        50,
+        0,
+        &public_setup,
+        &public_setup,
+    );
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_configuration.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_configuration.rs
@@ -1,0 +1,32 @@
+use crate::{
+    base::scalar::Curve25519Scalar,
+    proof_primitive::hyrax::base::hyrax_configuration::HyraxConfiguration,
+};
+use curve25519_dalek::{ristretto::CompressedRistretto, RistrettoPoint};
+
+#[derive(Default, Clone, Eq, Debug, PartialEq)]
+pub struct RistrettoHyraxConfiguration {}
+
+impl HyraxConfiguration for RistrettoHyraxConfiguration {
+    type OperableGroup = RistrettoPoint;
+
+    type OperableScalar = Curve25519Scalar;
+
+    type CompressedGroup = CompressedRistretto;
+
+    fn from_operable_to_compressed(
+        operable_element: &Self::OperableGroup,
+    ) -> Self::CompressedGroup {
+        operable_element.compress()
+    }
+
+    fn from_compressed_to_operable(
+        compressed_element: &Self::CompressedGroup,
+    ) -> Self::OperableGroup {
+        compressed_element.decompress().unwrap()
+    }
+
+    fn compressed_to_bytes(compressed_element: &Self::CompressedGroup) -> [u8; 32] {
+        compressed_element.to_bytes()
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_public_setup.rs
@@ -1,0 +1,4 @@
+use crate::proof_primitive::hyrax::base::hyrax_public_setup::HyraxPublicSetup;
+use curve25519_dalek::RistrettoPoint;
+
+pub type RistrettoHyraxPublicSetup<'a> = HyraxPublicSetup<'a, RistrettoPoint>;

--- a/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_scalar.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyrax/ristretto/ristretto_hyrax_scalar.rs
@@ -1,0 +1,8 @@
+use crate::{
+    base::scalar::Curve25519Scalar,
+    proof_primitive::hyrax::base::hyrax_scalar::{HyraxScalar, HyraxScalarWrapper},
+};
+
+pub type RistrettoHyraxScalar = HyraxScalarWrapper<Curve25519Scalar>;
+
+impl HyraxScalar for Curve25519Scalar {}

--- a/crates/proof-of-sql/src/proof_primitive/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/mod.rs
@@ -2,6 +2,8 @@
 pub mod dory;
 /// Central location for any code that requires the use of a dynamic matrix (for now, hyrax and dynamic dory).
 pub(super) mod dynamic_matrix_utils;
+/// The hyrax evaluation scheme, as outlined here: <https://eprint.iacr.org/2017/1132>
+pub mod hyrax;
 /// TODO: add docs
 pub(crate) mod sumcheck;
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

There is a need for a Hyrax scheme specifically for implementing proof of sql with the sp1 zkvm (docs [here](https://docs.succinct.xyz/docs/introduction)).

# What changes are included in this PR?

1. A generic Hyrax scheme.

# Are these changes tested?
There will be a follow up PR with a specific Sp1 implementation, which will have sp1 specific tests.
