### PR TITLE
test: tamper tests for equals expr

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -66,6 +66,7 @@ zerocopy = { workspace = true }
 arrow-csv = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
 merlin = { workspace = true }
+mockall = "0.13.1"
 opentelemetry = { workspace = true }
 opentelemetry-jaeger = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["std"] }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -209,3 +209,139 @@ pub fn verifier_evaluate_equals_zero<S: Scalar>(
 
     Ok(selection_eval)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EqualsExprProverUtilities;
+    use crate::{
+        base::{
+            polynomial::MultilinearExtension,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::{
+            proof::{mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder},
+            proof_exprs::equals_expr::{
+                prover_evaluate_equals_zero_base, verifier_evaluate_equals_zero,
+            },
+        },
+    };
+    use bumpalo::Bump;
+    use mockall::automock;
+    use num_traits::Inv;
+    use std::collections::VecDeque;
+
+    #[automock]
+    trait EqualsExprProverMockableFunctionality {
+        fn get_lhs_inverse(&self, lhs: Vec<TestScalar>) -> Vec<TestScalar>;
+        fn get_selection(&self, lhs: Vec<TestScalar>) -> Vec<bool>;
+    }
+
+    fn default_get_lhs_inverse(lhs: &[TestScalar]) -> Vec<TestScalar> {
+        lhs.iter()
+            .map(|s| s.inv().unwrap_or(TestScalar::ZERO))
+            .collect()
+    }
+
+    struct EqualsExprProverTestUtilities<F: EqualsExprProverMockableFunctionality> {
+        utils: F,
+    }
+
+    impl<F: EqualsExprProverMockableFunctionality> EqualsExprProverUtilities<TestScalar>
+        for EqualsExprProverTestUtilities<F>
+    {
+        fn get_lhs_inverse<'a>(&self, alloc: &'a Bump, lhs: &[TestScalar]) -> &'a [TestScalar] {
+            alloc.alloc_slice_copy(&self.utils.get_lhs_inverse(lhs.to_vec()))
+        }
+
+        fn get_selection<'a>(
+            &self,
+            alloc: &'a Bump,
+            _table_length: usize,
+            lhs: &[TestScalar],
+        ) -> &'a [bool] {
+            alloc.alloc_slice_copy(&self.utils.get_selection(lhs.to_vec()))
+        }
+    }
+
+    #[test]
+    fn we_can_reject_proof_if_selection_tampered() {
+        let alloc = Bump::new();
+        let lhs = &[
+            TestScalar::from(1),
+            TestScalar::from(-3),
+            TestScalar::from(0),
+        ];
+
+        let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
+            FinalRoundBuilder::new(3, VecDeque::new());
+
+        let mut mock_utils = MockEqualsExprProverMockableFunctionality::new();
+        mock_utils
+            .expect_get_lhs_inverse()
+            .returning(|scalars| default_get_lhs_inverse(&scalars));
+        let column_of_non_zeroes = vec![false; 3];
+        // Here we try to claim that the last row is not 0.
+        mock_utils
+            .expect_get_selection()
+            .return_const(column_of_non_zeroes);
+
+        let utils: EqualsExprProverTestUtilities<MockEqualsExprProverMockableFunctionality> =
+            EqualsExprProverTestUtilities { utils: mock_utils };
+
+        prover_evaluate_equals_zero_base(1, &mut final_round_builder, &alloc, lhs, &utils);
+
+        let matrix = run_verify_for_each_row(
+            3,
+            &final_round_builder,
+            3,
+            |verification_builder, chi_eval, evaluation_point| {
+                let lhs_eval = lhs.inner_product(evaluation_point);
+                verifier_evaluate_equals_zero(verification_builder, lhs_eval, chi_eval).unwrap();
+            },
+        )
+        .get_identity_results();
+        // Only the last row is wrong, and only the second constraint
+        let expected_matrix = vec![vec![true, true], vec![true, true], vec![true, false]];
+        assert_eq!(matrix, expected_matrix);
+    }
+
+    #[test]
+    fn we_can_reject_proof_if_lhs_inverse_is_tampered() {
+        let alloc = Bump::new();
+        let lhs = &[
+            TestScalar::from(1),
+            TestScalar::from(-3),
+            TestScalar::from(0),
+        ];
+
+        let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
+            FinalRoundBuilder::new(3, VecDeque::new());
+
+        let mut mock_utils = MockEqualsExprProverMockableFunctionality::new();
+        mock_utils
+            .expect_get_lhs_inverse()
+            .return_const(vec![TestScalar::ZERO; 3]);
+        // Here we try to claim that the last row is not 0.
+        mock_utils
+            .expect_get_selection()
+            .return_const(vec![true; 3]);
+
+        let utils: EqualsExprProverTestUtilities<MockEqualsExprProverMockableFunctionality> =
+            EqualsExprProverTestUtilities { utils: mock_utils };
+
+        prover_evaluate_equals_zero_base(1, &mut final_round_builder, &alloc, lhs, &utils);
+
+        let matrix = run_verify_for_each_row(
+            3,
+            &final_round_builder,
+            3,
+            |verification_builder, chi_eval, evaluation_point| {
+                let lhs_eval = lhs.inner_product(evaluation_point);
+                verifier_evaluate_equals_zero(verification_builder, lhs_eval, chi_eval).unwrap();
+            },
+        )
+        .get_identity_results();
+        let expected_matrix = vec![vec![false, true], vec![false, true], vec![true, true]];
+        assert_eq!(matrix, expected_matrix);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

There are no devious tamper tests for equals_expr. This PR attempts to rectify that.

# What changes are included in this PR?

New tests for equals_expr

# Are these changes tested?
Yes
