### PR TITLE
feat: div and mod exprs

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -65,6 +65,7 @@ zerocopy = { workspace = true }
 arrow-csv = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
 merlin = { workspace = true }
+mockall = "0.13.1"
 opentelemetry = { workspace = true }
 opentelemetry-jaeger = { workspace = true }
 rand = { workspace = true, default-features = false }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -521,6 +521,19 @@ impl ColumnType {
             }
         }
     }
+
+    /// Returns if the column type supports signed values.
+    #[must_use]
+    pub fn min_scalar<S: Scalar>(&self) -> Option<S> {
+        match self {
+            ColumnType::TinyInt => Some(S::from(i8::MIN)),
+            ColumnType::SmallInt => Some(S::from(i16::MIN)),
+            ColumnType::Int => Some(S::from(i32::MIN)),
+            ColumnType::BigInt => Some(S::from(i64::MIN)),
+            ColumnType::Int128 => Some(S::from(i128::MIN)),
+            _ => None,
+        }
+    }
 }
 
 /// Display the column type as a str name (in all caps)

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -379,7 +379,7 @@ impl ColumnType {
     }
 
     /// Returns the number of bits in the integer type if it is an integer type. Otherwise, return None.
-    fn to_integer_bits(self) -> Option<usize> {
+    pub(crate) fn to_integer_bits(self) -> Option<usize> {
         match self {
             ColumnType::Uint8 | ColumnType::TinyInt => Some(8),
             ColumnType::SmallInt => Some(16),

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -112,8 +112,35 @@ pub fn try_multiply_column_types(
     }
 }
 
+/// Determine the output type of a divide/modulo operation if it is possible
+/// to divide and modulo the two input types. If the types are not compatible, return
+/// an error.
+pub fn try_divide_modulo_column_types(
+    lhs: ColumnType,
+    rhs: ColumnType,
+) -> ColumnOperationResult<(ColumnType, ColumnType)> {
+    if (lhs.is_integer() && lhs.is_signed() && rhs.is_integer() && lhs.is_signed())
+        || (lhs == ColumnType::Uint8 && rhs == ColumnType::Uint8)
+    {
+        Ok((
+            lhs,
+            if lhs.byte_size() > rhs.byte_size() {
+                lhs
+            } else {
+                rhs
+            },
+        ))
+    } else {
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType {
+            operator: "/".to_string(),
+            left_type: lhs,
+            right_type: rhs,
+        })
+    }
+}
+
 /// Determine the output type of a division operation if it is possible
-/// to multiply the two input types. If the types are not compatible, return
+/// to divide the two input types. If the types are not compatible, return
 /// an error.
 ///
 /// # Panics

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -14,7 +14,8 @@ mod slice_decimal_operation;
 
 mod column_type_operation;
 pub use column_type_operation::{
-    try_add_subtract_column_types, try_divide_column_types, try_multiply_column_types,
+    try_add_subtract_column_types, try_divide_column_types, try_divide_modulo_column_types,
+    try_multiply_column_types,
 };
 
 mod column_arithmetic_operation;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -444,6 +444,14 @@ where
             u64::MAX >> (T::MODULUS.0[3].leading_zeros() + 1),
         ])
     };
+    #[allow(clippy::cast_possible_truncation)]
+    const MAX_BITS: u8 = {
+        assert!(
+            T::MODULUS.0[3].leading_zeros() < 64,
+            "modulus expected to be larger than 1 << (64*3)"
+        );
+        255 - T::MODULUS.0[3].leading_zeros() as u8
+    };
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -1,11 +1,13 @@
 use crate::base::{
     map::IndexSet,
     scalar::{
-        test_scalar::TestScalar, test_scalar_constants, Curve25519Scalar, Scalar,
-        ScalarConversionError,
+        test_scalar::{TestMontConfig, TestScalar},
+        test_scalar_constants, Curve25519Scalar, Scalar, ScalarConversionError,
     },
 };
 use alloc::{format, string::ToString, vec::Vec};
+use ark_ff::MontConfig;
+use bnum::types::U256;
 use byte_slice_cast::AsByteSlice;
 use num_bigint::BigInt;
 use num_traits::{Inv, One, Zero};
@@ -503,4 +505,13 @@ fn test_bigint_to_scalar_overflow() {
         ),
         Err(ScalarConversionError::Overflow { .. })
     ));
+}
+
+#[test]
+fn we_can_bound_modulus_using_max_bits() {
+    let modulus_of_i_max_bits = U256::ONE << TestScalar::MAX_BITS;
+    let modulus_of_i_max_bits_plus_1 = U256::ONE << (TestScalar::MAX_BITS + 1);
+    let modulus_of_test_scalar = U256::from(TestMontConfig::MODULUS.0);
+    assert!(modulus_of_i_max_bits <= modulus_of_test_scalar);
+    assert!(modulus_of_i_max_bits_plus_1 > modulus_of_test_scalar);
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -81,4 +81,6 @@ pub trait Scalar:
     /// The value to mask the challenge with to ensure it is in the field.
     /// This one less than the largest power of 2 that is less than the field modulus.
     const CHALLENGE_MASK: U256;
+    /// The largest n such that 2^n <=p
+    const MAX_BITS: u8;
 }

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -337,7 +337,9 @@ pub(crate) fn type_check_binary_operation(
             try_add_subtract_column_types(left_dtype, right_dtype).is_ok()
         }
         BinaryOperator::Multiply => try_multiply_column_types(left_dtype, right_dtype).is_ok(),
-        BinaryOperator::Divide => left_dtype.is_numeric() && right_dtype.is_numeric(),
+        BinaryOperator::Divide | BinaryOperator::Modulo => {
+            left_dtype.is_numeric() && right_dtype.is_numeric()
+        }
         _ => {
             // Handle unsupported binary operations
             false

--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -1,0 +1,147 @@
+use super::{SumcheckSubpolynomialType, VerificationBuilder};
+use crate::base::{bit::BitDistribution, proof::ProofSizeMismatch, scalar::Scalar};
+use alloc::vec::Vec;
+use core::iter;
+
+/// Track components used to verify a query's proof
+pub struct MockVerificationBuilder<S: Scalar> {
+    bit_distributions: Vec<BitDistribution>,
+    bit_distribution_offset: usize,
+    consumed_final_round_pcs_proof_mles: usize,
+    subpolynomial_max_multiplicands: usize,
+
+    evaluation_row_index: usize,
+    final_round_mles: Vec<Vec<S>>,
+    pub(crate) identity_subpolynomial_evaluations: Vec<Vec<S>>,
+    pub(crate) zerosum_subpolynomial_evaluations: Vec<Vec<S>>,
+}
+
+impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
+    /// Consume the evaluation of a one evaluation
+    ///
+    /// # Panics
+    /// It should never panic, as the length of the one evaluation is guaranteed to be present
+    fn try_consume_chi_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        unimplemented!()
+    }
+
+    fn try_produce_sumcheck_subpolynomial_evaluation(
+        &mut self,
+        subpolynomial_type: SumcheckSubpolynomialType,
+        eval: S,
+        degree: usize,
+    ) -> Result<(), ProofSizeMismatch> {
+        match subpolynomial_type {
+            SumcheckSubpolynomialType::Identity => {
+                if self.identity_subpolynomial_evaluations.len() <= self.evaluation_row_index {
+                    self.identity_subpolynomial_evaluations
+                        .extend(iter::repeat(Vec::new()).take(
+                            self.evaluation_row_index
+                                - self.identity_subpolynomial_evaluations.len()
+                                + 1,
+                        ));
+                }
+                if degree + 1 > self.subpolynomial_max_multiplicands {
+                    Err(ProofSizeMismatch::SumcheckProofTooSmall)?;
+                }
+                self.identity_subpolynomial_evaluations[self.evaluation_row_index].push(eval);
+            }
+            SumcheckSubpolynomialType::ZeroSum => {
+                if self.zerosum_subpolynomial_evaluations.len() <= self.evaluation_row_index {
+                    self.zerosum_subpolynomial_evaluations
+                        .extend(iter::repeat(Vec::new()).take(
+                            self.evaluation_row_index
+                                - self.zerosum_subpolynomial_evaluations.len()
+                                + 1,
+                        ));
+                }
+                if degree > self.subpolynomial_max_multiplicands {
+                    Err(ProofSizeMismatch::SumcheckProofTooSmall)?;
+                }
+                self.zerosum_subpolynomial_evaluations[self.evaluation_row_index].push(eval);
+            }
+        }
+        Ok(())
+    }
+
+    fn try_consume_bit_distribution(&mut self) -> Result<BitDistribution, ProofSizeMismatch> {
+        let res = self
+            .bit_distributions
+            .get(self.bit_distribution_offset)
+            .cloned()
+            .ok_or(ProofSizeMismatch::TooFewBitDistributions)?;
+        self.bit_distribution_offset += 1;
+        Ok(res)
+    }
+
+    fn try_consume_rho_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        unimplemented!()
+    }
+
+    fn try_consume_first_round_mle_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        unimplemented!()
+    }
+
+    fn try_consume_final_round_mle_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        let index = self.consumed_final_round_pcs_proof_mles;
+        self.consumed_final_round_pcs_proof_mles += 1;
+        Ok(*self
+            .final_round_mles
+            .get(self.evaluation_row_index)
+            .cloned()
+            .ok_or(ProofSizeMismatch::TooFewMLEEvaluations)?
+            .get(index)
+            .unwrap_or(&S::ZERO))
+    }
+
+    fn singleton_chi_evaluation(&self) -> S {
+        unimplemented!()
+    }
+
+    fn rho_256_evaluation(&self) -> Option<S> {
+        unimplemented!()
+    }
+
+    fn try_consume_post_result_challenge(&mut self) -> Result<S, ProofSizeMismatch> {
+        unimplemented!()
+    }
+
+    fn try_consume_final_round_mle_evaluations(
+        &mut self,
+        count: usize,
+    ) -> Result<Vec<S>, ProofSizeMismatch> {
+        iter::repeat_with(|| self.try_consume_final_round_mle_evaluation())
+            .take(count)
+            .collect()
+    }
+}
+
+impl<S: Scalar> MockVerificationBuilder<S> {
+    #[allow(
+        clippy::missing_panics_doc,
+        reason = "The only possible panic is from the assertion comparing lengths, which is clear from context."
+    )]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        bit_distributions: Vec<BitDistribution>,
+        subpolynomial_max_multiplicands: usize,
+        final_round_mles: Vec<Vec<S>>,
+    ) -> Self {
+        Self {
+            bit_distributions,
+            bit_distribution_offset: 0,
+            consumed_final_round_pcs_proof_mles: 0,
+            subpolynomial_max_multiplicands,
+            evaluation_row_index: 0,
+            final_round_mles,
+            identity_subpolynomial_evaluations: Vec::new(),
+            zerosum_subpolynomial_evaluations: Vec::new(),
+        }
+    }
+
+    pub fn increment_row_index(&mut self) {
+        self.bit_distribution_offset = 0;
+        self.consumed_final_round_pcs_proof_mles = 0;
+        self.evaluation_row_index += 1;
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -1,6 +1,8 @@
 //! TODO: add docs
 
 mod final_round_builder;
+#[cfg(test)]
+pub(crate) mod mock_verification_builder;
 pub(crate) use final_round_builder::FinalRoundBuilder;
 #[cfg(all(test, feature = "blitzar"))]
 mod final_round_builder_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -2,14 +2,19 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, table_utility::*, Column, OwnedTableTestAccessor, TableRef,
-            TableTestAccessor,
+            owned_table_utility::*, table_utility::*, Column, ColumnRef, ColumnType,
+            OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
         },
-        scalar::test_scalar::TestScalar,
+        map::indexmap,
+        polynomial::MultilinearExtension,
+        scalar::{test_scalar::TestScalar, Scalar},
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::{test_utility::*, DynProofExpr, ProofExpr},
+        proof::{
+            exercise_verification, mock_verification_builder::MockVerificationBuilder,
+            FinalRoundBuilder, VerifiableQueryResult,
+        },
+        proof_exprs::{test_utility::*, AndExpr, ColumnExpr, DynProofExpr, ProofExpr},
         proof_plans::test_utility::*,
     },
 };
@@ -20,6 +25,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use sqlparser::ast::Ident;
+use std::collections::VecDeque;
 
 #[test]
 fn we_can_prove_a_simple_and_query() {
@@ -175,4 +182,96 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
     let res = and_expr.result_evaluate(&alloc, &data);
     let expected_res = Column::Boolean(&[false, true, false, false]);
     assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_verify_a_simple_proof() {
+    let alloc = Bump::new();
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let lhs = &[true, true, false, false];
+    let rhs = &[true, false, true, false];
+    let table = Table::try_new(indexmap! {
+        "a".into() => Column::Boolean::<TestScalar>(lhs),
+        "b".into() => Column::Boolean::<TestScalar>(rhs),
+    })
+    .unwrap();
+    let a = ColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
+    let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+    let and_expr = AndExpr::new(
+        Box::new(DynProofExpr::Column(ColumnExpr::new(a.clone()))),
+        Box::new(DynProofExpr::Column(ColumnExpr::new(b.clone()))),
+    );
+
+    let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
+        FinalRoundBuilder::new(4, VecDeque::new());
+
+    and_expr.prover_evaluate(&mut final_round_builder, &alloc, &table);
+
+    let matrix = verify_row_by_row(
+        4,
+        &final_round_builder,
+        3,
+        |verification_builder, chi_eval, evaluation_point| {
+            let accessor = indexmap! {
+                a.clone() => lhs.inner_product(evaluation_point),
+                b.clone() => rhs.inner_product(evaluation_point)
+            };
+            and_expr
+                .verifier_evaluate(verification_builder, &accessor, chi_eval)
+                .unwrap();
+        },
+    );
+    assert_eq!(matrix, vec![vec![true]; 4]);
+}
+
+#[test]
+fn we_can_reject_a_simple_tampered_proof() {
+    let alloc = Bump::new();
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let lhs = &[true, true, false, false];
+    let rhs = &[true, false, true, false];
+    let a = ColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
+    let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+    let and_expr = AndExpr::new(
+        Box::new(DynProofExpr::Column(ColumnExpr::new(a.clone()))),
+        Box::new(DynProofExpr::Column(ColumnExpr::new(b.clone()))),
+    );
+
+    let evaluation_points = (0..4).map(|i| {
+        alloc.alloc_slice_fill_with(4, |j| {
+            if i == j {
+                TestScalar::ONE
+            } else {
+                TestScalar::ZERO
+            }
+        })
+    });
+    let zero_vec = vec![TestScalar::ZERO];
+    // Tampering occurs here. All four rows return false for lhs and rhs
+    let final_round_mles: Vec<_> = evaluation_points
+        .clone()
+        .map(|_| zero_vec.clone())
+        .collect();
+    let mut verification_builder = MockVerificationBuilder::new(Vec::new(), 3, final_round_mles);
+
+    for evaluation_point in evaluation_points {
+        let chi_eval = (&[1, 1, 1, 1]).inner_product(evaluation_point);
+        let accessor = indexmap! {
+            a.clone() => lhs.inner_product(evaluation_point),
+            b.clone() => rhs.inner_product(evaluation_point)
+        };
+        and_expr
+            .verifier_evaluate(&mut verification_builder, &accessor, chi_eval)
+            .unwrap();
+        verification_builder.increment_row_index();
+    }
+    assert_eq!(
+        verification_builder.identity_subpolynomial_evaluations,
+        vec![
+            vec![-TestScalar::ONE],
+            zero_vec.clone(),
+            zero_vec.clone(),
+            zero_vec
+        ]
+    );
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/divide_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/divide_expr.rs
@@ -1,0 +1,72 @@
+use super::{numerical_util::divide_columns, DynProofExpr, ProofExpr};
+use crate::{
+    base::{
+        database::{Column, ColumnRef, ColumnType, Table},
+        map::{IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        proof_gadgets::divide_and_modulo_expr::DivideAndModuloExpr,
+    },
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+/// Provable numerical `/` expression
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DivideExpr {
+    inner_expr: DivideAndModuloExpr,
+}
+
+impl DivideExpr {
+    /// Create numerical `/` expression
+    pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
+        Self {
+            inner_expr: DivideAndModuloExpr::new(lhs, rhs),
+        }
+    }
+}
+
+impl ProofExpr for DivideExpr {
+    fn data_type(&self) -> ColumnType {
+        self.inner_expr.data_type()
+    }
+
+    fn result_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+    ) -> Column<'a, S> {
+        let lhs_column: Column<'a, S> = self.inner_expr.lhs.result_evaluate(alloc, table);
+        let rhs_column: Column<'a, S> = self.inner_expr.rhs.result_evaluate(alloc, table);
+        divide_columns(&lhs_column, &rhs_column, alloc).0
+    }
+
+    fn prover_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+    ) -> Column<'a, S> {
+        self.inner_expr.prover_evaluate(builder, alloc, table).0
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        one_eval: S,
+    ) -> Result<S, ProofError> {
+        Ok(self
+            .inner_expr
+            .verifier_evaluate(builder, accessor, one_eval)?
+            .0)
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.inner_expr.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/divide_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/divide_expr_test.rs
@@ -1,0 +1,188 @@
+use crate::{
+    base::{
+        commitment::InnerProductProof,
+        database::{owned_table_utility::*, OwnedTableTestAccessor, TableRef},
+    },
+    sql::{
+        proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::test_utility::*,
+    },
+};
+
+fn verify_tinyint_division(a: &[i8], b: &[i8], q: &[i8]) {
+    let data = owned_table([
+        tinyint("a", a.iter().copied()),
+        tinyint("b", b.iter().copied()),
+    ]);
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = projection(
+        vec![aliased_plan(
+            divide(column(&t, "a", &accessor), column(&t, "b", &accessor)),
+            "q",
+        )],
+        tab(&t),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([tinyint("q", q.iter().copied())]);
+    assert_eq!(res, expected_res);
+}
+
+fn verify_int128_division(a: &[i128], b: &[i128], q: &[i128]) {
+    let data = owned_table([
+        int128("a", a.iter().copied()),
+        int128("b", b.iter().copied()),
+    ]);
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = projection(
+        vec![aliased_plan(
+            divide(column(&t, "a", &accessor), column(&t, "b", &accessor)),
+            "q",
+        )],
+        tab(&t),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([int128("q", q.iter().copied())]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_prove_int_division_query() {
+    let data = owned_table([
+        tinyint("b", [2_i8, -115, 6, 126]),
+        smallint("c", [7_i16, 36, -30000, 31104]),
+        int("d", [4_i32, -115, i32::MIN + 12, 52]),
+        bigint("e", [i64::MIN + 366, -68, i64::MAX, 126]),
+        int128("f", [6_i128, i128::MIN + 3, 99, i128::MAX - 6]),
+    ]);
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+
+    let ast = projection(
+        vec![
+            aliased_plan(divide(column(&t, "b", &accessor), const_tinyint(2)), "b2"),
+            aliased_plan(
+                divide(column(&t, "b", &accessor), column(&t, "c", &accessor)),
+                "bc",
+            ),
+            aliased_plan(
+                divide(column(&t, "b", &accessor), column(&t, "d", &accessor)),
+                "bd",
+            ),
+            aliased_plan(
+                divide(column(&t, "b", &accessor), column(&t, "e", &accessor)),
+                "be",
+            ),
+            aliased_plan(
+                divide(column(&t, "b", &accessor), column(&t, "f", &accessor)),
+                "bf",
+            ),
+            aliased_plan(divide(column(&t, "c", &accessor), const_smallint(2)), "c2"),
+            aliased_plan(
+                divide(column(&t, "c", &accessor), column(&t, "b", &accessor)),
+                "cb",
+            ),
+            aliased_plan(
+                divide(column(&t, "c", &accessor), column(&t, "d", &accessor)),
+                "cd",
+            ),
+            aliased_plan(
+                divide(column(&t, "c", &accessor), column(&t, "e", &accessor)),
+                "ce",
+            ),
+            aliased_plan(
+                divide(column(&t, "c", &accessor), column(&t, "f", &accessor)),
+                "cf",
+            ),
+        ],
+        tab(&t),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        tinyint("b2", [1_i8, -57, 3, 63]),
+        tinyint("bc", [0_i8, -3, 0, 0]),
+        tinyint("bd", [0_i8, 1, 0, 2]),
+        tinyint("be", [0_i8, 1, 0, 1]),
+        tinyint("bf", [0_i8, 0, 0, 0]),
+        smallint("c2", [3_i16, 18, -15000, 15552]),
+        smallint("cb", [3_i16, 0, -5000, 246]),
+        smallint("cd", [1_i16, 0, 0, 598]),
+        smallint("ce", [0_i16, 0, 0, 246]),
+        smallint("cf", [1_i16, 0, -303, 0]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_verify_nonnegative_only_division() {
+    verify_tinyint_division(&[2, 7, 0, 54], &[1, 33, 6, 36], &[2, 0, 0, 1]);
+}
+
+#[test]
+fn we_can_verify_nonpositive_only_division() {
+    verify_tinyint_division(&[-2, -7, 0, -54], &[-1, -33, -6, -36], &[2, 0, 0, 1]);
+}
+
+#[test]
+fn we_can_verify_nonpositive_numerator_and_positive_denominator_division() {
+    verify_tinyint_division(&[-2, -7, 0, -54], &[1, 33, 6, 36], &[-2, 0, 0, -1]);
+}
+
+#[test]
+fn we_can_verify_nonnegative_numerator_and_negative_denominator_division() {
+    verify_tinyint_division(&[2, 7, 0, 54], &[-1, -33, -6, -36], &[-2, 0, 0, -1]);
+}
+
+#[test]
+fn we_can_verify_zero_denominator_division() {
+    verify_tinyint_division(
+        &[1, -1, 0, i8::MAX, i8::MIN],
+        &[0, 0, 0, 0, 0],
+        &[0, 0, 0, 0, 0],
+    );
+}
+
+#[test]
+fn we_can_verify_minmax_numerator_and_plusminusonezero_denominator_division() {
+    verify_tinyint_division(
+        &[i8::MAX, i8::MIN, i8::MAX, i8::MIN, i8::MAX, i8::MIN],
+        &[1, 1, -1, -1, 0, 0],
+        &[i8::MAX, i8::MIN, -i8::MAX, i8::MIN, 0, 0],
+    );
+}
+
+#[test]
+fn we_can_verify_minmax_numerator_and_plusminusonezero_denominator_division_i128() {
+    verify_int128_division(
+        &[
+            i128::MAX,
+            i128::MIN,
+            i128::MAX,
+            i128::MIN,
+            i128::MAX,
+            i128::MIN,
+        ],
+        &[1, 1, -1, -1, 0, 0],
+        &[i128::MAX, i128::MIN, -i128::MAX, i128::MIN, 0, 0],
+    );
+}
+
+#[test]
+fn we_can_verify_large_quotient_and_rhs() {
+    let floor_of_sqrt: i128 = 13_043_817_825_332_782_212;
+    verify_int128_division(
+        &[i128::MAX, i128::MIN, i128::MAX, i128::MIN],
+        // Floor of sqrt{i128::MAX}
+        &[floor_of_sqrt, floor_of_sqrt, -floor_of_sqrt, -floor_of_sqrt],
+        &[floor_of_sqrt, -floor_of_sqrt, -floor_of_sqrt, floor_of_sqrt],
+    );
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -1,6 +1,6 @@
 use super::{
-    AddSubtractExpr, AggregateExpr, AndExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr,
-    MultiplyExpr, NotExpr, OrExpr, ProofExpr,
+    divide_expr::DivideExpr, modulo_expr::ModuloExpr, AddSubtractExpr, AggregateExpr, AndExpr,
+    ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr, MultiplyExpr, NotExpr, OrExpr, ProofExpr,
 };
 use crate::{
     base::{
@@ -45,6 +45,10 @@ pub enum DynProofExpr {
     Multiply(MultiplyExpr),
     /// Provable aggregate expression
     Aggregate(AggregateExpr),
+    /// Provable numeric `/` expression
+    Divide(DivideExpr),
+    /// Provable numeric `%` expression
+    Modulo(ModuloExpr),
 }
 impl DynProofExpr {
     /// Create column expression
@@ -152,6 +156,34 @@ impl DynProofExpr {
                 Box::new(lhs),
                 Box::new(rhs),
             )))
+        } else {
+            Err(ConversionError::DataTypeMismatch {
+                left_type: lhs_datatype.to_string(),
+                right_type: rhs_datatype.to_string(),
+            })
+        }
+    }
+
+    /// Create a new divide expression
+    pub fn try_new_divide(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
+        let lhs_datatype = lhs.data_type();
+        let rhs_datatype = rhs.data_type();
+        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Divide) {
+            Ok(Self::Divide(DivideExpr::new(Box::new(lhs), Box::new(rhs))))
+        } else {
+            Err(ConversionError::DataTypeMismatch {
+                left_type: lhs_datatype.to_string(),
+                right_type: rhs_datatype.to_string(),
+            })
+        }
+    }
+
+    /// Create a new modulo expression
+    pub fn try_new_modulo(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
+        let lhs_datatype = lhs.data_type();
+        let rhs_datatype = rhs.data_type();
+        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Modulo) {
+            Ok(Self::Modulo(ModuloExpr::new(Box::new(lhs), Box::new(rhs))))
         } else {
             Err(ConversionError::DataTypeMismatch {
                 left_type: lhs_datatype.to_string(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -111,7 +111,7 @@ impl ProofExpr for InequalityExpr {
         };
 
         // sign(diff) == -1
-        verifier_evaluate_sign(builder, diff_eval, chi_eval)
+        verifier_evaluate_sign(builder, diff_eval, chi_eval, 251)
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -111,7 +111,7 @@ impl ProofExpr for InequalityExpr {
         };
 
         // sign(diff) == -1
-        verifier_evaluate_sign(builder, diff_eval, chi_eval, 251)
+        verifier_evaluate_sign(builder, diff_eval, chi_eval, None)
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -1,4 +1,6 @@
 //! This module proves provable expressions.
+mod divide_expr;
+mod modulo_expr;
 mod proof_expr;
 pub(crate) use proof_expr::ProofExpr;
 #[cfg(all(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -53,7 +53,8 @@ pub(crate) use comparison_util::scale_and_subtract;
 
 mod numerical_util;
 pub(crate) use numerical_util::{
-    add_subtract_columns, multiply_columns, scale_and_add_subtract_eval,
+    add_subtract_columns, columns_to_scalar_slice, divide_columns, modulo_columns,
+    multiply_columns, scale_and_add_subtract_eval,
 };
 
 mod equals_expr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -1,6 +1,10 @@
 //! This module proves provable expressions.
 mod divide_expr;
+#[cfg(all(test, feature = "blitzar"))]
+mod divide_expr_test;
 mod modulo_expr;
+#[cfg(all(test, feature = "blitzar"))]
+mod modulo_expr_test;
 mod proof_expr;
 pub(crate) use proof_expr::ProofExpr;
 #[cfg(all(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/proof_exprs/modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/modulo_expr.rs
@@ -1,0 +1,77 @@
+use super::{numerical_util::modulo_columns, DynProofExpr, ProofExpr};
+use crate::{
+    base::{
+        database::{try_divide_modulo_column_types, Column, ColumnRef, Table},
+        map::{IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        proof_gadgets::divide_and_modulo_expr::DivideAndModuloExpr,
+    },
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+/// Provable numerical `/` expression
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ModuloExpr {
+    inner_expr: DivideAndModuloExpr,
+}
+
+impl ModuloExpr {
+    /// Create numerical `%` expression
+    pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
+        Self {
+            inner_expr: DivideAndModuloExpr::new(lhs, rhs),
+        }
+    }
+}
+
+impl ProofExpr for ModuloExpr {
+    fn data_type(&self) -> crate::base::database::ColumnType {
+        try_divide_modulo_column_types(
+            self.inner_expr.lhs.data_type(),
+            self.inner_expr.rhs.data_type(),
+        )
+        .expect("Failed to take modulo of column types")
+        .1
+    }
+
+    fn result_evaluate<'a, S: crate::base::scalar::Scalar>(
+        &self,
+        alloc: &'a bumpalo::Bump,
+        table: &crate::base::database::Table<'a, S>,
+    ) -> crate::base::database::Column<'a, S> {
+        let lhs_column: Column<'a, S> = self.inner_expr.lhs.result_evaluate(alloc, table);
+        let rhs_column: Column<'a, S> = self.inner_expr.rhs.result_evaluate(alloc, table);
+        modulo_columns(&lhs_column, &rhs_column, alloc)
+    }
+
+    fn prover_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+    ) -> Column<'a, S> {
+        self.inner_expr.prover_evaluate(builder, alloc, table).1
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        one_eval: S,
+    ) -> Result<S, ProofError> {
+        Ok(self
+            .inner_expr
+            .verifier_evaluate(builder, accessor, one_eval)?
+            .1)
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.inner_expr.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/modulo_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/modulo_expr_test.rs
@@ -1,0 +1,193 @@
+use crate::{
+    base::{
+        commitment::InnerProductProof,
+        database::{owned_table_utility::*, OwnedTableTestAccessor},
+    },
+    sql::{
+        proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::test_utility::*,
+    },
+};
+
+fn verify_tinyint_modulo(a: &[i8], b: &[i8], q: &[i8]) {
+    let data = owned_table([
+        tinyint("a", a.iter().copied()),
+        tinyint("b", b.iter().copied()),
+    ]);
+    let t: crate::base::database::TableRef = "sxt.t".parse().unwrap();
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = projection(
+        vec![aliased_plan(
+            modulo(column(&t, "a", &accessor), column(&t, "b", &accessor)),
+            "q",
+        )],
+        tab(&t),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([tinyint("q", q.iter().copied())]);
+    assert_eq!(res, expected_res);
+}
+
+fn verify_int128_modulo(a: &[i128], b: &[i128], r: &[i128]) {
+    let data = owned_table([
+        int128("a", a.iter().copied()),
+        int128("b", b.iter().copied()),
+    ]);
+    let t: crate::base::database::TableRef = "sxt.t".parse().unwrap();
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = projection(
+        vec![aliased_plan(
+            modulo(column(&t, "a", &accessor), column(&t, "b", &accessor)),
+            "r",
+        )],
+        tab(&t),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([int128("r", r.iter().copied())]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_prove_int_modulus_query() {
+    let data = owned_table([
+        tinyint("b", [2_i8, -115, 6, 126]),
+        smallint("c", [7_i16, 36, -30000, 31104]),
+        int("d", [4_i32, -115, i32::MIN + 12, 52]),
+        bigint("e", [i64::MIN + 366, -68, i64::MAX, 126]),
+        int128("f", [6_i128, i128::MIN + 3, 99, i128::MAX - 6]),
+    ]);
+    let t: crate::base::database::TableRef = "sxt.t".parse().unwrap();
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+
+    let ast = projection(
+        vec![
+            aliased_plan(modulo(column(&t, "b", &accessor), const_tinyint(2)), "b2"),
+            aliased_plan(
+                modulo(column(&t, "b", &accessor), column(&t, "c", &accessor)),
+                "bc",
+            ),
+            aliased_plan(
+                modulo(column(&t, "b", &accessor), column(&t, "d", &accessor)),
+                "bd",
+            ),
+            aliased_plan(
+                modulo(column(&t, "b", &accessor), column(&t, "e", &accessor)),
+                "be",
+            ),
+            aliased_plan(
+                modulo(column(&t, "b", &accessor), column(&t, "f", &accessor)),
+                "bf",
+            ),
+            aliased_plan(modulo(column(&t, "c", &accessor), const_smallint(2)), "c2"),
+            aliased_plan(
+                modulo(column(&t, "c", &accessor), column(&t, "b", &accessor)),
+                "cb",
+            ),
+            aliased_plan(
+                modulo(column(&t, "c", &accessor), column(&t, "d", &accessor)),
+                "cd",
+            ),
+            aliased_plan(
+                modulo(column(&t, "c", &accessor), column(&t, "e", &accessor)),
+                "ce",
+            ),
+            aliased_plan(
+                modulo(column(&t, "c", &accessor), column(&t, "f", &accessor)),
+                "cf",
+            ),
+        ],
+        tab(&t),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        tinyint("b2", [0_i8, -1, 0, 0]),
+        smallint("bc", [2_i16, -7, 6, 126]),
+        int("bd", [2_i32, 0, 6, 22]),
+        bigint("be", [2_i64, -47, 6, 0]),
+        int128("bf", [2_i128, -115, 6, 126]),
+        smallint("c2", [1_i16, 0, 0, 0]),
+        smallint("cb", [1_i16, 36, 0, 108]),
+        int("cd", [3_i32, 36, -30000, 8]),
+        bigint("ce", [7_i64, 36, -30000, 108]),
+        int128("cf", [1_i128, 36, -3, 31104]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_verify_nonnegative_only_modulus() {
+    verify_tinyint_modulo(&[2, 7, 0, 54], &[1, 33, 6, 36], &[0, 7, 0, 18]);
+}
+
+#[test]
+fn we_can_verify_nonpositive_only_modulus() {
+    verify_tinyint_modulo(&[-2, -7, 0, -54], &[-1, -33, -6, -36], &[0, -7, 0, -18]);
+}
+
+#[test]
+fn we_can_verify_nonpositive_numerator_and_positive_denominator_modulus() {
+    verify_tinyint_modulo(&[-2, -7, 0, -54], &[1, 33, 6, 36], &[0, -7, 0, -18]);
+}
+
+#[test]
+fn we_can_verify_nonnegative_numerator_and_negative_denominator_modulus() {
+    verify_tinyint_modulo(&[2, 7, 0, 54], &[-1, -33, -6, -36], &[0, 7, 0, 18]);
+}
+
+#[test]
+fn we_can_verify_zero_denominator_modulus() {
+    verify_tinyint_modulo(
+        &[1, -1, 0, i8::MAX, i8::MIN],
+        &[0, 0, 0, 0, 0],
+        &[1, -1, 0, i8::MAX, i8::MIN],
+    );
+}
+
+#[test]
+fn we_can_verify_minmax_numerator_and_plusminusonezero_denominator_modulus() {
+    verify_tinyint_modulo(
+        &[i8::MAX, i8::MIN, i8::MAX, i8::MIN, i8::MAX, i8::MIN],
+        &[1, 1, -1, -1, 0, 0],
+        &[0, 0, 0, 0, i8::MAX, i8::MIN],
+    );
+}
+
+#[test]
+fn we_can_verify_minmax_numerator_and_plusminusonezero_denominator_modulus_i128() {
+    verify_int128_modulo(
+        &[
+            i128::MAX,
+            i128::MIN,
+            i128::MAX,
+            i128::MIN,
+            i128::MAX,
+            i128::MIN,
+        ],
+        &[1, 1, -1, -1, 0, 0],
+        &[0, 0, 0, 0, i128::MAX, i128::MIN],
+    );
+}
+
+#[test]
+fn we_can_verify_large_remainder_and_rhs() {
+    let floor_of_sqrt: i128 = 13_043_817_825_332_782_212;
+    verify_int128_modulo(
+        &[i128::MAX, i128::MIN, i128::MAX, i128::MIN],
+        // Floor of sqrt{i128::MAX}
+        &[floor_of_sqrt, floor_of_sqrt, -floor_of_sqrt, -floor_of_sqrt],
+        &[
+            9_119_501_915_260_492_783,
+            -9_119_501_915_260_492_784,
+            9_119_501_915_260_492_783,
+            -9_119_501_915_260_492_784,
+        ],
+    );
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -135,7 +135,7 @@ pub(crate) fn multiply_columns<'a, S: Scalar>(
 
 /// Convert column to scalar slice.
 #[allow(clippy::missing_panics_doc)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn columns_to_scalar_slice<'a, S: Scalar>(
     column: &Column<'a, S>,
     alloc: &'a Bump,
@@ -202,7 +202,7 @@ pub(crate) fn scale_and_add_subtract_eval<S: Scalar>(
 /// Therefore, this value wraps around to `i128::MIN`.
 /// Division by 0 returns 0.
 #[allow(clippy::missing_panics_doc)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn divide_integer_columns<
     'a,
     L: NumCast + Copy + PrimInt + Neg<Output = L>,
@@ -246,7 +246,7 @@ fn divide_integer_columns<
 /// but modulo still returns 0 here.
 /// Division by 0 returns the numerator for modulo.
 #[allow(clippy::missing_panics_doc)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn modulo_integer_columns<
     'a,
     L: NumCast + Copy + PrimInt + Neg<Output = L>,
@@ -280,7 +280,7 @@ fn modulo_integer_columns<
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length or column type division is unsupported.
 #[allow(clippy::too_many_lines)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn divide_columns<'a, S: Scalar>(
     lhs: &Column<'a, S>,
     rhs: &Column<'a, S>,
@@ -401,7 +401,7 @@ pub(crate) fn divide_columns<'a, S: Scalar>(
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 /// Take the modulo of one column against another.
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length.

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -135,7 +135,6 @@ pub(crate) fn multiply_columns<'a, S: Scalar>(
 
 /// Convert column to scalar slice.
 #[allow(clippy::missing_panics_doc)]
-#[expect(dead_code)]
 pub(crate) fn columns_to_scalar_slice<'a, S: Scalar>(
     column: &Column<'a, S>,
     alloc: &'a Bump,
@@ -202,7 +201,6 @@ pub(crate) fn scale_and_add_subtract_eval<S: Scalar>(
 /// Therefore, this value wraps around to `i128::MIN`.
 /// Division by 0 returns 0.
 #[allow(clippy::missing_panics_doc)]
-#[expect(dead_code)]
 fn divide_integer_columns<
     'a,
     L: NumCast + Copy + PrimInt + Neg<Output = L>,
@@ -246,7 +244,6 @@ fn divide_integer_columns<
 /// but modulo still returns 0 here.
 /// Division by 0 returns the numerator for modulo.
 #[allow(clippy::missing_panics_doc)]
-#[expect(dead_code)]
 fn modulo_integer_columns<
     'a,
     L: NumCast + Copy + PrimInt + Neg<Output = L>,
@@ -280,7 +277,6 @@ fn modulo_integer_columns<
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length or column type division is unsupported.
 #[allow(clippy::too_many_lines)]
-#[expect(dead_code)]
 pub(crate) fn divide_columns<'a, S: Scalar>(
     lhs: &Column<'a, S>,
     rhs: &Column<'a, S>,
@@ -401,7 +397,6 @@ pub(crate) fn divide_columns<'a, S: Scalar>(
     }
 }
 
-#[expect(dead_code)]
 /// Take the modulo of one column against another.
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length.

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -205,7 +205,7 @@ pub(crate) fn scale_and_add_subtract_eval<S: Scalar>(
 #[allow(dead_code)]
 fn divide_integer_columns<
     'a,
-    L: NumCast + Copy + PrimInt,
+    L: NumCast + Copy + PrimInt + Neg<Output = L>,
     R: NumCast + Copy + PrimInt + Neg<Output = R>,
     S: Scalar + From<L>,
 >(
@@ -249,7 +249,7 @@ fn divide_integer_columns<
 #[allow(dead_code)]
 fn modulo_integer_columns<
     'a,
-    L: NumCast + Copy + PrimInt,
+    L: NumCast + Copy + PrimInt + Neg<Output = L>,
     R: NumCast + Copy + PrimInt + Neg<Output = R>,
     O: NumCast + PrimInt,
 >(

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -89,8 +89,26 @@ pub fn multiply(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_multiply(left, right).unwrap()
 }
 
+/// # Panics
+/// Panics if:
+/// - `DynProofExpr::try_new_divide()` returns an error.
+pub fn divide(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
+    DynProofExpr::try_new_divide(left, right).unwrap()
+}
+
+/// # Panics
+/// Panics if:
+/// - `DynProofExpr::try_new_modulo()` returns an error.
+pub fn modulo(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
+    DynProofExpr::try_new_modulo(left, right).unwrap()
+}
+
 pub fn const_bool(val: bool) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::Boolean(val))
+}
+
+pub fn const_tinyint(val: i8) -> DynProofExpr {
+    DynProofExpr::new_literal(LiteralValue::TinyInt(val))
 }
 
 pub fn const_smallint(val: i16) -> DynProofExpr {

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -1,8 +1,12 @@
 use super::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr};
-use crate::base::{
-    database::{ColumnRef, LiteralValue, SchemaAccessor, TableRef},
-    math::{decimal::Precision, i256::I256},
-    scalar::Scalar,
+use crate::{
+    base::{
+        database::{ColumnRef, LiteralValue, SchemaAccessor, TableRef},
+        math::{decimal::Precision, i256::I256},
+        polynomial::MultilinearExtension,
+        scalar::{test_scalar::TestScalar, Scalar},
+    },
+    sql::proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
 };
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use sqlparser::ast::Ident;
@@ -217,4 +221,50 @@ pub fn sum_expr(expr: DynProofExpr, alias: &str) -> AliasedDynProofExpr {
         expr: DynProofExpr::new_aggregate(AggregationOperator::Sum, expr),
         alias: alias.into(),
     }
+}
+
+/// Allows testing `verify_evaluate` and other verify gadgets row by row.
+/// The return matrix will tell which constraints failed.
+/// The length of the vector should be the length of the data.
+pub fn verify_row_by_row<
+    F: FnMut(&mut MockVerificationBuilder<TestScalar>, TestScalar, &[TestScalar]),
+>(
+    table_length: usize,
+    final_round_builder: &FinalRoundBuilder<'_, TestScalar>,
+    subpolynomial_max_multiplicands: usize,
+    mut row_verification: F,
+) -> Vec<Vec<bool>> {
+    let evaluation_points: Vec<Vec<_>> = (0..table_length)
+        .map(|i| {
+            (0..table_length)
+                .map(|j| {
+                    if i == j {
+                        TestScalar::ONE
+                    } else {
+                        TestScalar::ZERO
+                    }
+                })
+                .collect()
+        })
+        .collect();
+    let final_round_mles: Vec<_> = evaluation_points
+        .iter()
+        .map(|evaluation_point| final_round_builder.evaluate_pcs_proof_mles(evaluation_point))
+        .collect();
+    let mut verification_builder = MockVerificationBuilder::new(
+        final_round_builder.bit_distributions().to_vec(),
+        subpolynomial_max_multiplicands,
+        final_round_mles,
+    );
+
+    for evaluation_point in evaluation_points {
+        let one_eval = (&[1, 1, 1, 1]).inner_product(&evaluation_point);
+        row_verification(&mut verification_builder, one_eval, &evaluation_point);
+        verification_builder.increment_row_index();
+    }
+    verification_builder
+        .identity_subpolynomial_evaluations
+        .iter()
+        .map(|v| v.iter().map(|s| *s == TestScalar::ZERO).collect())
+        .collect()
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -1,0 +1,406 @@
+use super::{prover_evaluate_sign, verifier_evaluate_sign};
+use crate::{
+    base::{
+        database::{try_divide_modulo_column_types, Column, ColumnRef, ColumnType, Table},
+        map::{IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::{
+        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        proof_exprs::{
+            add_subtract_columns, columns_to_scalar_slice, divide_columns, modulo_columns,
+            DynProofExpr, ProofExpr,
+        },
+    },
+    utils::log,
+};
+use alloc::{boxed::Box, vec};
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DivideAndModuloExpr {
+    pub lhs: Box<DynProofExpr>,
+    pub rhs: Box<DynProofExpr>,
+}
+
+const SQRT_MIN_I128: u64 = 13_043_817_825_332_782_212;
+
+impl DivideAndModuloExpr {
+    pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
+        Self { lhs, rhs }
+    }
+
+    #[allow(clippy::missing_panics_doc)]
+    fn min_scalar<S: Scalar>(&self) -> S {
+        self.lhs.data_type().min_scalar::<S>().unwrap()
+    }
+
+    #[allow(clippy::missing_panics_doc)]
+    pub fn data_type(&self) -> ColumnType {
+        try_divide_modulo_column_types(self.lhs.data_type(), self.rhs.data_type())
+            .expect("Failed to divide/modulo column types")
+            .0
+    }
+
+    #[allow(clippy::too_many_lines)]
+    pub fn prover_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+    ) -> (Column<'a, S>, Column<'a, S>) {
+        log::log_memory_usage("Start");
+
+        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table);
+        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table);
+
+        let (quotient_wrapped, quotient) = divide_columns(&lhs_column, &rhs_column, alloc);
+        let remainder = modulo_columns(&lhs_column, &rhs_column, alloc);
+        builder.produce_intermediate_mle(quotient_wrapped);
+        builder.produce_intermediate_mle(quotient);
+        builder.produce_intermediate_mle(remainder);
+
+        // subpolynomial: q * b + r - a = 0
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(quotient), Box::new(rhs_column)]),
+                (S::one(), vec![Box::new(remainder)]),
+                (-S::one(), vec![Box::new(lhs_column)]),
+            ],
+        );
+
+        // (r - b) * (r + b) * t' - b = 0, where t' = b / ((r - b) * (r + b)) when |r| is not |b|
+        // This confirms |r| = |b| only if b = 0.
+        let remainder_minus_rhs = add_subtract_columns(remainder, rhs_column, 0, 0, alloc, true);
+        let remainder_plus_rhs = add_subtract_columns(remainder, rhs_column, 0, 0, alloc, false);
+        let rhs_as_scalars = rhs_column.to_scalar_with_scaling(0);
+        let rhs_div_remainder_rhs_difference_of_squares =
+            alloc.alloc_slice_fill_with(rhs_column.len(), |_i| S::ZERO);
+        for (res, ((diff, add), b)) in rhs_div_remainder_rhs_difference_of_squares.iter_mut().zip(
+            remainder_minus_rhs
+                .iter()
+                .copied()
+                .zip(remainder_plus_rhs.iter().copied())
+                .zip(rhs_as_scalars.clone()),
+        ) {
+            *res = (diff * add).inv().unwrap_or(S::ONE) * b;
+        }
+        let t = Column::Scalar(rhs_div_remainder_rhs_difference_of_squares);
+        builder.produce_intermediate_mle(t);
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (
+                    S::one(),
+                    vec![
+                        Box::new(remainder_minus_rhs),
+                        Box::new(remainder_plus_rhs),
+                        Box::new(t),
+                    ],
+                ),
+                (-S::one(), vec![Box::new(rhs_column)]),
+            ],
+        );
+
+        // (s - q) * (s - b) = 0
+        // Introduces a value s that must be either q or b.
+        // We choose s to be a value of q or b such that -sqrt(-MIN) < s < sqrt(-MIN)
+        let min_sqrt_scalar = -S::from(SQRT_MIN_I128);
+        let in_range_q_or_b = alloc.alloc_slice_fill_with(quotient.len(), |_i| S::ZERO);
+        for (res, (q, b)) in in_range_q_or_b
+            .iter_mut()
+            .zip(quotient.iter().copied().zip(rhs_as_scalars.clone()))
+        {
+            // We do or rather than and here because scalars wrap negative values, so only one can be true at a time
+            let in_range_value = if q > min_sqrt_scalar || q < -min_sqrt_scalar {
+                q
+            } else {
+                b
+            };
+            *res = in_range_value;
+        }
+        let s = Column::Scalar(in_range_q_or_b);
+        builder.produce_intermediate_mle(s);
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(s), Box::new(s)]),
+                (S::one(), vec![Box::new(rhs_column), Box::new(quotient)]),
+                (-S::one(), vec![Box::new(s), Box::new(rhs_column)]),
+                (-S::one(), vec![Box::new(s), Box::new(quotient)]),
+            ],
+        );
+
+        // b * u = q where u = q / b if b is not 0
+        // This ensures that q = 0 if b = 0
+        let q_div_b = alloc.alloc_slice_fill_with(quotient.len(), |_i| S::ZERO);
+        for (res, (q, b)) in q_div_b
+            .iter_mut()
+            .zip(quotient.iter().copied().zip(rhs_as_scalars))
+        {
+            *res = b.inv().unwrap_or(S::ONE) * q;
+        }
+        let u = Column::Scalar(q_div_b);
+        builder.produce_intermediate_mle(u);
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(rhs_column), Box::new(u)]),
+                (-S::one(), vec![Box::new(quotient)]),
+            ],
+        );
+        // (q′ − q) * (q + MIN) = 0
+        // Ensures that either q = q' or q = -MIN
+        // Simplifies to
+        // q' * q - MIN * q - q * q + MIN * q'
+
+        let min_scalar = self.min_scalar();
+        let min_column =
+            Column::Scalar(alloc.alloc_slice_fill_with(quotient.len(), |_i| min_scalar));
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (
+                    S::one(),
+                    vec![Box::new(quotient_wrapped), Box::new(quotient)],
+                ),
+                (-S::one(), vec![Box::new(min_column), Box::new(quotient)]),
+                (-S::one(), vec![Box::new(quotient), Box::new(quotient)]),
+                (
+                    S::one(),
+                    vec![Box::new(quotient_wrapped), Box::new(min_column)],
+                ),
+            ],
+        );
+
+        // (q' - MIN) * (q + MIN) * v - (q' - MIN) = 0 where v = 1 / (q + MIN) if q is not - MIN
+        // Ensures q = -MIN only if q' = MIN
+        let quotient_plus_min_inverse = alloc.alloc_slice_fill_with(quotient.len(), |_i| S::ZERO);
+        for (res, q) in quotient_plus_min_inverse
+            .iter_mut()
+            .zip(quotient.iter().copied())
+        {
+            *res = (q + min_scalar).inv().unwrap_or(S::ONE);
+        }
+        let v = Column::Scalar(quotient_plus_min_inverse);
+        builder.produce_intermediate_mle(v);
+
+        let min_scalar_column =
+            Column::Scalar(alloc.alloc_slice_fill_with(quotient.len(), |_i| min_scalar));
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (
+                    S::one(),
+                    vec![Box::new(quotient_wrapped), Box::new(quotient), Box::new(v)],
+                ),
+                (S::one(), vec![Box::new(min_scalar_column)]),
+                (-S::one(), vec![Box::new(quotient_wrapped)]),
+                (
+                    -S::one(),
+                    vec![
+                        Box::new(min_scalar_column),
+                        Box::new(min_scalar_column),
+                        Box::new(v),
+                    ],
+                ),
+                (
+                    -S::one(),
+                    vec![Box::new(min_scalar_column), Box::new(quotient), Box::new(v)],
+                ),
+                (
+                    S::one(),
+                    vec![
+                        Box::new(min_scalar_column),
+                        Box::new(quotient_wrapped),
+                        Box::new(v),
+                    ],
+                ),
+            ],
+        );
+
+        // sign(sqrt(-min) + s) = 1
+        // sign(sqrt(-min) - s) = 1
+        // These confirm that q * b does not wrap in the Scalar field. Either q or b must be smaller than sqrt(-min), which confines qb to less than the order of the field.
+        let neg_min_sqrt_scalar_column =
+            Column::Scalar(alloc.alloc_slice_fill_with(quotient.len(), |_i| -min_sqrt_scalar));
+        prover_evaluate_sign(
+            builder,
+            alloc,
+            add_subtract_columns(neg_min_sqrt_scalar_column, s, 0, 0, alloc, false),
+        );
+        prover_evaluate_sign(
+            builder,
+            alloc,
+            add_subtract_columns(neg_min_sqrt_scalar_column, s, 0, 0, alloc, true),
+        );
+
+        // sign<128>(q)
+        // Confirms that q is not too big.
+        prover_evaluate_sign(builder, alloc, quotient);
+
+        // sign(a) * r = sign(r) * r and sign(r - b) * b + sign(r - b) - b = 0
+        // constrains remainder to be in the correct range
+        let lhs_sign =
+            prover_evaluate_sign(builder, alloc, columns_to_scalar_slice(&lhs_column, alloc));
+        let remainder_sign =
+            prover_evaluate_sign(builder, alloc, columns_to_scalar_slice(&remainder, alloc));
+
+        let remainder_minus_rhs_sign = prover_evaluate_sign(builder, alloc, remainder_minus_rhs);
+        let remainder_plus_rhs_sign = prover_evaluate_sign(builder, alloc, remainder_plus_rhs);
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(lhs_sign), Box::new(remainder)]),
+                (
+                    -S::one(),
+                    vec![Box::new(remainder_sign), Box::new(remainder)],
+                ),
+            ],
+        );
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (
+                    S::one(),
+                    vec![Box::new(remainder_minus_rhs_sign), Box::new(rhs_column)],
+                ),
+                (
+                    S::one(),
+                    vec![Box::new(remainder_plus_rhs_sign), Box::new(rhs_column)],
+                ),
+                (-S::one(), vec![Box::new(rhs_column)]),
+            ],
+        );
+
+        log::log_memory_usage("End");
+
+        (quotient_wrapped, remainder)
+    }
+
+    pub fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        one_eval: S,
+    ) -> Result<(S, S), ProofError> {
+        let lhs = self.lhs.verifier_evaluate(builder, accessor, one_eval)?;
+        let rhs = self.rhs.verifier_evaluate(builder, accessor, one_eval)?;
+
+        // lhs_times_rhs
+        let quotient_wrapped = builder.try_consume_final_round_mle_evaluation()?;
+        let quotient = builder.try_consume_final_round_mle_evaluation()?;
+        let remainder = builder.try_consume_final_round_mle_evaluation()?;
+
+        // subpolynomial: q * b - a + r = 0
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            quotient * rhs - lhs + remainder,
+            2,
+        )?;
+
+        // (r - b) * (r + b) * t' - b = 0
+        let t = builder.try_consume_final_round_mle_evaluation()?;
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            (remainder - rhs) * (remainder + rhs) * t - rhs,
+            3,
+        )?;
+
+        // (s - q)(s - b) = 0
+        let s = builder.try_consume_final_round_mle_evaluation()?;
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            (s - quotient) * (s - rhs),
+            2,
+        )?;
+
+        // b * t = q
+        let q_div_b = builder.try_consume_final_round_mle_evaluation()?;
+
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            rhs * q_div_b - quotient,
+            2,
+        )?;
+
+        // (q′ − q) * (q + MIN) = 0
+        let min_eval = self.min_scalar::<S>() * one_eval;
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            (quotient_wrapped - quotient) * (quotient + min_eval),
+            2,
+        )?;
+
+        // (q' - MIN) * (q + MIN) * v - (q' - MIN) = 0
+        let v = builder.try_consume_final_round_mle_evaluation()?;
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            (quotient_wrapped - min_eval) * (quotient + min_eval) * v - quotient_wrapped + min_eval,
+            3,
+        )?;
+
+        // sign(sqrt(-min) + s) = 1
+        // sign(sqrt(-min) - s) = 1
+        let min_sqrt_eval = S::from(SQRT_MIN_I128) * one_eval;
+        let sqrt_min_plus_s = verifier_evaluate_sign(builder, min_sqrt_eval + s, one_eval, None)?;
+        let sqrt_min_less_s = verifier_evaluate_sign(builder, min_sqrt_eval - s, one_eval, None)?;
+
+        if sqrt_min_plus_s != S::ZERO || sqrt_min_less_s != S::ZERO {
+            return Err(ProofError::VerificationError {
+                error: "Intermediate value out of range",
+            });
+        }
+
+        // MIN < q < -MIN
+        // We need at least and extra bit to allow for -MIN
+        verifier_evaluate_sign(
+            builder,
+            quotient,
+            one_eval,
+            Some(
+                (self.lhs.data_type().to_integer_bits().unwrap() + 1)
+                    .try_into()
+                    .unwrap(),
+            ),
+        )?;
+
+        // sign(a) * r = sign(r) * r and sign(r - b) * b + sign(r + b) * b = b
+        let lhs_sign = verifier_evaluate_sign(builder, lhs, one_eval, None)?;
+        let remainder_sign = verifier_evaluate_sign(builder, remainder, one_eval, None)?;
+
+        let remainder_and_rhs_difference_sign =
+            verifier_evaluate_sign(builder, remainder - rhs, one_eval, None)?;
+        let remainder_and_rhs_added_sign =
+            verifier_evaluate_sign(builder, remainder + rhs, one_eval, None)?;
+
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            remainder * (lhs_sign - remainder_sign),
+            2,
+        )?;
+
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            rhs * (remainder_and_rhs_difference_sign + remainder_and_rhs_added_sign - S::ONE),
+            2,
+        )?;
+
+        Ok((quotient, remainder))
+    }
+
+    pub fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.lhs.get_column_references(columns);
+        self.rhs.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -27,6 +27,74 @@ pub struct DivideAndModuloExpr {
 
 const SQRT_MIN_I128: u64 = 13_043_817_825_332_782_212;
 
+trait DivideAndModuloExprUtilities<S: Scalar> {
+    fn divide_columns<'a>(
+        &self,
+        lhs: &Column<'a, S>,
+        rhs: &Column<'a, S>,
+        alloc: &'a Bump,
+    ) -> (Column<'a, S>, &'a [S]);
+
+    fn modulo_columns<'a>(
+        &self,
+        lhs: &Column<'a, S>,
+        rhs: &Column<'a, S>,
+        alloc: &'a Bump,
+    ) -> Column<'a, S>;
+
+    fn get_in_range_column_from_quotient_and_rhs<'a>(
+        &self,
+        alloc: &'a Bump,
+        quotient: &'a [S],
+        rhs: Vec<S>,
+    ) -> &'a [S];
+}
+
+struct StandardDivideAndModuloExprUtilities;
+
+impl<S: Scalar> DivideAndModuloExprUtilities<S> for StandardDivideAndModuloExprUtilities {
+    fn divide_columns<'a>(
+        &self,
+        lhs: &Column<'a, S>,
+        rhs: &Column<'a, S>,
+        alloc: &'a Bump,
+    ) -> (Column<'a, S>, &'a [S]) {
+        divide_columns(lhs, rhs, alloc)
+    }
+
+    fn modulo_columns<'a>(
+        &self,
+        lhs: &Column<'a, S>,
+        rhs: &Column<'a, S>,
+        alloc: &'a Bump,
+    ) -> Column<'a, S> {
+        modulo_columns(lhs, rhs, alloc)
+    }
+
+    fn get_in_range_column_from_quotient_and_rhs<'a>(
+        &self,
+        alloc: &'a Bump,
+        quotient: &'a [S],
+        rhs: Vec<S>,
+    ) -> &'a [S] {
+        let min_sqrt_scalar = -S::from(SQRT_MIN_I128);
+        let in_range_q_or_b = alloc.alloc_slice_fill_with(quotient.len(), |_i| S::ZERO);
+        for (res, (q, b)) in in_range_q_or_b
+            .iter_mut()
+            .zip(quotient.iter().copied().zip(rhs.clone()))
+        {
+            // We do or rather than and here because scalars wrap negative values, so only one can be true at a time
+            let in_range_value = if q > min_sqrt_scalar || q < -min_sqrt_scalar {
+                q
+            } else {
+                b
+            };
+            *res = in_range_value;
+        }
+        in_range_q_or_b
+    }
+}
+
 impl DivideAndModuloExpr {
     pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
         Self { lhs, rhs }
@@ -44,20 +112,19 @@ impl DivideAndModuloExpr {
             .0
     }
 
-    #[allow(clippy::too_many_lines)]
-    pub fn prover_evaluate<'a, S: Scalar>(
+    fn prover_evaluate_base<'a, S: Scalar, U: DivideAndModuloExprUtilities<S>>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table: &Table<'a, S>,
+        utilities: U,
     ) -> (Column<'a, S>, Column<'a, S>) {
-        log::log_memory_usage("Start");
-
         let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table);
         let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table);
 
-        let (quotient_wrapped, quotient) = divide_columns(&lhs_column, &rhs_column, alloc);
-        let remainder = modulo_columns(&lhs_column, &rhs_column, alloc);
+        let (quotient_wrapped, quotient) =
+            utilities.divide_columns(&lhs_column, &rhs_column, alloc);
+        let remainder = utilities.modulo_columns(&lhs_column, &rhs_column, alloc);
         builder.produce_intermediate_mle(quotient_wrapped);
         builder.produce_intermediate_mle(quotient);
         builder.produce_intermediate_mle(remainder);
@@ -109,20 +176,11 @@ impl DivideAndModuloExpr {
         // (s - q) * (s - b) = 0
         // Introduces a value s that must be either q or b.
         // We choose s to be a value of q or b such that -sqrt(-MIN) < s < sqrt(-MIN)
-        let min_sqrt_scalar = -S::from(SQRT_MIN_I128);
-        let in_range_q_or_b = alloc.alloc_slice_fill_with(quotient.len(), |_i| S::ZERO);
-        for (res, (q, b)) in in_range_q_or_b
-            .iter_mut()
-            .zip(quotient.iter().copied().zip(rhs_as_scalars.clone()))
-        {
-            // We do or rather than and here because scalars wrap negative values, so only one can be true at a time
-            let in_range_value = if q > min_sqrt_scalar || q < -min_sqrt_scalar {
-                q
-            } else {
-                b
-            };
-            *res = in_range_value;
-        }
+        let in_range_q_or_b = utilities.get_in_range_column_from_quotient_and_rhs(
+            alloc,
+            quotient,
+            rhs_as_scalars.clone(),
+        );
         let s = Column::Scalar(in_range_q_or_b);
         builder.produce_intermediate_mle(s);
 
@@ -171,12 +229,15 @@ impl DivideAndModuloExpr {
                     S::one(),
                     vec![Box::new(quotient_wrapped), Box::new(quotient)],
                 ),
-                (-S::one(), vec![Box::new(min_column), Box::new(quotient)]),
-                (-S::one(), vec![Box::new(quotient), Box::new(quotient)]),
                 (
-                    S::one(),
-                    vec![Box::new(quotient_wrapped), Box::new(min_column)],
+                    -S::one(),
+                    vec![Box::new(min_column), Box::new(quotient)],
                 ),
+                (
+                    -S::one(),
+                    vec![Box::new(quotient), Box::new(quotient)],
+                ),
+                (S::one(), vec![Box::new(quotient_wrapped), Box::new(min_column)]),
             ],
         );
 
@@ -230,8 +291,9 @@ impl DivideAndModuloExpr {
         // sign(sqrt(-min) + s) = 1
         // sign(sqrt(-min) - s) = 1
         // These confirm that q * b does not wrap in the Scalar field. Either q or b must be smaller than sqrt(-min), which confines qb to less than the order of the field.
+        let min_sqrt_scalar = S::from(SQRT_MIN_I128);
         let neg_min_sqrt_scalar_column =
-            Column::Scalar(alloc.alloc_slice_fill_with(quotient.len(), |_i| -min_sqrt_scalar));
+            Column::Scalar(alloc.alloc_slice_fill_with(quotient.len(), |_i| min_sqrt_scalar));
         prover_evaluate_sign(
             builder,
             alloc,
@@ -283,14 +345,29 @@ impl DivideAndModuloExpr {
             ],
         );
 
-        log::log_memory_usage("End");
-
         (quotient_wrapped, remainder)
     }
 
-    pub fn verifier_evaluate<S: Scalar>(
+    #[allow(clippy::too_many_lines)]
+    pub fn prover_evaluate<'a, S: Scalar>(
         &self,
-        builder: &mut impl VerificationBuilder<S>,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+    ) -> (Column<'a, S>, Column<'a, S>) {
+        log::log_memory_usage("Start");
+        let utilities = StandardDivideAndModuloExprUtilities {};
+
+        let res = self.prover_evaluate_base(builder, alloc, table, utilities);
+
+        log::log_memory_usage("End");
+
+        res
+    }
+
+    pub fn verifier_evaluate<S: Scalar, B: VerificationBuilder<S>>(
+        &self,
+        builder: &mut B,
         accessor: &IndexMap<ColumnRef, S>,
         one_eval: S,
     ) -> Result<(S, S), ProofError> {
@@ -325,7 +402,7 @@ impl DivideAndModuloExpr {
             2,
         )?;
 
-        // b * t = q
+        // b * u = q
         let q_div_b = builder.try_consume_final_round_mle_evaluation()?;
 
         builder.try_produce_sumcheck_subpolynomial_evaluation(
@@ -402,5 +479,413 @@ impl DivideAndModuloExpr {
     pub fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DivideAndModuloExpr, DivideAndModuloExprUtilities, StandardDivideAndModuloExprUtilities,
+    };
+    use crate::{
+        base::{
+            database::{Column, ColumnRef, ColumnType, Table, TableRef}, map::indexmap, polynomial::MultilinearExtension, scalar::{test_scalar::TestScalar, Scalar}
+        },
+        sql::{
+            proof::FinalRoundBuilder,
+            proof_exprs::{columns_to_scalar_slice, test_utility::verify_row_by_row, ColumnExpr, DynProofExpr},
+        },
+    };
+    use bumpalo::Bump;
+    use mockall::automock;
+    use sqlparser::ast::Ident;
+    use std::collections::VecDeque;
+
+    #[automock]
+    trait MockableDivideAndModuloExprFunctionality {
+        fn divide_columns(&self, lhs: Vec<i128>, rhs: Vec<i128>) -> (Vec<TestScalar>, Vec<TestScalar>);
+
+        fn modulo_columns(&self, lhs: Vec<i128>, rhs: Vec<i128>) -> Vec<i128>;
+
+        fn get_in_range_column_from_quotient_and_rhs(
+            &self,
+            quotient: Vec<TestScalar>,
+            rhs: Vec<TestScalar>,
+        ) -> Vec<TestScalar>;
+    }
+
+    struct MockDivideAndModuloExprUtilities<F: MockableDivideAndModuloExprFunctionality> {
+        functions: F,
+    }
+
+    impl<F: MockableDivideAndModuloExprFunctionality> DivideAndModuloExprUtilities<TestScalar>
+        for MockDivideAndModuloExprUtilities<F>
+    {
+        fn divide_columns<'a>(
+            &self,
+            lhs: &Column<'a, TestScalar>,
+            rhs: &Column<'a, TestScalar>,
+            alloc: &'a Bump,
+        ) -> (Column<'a, TestScalar>, &'a [TestScalar]) {
+            if let (Column::Int128(a), Column::Int128(b)) = (lhs, rhs) {
+                let (quotient_wrapped, quotient) =
+                    self.functions.divide_columns(a.to_vec(), b.to_vec());
+                let quotient_wrapped_slice = alloc.alloc_slice_copy(&quotient_wrapped);
+                let quotient_slice = alloc.alloc_slice_copy(&quotient);
+                (Column::Scalar(quotient_wrapped_slice), quotient_slice)
+            } else {
+                panic!("MockDivideAndModuloExprUtilities should only be used with int128 columns");
+            }
+        }
+
+        fn modulo_columns<'a>(
+            &self,
+            lhs: &Column<'a, TestScalar>,
+            rhs: &Column<'a, TestScalar>,
+            alloc: &'a Bump,
+        ) -> Column<'a, TestScalar> {
+            if let (Column::Int128(a), Column::Int128(b)) = (lhs, rhs) {
+                let remainder = self.functions.modulo_columns(a.to_vec(), b.to_vec());
+                let remainder_slice = alloc.alloc_slice_copy(&remainder);
+                Column::Int128(remainder_slice)
+            } else {
+                panic!("MockDivideAndModuloExprUtilities should only be used with int128 columns");
+            }
+        }
+
+        fn get_in_range_column_from_quotient_and_rhs<'a>(
+            &self,
+            alloc: &'a Bump,
+            quotient: &'a [TestScalar],
+            rhs: Vec<TestScalar>,
+        ) -> &'a [TestScalar] {
+            alloc.alloc_slice_copy(
+                &self
+                    .functions
+                    .get_in_range_column_from_quotient_and_rhs(quotient.to_vec(), rhs),
+            )
+        }
+    }
+
+    fn default_divide_columns(lhs: Vec<i128>, rhs: Vec<i128>) -> (Vec<TestScalar>, Vec<TestScalar>) {
+        let alloc = Bump::new();
+        let standard_utilities = StandardDivideAndModuloExprUtilities;
+        let (quotient_wrapped, quotient) = standard_utilities.divide_columns(
+            &Column::Int128::<TestScalar>(&lhs.as_slice()),
+            &Column::Int128(&rhs.as_slice()),
+            &alloc,
+        );
+        (
+            columns_to_scalar_slice(&quotient_wrapped, &alloc).to_vec(),
+            quotient.to_vec(),
+        )
+    }
+
+    fn default_modulo_columns(lhs: Vec<i128>, rhs: Vec<i128>) -> Vec<i128> {
+        let alloc = Bump::new();
+        let standard_utilities = StandardDivideAndModuloExprUtilities;
+        standard_utilities
+            .modulo_columns(
+                &Column::Int128::<TestScalar>(&lhs.as_slice()),
+                &Column::Int128(&rhs.as_slice()),
+                &alloc,
+            )
+            .as_int128()
+            .unwrap()
+            .to_vec()
+    }
+
+    fn default_get_in_range_column_from_quotient_and_rhs(
+        quotient: Vec<TestScalar>,
+        rhs: Vec<TestScalar>,
+    ) -> Vec<TestScalar> {
+        let alloc = Bump::new();
+        let standard_utilities = StandardDivideAndModuloExprUtilities;
+        standard_utilities
+            .get_in_range_column_from_quotient_and_rhs(&alloc, &quotient, rhs)
+            .to_vec()
+    }
+
+    fn get_default_mock() -> MockMockableDivideAndModuloExprFunctionality {
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        mock_functionality
+            .expect_divide_columns()
+            .returning(default_divide_columns);
+        mock_functionality
+            .expect_modulo_columns()
+            .returning(default_modulo_columns);
+        mock_functionality
+            .expect_get_in_range_column_from_quotient_and_rhs()
+            .returning(default_get_in_range_column_from_quotient_and_rhs);
+        mock_functionality
+    }
+
+    fn get_constraint_bool_matrix(
+        mock_functionality: MockMockableDivideAndModuloExprFunctionality,
+        lhs: &[i128],
+        rhs: &[i128],
+    ) -> Vec<Vec<bool>> {
+        let alloc = Bump::new();
+        let mock_utilities = MockDivideAndModuloExprUtilities {
+            functions: mock_functionality,
+        };
+        let table_ref: TableRef = "sxt.t".parse().unwrap();
+        let lhs_ident = Ident::from("lhs");
+        let rhs_ident = Ident::from("rhs");
+        let lhs_ref = ColumnRef::new(table_ref.clone(), lhs_ident.clone(), ColumnType::Int128);
+        let rhs_ref = ColumnRef::new(table_ref, rhs_ident.clone(), ColumnType::Int128);
+        let divide_and_modulo_expr = DivideAndModuloExpr::new(
+            Box::new(DynProofExpr::Column(ColumnExpr::new(lhs_ref.clone()))),
+            Box::new(DynProofExpr::Column(ColumnExpr::new(rhs_ref.clone()))),
+        );
+        let mut final_round_builder = FinalRoundBuilder::new(lhs.len(), VecDeque::new());
+        let table = Table::try_new(indexmap! {
+            lhs_ident => Column::Int128::<TestScalar>(lhs),
+            rhs_ident => Column::Int128::<TestScalar>(rhs),
+        })
+        .unwrap();
+        divide_and_modulo_expr.prover_evaluate_base(
+            &mut final_round_builder,
+            &alloc,
+            &table,
+            mock_utilities,
+        );
+        let matrix = verify_row_by_row(
+            lhs.len(),
+            &final_round_builder,
+            4,
+            |verification_builder, chi_eval, evaluation_point| {
+                let accessor = indexmap! {
+                    lhs_ref.clone() => lhs.inner_product(evaluation_point),
+                    rhs_ref.clone() => rhs.inner_product(evaluation_point)
+                };
+                divide_and_modulo_expr
+                    .verifier_evaluate(verification_builder, &accessor, chi_eval)
+                    .unwrap();
+            },
+        );
+        matrix
+            .iter()
+            .map(|v| {
+                assert!(v[6..(v.len() - 2)].iter().all(|b| *b));
+                let mut vec = v[0..6].to_vec();
+                vec.extend(v[(v.len() - 2)..v.len()].iter());
+                vec
+            })
+            .collect()
+    }
+
+    #[derive(PartialEq, Debug)]
+    enum TestableConstraints {
+        /// q * b + r - a = 0
+        DivisionAlgorithm,
+        /// (r - b) * (r + b) * t' - b = 0
+        DenominatorZeroIfRemainderAndDenominatorMagnitudeEqual,
+        /// (s - q)(s - b) = 0
+        BoundedValueIsQuotientOrDenominator,
+        /// b * u - q = 0
+        ZeroDenominatorDictatesQuotient,
+        /// (q′ − q) * (q + MIN) = 0
+        WrappedIsQuotientOrMin,
+        /// (q' - MIN) * (q + MIN) * v - (q' - MIN) = 0
+        WrappedIsMinIfQuotientIsNegativeMin,
+        /// sign(a) * r - sign(r) * r = 0
+        RemainderSignMatchesNumerator,
+        /// sign(r - b) * b + sign(r + b) * b - b = 0
+        RemainderBound,
+    }
+
+    fn get_failing_constraints(row: Vec<bool>) -> Vec<TestableConstraints> {
+        row.iter()
+            .enumerate()
+            .filter_map(|(i, include)| {
+                if !*include {
+                    Some(if i == 0 {
+                        TestableConstraints::DivisionAlgorithm
+                    } else if i == 1 {
+                        TestableConstraints::DenominatorZeroIfRemainderAndDenominatorMagnitudeEqual
+                    } else if i == 2 {
+                        TestableConstraints::BoundedValueIsQuotientOrDenominator
+                    } else if i == 3 {
+                        TestableConstraints::ZeroDenominatorDictatesQuotient
+                    } else if i == 4 {
+                        TestableConstraints::WrappedIsQuotientOrMin
+                    } else if i == 5 {
+                        TestableConstraints::WrappedIsMinIfQuotientIsNegativeMin
+                    } else if i == 6 {
+                        TestableConstraints::RemainderSignMatchesNumerator
+                    } else {
+                        TestableConstraints::RemainderBound
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn we_can_verify_simple_expr() {
+        let mock_functionality = get_default_mock();
+        let lhs = &[i128::MAX, i128::MIN, 2];
+        let rhs = &[3i128, 3, -4];
+        let matrix = get_constraint_bool_matrix(mock_functionality, lhs, rhs);
+        assert!(matrix.iter().all(|v| v.iter().all(|b| *b)));
+    }
+
+    /// Shifting remainder by a very small amount will only fail the division algorithm
+    #[test]
+    fn we_can_reject_if_division_algorithm_fails(){
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        mock_functionality.expect_get_in_range_column_from_quotient_and_rhs().returning(default_get_in_range_column_from_quotient_and_rhs);
+        mock_functionality
+            .expect_divide_columns()
+            .returning(default_divide_columns);
+        mock_functionality
+            .expect_modulo_columns()
+            .return_const(vec![1i128, -4, 1, -1]);
+        let lhs = &[8i128, -12, 8, -8];
+        let rhs = &[3i128, 7, -3, -3];
+        let matrix = get_constraint_bool_matrix(mock_functionality, lhs, rhs);
+        for row in matrix{
+            let failing_constraints = get_failing_constraints(row);
+            assert_eq!(failing_constraints, vec![TestableConstraints::DivisionAlgorithm]);
+        }
+    }
+
+    /// When the remainder is 0, shifting the remainder to have the same magnitude as the denominator can trick both the
+    /// division algorithm and the remainder bound. However, this should result in the failure of
+    /// `TestableConstraints::DenominatorZeroIfRemainderAndDenominatorMagnitudeEqual`
+    #[test]
+    fn we_can_reject_if_nonzero_remainder_magnitude_equals_denominator_magnitude(){
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        mock_functionality.expect_get_in_range_column_from_quotient_and_rhs().returning(default_get_in_range_column_from_quotient_and_rhs);
+        mock_functionality
+            .expect_divide_columns()
+            .return_const((vec![TestScalar::ONE, -TestScalar::ONE], vec![TestScalar::ONE, -TestScalar::ONE]));
+        mock_functionality
+            .expect_modulo_columns()
+            .return_const(vec![-4i128, -6]);
+        let lhs = &[-8i128, -12];
+        let rhs = &[-4i128, 6];
+        let matrix = get_constraint_bool_matrix(mock_functionality, lhs, rhs);
+        for row in matrix{
+            let failing_constraints = get_failing_constraints(row);
+            assert_eq!(failing_constraints, vec![TestableConstraints::DenominatorZeroIfRemainderAndDenominatorMagnitudeEqual]);
+        }
+    }
+
+    /// There is a check to verify that quotient * denominator does not overflow the scalar field.
+    /// That check verifies that either quotient or denominator is less than a certain number.
+    /// This requires committing to a column of values composed of quotients and denominators.
+    /// Providing a value that is not either the quotient or denominator should fail
+    /// `TestableContraints::BoundedValueIsQuotientOrDenominator`
+    #[test]
+    fn we_can_reject_if_committed_in_range_column_is_not_quotient_or_denominator(){
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        mock_functionality.expect_get_in_range_column_from_quotient_and_rhs().return_const(vec![TestScalar::ONE]);
+        let quotient = vec![TestScalar::from(1i128 << 126)];
+        mock_functionality
+            .expect_divide_columns()
+            .return_const((quotient.clone(), quotient));
+        let rhs_i128 = (1i128 << 126) + 1;
+        let overflow: i128 = (TestScalar::from(1i128 << 126) * TestScalar::from(rhs_i128)).try_into().unwrap();
+        mock_functionality
+            .expect_modulo_columns()
+            .return_const(vec![rhs_i128 - overflow]);
+        let lhs = &[rhs_i128];
+        let rhs = &[rhs_i128];
+        let matrix = get_constraint_bool_matrix(mock_functionality, lhs, rhs);
+        for row in matrix{
+            let failing_constraints = get_failing_constraints(row);
+            assert_eq!(failing_constraints, vec![TestableConstraints::BoundedValueIsQuotientOrDenominator]);
+        }
+    }
+
+    /// When the denominator is zero, the quotient must be zero. Lying about quotient in this scenario
+    /// is rejected easily by `TestableConstraints::ZeroDenominatorDictatesQuotient`
+    #[test]
+    fn we_can_reject_if_denominator_is_zero_but_quotient_is_not() {
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        mock_functionality.expect_get_in_range_column_from_quotient_and_rhs().returning(default_get_in_range_column_from_quotient_and_rhs);
+        let quotient = vec![TestScalar::from(10000), TestScalar::from(-10000), TestScalar::from(10000), TestScalar::from(-10000)];
+        mock_functionality
+            .expect_divide_columns()
+            .return_const((quotient.clone(), quotient));
+        mock_functionality
+            .expect_modulo_columns()
+            .returning(default_modulo_columns);
+        let lhs = &[8i128, -12, -8, 12];
+        let rhs = &[0i128, 0, 0, 0];
+        let matrix = get_constraint_bool_matrix(mock_functionality, lhs, rhs);
+        for row in matrix{
+            let failing_constraints = get_failing_constraints(row);
+            assert_eq!(failing_constraints, vec![TestableConstraints::ZeroDenominatorDictatesQuotient]);
+        }
+    }
+
+    /// If the wrapped version of quotient is completely incorrect and quotient is not -MIN, the constraint
+    /// `TestableConstraints::WrappedIsQuotientOrMin` will catch it.
+    #[test]
+    fn we_can_reject_if_quotient_wrapped_is_incorrect() {
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        mock_functionality.expect_get_in_range_column_from_quotient_and_rhs().returning(default_get_in_range_column_from_quotient_and_rhs);
+        mock_functionality
+            .expect_divide_columns()
+            .return_const((vec![TestScalar::from(-20i128), TestScalar::from(-20), TestScalar::from(20), TestScalar::from(20)], vec![TestScalar::from(2), TestScalar::from(-2), TestScalar::from(2), TestScalar::from(-2)]));
+        mock_functionality
+            .expect_modulo_columns()
+            .returning(default_modulo_columns);
+        let lhs = &[8i128, -12, -8, 12];
+        let rhs = &[3i128, 5, -3, -5];
+        let matrix = get_constraint_bool_matrix(mock_functionality, lhs, rhs);
+        for row in matrix{
+            let failing_constraints = get_failing_constraints(row);
+            assert_eq!(failing_constraints, vec![TestableConstraints::WrappedIsQuotientOrMin]);
+        }
+    }
+
+    /// If the wrapped version of quotient is completely incorrect and quotient is -MIN, the constraint
+    /// `TestableConstraints::WrappedIsMinIfQuotientIsNegativeMin` will catch it.
+    #[test]
+    fn we_can_reject_if_quotient_is_negative_min_and_quotient_wrapped_is_incorrect() {
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        mock_functionality.expect_get_in_range_column_from_quotient_and_rhs().returning(default_get_in_range_column_from_quotient_and_rhs);
+        mock_functionality
+            .expect_divide_columns()
+            .return_const((vec![TestScalar::from(-20)], vec![-TestScalar::from(i128::MIN)]));
+        mock_functionality
+            .expect_modulo_columns()
+            .returning(default_modulo_columns);
+        let lhs = &[i128::MIN];
+        let rhs = &[-1i128];
+        let matrix = get_constraint_bool_matrix(mock_functionality, lhs, rhs);
+        for row in matrix{
+            let failing_constraints = get_failing_constraints(row);
+            assert_eq!(failing_constraints, vec![TestableConstraints::WrappedIsMinIfQuotientIsNegativeMin]);
+        }
+    } 
+
+    /// A malicious prover can try to shift the quotient by 1, adjusting the remainder accordingly,
+    /// which still satisfies the division algorithm and stays within the bounds of the +/- denominator.
+    /// However, this necessarily requires that the remainder flip sign, violating `TestableConstraints::RemainderSignMatchesNumerator`
+    #[test]
+    fn we_can_reject_if_remainder_sign_matches_numerator_fails() {
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        mock_functionality.expect_get_in_range_column_from_quotient_and_rhs().returning(default_get_in_range_column_from_quotient_and_rhs);
+        let quotient = vec![TestScalar::from(3i128), TestScalar::from(-2), TestScalar::from(-3), TestScalar::from(3)];
+        mock_functionality
+            .expect_divide_columns()
+            .return_const((quotient.clone(), quotient));
+        mock_functionality
+            .expect_modulo_columns()
+            .return_const(vec![-1i128, 2, -1, 1]);
+        let lhs = &[8i128, -12, 8, -8];
+        let rhs = &[3i128, 7, -3, -3];
+        let matrix = get_constraint_bool_matrix(mock_functionality, lhs, rhs);
+        for row in matrix{
+            let failing_constraints = get_failing_constraints(row);
+            assert_eq!(failing_constraints, vec![TestableConstraints::RemainderSignMatchesNumerator]);
+        }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,4 +1,5 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
+pub(crate) mod divide_and_modulo_expr;
 mod membership_check;
 mod monotonic;
 mod permutation_check;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -102,7 +102,7 @@ pub(crate) fn verify_monotonic<S: Scalar, const STRICT: bool, const ASC: bool>(
         (true, true) | (false, false) => shifted_column_eval - column_eval,
         _ => column_eval - shifted_column_eval,
     };
-    let sign_eval = verifier_evaluate_sign(builder, ind_eval, shifted_chi_eval)?;
+    let sign_eval = verifier_evaluate_sign(builder, ind_eval, shifted_chi_eval, None)?;
     let singleton_chi_eval = builder.singleton_chi_evaluation();
     let allowed_evals = if STRICT {
         // sign(ind) == 1 for all but the first element and the last element

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -174,11 +174,26 @@ fn verify_bit_decomposition<S: ScalarExt>(
 mod tests {
     use crate::{
         base::{
-            bit::BitDistribution,
+            bit::{BitDistribution, BitDistrubutionError},
             scalar::{test_scalar::TestScalar, Scalar},
         },
         sql::proof_gadgets::sign_expr::verify_bit_decomposition,
     };
+
+    fn evaluate_matrix(matrix: &[&[i32]], terms: &[TestScalar]) -> Vec<TestScalar> {
+        matrix
+            .iter()
+            .map(|row| evaluate_terms(row, terms))
+            .collect()
+    }
+
+    fn evaluate_terms(coeffs: &[i32], terms: &[TestScalar]) -> TestScalar {
+        coeffs
+            .iter()
+            .zip(terms)
+            .map(|(&coef, &term)| TestScalar::from(coef) * term)
+            .sum()
+    }
 
     #[test]
     fn we_can_verify_bit_decomposition() {
@@ -195,13 +210,13 @@ mod tests {
     }
 
     #[test]
-    fn we_can_verify_bit_decomposition_constant_sign() {
+    fn we_can_verify_bit_decomposition_positive_sign() {
         let dist = BitDistribution {
             vary_mask: [629, 0, 0, 0],
             leading_bit_mask: [2, 0, 0, 9_223_372_036_854_775_808],
         };
-        let a = TestScalar::ONE;
-        let b = TestScalar::ONE;
+        let a = TestScalar::TEN;
+        let b = TestScalar::TWO;
         let expr_eval = TestScalar::from(118) * (TestScalar::ONE - a) * (TestScalar::ONE - b)
             + TestScalar::from(562) * a * (TestScalar::ONE - b)
             + TestScalar::from(3) * (TestScalar::ONE - a) * b;
@@ -231,5 +246,47 @@ mod tests {
         let sign_eval =
             verify_bit_decomposition(expr_eval, chi_eval, &bit_evals, &dist, 128).unwrap();
         assert_eq!(sign_eval, chi_eval);
+    }
+
+    #[test]
+    fn we_can_verify_bit_decomposition_i8_sign() {
+        let dist = BitDistribution {
+            vary_mask: [125, 0, 0, 9_223_372_036_854_775_808],
+            leading_bit_mask: [2, 0, 0, 9_223_372_036_854_775_808],
+        };
+        let a = TestScalar::TEN;
+        let b = TestScalar::TWO;
+        let one_minus_a = TestScalar::ONE - a;
+        let one_minus_b = TestScalar::ONE - b;
+
+        let s = [
+            one_minus_a * one_minus_b,
+            a * one_minus_b,
+            one_minus_a * b,
+            a * b,
+        ];
+
+        let expr_eval = evaluate_terms(&[106, 23, -60, -76], &s);
+        let one_eval = evaluate_terms(&[1, 1, 1, 1], &s);
+
+        let bit_matrix: &[&[i32]] = &[
+            &[0, 1, 0, 0],
+            &[0, 1, 1, 1],
+            &[1, 0, 0, 0],
+            &[0, 1, 0, 1],
+            &[1, 0, 0, 1],
+            &[1, 0, 1, 0],
+            &[1, 1, 0, 0],
+        ];
+
+        let bit_evals = evaluate_matrix(bit_matrix, &s);
+
+        let expected_eval = evaluate_terms(&[1, 1, 0, 0], &s);
+
+        let sign_eval =
+            verify_bit_decomposition(expr_eval, one_eval, &bit_evals, &dist, 8).unwrap();
+        assert_eq!(sign_eval, expected_eval);
+        let err = verify_bit_decomposition(expr_eval, one_eval, &bit_evals, &dist, 7).unwrap_err();
+        assert!(matches!(err, BitDistrubutionError::Verification));
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -162,9 +162,12 @@ fn verify_bit_decomposition<S: ScalarExt>(
             rhs += S::from_wrapping(mult) * bit_eval;
         }
     }
-    let bits_that_must_match_inverse_lead_bit = U256::MAX
-        .shl(num_bits_allowed.unwrap_or(S::MAX_BITS).min(S::MAX_BITS) - 1)
-        ^ U256::ONE.shl(255);
+    let num_bits_allowed = num_bits_allowed.unwrap_or(S::MAX_BITS);
+    if num_bits_allowed > S::MAX_BITS {
+        return Err(BitDistrubutionError::Verification);
+    }
+    let bits_that_must_match_inverse_lead_bit =
+        U256::MAX.shl(num_bits_allowed - 1) ^ U256::ONE.shl(255);
     let is_eval_too_many_bits = bits_that_must_match_inverse_lead_bit
         & dist.leading_bit_inverse_mask()
         == bits_that_must_match_inverse_lead_bit;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -270,7 +270,7 @@ mod tests {
         ];
 
         let expr_eval = evaluate_terms(&[106, 23, -60, -76], &s);
-        let one_eval = evaluate_terms(&[1, 1, 1, 1], &s);
+        let chi_eval = evaluate_terms(&[1, 1, 1, 1], &s);
 
         let bit_matrix: &[&[i32]] = &[
             &[0, 1, 0, 0],
@@ -287,10 +287,10 @@ mod tests {
         let expected_eval = evaluate_terms(&[1, 1, 0, 0], &s);
 
         let sign_eval =
-            verify_bit_decomposition(expr_eval, one_eval, &bit_evals, &dist, Some(8)).unwrap();
+            verify_bit_decomposition(expr_eval, chi_eval, &bit_evals, &dist, Some(8)).unwrap();
         assert_eq!(sign_eval, expected_eval);
         let err =
-            verify_bit_decomposition(expr_eval, one_eval, &bit_evals, &dist, Some(7)).unwrap_err();
+            verify_bit_decomposition(expr_eval, chi_eval, &bit_evals, &dist, Some(7)).unwrap_err();
         assert!(matches!(err, BitDistrubutionError::Verification));
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -66,7 +66,7 @@ fn we_can_verify_a_constant_decomposition() {
         3,
     );
     let data_eval = (&data).evaluate_at_point(&evaluation_point);
-    let eval = verifier_evaluate_sign(&mut builder, data_eval, *chi_eval).unwrap();
+    let eval = verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, 8).unwrap();
     assert_eq!(eval, Curve25519Scalar::ZERO);
 }
 
@@ -100,7 +100,7 @@ fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_di
         3,
     );
     let data_eval = Curve25519Scalar::from(2) * (&data).evaluate_at_point(&evaluation_point);
-    assert!(verifier_evaluate_sign(&mut builder, data_eval, *chi_eval).is_err());
+    assert!(verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, 128).is_err());
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -66,7 +66,7 @@ fn we_can_verify_a_constant_decomposition() {
         3,
     );
     let data_eval = (&data).evaluate_at_point(&evaluation_point);
-    let eval = verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, 8).unwrap();
+    let eval = verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, Some(8)).unwrap();
     assert_eq!(eval, Curve25519Scalar::ZERO);
 }
 
@@ -100,7 +100,7 @@ fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_di
         3,
     );
     let data_eval = Curve25519Scalar::from(2) * (&data).evaluate_at_point(&evaluation_point);
-    assert!(verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, 128).is_err());
+    assert!(verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, None).is_err());
 }
 
 #[test]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

Providing new proof expressions `DivideExpr` and `ModuloExpr`

# What changes are included in this PR?

A new gadget `DivideAndModuloExpr` which is used by new proof expressions `DivideExpr` and `ModuloExpr`.

# Are these changes tested?
Yes. Several "completeness" tests for both `DivideExpr` and `ModuloExpr`. There will be "soundness" tests in a future PR (tests to confirm that verification will fail if any of the constraints are failing).