### PR TITLE
feat: add `AggregateExec`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
@@ -1,0 +1,563 @@
+use super::{fold_columns, fold_vals, DynProofPlan};
+use crate::{
+    base::{
+        database::{
+            group_by_util::{aggregate_columns, AggregatedColumns},
+            order_by_util::compare_indexes_by_owned_columns,
+            Column, ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTable, Table,
+            TableEvaluation, TableRef,
+        },
+        map::{IndexMap, IndexSet},
+        proof::{PlaceholderResult, ProofError},
+        scalar::Scalar,
+        slice_ops,
+    },
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
+            SumcheckSubpolynomialType, VerificationBuilder,
+        },
+        proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr},
+    },
+    utils::log,
+};
+use alloc::{boxed::Box, vec, vec::Vec};
+use bumpalo::Bump;
+use core::iter;
+use num_traits::{One, Zero};
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
+
+/// Provable expressions for queries of the form
+/// ```ignore
+///     SELECT <group_by_expr1>.expr as <group_by_expr1>.alias, ..., <group_by_exprM>.expr as <group_by_exprM>.alias,
+///         SUM(<sum_expr1>.expr) as <sum_expr1>.alias, ..., SUM(<sum_exprN>.expr) as <sum_exprN>.alias,
+///         COUNT(*) as <count_alias>
+///     FROM <input>
+///     WHERE <where_clause>
+///     GROUP BY <group_by_expr1>.expr, ..., <group_by_exprM>.expr
+/// ```
+///
+/// Note: if `group_by_exprs` is empty, then the query is equivalent to removing the `GROUP BY` clause.
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct AggregateExec {
+    group_by_exprs: Vec<AliasedDynProofExpr>,
+    sum_exprs: Vec<AliasedDynProofExpr>,
+    input: Box<DynProofPlan>,
+    where_clause: DynProofExpr,
+    count_alias: Ident,
+    is_top_level: bool,
+}
+
+impl AggregateExec {
+    /// Creates a new aggregate proof plan.
+    pub fn new(
+        group_by_exprs: Vec<AliasedDynProofExpr>,
+        sum_exprs: Vec<AliasedDynProofExpr>,
+        input: Box<DynProofPlan>,
+        where_clause: DynProofExpr,
+        count_alias: Ident,
+        is_top_level: bool,
+    ) -> Self {
+        Self {
+            group_by_exprs,
+            sum_exprs,
+            input,
+            where_clause,
+            count_alias,
+            is_top_level,
+        }
+    }
+
+    /// Get a reference to the input plan
+    pub fn input(&self) -> &DynProofPlan {
+        &self.input
+    }
+
+    /// Get a reference to the where clause
+    pub fn where_clause(&self) -> &DynProofExpr {
+        &self.where_clause
+    }
+
+    /// Get a reference to the group by expressions
+    pub fn group_by_exprs(&self) -> &[AliasedDynProofExpr] {
+        &self.group_by_exprs
+    }
+
+    /// Get a reference to the sum expressions
+    pub fn sum_exprs(&self) -> &[AliasedDynProofExpr] {
+        &self.sum_exprs
+    }
+
+    /// Get a reference to the count alias
+    pub fn count_alias(&self) -> &Ident {
+        &self.count_alias
+    }
+
+    /// Get whether this is a top level execution
+    pub fn is_top_level(&self) -> bool {
+        self.is_top_level
+    }
+}
+
+impl ProofPlan for AggregateExec {
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        result: Option<&OwnedTable<S>>,
+        chi_eval_map: &IndexMap<TableRef, S>,
+        params: &[LiteralValue],
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        let input_eval =
+            self.input
+                .verifier_evaluate(builder, accessor, None, chi_eval_map, params)?;
+        let input_chi_eval = input_eval.chi_eval();
+        // Build new accessors
+        let input_schema = self.input.get_column_result_fields();
+        // Check for tables - this is just error handling, we don't need the table ref
+        let current_accessor = input_schema
+            .iter()
+            .zip(input_eval.column_evals())
+            .map(|(field, eval)| (field.name().clone(), *eval))
+            .collect::<IndexMap<_, _>>();
+        // 1. selection
+        let where_eval = self.where_clause.verifier_evaluate(
+            builder,
+            &current_accessor,
+            input_chi_eval,
+            params,
+        )?;
+        // 2. columns
+        let group_by_evals = self
+            .group_by_exprs
+            .iter()
+            .map(|aliased_expr| {
+                aliased_expr.expr.verifier_evaluate(
+                    builder,
+                    &current_accessor,
+                    input_chi_eval,
+                    params,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let aggregate_evals = self
+            .sum_exprs
+            .iter()
+            .map(|aliased_expr| {
+                aliased_expr.expr.verifier_evaluate(
+                    builder,
+                    &current_accessor,
+                    input_chi_eval,
+                    params,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        // 3. filtered_columns
+        let group_by_result_columns_evals =
+            builder.try_consume_final_round_mle_evaluations(self.group_by_exprs.len())?;
+        let sum_result_columns_evals =
+            builder.try_consume_final_round_mle_evaluations(self.sum_exprs.len())?;
+        let count_column_eval = builder.try_consume_final_round_mle_evaluation()?;
+
+        let alpha = builder.try_consume_post_result_challenge()?;
+        let beta = builder.try_consume_post_result_challenge()?;
+        let output_chi_eval = builder.try_consume_chi_evaluation()?;
+
+        verify_group_by(
+            builder,
+            alpha,
+            beta,
+            input_chi_eval,
+            output_chi_eval,
+            (group_by_evals, aggregate_evals, where_eval),
+            (
+                group_by_result_columns_evals.clone(),
+                sum_result_columns_evals.clone(),
+                count_column_eval,
+            ),
+        )?;
+        match result {
+            Some(table) => {
+                // Get column references for the group-by expressions
+                let cols = (0..self.group_by_exprs.len())
+                    .filter_map(|i| table.inner_table().get_index(i).map(|(_, col)| col))
+                    .collect::<Vec<_>>();
+
+                if cols.len() != self.group_by_exprs.len() {
+                    return Err(ProofError::VerificationError {
+                        error: "Result does not have all correct group by columns.",
+                    });
+                }
+
+                if (0..table.num_rows() - 1)
+                    .any(|i| compare_indexes_by_owned_columns(&cols, i, i + 1).is_ge())
+                {
+                    Err(ProofError::VerificationError {
+                        error: "Result of group by not ordered as expected.",
+                    })?;
+                }
+            }
+            None => {
+                Err(ProofError::UnsupportedQueryPlan {
+                    error: "AggregateExec currently only supported at top level of query plan.",
+                })?;
+            }
+        }
+
+        let column_evals = group_by_result_columns_evals
+            .into_iter()
+            .chain(sum_result_columns_evals)
+            .chain(iter::once(count_column_eval))
+            .collect::<Vec<_>>();
+        Ok(TableEvaluation::new(column_evals, output_chi_eval))
+    }
+
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        let mut result = Vec::new();
+
+        // Add group by expressions
+        for aliased_expr in &self.group_by_exprs {
+            result.push(ColumnField::new(
+                aliased_expr.alias.clone(),
+                aliased_expr.expr.data_type(),
+            ));
+        }
+
+        // Add sum expressions
+        for aliased_expr in &self.sum_exprs {
+            result.push(ColumnField::new(
+                aliased_expr.alias.clone(),
+                aliased_expr.expr.data_type(),
+            ));
+        }
+
+        // Add count column
+        result.push(ColumnField::new(
+            self.count_alias.clone(),
+            ColumnType::BigInt,
+        ));
+
+        result
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        let mut columns = self.input.get_column_references();
+
+        for aliased_expr in &self.group_by_exprs {
+            aliased_expr.expr.get_column_references(&mut columns);
+        }
+
+        for aliased_expr in &self.sum_exprs {
+            aliased_expr.expr.get_column_references(&mut columns);
+        }
+
+        self.where_clause.get_column_references(&mut columns);
+
+        columns
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        self.input.get_table_references()
+    }
+}
+
+impl ProverEvaluate for AggregateExec {
+    #[tracing::instrument(
+        name = "AggregateExec::first_round_evaluate",
+        level = "debug",
+        skip_all
+    )]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Table<'a, S>> {
+        log::log_memory_usage("Start");
+
+        let input = self
+            .input
+            .first_round_evaluate(builder, alloc, table_map, params)?;
+        // 1. selection
+        let selection_column: Column<'a, S> = self
+            .where_clause
+            .first_round_evaluate(alloc, &input, params)?;
+
+        let selection = selection_column
+            .as_boolean()
+            .expect("selection is not boolean");
+
+        // 2. columns
+        let group_by_columns = self
+            .group_by_exprs
+            .iter()
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
+                aliased_expr
+                    .expr
+                    .first_round_evaluate(alloc, &input, params)
+            })
+            .collect::<PlaceholderResult<Vec<_>>>()?;
+        let sum_columns = self
+            .sum_exprs
+            .iter()
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
+                aliased_expr
+                    .expr
+                    .first_round_evaluate(alloc, &input, params)
+            })
+            .collect::<PlaceholderResult<Vec<_>>>()?;
+        // Compute filtered_columns
+        let AggregatedColumns {
+            group_by_columns: group_by_result_columns,
+            sum_columns: sum_result_columns,
+            count_column,
+            ..
+        } = aggregate_columns(alloc, &group_by_columns, &sum_columns, &[], &[], selection)
+            .expect("columns should be aggregatable");
+        let sum_result_columns_iter = sum_result_columns.iter().map(|col| Column::Scalar(col));
+        let res = Table::<'a, S>::try_from_iter(
+            self.get_column_result_fields()
+                .into_iter()
+                .map(|field| field.name())
+                .zip(
+                    group_by_result_columns
+                        .into_iter()
+                        .chain(sum_result_columns_iter)
+                        .chain(iter::once(Column::BigInt(count_column))),
+                ),
+        )
+        .expect("Failed to create table from column references");
+        builder.request_post_result_challenges(2);
+        builder.produce_chi_evaluation_length(count_column.len());
+
+        log::log_memory_usage("End");
+
+        Ok(res)
+    }
+
+    #[tracing::instrument(
+        name = "AggregateExec::final_round_evaluate",
+        level = "debug",
+        skip_all
+    )]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Table<'a, S>> {
+        log::log_memory_usage("Start");
+
+        let input = self
+            .input
+            .final_round_evaluate(builder, alloc, table_map, params)?;
+        // 1. selection
+        let selection_column: Column<'a, S> = self
+            .where_clause
+            .final_round_evaluate(builder, alloc, &input, params)?;
+        let selection = selection_column
+            .as_boolean()
+            .expect("selection is not boolean");
+
+        // 2. columns
+        let group_by_columns = self
+            .group_by_exprs
+            .iter()
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
+                aliased_expr
+                    .expr
+                    .final_round_evaluate(builder, alloc, &input, params)
+            })
+            .collect::<PlaceholderResult<Vec<_>>>()?;
+        let sum_columns = self
+            .sum_exprs
+            .iter()
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
+                aliased_expr
+                    .expr
+                    .final_round_evaluate(builder, alloc, &input, params)
+            })
+            .collect::<PlaceholderResult<Vec<_>>>()?;
+        // 3. Compute filtered_columns
+        let AggregatedColumns {
+            group_by_columns: group_by_result_columns,
+            sum_columns: sum_result_columns,
+            count_column,
+            ..
+        } = aggregate_columns(alloc, &group_by_columns, &sum_columns, &[], &[], selection)
+            .expect("columns should be aggregatable");
+
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+
+        // 4. Tally results
+        let sum_result_columns_iter = sum_result_columns.iter().map(|col| Column::Scalar(col));
+        let columns = group_by_result_columns
+            .clone()
+            .into_iter()
+            .chain(sum_result_columns_iter)
+            .chain(iter::once(Column::BigInt(count_column)));
+        let res = Table::<'a, S>::try_from_iter(
+            self.get_column_result_fields()
+                .into_iter()
+                .map(|field| field.name())
+                .zip(columns.clone()),
+        )
+        .expect("Failed to create table from column references");
+        // 5. Produce MLEs
+        for column in columns {
+            builder.produce_intermediate_mle(column);
+        }
+        // 6. Prove group by
+        prove_group_by(
+            builder,
+            alloc,
+            alpha,
+            beta,
+            (&group_by_columns, &sum_columns, selection),
+            (&group_by_result_columns, &sum_result_columns, count_column),
+            input.num_rows(),
+        );
+
+        log::log_memory_usage("End");
+
+        Ok(res)
+    }
+}
+
+fn verify_group_by<S: Scalar>(
+    builder: &mut impl VerificationBuilder<S>,
+    alpha: S,
+    beta: S,
+    input_chi_eval: S,
+    output_chi_eval: S,
+    (g_in_evals, sum_in_evals, sel_in_eval): (Vec<S>, Vec<S>, S),
+    (g_out_evals, sum_out_evals, count_out_eval): (Vec<S>, Vec<S>, S),
+) -> Result<(), ProofError> {
+    // g_in_fold = alpha * sum beta^j * g_in[j]
+    let g_in_fold_eval = alpha * fold_vals(beta, &g_in_evals);
+    // g_out_fold = alpha * sum beta^j * g_out[j]
+    let g_out_fold_eval = alpha * fold_vals(beta, &g_out_evals);
+    // sum_in_fold = chi_n + sum beta^(j+1) * sum_in[j]
+    let sum_in_fold_eval = input_chi_eval + beta * fold_vals(beta, &sum_in_evals);
+    // sum_out_fold = count_out + sum beta^(j+1) * sum_out[j]
+    let sum_out_fold_eval = count_out_eval + beta * fold_vals(beta, &sum_out_evals);
+
+    let g_in_star_eval = builder.try_consume_final_round_mle_evaluation()?;
+    let g_out_star_eval = builder.try_consume_final_round_mle_evaluation()?;
+
+    // sum g_in_star * sel_in * sum_in_fold - g_out_star * sum_out_fold = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::ZeroSum,
+        g_in_star_eval * sel_in_eval * sum_in_fold_eval - g_out_star_eval * sum_out_fold_eval,
+        3,
+    )?;
+
+    // g_in_star + g_in_star * g_in_fold - chi_n = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        g_in_star_eval + g_in_star_eval * g_in_fold_eval - input_chi_eval,
+        2,
+    )?;
+
+    // g_out_star + g_out_star * g_out_fold - chi_m = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        g_out_star_eval + g_out_star_eval * g_out_fold_eval - output_chi_eval,
+        2,
+    )?;
+
+    Ok(())
+}
+
+pub fn prove_group_by<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    (g_in, sum_in, sel_in): (&[Column<S>], &[Column<S>], &'a [bool]),
+    (g_out, sum_out, count_out): (&[Column<S>], &[&'a [S]], &'a [i64]),
+    n: usize,
+) {
+    let m = count_out.len();
+    let chi_n = alloc.alloc_slice_fill_copy(n, true);
+    let chi_m = alloc.alloc_slice_fill_copy(m, true);
+
+    // g_in_fold = alpha * sum beta^j * g_in[j]
+    let g_in_fold = alloc.alloc_slice_fill_copy(n, Zero::zero());
+    fold_columns(g_in_fold, alpha, beta, g_in);
+
+    // g_out_fold = alpha * sum beta^j * g_out[j]
+    let g_out_fold = alloc.alloc_slice_fill_copy(m, Zero::zero());
+    fold_columns(g_out_fold, alpha, beta, g_out);
+
+    // sum_in_fold = 1 + sum beta^(j+1) * sum_in[j]
+    let sum_in_fold = alloc.alloc_slice_fill_copy(n, One::one());
+    fold_columns(sum_in_fold, beta, beta, sum_in);
+
+    // sum_out_fold = count_out + sum beta^(j+1) * sum_out[j]
+    let sum_out_fold = alloc.alloc_slice_fill_default(m);
+    slice_ops::slice_cast_mut(count_out, sum_out_fold);
+    fold_columns(sum_out_fold, beta, beta, sum_out);
+
+    // g_in_star = (1 + g_in_fold)^(-1)
+    let g_in_star = alloc.alloc_slice_copy(g_in_fold);
+    slice_ops::add_const::<S, S>(g_in_star, One::one());
+    slice_ops::batch_inversion(g_in_star);
+
+    // g_out_star = (1 + g_out_fold)^(-1)
+    let g_out_star = alloc.alloc_slice_copy(g_out_fold);
+    slice_ops::add_const::<S, S>(g_out_star, One::one());
+    slice_ops::batch_inversion(g_out_star);
+
+    builder.produce_intermediate_mle(g_in_star as &[_]);
+    builder.produce_intermediate_mle(g_out_star as &[_]);
+
+    // sum g_in_star * sel_in * sum_in_fold - g_out_star * sum_out_fold = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::ZeroSum,
+        vec![
+            (
+                S::one(),
+                vec![
+                    Box::new(g_in_star as &[_]),
+                    Box::new(sel_in),
+                    Box::new(sum_in_fold as &[_]),
+                ],
+            ),
+            (
+                -S::one(),
+                vec![Box::new(g_out_star as &[_]), Box::new(sum_out_fold as &[_])],
+            ),
+        ],
+    );
+
+    // g_in_star + g_in_star * g_in_fold - chi_n = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (S::one(), vec![Box::new(g_in_star as &[_])]),
+            (
+                S::one(),
+                vec![Box::new(g_in_star as &[_]), Box::new(g_in_fold as &[_])],
+            ),
+            (-S::one(), vec![Box::new(chi_n as &[_])]),
+        ],
+    );
+
+    // g_out_star + g_out_star * g_out_fold - chi_m = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (S::one(), vec![Box::new(g_out_star as &[_])]),
+            (
+                S::one(),
+                vec![Box::new(g_out_star as &[_]), Box::new(g_out_fold as &[_])],
+            ),
+            (-S::one(), vec![Box::new(chi_m as &[_])]),
+        ],
+    );
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
@@ -1,0 +1,407 @@
+use super::test_utility::*;
+use crate::{
+    base::{
+        commitment::InnerProductProof,
+        database::{
+            owned_table_utility::*, table_utility::*, ColumnField, ColumnType, TableRef,
+            TableTestAccessor, TestAccessor,
+        },
+    },
+    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+    sql::{
+        proof::{exercise_verification, VerifiableQueryResult},
+        proof_exprs::{test_utility::*, TableExpr},
+        proof_plans::{DynProofPlan, FilterExec},
+    },
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+
+/// `select sum(c) as sum_c, count(*) as __count__ from sxt.t where b = 99`
+#[test]
+fn we_can_prove_aggregation_without_group_by() {
+    let alloc = Bump::new();
+    let data = table([
+        borrowed_bigint("a", [1, 2, 2, 1, 2], &alloc),
+        borrowed_bigint("b", [99, 99, 99, 99, 0], &alloc),
+        borrowed_bigint("c", [101, 102, 103, 104, 105], &alloc),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(t.clone(), data, 0);
+    let expr = aggregate(
+        vec![],
+        vec![sum_expr(column(&t, "c", &accessor), "sum_c")],
+        "__count__",
+        Box::new(table_exec(
+            t.clone(),
+            vec![
+                ColumnField::new("a".into(), ColumnType::BigInt),
+                ColumnField::new("b".into(), ColumnType::BigInt),
+                ColumnField::new("c".into(), ColumnType::BigInt),
+            ],
+        )),
+        equal(column(&t, "b", &accessor), const_int128(99)),
+        true,
+    );
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    exercise_verification(&res, &expr, &accessor, &t);
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let expected = owned_table([
+        bigint("sum_c", [101 + 104 + 102 + 103]),
+        bigint("__count__", [4]),
+    ]);
+    assert_eq!(res, expected);
+}
+
+/// `select a, sum(c) as sum_c, count(*) as __count__ from sxt.t where b = 99 group by a`
+#[test]
+fn we_can_prove_a_simple_group_by_with_bigint_columns() {
+    let alloc = Bump::new();
+    let data = table([
+        borrowed_bigint("a", [1, 2, 2, 1, 2], &alloc),
+        borrowed_bigint("b", [99, 99, 99, 99, 0], &alloc),
+        borrowed_bigint("c", [101, 102, 103, 104, 105], &alloc),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(t.clone(), data, 0);
+    let expr = aggregate(
+        vec![col_expr_plan(&t, "a", &accessor)],
+        vec![sum_expr(column(&t, "c", &accessor), "sum_c")],
+        "__count__",
+        Box::new(table_exec(
+            t.clone(),
+            vec![
+                ColumnField::new("a".into(), ColumnType::BigInt),
+                ColumnField::new("b".into(), ColumnType::BigInt),
+                ColumnField::new("c".into(), ColumnType::BigInt),
+            ],
+        )),
+        equal(column(&t, "b", &accessor), const_int128(99)),
+        true,
+    );
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    exercise_verification(&res, &expr, &accessor, &t);
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let expected = owned_table([
+        bigint("a", [1, 2]),
+        bigint("sum_c", [101 + 104, 102 + 103]),
+        bigint("__count__", [2, 2]),
+    ]);
+    assert_eq!(res, expected);
+}
+
+/// `select a, sum(c * 2 + 1) as sum_c, count(*) as __count__ from sxt.t where b = 99 group by a`
+#[test]
+fn we_can_prove_a_group_by_with_bigint_columns() {
+    let alloc = Bump::new();
+    let data = table([
+        borrowed_bigint("a", [1, 2, 2, 1, 2], &alloc),
+        borrowed_bigint("b", [99, 99, 99, 99, 0], &alloc),
+        borrowed_bigint("c", [101, 102, 103, 104, 105], &alloc),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(t.clone(), data, 0);
+    let expr = aggregate(
+        vec![col_expr_plan(&t, "a", &accessor)],
+        vec![sum_expr(
+            add(
+                multiply(column(&t, "c", &accessor), const_bigint(2)),
+                const_bigint(1),
+            ),
+            "sum_c",
+        )],
+        "__count__",
+        Box::new(table_exec(
+            t.clone(),
+            vec![
+                ColumnField::new("a".into(), ColumnType::BigInt),
+                ColumnField::new("b".into(), ColumnType::BigInt),
+                ColumnField::new("c".into(), ColumnType::BigInt),
+            ],
+        )),
+        equal(column(&t, "b", &accessor), const_int128(99)),
+        true,
+    );
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    exercise_verification(&res, &expr, &accessor, &t);
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let expected = owned_table([
+        bigint("a", [1, 2]),
+        decimal75("sum_c", 40, 0, [(101 + 104) * 2 + 2, (102 + 103) * 2 + 2]),
+        bigint("__count__", [2, 2]),
+    ]);
+    assert_eq!(res, expected);
+}
+
+#[expect(clippy::too_many_lines)]
+#[test]
+fn we_can_prove_a_complex_group_by_query_with_many_columns() {
+    let alloc = Bump::new();
+    let scalar_filter_data: Vec<Curve25519Scalar> = [
+        333, 222, 222, 333, 222, 333, 333, 333, 222, 222, 222, 333, 222, 222, 222, 222, 222, 222,
+        333, 333,
+    ]
+    .iter()
+    .map(core::convert::Into::into)
+    .collect();
+    let scalar_group_data: Vec<Curve25519Scalar> =
+        [5, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 4, 5]
+            .iter()
+            .map(core::convert::Into::into)
+            .collect();
+    let scalar_sum_data: Vec<Curve25519Scalar> = [
+        119, 522, 100, 325, 501, 447, 759, 375, 212, 532, 459, 616, 579, 179, 695, 963, 532, 868,
+        331, 830,
+    ]
+    .iter()
+    .map(core::convert::Into::into)
+    .collect();
+    let data = table([
+        borrowed_bigint(
+            "bigint_filter",
+            [
+                30, 20, 30, 30, 30, 20, 30, 20, 30, 20, 30, 20, 20, 20, 30, 30, 20, 20, 20, 30,
+            ],
+            &alloc,
+        ),
+        borrowed_bigint(
+            "bigint_group",
+            [7, 6, 6, 6, 7, 7, 6, 6, 6, 6, 7, 7, 6, 7, 6, 7, 7, 7, 6, 7],
+            &alloc,
+        ),
+        borrowed_bigint(
+            "bigint_sum",
+            [
+                834, 985, 832, 300, 146, 624, 553, 637, 770, 574, 913, 600, 336, 984, 198, 257,
+                781, 196, 537, 358,
+            ],
+            &alloc,
+        ),
+        borrowed_int128(
+            "int128_filter",
+            [
+                1030, 1030, 1030, 1020, 1020, 1030, 1020, 1020, 1020, 1030, 1030, 1030, 1020, 1020,
+                1030, 1020, 1020, 1030, 1020, 1030,
+            ],
+            &alloc,
+        ),
+        borrowed_int128(
+            "int128_group",
+            [8, 8, 8, 8, 8, 8, 9, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 8, 8, 8],
+            &alloc,
+        ),
+        borrowed_int128(
+            "int128_sum",
+            [
+                275, 225, 315, 199, 562, 578, 563, 513, 634, 829, 613, 295, 509, 923, 133, 973,
+                700, 464, 622, 943,
+            ],
+            &alloc,
+        ),
+        borrowed_varchar(
+            "varchar_filter",
+            [
+                "f2", "f2", "f3", "f2", "f2", "f3", "f3", "f2", "f2", "f3", "f2", "f2", "f2", "f3",
+                "f2", "f3", "f2", "f2", "f3", "f3",
+            ],
+            &alloc,
+        ),
+        borrowed_varchar(
+            "varchar_group",
+            [
+                "g1", "g2", "g1", "g1", "g1", "g1", "g2", "g1", "g1", "g1", "g2", "g2", "g1", "g1",
+                "g1", "g2", "g1", "g2", "g1", "g1",
+            ],
+            &alloc,
+        ),
+        borrowed_scalar("scalar_filter", scalar_filter_data, &alloc),
+        borrowed_scalar("scalar_group", scalar_group_data, &alloc),
+        borrowed_scalar("scalar_sum", scalar_sum_data, &alloc),
+    ]);
+
+    let t = TableRef::new("sxt", "t");
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(t.clone(), data, 0);
+
+    // SELECT scalar_group, int128_group, bigint_group, sum(bigint_sum + 1) as sum_int, sum(bigint_sum - int128_sum) as sum_bigint, sum(scalar_filter) as sum_scal, count(*) as __count__
+    //  FROM sxt.t WHERE int128_filter = 1020 AND varchar_filter = 'f2'
+    //  GROUP BY scalar_group, int128_group, bigint_group
+    let expr = aggregate(
+        cols_expr_plan(
+            &t,
+            &["scalar_group", "int128_group", "bigint_group"],
+            &accessor,
+        ),
+        vec![
+            sum_expr(
+                add(column(&t, "bigint_sum", &accessor), const_bigint(1)),
+                "sum_int",
+            ),
+            sum_expr(
+                subtract(
+                    column(&t, "bigint_sum", &accessor),
+                    column(&t, "int128_sum", &accessor),
+                ),
+                "sum_128",
+            ),
+            sum_expr(column(&t, "scalar_sum", &accessor), "sum_scal"),
+        ],
+        "__count__",
+        Box::new(table_exec(
+            t.clone(),
+            vec![
+                ColumnField::new("bigint_filter".into(), ColumnType::BigInt),
+                ColumnField::new("bigint_group".into(), ColumnType::BigInt),
+                ColumnField::new("bigint_sum".into(), ColumnType::BigInt),
+                ColumnField::new("int128_filter".into(), ColumnType::Int128),
+                ColumnField::new("int128_group".into(), ColumnType::Int128),
+                ColumnField::new("int128_sum".into(), ColumnType::Int128),
+                ColumnField::new("varchar_filter".into(), ColumnType::VarChar),
+                ColumnField::new("varchar_group".into(), ColumnType::VarChar),
+                ColumnField::new("scalar_filter".into(), ColumnType::Scalar),
+                ColumnField::new("scalar_group".into(), ColumnType::Scalar),
+                ColumnField::new("scalar_sum".into(), ColumnType::Scalar),
+            ],
+        )),
+        and(
+            equal(column(&t, "int128_filter", &accessor), const_int128(1020)),
+            equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
+        ),
+        true,
+    );
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    exercise_verification(&res, &expr, &accessor, &t);
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let expected = owned_table([
+        scalar("scalar_group", [4, 4, 4]),
+        int128("int128_group", [8, 8, 9]),
+        bigint("bigint_group", [6, 7, 6]),
+        decimal75("sum_int", 20, 0, [1409, 929, 638]),
+        decimal75("sum_128", 40, 0, [64, -335, 124]),
+        scalar("sum_scal", [1116, 1033, 375]),
+        bigint("__count__", [3, 2, 1]),
+    ]);
+    assert_eq!(res, expected);
+
+    // SELECT sum(bigint_sum) as sum_int, sum(int128_sum * 4) as sum_128, sum(scalar_sum) as sum_scal, count(*) as __count__
+    //  FROM sxt.t WHERE int128_filter = 1020 AND varchar_filter = 'f2'
+    let expr = aggregate(
+        vec![],
+        vec![
+            sum_expr(column(&t, "bigint_sum", &accessor), "sum_int"),
+            sum_expr(
+                multiply(column(&t, "int128_sum", &accessor), const_bigint(4)),
+                "sum_128",
+            ),
+            sum_expr(column(&t, "scalar_sum", &accessor), "sum_scal"),
+        ],
+        "__count__",
+        Box::new(table_exec(
+            t.clone(),
+            vec![
+                ColumnField::new("bigint_filter".into(), ColumnType::BigInt),
+                ColumnField::new("bigint_group".into(), ColumnType::BigInt),
+                ColumnField::new("bigint_sum".into(), ColumnType::BigInt),
+                ColumnField::new("int128_filter".into(), ColumnType::Int128),
+                ColumnField::new("int128_group".into(), ColumnType::Int128),
+                ColumnField::new("int128_sum".into(), ColumnType::Int128),
+                ColumnField::new("varchar_filter".into(), ColumnType::VarChar),
+                ColumnField::new("varchar_group".into(), ColumnType::VarChar),
+                ColumnField::new("scalar_filter".into(), ColumnType::Scalar),
+                ColumnField::new("scalar_group".into(), ColumnType::Scalar),
+                ColumnField::new("scalar_sum".into(), ColumnType::Scalar),
+            ],
+        )),
+        and(
+            equal(column(&t, "int128_filter", &accessor), const_int128(1020)),
+            equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
+        ),
+        true,
+    );
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    exercise_verification(&res, &expr, &accessor, &t);
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let expected = owned_table([
+        bigint("sum_int", [1406 + 927 + 637]),
+        decimal75("sum_128", 59, 0, [(1342 + 1262 + 513) * 4]),
+        scalar("sum_scal", [1116 + 1033 + 375]),
+        bigint("__count__", [3 + 2 + 1]),
+    ]);
+    assert_eq!(res, expected);
+}
+
+/// Test for non-trivial composition of `AggregateExec` and `FilterExec`
+#[test]
+fn we_can_compose_aggregate_with_filter() {
+    let alloc = Bump::new();
+    let data = table([
+        borrowed_bigint("a", [1, 3, 3, 5, 5], &alloc),
+        borrowed_bigint("b", [10, 20, 20, 40, 40], &alloc),
+        borrowed_bigint("c", [100, 200, 300, 400, 500], &alloc),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(t.clone(), data, 0);
+    let intermediate_data = table([
+        borrowed_decimal75("a", 39, 0, [6, 6, 10, 10], &alloc),
+        borrowed_decimal75("b", 39, 0, [40, 40, 80, 80], &alloc),
+        borrowed_decimal75("c", 39, 0, [400, 600, 800, 1000], &alloc),
+    ]);
+    let mut intermediate_accessor =
+        TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    intermediate_accessor.add_table(t.clone(), intermediate_data, 0);
+
+    // First create a `FilterExec` that filters rows where a >= 2 and doubles the value of column a, b, c
+    let filter_plan = Box::new(DynProofPlan::Filter(FilterExec::new(
+        vec![
+            aliased_plan(multiply(column(&t, "a", &accessor), const_bigint(2)), "a"),
+            aliased_plan(multiply(column(&t, "b", &accessor), const_bigint(2)), "b"),
+            aliased_plan(multiply(column(&t, "c", &accessor), const_bigint(2)), "c"),
+        ],
+        TableExpr {
+            table_ref: t.clone(),
+        },
+        gte(column(&t, "a", &accessor), const_smallint(2)),
+    )));
+
+    // Then create an `AggregateExec` that groups by a + b and 2 * a and sums column c
+    let aggregate_expr = aggregate(
+        vec![
+            aliased_plan(
+                add(
+                    column(&t, "a", &intermediate_accessor),
+                    column(&t, "b", &intermediate_accessor),
+                ),
+                "a_plus_b",
+            ),
+            aliased_plan(
+                multiply(column(&t, "a", &intermediate_accessor), const_bigint(2)),
+                "two_a",
+            ),
+        ],
+        vec![sum_expr(column(&t, "c", &intermediate_accessor), "sum_c")],
+        "__count__",
+        filter_plan,
+        const_bool(true),
+        true,
+    );
+
+    let res = VerifiableQueryResult::new(&aggregate_expr, &accessor, &(), &[]).unwrap();
+    exercise_verification(&res, &aggregate_expr, &accessor, &t);
+    let res = res
+        .verify(&aggregate_expr, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    let expected = owned_table([
+        decimal75("a_plus_b", 40, 0, [46, 90]),
+        decimal75("two_a", 59, 0, [12, 20]),
+        decimal75("sum_c", 39, 0, [1000, 1800]),
+        bigint("__count__", [2, 2]),
+    ]);
+
+    assert_eq!(res, expected);
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,6 +1,6 @@
 use super::{
-    EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, SortMergeJoinExec, TableExec,
-    UnionExec,
+    AggregateExec, EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec,
+    SortMergeJoinExec, TableExec, UnionExec,
 };
 use crate::{
     base::{
@@ -47,6 +47,17 @@ pub enum DynProofPlan {
     ///     GROUP BY <group_by_expr1>, ..., <group_by_exprM>
     /// ```
     GroupBy(GroupByExec),
+    /// Provable expressions for queries of the form
+    /// ```ignore
+    ///     SELECT <group_by_expr1>.expr as <group_by_expr1>.alias, ..., <group_by_exprM>.expr as <group_by_exprM>.alias,
+    ///         SUM(<sum_expr1>.expr) as <sum_expr1>.alias, ..., SUM(<sum_exprN>.expr) as <sum_exprN>.alias,
+    ///         COUNT(*) as <count_alias>
+    ///     FROM <input>
+    ///     WHERE <where_clause>
+    ///     GROUP BY <group_by_expr1>.expr, ..., <group_by_exprM>.expr
+    /// ```
+    /// Similar to GroupBy but accepts a DynProofPlan as input
+    Aggregate(AggregateExec),
     /// Provable expressions for queries of the form, where the result is sent in a dense form
     /// ```ignore
     ///     SELECT <result_expr1>, ..., <result_exprN> FROM <table> WHERE <where_clause>
@@ -119,6 +130,26 @@ impl DynProofPlan {
             count_alias,
             table,
             where_clause,
+        ))
+    }
+
+    /// Creates a new aggregate plan.
+    #[must_use]
+    pub fn new_aggregate(
+        group_by_exprs: Vec<AliasedDynProofExpr>,
+        sum_exprs: Vec<AliasedDynProofExpr>,
+        input: DynProofPlan,
+        where_clause: DynProofExpr,
+        count_alias: Ident,
+        is_top_level: bool,
+    ) -> Self {
+        Self::Aggregate(AggregateExec::new(
+            group_by_exprs,
+            sum_exprs,
+            Box::new(input),
+            where_clause,
+            count_alias,
+            is_top_level,
         ))
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -35,6 +35,12 @@ pub(crate) use group_by_exec::GroupByExec;
 #[cfg(all(test, feature = "blitzar"))]
 mod group_by_exec_test;
 
+mod aggregate_exec;
+pub(crate) use aggregate_exec::AggregateExec;
+
+#[cfg(all(test, feature = "blitzar"))]
+mod aggregate_exec_test;
+
 mod slice_exec;
 pub(crate) use slice_exec::SliceExec;
 #[cfg(all(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
@@ -1,11 +1,12 @@
 use super::{
-    DynProofPlan, EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, SortMergeJoinExec,
-    TableExec, UnionExec,
+    AggregateExec, DynProofPlan, EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec,
+    SortMergeJoinExec, TableExec, UnionExec,
 };
 use crate::{
     base::database::{ColumnField, ColumnType, TableRef},
     sql::proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
 };
+use alloc::boxed::Box;
 use sqlparser::ast::Ident;
 
 pub fn column_field(name: &str, column_type: ColumnType) -> ColumnField {
@@ -48,6 +49,27 @@ pub fn group_by(
         count_alias.into(),
         table,
         where_clause,
+    ))
+}
+
+/// # Panics
+///
+/// Will panic if `count_alias` cannot be parsed as a valid identifier.
+pub fn aggregate(
+    group_by_exprs: Vec<AliasedDynProofExpr>,
+    sum_exprs: Vec<AliasedDynProofExpr>,
+    count_alias: &str,
+    input: Box<DynProofPlan>,
+    where_clause: DynProofExpr,
+    is_top_level: bool,
+) -> DynProofPlan {
+    DynProofPlan::Aggregate(AggregateExec::new(
+        group_by_exprs,
+        sum_exprs,
+        input,
+        where_clause,
+        count_alias.into(),
+        is_top_level,
     ))
 }
 


### PR DESCRIPTION
# Rationale for this change
This PR introduces a new proof plan node `AggregateExec` which will replace `GroupByExec` and hooks it into the dynamic proof plan framework.  

# What changes are included in this PR?

- **New proof plan node**  
  - Add `AggregateExec` in `proof_plans/aggregate_exec.rs`, implementing both `ProofPlan` (verification) and `ProverEvaluate` (first- and final-round evaluation) for queries of the form  
```sql
SELECT
    <group_by_expr1>.expr as <group_by_expr1>.alias, 
    ..., 
    <group_by_exprM>.expr as <group_by_exprM>.alias,
    SUM(<sum_expr1>.expr) as <sum_expr1>.alias, 
    ..., 
    SUM(<sum_exprN>.expr) as <sum_exprN>.alias,
    COUNT(*) as <count_alias>
FROM <input>
WHERE <where_clause>
GROUP BY 
    <group_by_expr1>.expr,
    ...,
    <group_by_exprM>.expr;
```

- **Dynamic plan integration**  
  - Extend the `DynProofPlan` enum with a new `Aggregate(AggregateExec)` variant and add the `new_aggregate(...)` constructor in `dyn_proof_plan.rs`.
  - Export `AggregateExec` from `proof_plans/mod.rs` so it’s available for higher-level planning.

- **Comprehensive tests**  
  - Add `aggregate_exec_test.rs` covering:
    - Aggregation without any GROUP BY (global SUM + COUNT).
    - Simple GROUP BY on a single bigint column.
    - GROUP BY with arithmetic expressions inside the SUM.
    - A complex multi-column GROUP BY over bigint, int128, varchar, scalar types.
    - Composing `AggregateExec` with `FilterExec` to verify that chaining works correctly.

# Are these changes tested?

Yes — all new functionality is covered by unit tests in `proof_plans/aggregate_exec_test.rs`, and `exercise_verification` ensures proofs both construct and verify correctly for each scenario.  
