### PR TITLE
feat: support Uint16 type

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -12,6 +12,7 @@ impl From<&ColumnType> for DataType {
         match column_type {
             ColumnType::Boolean => DataType::Boolean,
             ColumnType::Uint8 => DataType::UInt8,
+            ColumnType::Uint16 => DataType::UInt16,
             ColumnType::TinyInt => DataType::Int8,
             ColumnType::SmallInt => DataType::Int16,
             ColumnType::Int => DataType::Int32,

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -24,7 +24,8 @@ use arrow::{
     array::{
         ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Decimal256Array, Int16Array,
         Int32Array, Int64Array, Int8Array, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt16Array,
+        UInt8Array,
     },
     datatypes::{i256, DataType, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
     error::ArrowError,
@@ -85,6 +86,7 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
         match value {
             OwnedColumn::Boolean(col) => Arc::new(BooleanArray::from(col)),
             OwnedColumn::Uint8(col) => Arc::new(UInt8Array::from(col)),
+            OwnedColumn::Uint16(col) => Arc::new(UInt16Array::from(col)),
             OwnedColumn::TinyInt(col) => Arc::new(Int8Array::from(col)),
             OwnedColumn::SmallInt(col) => Arc::new(Int16Array::from(col)),
             OwnedColumn::Int(col) => Arc::new(Int32Array::from(col)),

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -205,6 +205,8 @@ pub enum ColumnBounds {
     NoOrder,
     /// The bounds of a `Uint8` column.
     Uint8(Bounds<u8>),
+    /// The bounds of a `Uint8` column.
+    Uint16(Bounds<u16>),
     /// The bounds of a `TinyInt` column.
     TinyInt(Bounds<i8>),
     /// The bounds of a `SmallInt` column.
@@ -228,6 +230,7 @@ impl ColumnBounds {
         match column {
             CommittableColumn::TinyInt(ints) => ColumnBounds::TinyInt(Bounds::from_iter(*ints)),
             CommittableColumn::Uint8(ints) => ColumnBounds::Uint8(Bounds::from_iter(*ints)),
+            CommittableColumn::Uint16(ints) => ColumnBounds::Uint16(Bounds::from_iter(*ints)),
             CommittableColumn::SmallInt(ints) => ColumnBounds::SmallInt(Bounds::from_iter(*ints)),
             CommittableColumn::Int(ints) => ColumnBounds::Int(Bounds::from_iter(*ints)),
             CommittableColumn::BigInt(ints) => ColumnBounds::BigInt(Bounds::from_iter(*ints)),

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -125,6 +125,9 @@ impl Commitment for NaiveCommitment {
                     CommittableColumn::Uint8(u8_vec) => {
                         u8_vec.iter().map(core::convert::Into::into).collect()
                     }
+                    CommittableColumn::Uint16(u16_vec) => {
+                        u16_vec.iter().map(core::convert::Into::into).collect()
+                    }
                     CommittableColumn::TinyInt(tiny_int_vec) => {
                         tiny_int_vec.iter().map(core::convert::Into::into).collect()
                     }

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -46,6 +46,9 @@ pub fn filter_column_by_index<'a, S: Scalar>(
         Column::Uint8(col) => {
             Column::Uint8(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
+        Column::Uint16(col) => {
+            Column::Uint16(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        }
         Column::TinyInt(col) => {
             Column::TinyInt(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -155,6 +155,7 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
 ) -> &'a [S] {
     match column {
         Column::Uint8(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Uint16(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::TinyInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
@@ -188,7 +189,7 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
     match column {
         Column::Boolean(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Uint8(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-
+        Column::Uint16(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::TinyInt(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
@@ -222,7 +223,7 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
     match column {
         Column::Boolean(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Uint8(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-
+        Column::Uint16(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::TinyInt(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -23,6 +23,7 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
         .map(|col| match col {
             Column::Boolean(col) => col[i].cmp(&col[j]),
             Column::Uint8(col) => col[i].cmp(&col[j]),
+            Column::Uint16(col) => col[i].cmp(&col[j]),
             Column::TinyInt(col) => col[i].cmp(&col[j]),
             Column::SmallInt(col) => col[i].cmp(&col[j]),
             Column::Int(col) => col[i].cmp(&col[j]),
@@ -138,6 +139,7 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
             let ordering = match col {
                 OwnedColumn::Boolean(col) => col[i].cmp(&col[j]),
                 OwnedColumn::Uint8(col) => col[i].cmp(&col[j]),
+                OwnedColumn::Uint16(col) => col[i].cmp(&col[j]),
                 OwnedColumn::TinyInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::SmallInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::Int(col) => col[i].cmp(&col[j]),

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -94,6 +94,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
             OwnedColumn::Boolean(col) => Column::Boolean(col),
             OwnedColumn::TinyInt(col) => Column::TinyInt(col),
             OwnedColumn::Uint8(col) => Column::Uint8(col),
+            OwnedColumn::Uint16(col) => Column::Uint16(col),
             OwnedColumn::SmallInt(col) => Column::SmallInt(col),
             OwnedColumn::Int(col) => Column::Int(col),
             OwnedColumn::BigInt(col) => Column::BigInt(col),

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -63,6 +63,16 @@ pub fn column_union<'a, S: Scalar>(
                 iter.next().expect("Iterator should have enough elements")
             }) as &[_])
         }
+        ColumnType::Uint16 => {
+            let mut iter = columns
+                .iter()
+                .flat_map(|col| col.as_uint16().expect("Column types should match"))
+                .copied();
+
+            Column::Uint16(alloc.alloc_slice_fill_with(len, |_| {
+                iter.next().expect("Iterator should have enough elements")
+            }) as &[_])
+        }
         ColumnType::TinyInt => {
             let mut iter = columns
                 .iter()
@@ -278,6 +288,15 @@ mod tests {
             result,
             Column::VarChar((&doubled_strings, &doubled_scalars))
         );
+
+        let alloc = Bump::new();
+        let col0: Column<TestScalar> = Column::Uint16(&[]);
+        let col1: Column<TestScalar> = Column::Uint16(&[1, 2, 3]);
+        let col2: Column<TestScalar> = Column::Uint16(&[4, 5, 6]);
+        let col3: Column<TestScalar> = Column::Uint16(&[7, 8, 9]);
+        let result =
+            column_union(&[&col0, &col1, &col2, &col3], &alloc, ColumnType::Uint16).unwrap();
+        assert_eq!(result, Column::Uint16(&[1, 2, 3, 4, 5, 6, 7, 8, 9]));
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -104,6 +104,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             | Column::VarBinary((_, c))
             | Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
             Column::Uint8(c) => c.inner_product(evaluation_vec),
+            Column::Uint16(c) => c.inner_product(evaluation_vec),
             Column::TinyInt(c) => c.inner_product(evaluation_vec),
             Column::SmallInt(c) => c.inner_product(evaluation_vec),
             Column::Int(c) => c.inner_product(evaluation_vec),
@@ -122,6 +123,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
                 c.mul_add(res, multiplier);
             }
             Column::Uint8(c) => c.mul_add(res, multiplier),
+            Column::Uint16(c) => c.mul_add(res, multiplier),
             Column::TinyInt(c) => c.mul_add(res, multiplier),
             Column::SmallInt(c) => c.mul_add(res, multiplier),
             Column::Int(c) => c.mul_add(res, multiplier),
@@ -138,6 +140,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             | Column::VarBinary((_, c))
             | Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
             Column::Uint8(c) => c.to_sumcheck_term(num_vars),
+            Column::Uint16(c) => c.to_sumcheck_term(num_vars),
             Column::TinyInt(c) => c.to_sumcheck_term(num_vars),
             Column::SmallInt(c) => c.to_sumcheck_term(num_vars),
             Column::Int(c) => c.to_sumcheck_term(num_vars),
@@ -154,6 +157,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             | Column::VarBinary((_, c))
             | Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
             Column::Uint8(c) => MultilinearExtension::<S>::id(c),
+            Column::Uint16(c) => MultilinearExtension::<S>::id(c),
             Column::TinyInt(c) => MultilinearExtension::<S>::id(c),
             Column::SmallInt(c) => MultilinearExtension::<S>::id(c),
             Column::Int(c) => MultilinearExtension::<S>::id(c),

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -504,6 +504,36 @@ where
     }
 }
 
+impl<T> TryFrom<MontScalar<T>> for u16
+where
+    T: MontConfig<4>,
+    MontScalar<T>: Scalar,
+{
+    type Error = ScalarConversionError;
+
+    fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
+        if value < MontScalar::<T>::ZERO {
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{value} is negative and cannot fit in a u16"),
+            });
+        }
+
+        let abs: [u64; 4] = value.into();
+
+        if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{value} is too large to fit in a u16"),
+            });
+        }
+
+        abs[0]
+            .try_into()
+            .map_err(|_| ScalarConversionError::Overflow {
+                error: format!("{value} is too large to fit in a u16"),
+            })
+    }
+}
+
 impl<T> TryFrom<MontScalar<T>> for i8
 where
     T: MontConfig<4>,

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -1,7 +1,7 @@
 use crate::base::{
     map::IndexSet,
     scalar::{
-        test_scalar::TestScalar, test_scalar_constants, Curve25519Scalar, Scalar,
+        test_scalar::TestScalar, test_scalar_constants, Curve25519Scalar, MontScalar, Scalar,
         ScalarConversionError,
     },
 };
@@ -15,6 +15,25 @@ use rand::{
     Rng,
 };
 use rand_core::SeedableRng;
+
+#[test]
+fn test_try_from_mont_scalar_for_u16() {
+    let val = MontScalar::<ark_curve25519::FrConfig>::from(123u64);
+    let converted: u16 = val.try_into().unwrap();
+    assert_eq!(converted, 123);
+
+    let val = MontScalar::<ark_curve25519::FrConfig>::from(65535u64);
+    let converted: u16 = val.try_into().unwrap();
+    assert_eq!(converted, 65535);
+
+    let val = MontScalar::<ark_curve25519::FrConfig>::from(65536u64);
+
+    let val: Result<u16, _> = val.try_into();
+    assert!(val.is_err());
+
+    let val: Result<u16, _> = MontScalar::<ark_curve25519::FrConfig>::from(-1i64).try_into();
+    assert!(val.is_err());
+}
 
 #[test]
 fn we_have_correct_constants_for_curve_25519_scalar() {

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -32,9 +32,11 @@ pub trait Scalar:
     + for<'a> core::convert::From<&'a i64> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a i128> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a u8> // Required for `Column` to implement `MultilinearExtension`
+    + for<'a> core::convert::From<&'a u16> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a u64> // Required for `Column` to implement `MultilinearExtension`
     + core::convert::TryInto <bool>
     + core::convert::TryInto<u8>
+    + core::convert::TryInto<u16>
     + core::convert::TryInto <i8>
     + core::convert::TryInto <i16>
     + core::convert::TryInto <i32>
@@ -43,6 +45,7 @@ pub trait Scalar:
     + core::convert::Into<[u64; 4]>
     + core::convert::From<[u64; 4]>
     + core::convert::From<u8>
+    + core::convert::From<u16>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
     + num_traits::Zero

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -38,6 +38,7 @@ pub const fn min_as_f(column_type: ColumnType) -> F {
         ColumnType::Int128 => MontFp!("-170141183460469231731687303715884105728"),
         ColumnType::Decimal75(_, _)
         | ColumnType::Uint8
+        | ColumnType::Uint16
         | ColumnType::Scalar
         | ColumnType::VarChar
         | ColumnType::VarBinary
@@ -113,6 +114,9 @@ fn copy_column_data_to_slice(
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
         CommittableColumn::Uint8(column) => {
+            scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
+        }
+        CommittableColumn::Uint16(column) => {
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
         CommittableColumn::TinyInt(column) => {

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -67,6 +67,7 @@ fn compute_dory_commitment(
     match committable_column {
         CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Uint8(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::Uint16(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TinyInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::SmallInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Int(column) => compute_dory_commitment_impl(column, offset, setup),

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -76,6 +76,7 @@ fn compute_dory_commitment(
     match committable_column {
         CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Uint8(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::Uint16(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TinyInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::SmallInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Int(column) => compute_dory_commitment_impl(column, offset, setup),

--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -8,6 +8,13 @@ impl OffsetToBytes<1> for u8 {
     }
 }
 
+impl OffsetToBytes<2> for u16 {
+    fn offset_to_bytes(&self) -> [u8; 2] {
+        let shifted = self.wrapping_sub(u16::MIN);
+        shifted.to_le_bytes()
+    }
+}
+
 impl OffsetToBytes<1> for i8 {
     fn offset_to_bytes(&self) -> [u8; 1] {
         let shifted = self.wrapping_sub(i8::MIN);

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -378,6 +378,17 @@ pub fn bit_table_and_scalars_for_packed_msm(
                     num_matrix_commitment_columns,
                 );
             }
+            CommittableColumn::Uint16(column) => {
+                pack_bit(
+                    column,
+                    &mut packed_scalars,
+                    cumulative_bit_sum_table[i],
+                    offset,
+                    committable_columns[i].column_type().byte_size(),
+                    bit_table_full_sum_in_bytes,
+                    num_matrix_commitment_columns,
+                );
+            }
             CommittableColumn::TinyInt(column) => {
                 pack_bit(
                     column,
@@ -476,6 +487,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::SmallInt(&[1]),
             CommittableColumn::Int(&[1, 2]),
+            CommittableColumn::Uint16(&[1, 2]),
             CommittableColumn::BigInt(&[1, 2, 3]),
             CommittableColumn::Int128(&[1, 2, 3, 4]),
             CommittableColumn::Decimal75(
@@ -500,8 +512,8 @@ mod tests {
         let bit_table: Vec<u32> =
             output_bit_table(&committable_columns, offset, num_matrix_commitment_columns);
         let expected = [
-            16, 32, 32, 64, 64, 64, 128, 128, 128, 128, 256, 256, 256, 256, 256, 256, 256, 256,
-            256, 256, 256, 256, 8, 8, 64,
+            16, 32, 32, 16, 16, 64, 64, 64, 128, 128, 128, 128, 256, 256, 256, 256, 256, 256, 256,
+            256, 256, 256, 256, 256, 8, 8, 64,
         ];
         assert_eq!(bit_table, expected);
     }
@@ -511,6 +523,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::SmallInt(&[1]),
             CommittableColumn::Int(&[1, 2]),
+            CommittableColumn::Uint16(&[1, 2]),
             CommittableColumn::BigInt(&[1, 2, 3]),
             CommittableColumn::Int128(&[1, 2, 3, 4]),
             CommittableColumn::Decimal75(
@@ -535,8 +548,8 @@ mod tests {
         let bit_table: Vec<u32> =
             output_bit_table(&committable_columns, offset, num_matrix_commitment_columns);
         let expected = [
-            16, 16, 32, 32, 32, 64, 64, 64, 64, 128, 128, 128, 128, 128, 256, 256, 256, 256, 256,
-            256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 8, 8, 8, 64, 64,
+            16, 16, 32, 32, 32, 16, 16, 16, 64, 64, 64, 64, 128, 128, 128, 128, 128, 256, 256, 256,
+            256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 8, 8, 8, 64, 64,
         ];
         assert_eq!(bit_table, expected);
     }
@@ -546,6 +559,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::SmallInt(&[1]),
             CommittableColumn::Int(&[1, 2]),
+            CommittableColumn::Uint16(&[1, 2]),
             CommittableColumn::BigInt(&[1, 2, 3]),
             CommittableColumn::Int128(&[1, 2, 3, 4]),
             CommittableColumn::Decimal75(
@@ -567,7 +581,7 @@ mod tests {
 
         let offset = 0;
         let num_matrix_commitment_columns = 1;
-        let expected: Vec<usize> = vec![1, 2, 3, 4, 5, 4, 3, 2, 1];
+        let expected: Vec<usize> = vec![1, 2, 2, 3, 4, 5, 4, 3, 2, 1];
         let num_sub_commits: Vec<usize> = (0..committable_columns.len())
             .map(|i| {
                 num_sub_commits(
@@ -586,6 +600,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::SmallInt(&[1]),
             CommittableColumn::Int(&[1, 2]),
+            CommittableColumn::Uint16(&[1, 2]),
             CommittableColumn::BigInt(&[1, 2, 3]),
             CommittableColumn::Int128(&[1, 2, 3, 4]),
             CommittableColumn::Decimal75(
@@ -607,7 +622,7 @@ mod tests {
 
         let offset = 2;
         let num_matrix_commitment_columns = 1;
-        let expected: Vec<usize> = vec![3, 4, 5, 6, 7, 6, 5, 4, 3];
+        let expected: Vec<usize> = vec![3, 4, 4, 5, 6, 7, 6, 5, 4, 3];
         let num_sub_commits: Vec<usize> = (0..committable_columns.len())
             .map(|i| {
                 num_sub_commits(
@@ -626,6 +641,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::SmallInt(&[1]),
             CommittableColumn::Int(&[1, 2]),
+            CommittableColumn::Uint16(&[1, 2]),
             CommittableColumn::BigInt(&[1, 2, 3]),
             CommittableColumn::Int128(&[1, 2, 3, 4]),
             CommittableColumn::Decimal75(
@@ -647,7 +663,7 @@ mod tests {
 
         let offset = 0;
         let num_matrix_commitment_columns = 4;
-        let expected: Vec<usize> = vec![1, 1, 1, 1, 2, 1, 1, 1, 1];
+        let expected: Vec<usize> = vec![1, 1, 1, 1, 1, 2, 1, 1, 1, 1];
         let num_sub_commits: Vec<usize> = (0..committable_columns.len())
             .map(|i| {
                 num_sub_commits(
@@ -666,6 +682,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::SmallInt(&[1]),
             CommittableColumn::Int(&[1, 2]),
+            CommittableColumn::Uint16(&[1, 2]),
             CommittableColumn::BigInt(&[1, 2, 3]),
             CommittableColumn::Int128(&[1, 2, 3, 4]),
             CommittableColumn::Decimal75(
@@ -687,7 +704,7 @@ mod tests {
 
         let offset = 1;
         let num_matrix_commitment_columns = 4;
-        let expected: Vec<usize> = vec![1, 1, 1, 2, 2, 2, 1, 1, 1];
+        let expected: Vec<usize> = vec![1, 1, 1, 1, 2, 2, 2, 1, 1, 1];
         let num_sub_commits: Vec<usize> = (0..committable_columns.len())
             .map(|i| {
                 num_sub_commits(
@@ -706,6 +723,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
             CommittableColumn::Scalar(vec![[1, 0, 0, 0]]),
+            CommittableColumn::Uint16(&[1, 2]),
         ];
 
         let offset = 0;
@@ -726,6 +744,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
             CommittableColumn::Scalar(vec![[1, 0, 0, 0]]),
+            CommittableColumn::Uint16(&[1, 2]),
         ];
 
         let offset = 3;
@@ -748,6 +767,7 @@ mod tests {
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
             ]),
             CommittableColumn::Int(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+            CommittableColumn::Uint16(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
             CommittableColumn::SmallInt(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         ];
 
@@ -764,7 +784,7 @@ mod tests {
         );
         assert_eq!(
             num_sub_commits(&committable_columns[2], offset, num_columns),
-            3
+            4
         );
     }
 
@@ -775,6 +795,7 @@ mod tests {
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
             ]),
             CommittableColumn::Int(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+            CommittableColumn::Uint16(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
             CommittableColumn::SmallInt(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         ];
 
@@ -791,7 +812,7 @@ mod tests {
         );
         assert_eq!(
             num_sub_commits(&committable_columns[2], offset, num_columns),
-            3
+            4
         );
     }
 
@@ -807,6 +828,9 @@ mod tests {
             CommittableColumn::SmallInt(&[
                 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
             ]),
+            CommittableColumn::Uint16(&[
+                38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
+            ]),
         ];
 
         let offset = 0;
@@ -816,19 +840,21 @@ mod tests {
             bit_table_and_scalars_for_packed_msm(&committable_columns, offset, num_columns);
 
         let expected_bit_table = [
-            16, 16, 16, 16, 16, 32, 32, 32, 32, 32, 16, 16, 16, 16, 16, 8, 8, 8, 8, 8,
+            16, 16, 16, 16, 16, 32, 32, 32, 32, 32, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 8, 8,
+            8, 8, 8, 8,
         ];
 
         let expected_packed_scalar = [
             0, 128, 4, 128, 8, 128, 12, 128, 16, 128, 19, 0, 0, 128, 23, 0, 0, 128, 27, 0, 0, 128,
-            31, 0, 0, 128, 35, 0, 0, 128, 38, 128, 42, 128, 46, 128, 50, 128, 54, 128, 1, 1, 1, 1,
-            1, 1, 128, 5, 128, 9, 128, 13, 128, 17, 128, 20, 0, 0, 128, 24, 0, 0, 128, 28, 0, 0,
-            128, 32, 0, 0, 128, 36, 0, 0, 128, 39, 128, 43, 128, 47, 128, 51, 128, 55, 128, 1, 1,
-            1, 1, 1, 2, 128, 6, 128, 10, 128, 14, 128, 18, 128, 21, 0, 0, 128, 25, 0, 0, 128, 29,
-            0, 0, 128, 33, 0, 0, 128, 37, 0, 0, 128, 40, 128, 44, 128, 48, 128, 52, 128, 56, 128,
-            1, 1, 1, 1, 1, 3, 128, 7, 128, 11, 128, 15, 128, 0, 0, 22, 0, 0, 128, 26, 0, 0, 128,
-            30, 0, 0, 128, 34, 0, 0, 128, 0, 0, 0, 0, 41, 128, 45, 128, 49, 128, 53, 128, 0, 0, 1,
-            1, 0, 0, 0,
+            31, 0, 0, 128, 35, 0, 0, 128, 38, 128, 42, 128, 46, 128, 50, 128, 54, 128, 38, 0, 42,
+            0, 46, 0, 50, 0, 54, 0, 1, 1, 1, 1, 1, 0, 1, 128, 5, 128, 9, 128, 13, 128, 17, 128, 20,
+            0, 0, 128, 24, 0, 0, 128, 28, 0, 0, 128, 32, 0, 0, 128, 36, 0, 0, 128, 39, 128, 43,
+            128, 47, 128, 51, 128, 55, 128, 39, 0, 43, 0, 47, 0, 51, 0, 55, 0, 1, 1, 1, 1, 1, 0, 2,
+            128, 6, 128, 10, 128, 14, 128, 18, 128, 21, 0, 0, 128, 25, 0, 0, 128, 29, 0, 0, 128,
+            33, 0, 0, 128, 37, 0, 0, 128, 40, 128, 44, 128, 48, 128, 52, 128, 56, 128, 40, 0, 44,
+            0, 48, 0, 52, 0, 56, 0, 1, 1, 1, 1, 1, 0, 3, 128, 7, 128, 11, 128, 15, 128, 0, 0, 22,
+            0, 0, 128, 26, 0, 0, 128, 30, 0, 0, 128, 34, 0, 0, 128, 0, 0, 0, 0, 41, 128, 45, 128,
+            49, 128, 53, 128, 0, 0, 41, 0, 45, 0, 49, 0, 53, 0, 0, 0, 1, 1, 0, 0, 0, 0,
         ];
 
         assert_eq!(bit_table, expected_bit_table);
@@ -841,6 +867,7 @@ mod tests {
             CommittableColumn::SmallInt(&[0, 1, 2, 3]),
             CommittableColumn::Int(&[4, 5, 6, 7]),
             CommittableColumn::SmallInt(&[8, 9, 10, 11]),
+            CommittableColumn::Uint16(&[8, 9, 10, 11]),
         ];
 
         let offset = 1;
@@ -849,13 +876,13 @@ mod tests {
         let (bit_table, packed_scalar) =
             bit_table_and_scalars_for_packed_msm(&committable_columns, offset, num_columns);
 
-        let expected_bit_table = [16, 16, 32, 32, 16, 16, 8, 8, 8, 8, 8];
+        let expected_bit_table = [16, 16, 32, 32, 16, 16, 16, 16, 8, 8, 8, 8, 8, 8];
 
         let expected_packed_scalar = [
-            0, 0, 3, 128, 0, 0, 0, 0, 7, 0, 0, 128, 0, 0, 11, 128, 0, 1, 1, 1, 1, 0, 128, 0, 0, 4,
-            0, 0, 128, 0, 0, 0, 0, 8, 128, 0, 0, 1, 1, 0, 0, 0, 1, 128, 0, 0, 5, 0, 0, 128, 0, 0,
-            0, 0, 9, 128, 0, 0, 1, 1, 0, 0, 0, 2, 128, 0, 0, 6, 0, 0, 128, 0, 0, 0, 0, 10, 128, 0,
-            0, 1, 1, 0, 0, 0,
+            0, 0, 3, 128, 0, 0, 0, 0, 7, 0, 0, 128, 0, 0, 11, 128, 0, 0, 11, 0, 0, 1, 1, 1, 1, 0,
+            0, 128, 0, 0, 4, 0, 0, 128, 0, 0, 0, 0, 8, 128, 0, 0, 8, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1,
+            128, 0, 0, 5, 0, 0, 128, 0, 0, 0, 0, 9, 128, 0, 0, 9, 0, 0, 0, 1, 1, 0, 0, 0, 0, 2,
+            128, 0, 0, 6, 0, 0, 128, 0, 0, 0, 0, 10, 128, 0, 0, 10, 0, 0, 0, 1, 1, 0, 0, 0, 0,
         ];
 
         assert_eq!(bit_table, expected_bit_table);
@@ -878,6 +905,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::BigInt(&[1, 2]),
             CommittableColumn::BigInt(&[3, 4]),
+            CommittableColumn::Uint16(&[3, 4]),
         ];
 
         let offset = 0;
@@ -887,11 +915,11 @@ mod tests {
             bit_table_and_scalars_for_packed_msm(&committable_columns, offset, num_columns);
 
         let expected_packed_scalar = [
-            1, 0, 0, 0, 0, 0, 0, 128, 3, 0, 0, 0, 0, 0, 0, 128, 1, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0,
-            128, 4, 0, 0, 0, 0, 0, 0, 128, 1, 1, 1, 1,
+            1, 0, 0, 0, 0, 0, 0, 128, 3, 0, 0, 0, 0, 0, 0, 128, 3, 0, 1, 1, 1, 1, 0, 2, 0, 0, 0, 0,
+            0, 0, 128, 4, 0, 0, 0, 0, 0, 0, 128, 4, 0, 1, 1, 1, 1, 0,
         ];
 
-        let expected_bit_table = [64, 64, 8, 8, 8, 8];
+        let expected_bit_table = [64, 64, 16, 8, 8, 8, 8, 8];
 
         assert_eq!(bit_table, expected_bit_table);
         assert_eq!(packed_scalar, expected_packed_scalar);
@@ -902,6 +930,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::BigInt(&[1, 2]),
             CommittableColumn::BigInt(&[3, 4]),
+            CommittableColumn::Uint16(&[3, 4]),
         ];
 
         let offset = 0;
@@ -911,11 +940,11 @@ mod tests {
             bit_table_and_scalars_for_packed_msm(&committable_columns, offset, num_columns);
 
         let expected_packed_scalar = [
-            1, 0, 0, 0, 0, 0, 0, 128, 3, 0, 0, 0, 0, 0, 0, 128, 1, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0,
-            128, 4, 0, 0, 0, 0, 0, 0, 128, 1, 1, 1, 1,
+            1, 0, 0, 0, 0, 0, 0, 128, 3, 0, 0, 0, 0, 0, 0, 128, 3, 0, 1, 1, 1, 1, 0, 2, 0, 0, 0, 0,
+            0, 0, 128, 4, 0, 0, 0, 0, 0, 0, 128, 4, 0, 1, 1, 1, 1, 0,
         ];
 
-        let expected_bit_table = [64, 64, 8, 8, 8, 8];
+        let expected_bit_table = [64, 64, 16, 8, 8, 8, 8, 8];
 
         assert_eq!(bit_table, expected_bit_table);
         assert_eq!(packed_scalar, expected_packed_scalar);
@@ -926,6 +955,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::BigInt(&[1, 2]),
             CommittableColumn::BigInt(&[3, 4]),
+            CommittableColumn::Uint16(&[3, 4]),
         ];
 
         let offset = 1;
@@ -936,11 +966,11 @@ mod tests {
 
         let expected_packed_scalar = [
             0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0,
-            0, 0, 0, 128, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0,
-            0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+            0, 0, 0, 128, 0, 0, 4, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0,
+            0, 3, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 1, 1, 0, 0, 0,
         ];
 
-        let expected_bit_table = [64, 64, 64, 64, 8, 8, 8, 8];
+        let expected_bit_table = [64, 64, 64, 64, 16, 16, 8, 8, 8, 8, 8];
 
         assert_eq!(bit_table, expected_bit_table);
         assert_eq!(packed_scalar, expected_packed_scalar);
@@ -951,13 +981,14 @@ mod tests {
         let committable_columns = [
             CommittableColumn::BigInt(&[1, 2]),
             CommittableColumn::BigInt(&[3, 4]),
+            CommittableColumn::Uint16(&[3, 4]),
         ];
 
         // No offset
         let offset = 0;
         let num_columns = 1 << 1;
 
-        let expected: Vec<u8> = vec![1, 1, 1, 1, 1, 1, 1, 1];
+        let expected: Vec<u8> = vec![1, 1, 1, 1, 1, 1, 1, 1, 0, 0];
 
         let mut buffer = vec![0_u8; (OFFSET_SIZE + committable_columns.len()) * num_columns];
         offset_column(&committable_columns, offset, num_columns, &mut buffer);
@@ -968,7 +999,7 @@ mod tests {
         let offset = 1;
         let num_columns = 1 << 1;
 
-        let expected: Vec<u8> = vec![0, 1, 1, 1, 1, 0, 1, 0];
+        let expected: Vec<u8> = vec![0, 1, 1, 1, 1, 0, 1, 0, 0, 0];
 
         let mut buffer = vec![0_u8; (OFFSET_SIZE + committable_columns.len()) * num_columns];
         offset_column(&committable_columns, offset, num_columns, &mut buffer);
@@ -979,7 +1010,7 @@ mod tests {
         let offset = 0;
         let num_columns = 1;
 
-        let expected: Vec<u8> = vec![1, 1, 1, 1];
+        let expected: Vec<u8> = vec![1, 1, 1, 1, 0];
 
         let mut buffer = vec![0_u8; (OFFSET_SIZE + committable_columns.len()) * num_columns];
         offset_column(&committable_columns, offset, num_columns, &mut buffer);
@@ -993,6 +1024,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::BigInt(&[1, 2]),
             CommittableColumn::BigInt(&[3, 4]),
+            CommittableColumn::Uint16(&[1, 2]),
         ];
 
         let offset = 1;
@@ -1006,6 +1038,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::SmallInt(&[1, 2, 3, 4, 5]),
             CommittableColumn::Int(&[1, 2, 3, 4, 5, 6]),
+            CommittableColumn::Uint16(&[1, 2, 3, 4, 5, 6]),
             CommittableColumn::BigInt(&[1, 2, 3, 4, 5, 6, 7]),
             CommittableColumn::Int128(&[1, 2, 3, 4, 5, 6, 7, 8]),
             CommittableColumn::Decimal75(
@@ -1034,8 +1067,8 @@ mod tests {
         let mut buffer = vec![0_u8; (OFFSET_SIZE + committable_columns.len()) * num_columns];
         offset_column(&committable_columns, offset, num_columns, &mut buffer);
         let expected: Vec<u8> = vec![
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
         ];
         assert_eq!(buffer, expected);
     }
@@ -1045,6 +1078,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::SmallInt(&[1, 2, 3, 4, 5]),
             CommittableColumn::Int(&[1, 2, 3, 4, 5, 6]),
+            CommittableColumn::Uint16(&[1, 2, 3, 4, 5, 6]),
             CommittableColumn::BigInt(&[1, 2, 3, 4, 5, 6, 7]),
             CommittableColumn::Int128(&[1, 2, 3, 4, 5, 6, 7, 8]),
             CommittableColumn::Decimal75(
@@ -1073,8 +1107,8 @@ mod tests {
         let mut buffer = vec![0_u8; (OFFSET_SIZE + committable_columns.len()) * num_columns];
         offset_column(&committable_columns, offset, num_columns, &mut buffer);
         let expected: Vec<u8> = vec![
-            0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+            0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
         ];
         assert_eq!(buffer, expected);
     }
@@ -1084,6 +1118,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::BigInt(&[1, 2]),
             CommittableColumn::BigInt(&[3, 4]),
+            CommittableColumn::Uint16(&[3, 4]),
         ];
 
         let offset = 0;
@@ -1094,10 +1129,10 @@ mod tests {
 
         let expected_packed_scalar = [
             1, 0, 0, 0, 0, 0, 0, 128, 2, 0, 0, 0, 0, 0, 0, 128, 3, 0, 0, 0, 0, 0, 0, 128, 4, 0, 0,
-            0, 0, 0, 0, 128, 1, 1, 1, 1,
+            0, 0, 0, 0, 128, 3, 0, 4, 0, 1, 1, 1, 1, 0,
         ];
 
-        let expected_bit_table = [64, 64, 64, 64, 8, 8, 8, 8];
+        let expected_bit_table = [64, 64, 64, 64, 16, 16, 8, 8, 8, 8, 8];
 
         assert_eq!(bit_table, expected_bit_table);
         assert_eq!(packed_scalar, expected_packed_scalar);
@@ -1108,6 +1143,7 @@ mod tests {
         let committable_columns = [
             CommittableColumn::BigInt(&[1, 2]),
             CommittableColumn::BigInt(&[3, 4]),
+            CommittableColumn::Uint16(&[3, 4]),
         ];
 
         let offset = 1;
@@ -1118,11 +1154,11 @@ mod tests {
 
         let expected_packed_scalar = [
             0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0,
-            0, 0, 0, 128, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0,
-            0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+            0, 0, 0, 128, 0, 0, 4, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0,
+            0, 3, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 1, 1, 0, 0, 0,
         ];
 
-        let expected_bit_table = [64, 64, 64, 64, 8, 8, 8, 8];
+        let expected_bit_table = [64, 64, 64, 64, 16, 16, 8, 8, 8, 8, 8];
 
         assert_eq!(bit_table, expected_bit_table);
         assert_eq!(packed_scalar, expected_packed_scalar);
@@ -1132,6 +1168,7 @@ mod tests {
     fn we_can_create_a_mixed_packed_scalar_with_offset_and_more_rows_than_columns() {
         let committable_columns = [
             CommittableColumn::SmallInt(&[0, 1, 2, 3, 4, 5]),
+            CommittableColumn::Uint16(&[0, 1, 2, 3, 4, 5]),
             CommittableColumn::Int(&[6, 7, 8, 9]),
             CommittableColumn::Scalar(vec![[10, 0, 0, 0], [11, 0, 0, 0], [12, 0, 0, 0]]),
         ];
@@ -1143,15 +1180,15 @@ mod tests {
             bit_table_and_scalars_for_packed_msm(&committable_columns, offset, num_columns);
 
         let expected_packed_scalar = [
-            0, 128, 3, 128, 6, 0, 0, 128, 9, 0, 0, 128, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 128, 4, 128, 7,
-            0, 0, 128, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 2, 128, 5, 128, 8, 0, 0, 128, 0, 0, 0,
-            0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 1, 1, 1, 0, 0,
+            0, 128, 3, 128, 0, 0, 3, 0, 6, 0, 0, 128, 9, 0, 0, 128, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1,
+            128, 4, 128, 1, 0, 4, 0, 7, 0, 0, 128, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 2, 128,
+            5, 128, 2, 0, 5, 0, 8, 0, 0, 128, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0,
         ];
 
-        let expected_bit_table = [16, 16, 32, 32, 256, 8, 8, 8, 8, 8];
+        let expected_bit_table = [16, 16, 16, 16, 32, 32, 256, 8, 8, 8, 8, 8, 8];
 
         assert_eq!(packed_scalar, expected_packed_scalar);
         assert_eq!(bit_table, expected_bit_table);

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -124,6 +124,7 @@ impl Commitment for HyperKZGCommitment {
             .map(|column| match column {
                 CommittableColumn::Boolean(vals) => compute_commitments_impl(setup, offset, vals),
                 CommittableColumn::Uint8(vals) => compute_commitments_impl(setup, offset, vals),
+                CommittableColumn::Uint16(vals) => compute_commitments_impl(setup, offset, vals),
                 CommittableColumn::TinyInt(vals) => compute_commitments_impl(setup, offset, vals),
                 CommittableColumn::SmallInt(vals) => compute_commitments_impl(setup, offset, vals),
                 CommittableColumn::Int(vals) => compute_commitments_impl(setup, offset, vals),

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -112,6 +112,7 @@ impl ProvableQueryResult {
                 let (x, sz) = match field.data_type() {
                     ColumnType::Boolean => decode_and_convert::<bool, S>(&self.data[offset..]),
                     ColumnType::Uint8 => decode_and_convert::<u8, S>(&self.data[offset..]),
+                    ColumnType::Uint16 => decode_and_convert::<u16, S>(&self.data[offset..]),
                     ColumnType::TinyInt => decode_and_convert::<i8, S>(&self.data[offset..]),
                     ColumnType::SmallInt => decode_and_convert::<i16, S>(&self.data[offset..]),
                     ColumnType::Int => decode_and_convert::<i32, S>(&self.data[offset..]),
@@ -175,6 +176,11 @@ impl ProvableQueryResult {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
                         Ok((field.name(), OwnedColumn::Uint8(col)))
+                    }
+                    ColumnType::Uint16 => {
+                        let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
+                        offset += num_read;
+                        Ok((field.name(), OwnedColumn::Uint16(col)))
                     }
                     ColumnType::TinyInt => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -33,6 +33,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
         match self {
             Column::Boolean(col) => col.num_bytes(length),
             Column::Uint8(col) => col.num_bytes(length),
+            Column::Uint16(col) => col.num_bytes(length),
             Column::TinyInt(col) => col.num_bytes(length),
             Column::SmallInt(col) => col.num_bytes(length),
             Column::Int(col) => col.num_bytes(length),
@@ -48,6 +49,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
         match self {
             Column::Boolean(col) => col.write(out, length),
             Column::Uint8(col) => col.write(out, length),
+            Column::Uint16(col) => col.write(out, length),
             Column::TinyInt(col) => col.write(out, length),
             Column::SmallInt(col) => col.write(out, length),
             Column::Int(col) => col.write(out, length),

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -168,6 +168,7 @@ fn make_empty_query_result<S: Scalar>(result_fields: &[ColumnField]) -> QueryRes
                     match field.data_type() {
                         ColumnType::Boolean => OwnedColumn::Boolean(vec![]),
                         ColumnType::Uint8 => OwnedColumn::Uint8(vec![]),
+                        ColumnType::Uint16 => OwnedColumn::Uint16(vec![]),
                         ColumnType::TinyInt => OwnedColumn::TinyInt(vec![]),
                         ColumnType::SmallInt => OwnedColumn::SmallInt(vec![]),
                         ColumnType::Int => OwnedColumn::Int(vec![]),

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -119,6 +119,7 @@ fn append_single_row_to_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedColum
     match &mut column {
         OwnedColumn::Boolean(col) => col.push(false),
         OwnedColumn::Uint8(col) => col.push(0),
+        OwnedColumn::Uint16(col) => col.push(0),
         OwnedColumn::TinyInt(col) => col.push(0),
         OwnedColumn::SmallInt(col) => col.push(0),
         OwnedColumn::Int(col) => col.push(0),
@@ -154,6 +155,7 @@ pub fn tamper_first_row_of_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedCo
     match &mut column {
         OwnedColumn::Boolean(col) => col[0] ^= true,
         OwnedColumn::Uint8(col) => col[0] = col[0].wrapping_add(1),
+        OwnedColumn::Uint16(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::TinyInt(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::SmallInt(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::Int(col) => col[0] = col[0].wrapping_add(1),


### PR DESCRIPTION
# Rationale for this change

Introduces support for additional unsigned integer type uint 16. The main need for this is found in the range check protocol which is found under certain conditions to operate significantly better with a wider word size. This type is also useful in other database contexts.

# What changes are included in this PR?

- [x] Standard initial support procedure for u16 type

# Are these changes tested?
- [x] existing tests currently passing, more tests can be added depending on codecov report
