### PR TITLE
fix(ci): broken slither action

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -238,8 +238,8 @@ jobs:
           cd solidity
           solhint '**/*.sol' -w 0
           cd ..
-      # - name: Run slither (Needs to be fixed)
-      #   uses: crytic/slither-action@v0.4.0
-      #   with:
-      #     target: solidity
-      #     slither-config: solidity/slither.config.json
+      - name: Run slither
+        uses: crytic/slither-action@d86660fe7e45835a0ec7b7aeb768d271fb421ea0
+        with:
+          target: solidity
+          slither-config: solidity/slither.config.json


### PR DESCRIPTION
# Rationale for this change

The most recent nightly release of foundry broke the slither workflow we use.

# What changes are included in this PR?

* Use a branch for slither action (see https://github.com/crytic/slither-action/pull/93) which has the fix.
* Unrelated: Made the solidity CI a bit more verbose.

# Are these changes tested?
Yes