### PR TITLE
chore: Improved performance in `fmt` method of `ResourceId`

### DIFF
--- a/crates/proof-of-sql-parser/src/resource_id.rs
+++ b/crates/proof-of-sql-parser/src/resource_id.rs
@@ -89,7 +89,7 @@ impl Display for ResourceId {
             object_name,
         } = self;
 
-        formatter.write_str(format!("{schema}.{object_name}").as_str())
+        formatter.write_fmt(format_args!("{schema}.{object_name}"))
     }
 }
 


### PR DESCRIPTION
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
The change improves the performance and readability of the `fmt` method for `ResourceId` by replacing `formatter.write_str(format!("{schema}.{object_name}").as_str())` with `formatter.write_fmt(format_args!("{schema}.{object_name}"))`. This eliminates the unnecessary creation of a temporary string.

# What changes are included in this PR?
- Replaced `write_str` with `write_fmt` in the `fmt` method for `ResourceId`.

# Are these changes tested?
Yes, the functionality has been verified with the existing tests.
