### PR TITLE
feat: add `OrderByExec`

### DIFF
--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -196,7 +196,7 @@ impl QueryContext {
         Ok(&self.res_aliased_exprs)
     }
 
-    pub fn get_order_by_exprs(&self) -> &[(usize, bool)] {
+    pub fn get_order_by_exprs(&self) -> &OrderIndexDirectionPairs {
         &self.order_by_exprs
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/order_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/order_by_exec.rs
@@ -1,0 +1,178 @@
+use super::{
+    filter_exec::{prove_filter, verify_filter},
+    DynProofPlan,
+};
+use crate::{
+    base::{
+        database::{
+            order_by_util::OrderIndexDirectionPairs, ColumnField, ColumnRef, OwnedTable, Table,
+            TableEvaluation, TableOptions, TableRef,
+        },
+        map::{IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    },
+    utils::log,
+};
+use alloc::{boxed::Box, vec::Vec};
+use bumpalo::Bump;
+use core::iter::repeat;
+use itertools::repeat_n;
+use serde::{Deserialize, Serialize};
+
+/// `ProofPlan` for queries of the form
+/// ```ignore
+///     <ProofPlan> ORDER BY <OrderByExpr>
+/// ```
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct OrderByExec {
+    pub(super) input: Box<DynProofPlan>,
+    pub(super) order_index_dir_pairs: OrderIndexDirectionPairs,
+}
+
+impl OrderByExec {
+    /// Creates a new ORDER BY execution plan.
+    #[allow(dead_code)]
+    pub fn new(input: Box<DynProofPlan>, order_index_dir_pairs: OrderIndexDirectionPairs) -> Self {
+        Self { input, order_index_dir_pairs }
+    }
+}
+
+impl ProofPlan for OrderByExec
+where
+    OrderByExec: ProverEvaluate,
+{
+    #[allow(unused_variables)]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        chi_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        // 1. columns
+        let input_table_eval =
+            self.input
+                .verifier_evaluate(builder, accessor, None, chi_eval_map)?;
+        let output_chi_eval = builder.try_consume_chi_evaluation()?;
+        let columns_evals = input_table_eval.column_evals();
+        // 2. selection
+        // The selected range is (offset_index, max_index]
+        let offset_chi_eval = builder.try_consume_chi_evaluation()?;
+        let max_chi_eval = builder.try_consume_chi_evaluation()?;
+        let selection_eval = max_chi_eval - offset_chi_eval;
+        // 3. filtered_columns
+        let filtered_columns_evals =
+            builder.try_consume_final_round_mle_evaluations(columns_evals.len())?;
+        let alpha = builder.try_consume_post_result_challenge()?;
+        let beta = builder.try_consume_post_result_challenge()?;
+
+        verify_filter(
+            builder,
+            alpha,
+            beta,
+            input_table_eval.chi_eval(),
+            output_chi_eval,
+            columns_evals,
+            selection_eval,
+            &filtered_columns_evals,
+        )?;
+        Ok(TableEvaluation::new(
+            filtered_columns_evals,
+            output_chi_eval,
+        ))
+    }
+
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        self.input.get_column_result_fields()
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        self.input.get_column_references()
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        self.input.get_table_references()
+    }
+}
+
+impl ProverEvaluate for OrderByExec {
+    #[tracing::instrument(name = "OrderByExec::first_round_evaluate", level = "debug", skip_all)]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
+        // 1. columns
+        let input = self.input.first_round_evaluate(builder, alloc, table_map);
+        let input_length = input.num_rows();
+        let columns = input.columns().copied().collect::<Vec<_>>();
+        // 2. R is a permutation of A
+        // 3. R is monotonic on the selected column
+        builder.request_post_result_challenges(2);
+        builder.produce_chi_evaluation_length(output_length);
+        builder.produce_chi_evaluation_length(offset_index);
+        builder.produce_chi_evaluation_length(max_index);
+
+        log::log_memory_usage("End");
+
+        res
+    }
+
+    #[tracing::instrument(name = "OrderByExec::prover_evaluate", level = "debug", skip_all)]
+    #[allow(unused_variables)]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
+        // 1. columns
+        let input = self.input.final_round_evaluate(builder, alloc, table_map);
+        let columns = input.columns().copied().collect::<Vec<_>>();
+        // 2. select
+        let select = get_slice_select(input.num_rows(), self.skip, self.fetch);
+        let select_ref: &'a [_] = alloc.alloc_slice_copy(&select);
+        let output_length = select.iter().filter(|b| **b).count();
+        // Compute filtered_columns and indexes
+        let (filtered_columns, result_len) = filter_columns(alloc, &columns, &select);
+        // 3. Produce MLEs
+        filtered_columns.iter().copied().for_each(|column| {
+            builder.produce_intermediate_mle(column);
+        });
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+
+        prove_filter::<S>(
+            builder,
+            alloc,
+            alpha,
+            beta,
+            &columns,
+            select_ref,
+            &filtered_columns,
+            input.num_rows(),
+            result_len,
+        );
+        let res = Table::<'a, S>::try_from_iter_with_options(
+            self.get_column_result_fields()
+                .into_iter()
+                .map(|expr| expr.name())
+                .zip(filtered_columns),
+            TableOptions::new(Some(output_length)),
+        )
+        .expect("Failed to create table from iterator");
+
+        log::log_memory_usage("End");
+
+        res
+    }
+}

--- a/docs/protocols/order_by.tex
+++ b/docs/protocols/order_by.tex
@@ -1,0 +1,43 @@
+\documentclass[11pt]{article}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage[margin=1in]{geometry}
+\usepackage{graphicx}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{hyperref}
+\usepackage{microtype}
+\usepackage{todonotes}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,
+  citecolor=blue,
+  urlcolor=blue
+}
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt}
+
+\title{Order By}
+\author{Space and Time Inc}
+\date{February 2025}
+
+\begin{document}
+\maketitle
+
+\noindent Let $A$ be a table. We need to prove that $R$ is an ordered version of $A$ with column $i$ increasing (or decreasing). \\
+
+\section{Summary}
+\begin{itemize}
+    \item Plan values: $i$ and number of columns in $A$
+    \item Inputs: $A$
+    \item Outputs: $R$
+    \item Hints: The internal hints for the gadgets.
+\end{itemize}
+
+\section{Details}
+\begin{itemize}
+    \item $R$ is a permutation of $A$
+    \item $R_i$ is monotonically increasing (or decreasing)
+\end{itemize}
+\end{document}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

Depends on #450.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
