### PR TITLE
feat: add div-mod constraints

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -66,6 +66,7 @@ zerocopy = { workspace = true }
 arrow-csv = { workspace = true }
 hex = { workspace = true }
 merlin = { workspace = true }
+mockall = "0.13.1"
 rand = { workspace = true, default-features = false, features = ["std"] }
 rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -425,9 +425,7 @@ impl ColumnType {
     /// Returns `None` if the type is not a signed integer.
     /// `sqrt_negative_min(NumericalType) = floor(sqrt(-NumericalType::MIN))`
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code))]
-    #[expect(clippy::trivially_copy_pass_by_ref)]
-    fn sqrt_negative_min(&self) -> Option<u64> {
+    pub(crate) fn sqrt_negative_min(self) -> Option<u64> {
         match self {
             ColumnType::TinyInt => Some(11),
             ColumnType::SmallInt => Some(181),
@@ -439,7 +437,7 @@ impl ColumnType {
     }
 
     /// Returns the number of bits in the integer type if it is an integer type. Otherwise, return None.
-    fn to_integer_bits(self) -> Option<usize> {
+    pub(crate) fn to_integer_bits(self) -> Option<usize> {
         match self {
             ColumnType::Uint8 | ColumnType::TinyInt => Some(8),
             ColumnType::SmallInt => Some(16),

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -132,8 +132,7 @@ pub fn try_multiply_column_types(
 /// Determine the output type of a divide/modulo operation if it is possible
 /// to divide and modulo the two input types. If the types are not compatible, return
 /// an error.
-#[cfg_attr(not(test), expect(dead_code))]
-fn try_divide_modulo_column_types(
+pub fn try_divide_modulo_column_types(
     lhs: ColumnType,
     rhs: ColumnType,
 ) -> ColumnOperationResult<(ColumnType, ColumnType)> {

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -16,8 +16,9 @@ mod column_type_operation;
 pub use column_type_operation::{
     can_and_or_types, can_not_type, try_add_subtract_column_types,
     try_add_subtract_column_types_with_scaling, try_cast_types, try_divide_column_types,
-    try_equals_types, try_equals_types_with_scaling, try_inequality_types,
-    try_inequality_types_with_scaling, try_multiply_column_types, try_scale_cast_types,
+    try_divide_modulo_column_types, try_equals_types, try_equals_types_with_scaling,
+    try_inequality_types, try_inequality_types_with_scaling, try_multiply_column_types,
+    try_scale_cast_types,
 };
 
 mod column_arithmetic_operation;

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -54,9 +54,9 @@ pub(crate) use not_expr::NotExpr;
 mod not_expr_test;
 
 mod numerical_util;
-pub(crate) use numerical_util::{add_subtract_columns, multiply_columns};
-#[cfg(test)]
-pub(crate) use numerical_util::{divide_columns, modulo_columns};
+pub(crate) use numerical_util::{
+    add_subtract_columns, divide_columns, modulo_columns, multiply_columns,
+};
 
 mod equals_expr;
 pub(crate) use equals_expr::EqualsExpr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -141,7 +141,6 @@ fn modulo_integer_columns<
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length or column type division is unsupported.
 #[expect(clippy::too_many_lines)]
-#[cfg_attr(not(test), expect(dead_code))]
 pub(crate) fn divide_columns<'a, S: Scalar>(
     lhs: &Column<'a, S>,
     rhs: &Column<'a, S>,
@@ -265,7 +264,6 @@ pub(crate) fn divide_columns<'a, S: Scalar>(
 /// Take the modulo of one column against another.
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length.
-#[cfg_attr(not(test), expect(dead_code))]
 pub(crate) fn modulo_columns<'a, S: Scalar>(
     lhs: &Column<'a, S>,
     rhs: &Column<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -1,17 +1,20 @@
+use super::{final_round_evaluate_sign, verifier_evaluate_sign};
 use crate::{
     base::{
-        database::{Column, LiteralValue, Table},
+        database::{try_divide_modulo_column_types, Column, ColumnType, LiteralValue, Table},
         map::IndexMap,
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
-        proof::{FinalRoundBuilder, VerificationBuilder},
-        proof_exprs::{divide_columns, modulo_columns, DynProofExpr, ProofExpr},
+        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        proof_exprs::{
+            add_subtract_columns, divide_columns, modulo_columns, DynProofExpr, ProofExpr,
+        },
     },
     utils::log,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
@@ -39,6 +42,14 @@ trait DivideAndModuloExprUtilities<S: Scalar> {
         rhs: &Column<'a, S>,
         alloc: &'a Bump,
     ) -> Column<'a, S>;
+
+    fn get_in_range_column_from_quotient_and_rhs<'a>(
+        &self,
+        alloc: &'a Bump,
+        quotient: &'a [S],
+        rhs: Vec<S>,
+        min_sqrt_scalar: S,
+    ) -> &'a [S];
 }
 
 struct StandardDivideAndModuloExprUtilities;
@@ -61,6 +72,29 @@ impl<S: Scalar> DivideAndModuloExprUtilities<S> for StandardDivideAndModuloExprU
     ) -> Column<'a, S> {
         modulo_columns(lhs, rhs, alloc)
     }
+
+    fn get_in_range_column_from_quotient_and_rhs<'a>(
+        &self,
+        alloc: &'a Bump,
+        quotient: &'a [S],
+        rhs: Vec<S>,
+        min_sqrt_scalar: S,
+    ) -> &'a [S] {
+        let in_range_q_or_b = alloc.alloc_slice_fill_with(quotient.len(), |_i| S::ZERO);
+        for (res, (q, b)) in in_range_q_or_b
+            .iter_mut()
+            .zip(quotient.iter().copied().zip(rhs.clone()))
+        {
+            // We do `or` rather than `and` here because scalars wrap negative values, so only one can be true at a time
+            let in_range_value = if q < min_sqrt_scalar || q > -min_sqrt_scalar {
+                q
+            } else {
+                b
+            };
+            *res = in_range_value;
+        }
+        in_range_q_or_b
+    }
 }
 
 impl DivideAndModuloExpr {
@@ -69,9 +103,23 @@ impl DivideAndModuloExpr {
         Self { lhs, rhs }
     }
 
+    #[expect(clippy::missing_panics_doc)]
+    fn min_scalar<S: Scalar>(&self) -> S {
+        self.lhs.data_type().min_scalar::<S>().unwrap()
+    }
+
+    #[expect(clippy::missing_panics_doc)]
+    fn data_type(&self) -> (ColumnType, ColumnType) {
+        try_divide_modulo_column_types(self.lhs.data_type(), self.rhs.data_type())
+            .expect("Failed to divide/modulo column types")
+    }
+
     /// This is abstracted into its own function for ease of unit testing.
     /// The `utilities` function is where any functionality that needs to be mocked
     /// can be provided.
+    /// # Panics
+    /// Panics if the datatype is not supported
+    #[expect(clippy::too_many_lines)]
     fn final_round_evaluate_base<'a, S: Scalar, U: DivideAndModuloExprUtilities<S>>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
@@ -87,12 +135,235 @@ impl DivideAndModuloExpr {
             .rhs
             .final_round_evaluate(builder, alloc, table, params)?;
 
-        let (quotient_wrapped, _quotient) =
+        let (quotient_wrapped, quotient) =
             utilities.divide_columns(&lhs_column, &rhs_column, alloc);
         let remainder = utilities.modulo_columns(&lhs_column, &rhs_column, alloc);
-
         builder.produce_intermediate_mle(quotient_wrapped);
+        builder.produce_intermediate_mle(quotient);
         builder.produce_intermediate_mle(remainder);
+
+        // subpolynomial: q * b + r - a = 0
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(quotient), Box::new(rhs_column)]),
+                (S::one(), vec![Box::new(remainder)]),
+                (-S::one(), vec![Box::new(lhs_column)]),
+            ],
+        );
+
+        // (r - b) * (r + b) * t + b = 0, where t = - b / ((r - b) * (r + b)) when |r| is not |b|
+        // This confirms |r| = |b| only if b = 0.
+        let remainder_minus_rhs = add_subtract_columns(remainder, rhs_column, alloc, true);
+        let remainder_plus_rhs = add_subtract_columns(remainder, rhs_column, alloc, false);
+        let rhs_as_scalars = rhs_column.to_scalar();
+        let rhs_div_remainder_rhs_difference_of_squares =
+            alloc.alloc_slice_fill_with(rhs_column.len(), |_i| S::ZERO);
+        for (res, ((diff, add), b)) in rhs_div_remainder_rhs_difference_of_squares.iter_mut().zip(
+            remainder_minus_rhs
+                .iter()
+                .copied()
+                .zip(remainder_plus_rhs.iter().copied())
+                .zip(rhs_as_scalars.clone()),
+        ) {
+            *res = (diff * add).inv().unwrap_or(S::ONE) * (-b);
+        }
+        let t = Column::Scalar(rhs_div_remainder_rhs_difference_of_squares);
+        builder.produce_intermediate_mle(t);
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (
+                    S::one(),
+                    vec![
+                        Box::new(remainder_minus_rhs),
+                        Box::new(remainder_plus_rhs),
+                        Box::new(t),
+                    ],
+                ),
+                (S::one(), vec![Box::new(rhs_column)]),
+            ],
+        );
+
+        // (s - q) * (s - b) = 0
+        // Introduces a value s that must be either q or b.
+        // We choose s to be a value of q or b such that -sqrt(-MIN) < s < sqrt(-MIN)
+        let min_sqrt_scalar = S::from(self.lhs.data_type().sqrt_negative_min().unwrap());
+        let in_range_q_or_b = utilities.get_in_range_column_from_quotient_and_rhs(
+            alloc,
+            quotient,
+            rhs_as_scalars.clone(),
+            min_sqrt_scalar,
+        );
+        let s = Column::Scalar(in_range_q_or_b);
+        builder.produce_intermediate_mle(s);
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(s), Box::new(s)]),
+                (S::one(), vec![Box::new(rhs_column), Box::new(quotient)]),
+                (-S::one(), vec![Box::new(s), Box::new(rhs_column)]),
+                (-S::one(), vec![Box::new(s), Box::new(quotient)]),
+            ],
+        );
+
+        // b * u = q where u = q / b if b is not 0
+        // This ensures that q = 0 if b = 0
+        let q_div_b = alloc.alloc_slice_fill_with(quotient.len(), |_i| S::ZERO);
+        for (res, (q, b)) in q_div_b
+            .iter_mut()
+            .zip(quotient.iter().copied().zip(rhs_as_scalars))
+        {
+            *res = b.inv().unwrap_or(S::ONE) * q;
+        }
+        let u = Column::Scalar(q_div_b);
+        builder.produce_intermediate_mle(u);
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(rhs_column), Box::new(u)]),
+                (-S::one(), vec![Box::new(quotient)]),
+            ],
+        );
+        // (q' - q) * (q + MIN) = 0
+        // Ensures that either q = q' or q = -MIN
+        // Simplifies to
+        // q' * q - MIN * q - q * q + MIN * q'
+
+        let min_scalar = self.min_scalar();
+        let min_column =
+            Column::Scalar(alloc.alloc_slice_fill_with(quotient.len(), |_i| min_scalar));
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (
+                    S::one(),
+                    vec![Box::new(quotient_wrapped), Box::new(quotient)],
+                ),
+                (-S::one(), vec![Box::new(min_column), Box::new(quotient)]),
+                (-S::one(), vec![Box::new(quotient), Box::new(quotient)]),
+                (
+                    S::one(),
+                    vec![Box::new(quotient_wrapped), Box::new(min_column)],
+                ),
+            ],
+        );
+
+        // (q + MIN) * v - (q' - MIN) = 0 where v = (q' - MIN) / (q + MIN) if q is not - MIN
+        // Ensures q = -MIN only if q' = MIN
+        let quotient_wrapped_slice =
+            alloc.alloc_slice_fill_iter(quotient_wrapped.to_scalar()) as &[_];
+        let v = alloc.alloc_slice_fill_iter(quotient.iter().zip(quotient_wrapped_slice).map(
+            |(q, q_prime)| (*q + min_scalar).inv().unwrap_or(S::ONE) * (*q_prime - min_scalar),
+        ));
+        let v = Column::Scalar(v);
+        builder.produce_intermediate_mle(v);
+
+        let min_scalar_column =
+            Column::Scalar(alloc.alloc_slice_fill_with(quotient.len(), |_i| min_scalar));
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (
+                    S::one(),
+                    vec![
+                        Box::new(quotient_wrapped_slice),
+                        Box::new(quotient),
+                        Box::new(v),
+                    ],
+                ),
+                (S::one(), vec![Box::new(min_scalar_column)]),
+                (-S::one(), vec![Box::new(quotient_wrapped_slice)]),
+                (
+                    -S::one(),
+                    vec![
+                        Box::new(min_scalar_column),
+                        Box::new(min_scalar_column),
+                        Box::new(v),
+                    ],
+                ),
+                (
+                    -S::one(),
+                    vec![Box::new(min_scalar_column), Box::new(quotient), Box::new(v)],
+                ),
+                (
+                    S::one(),
+                    vec![
+                        Box::new(min_scalar_column),
+                        Box::new(quotient_wrapped_slice),
+                        Box::new(v),
+                    ],
+                ),
+            ],
+        );
+
+        // sign(sqrt(-min) + s) = 1
+        // sign(sqrt(-min) - s) = 1
+        // These confirm that q * b does not wrap in the Scalar field. Either q or b must be smaller than sqrt(-min), which confines qb to less than the order of the field.
+        let neg_min_sqrt_scalar_column =
+            Column::Scalar(alloc.alloc_slice_fill_with(quotient.len(), |_i| min_sqrt_scalar));
+        final_round_evaluate_sign(
+            builder,
+            alloc,
+            add_subtract_columns(neg_min_sqrt_scalar_column, s, alloc, false),
+        );
+        final_round_evaluate_sign(
+            builder,
+            alloc,
+            add_subtract_columns(neg_min_sqrt_scalar_column, s, alloc, true),
+        );
+
+        // MIN < q' < MAX
+        // Confirms that q is not too big.
+        final_round_evaluate_sign(builder, alloc, quotient_wrapped_slice);
+
+        // sign(a) * r = sign(r) * r and sign(r - b) * b + sign(r - b) - b = 0
+        // constrains remainder to be in the correct range
+        let lhs_sign = final_round_evaluate_sign(
+            builder,
+            alloc,
+            alloc.alloc_slice_fill_iter(lhs_column.to_scalar()) as &[_],
+        );
+        let remainder_sign = final_round_evaluate_sign(
+            builder,
+            alloc,
+            alloc.alloc_slice_fill_iter(remainder.to_scalar()) as &[_],
+        );
+
+        let remainder_minus_rhs_sign =
+            final_round_evaluate_sign(builder, alloc, remainder_minus_rhs);
+        let remainder_plus_rhs_sign = final_round_evaluate_sign(builder, alloc, remainder_plus_rhs);
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(lhs_sign), Box::new(remainder)]),
+                (
+                    -S::one(),
+                    vec![Box::new(remainder_sign), Box::new(remainder)],
+                ),
+            ],
+        );
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (
+                    S::one(),
+                    vec![Box::new(remainder_minus_rhs_sign), Box::new(rhs_column)],
+                ),
+                (
+                    S::one(),
+                    vec![Box::new(remainder_plus_rhs_sign), Box::new(rhs_column)],
+                ),
+                (-S::one(), vec![Box::new(rhs_column)]),
+            ],
+        );
 
         Ok((quotient_wrapped, remainder))
     }
@@ -115,6 +386,8 @@ impl DivideAndModuloExpr {
         Ok(res)
     }
 
+    /// # Panics
+    /// Panics if the datatype is not supported
     #[cfg_attr(not(test), expect(dead_code))]
     fn verifier_evaluate<S: Scalar, B: VerificationBuilder<S>>(
         &self,
@@ -123,16 +396,117 @@ impl DivideAndModuloExpr {
         one_eval: S,
         params: &[LiteralValue],
     ) -> Result<(S, S), ProofError> {
-        let _lhs = self
+        let lhs = self
             .lhs
             .verifier_evaluate(builder, accessor, one_eval, params)?;
-        let _rhs = self
+        let rhs = self
             .rhs
             .verifier_evaluate(builder, accessor, one_eval, params)?;
 
-        // lhs_times_rhs
         let quotient_wrapped = builder.try_consume_final_round_mle_evaluation()?;
+        let quotient = builder.try_consume_final_round_mle_evaluation()?;
         let remainder = builder.try_consume_final_round_mle_evaluation()?;
+        let t = builder.try_consume_final_round_mle_evaluation()?;
+        let s = builder.try_consume_final_round_mle_evaluation()?;
+        let u = builder.try_consume_final_round_mle_evaluation()?;
+        let v = builder.try_consume_final_round_mle_evaluation()?;
+
+        // For the following constraints, the comments shall denote the vraiables as follows
+        // q: quotient
+        // q': quotient_wrapped
+        // r: remainder
+        // a: lhs
+        // b: rhs
+
+        // subpolynomial: q * b - a + r = 0
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            quotient * rhs - lhs + remainder,
+            2,
+        )?;
+
+        // (r - b) * (r + b) * t + b = 0
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            (remainder - rhs) * (remainder + rhs) * t + rhs,
+            3,
+        )?;
+
+        // (s - q)(s - b) = 0
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            (s - quotient) * (s - rhs),
+            2,
+        )?;
+
+        // b * u = q
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            rhs * u - quotient,
+            2,
+        )?;
+
+        // (q' - q) * (q + MIN) = 0
+        let min_eval = self.min_scalar::<S>() * one_eval;
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            (quotient_wrapped - quotient) * (quotient + min_eval),
+            2,
+        )?;
+
+        // (q + MIN) * v - (q' - MIN) = 0
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            (quotient + min_eval) * v - quotient_wrapped + min_eval,
+            3,
+        )?;
+
+        // get sign(sqrt(-min) + s)
+        // get sign(sqrt(-min) - s)
+        let min_sqrt_eval = S::from(self.data_type().0.sqrt_negative_min().unwrap()) * one_eval;
+        let sqrt_min_plus_s = verifier_evaluate_sign(builder, min_sqrt_eval + s, one_eval, None)?;
+        let sqrt_min_less_s = verifier_evaluate_sign(builder, min_sqrt_eval - s, one_eval, None)?;
+
+        // -2^b <= q' < 2^b, where b is
+        verifier_evaluate_sign(
+            builder,
+            quotient_wrapped,
+            one_eval,
+            Some(
+                (self.data_type().0.to_integer_bits().unwrap())
+                    .try_into()
+                    .unwrap(),
+            ),
+        )?;
+
+        // sign(a) * r = sign(r) * r and sign(r - b) * b + sign(r + b) * b = b
+        let lhs_sign = verifier_evaluate_sign(builder, lhs, one_eval, None)?;
+        let remainder_sign = verifier_evaluate_sign(builder, remainder, one_eval, None)?;
+
+        let remainder_and_rhs_difference_sign =
+            verifier_evaluate_sign(builder, remainder - rhs, one_eval, None)?;
+        let remainder_and_rhs_added_sign =
+            verifier_evaluate_sign(builder, remainder + rhs, one_eval, None)?;
+
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            remainder * (lhs_sign - remainder_sign),
+            2,
+        )?;
+
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            rhs * (remainder_and_rhs_difference_sign + remainder_and_rhs_added_sign - S::ONE),
+            2,
+        )?;
+
+        // sign(sqrt(-min) + s) = 1
+        // sign(sqrt(-min) - s) = 1
+        if sqrt_min_plus_s != S::ZERO || sqrt_min_less_s != S::ZERO {
+            return Err(ProofError::VerificationError {
+                error: "Intermediate value out of range",
+            });
+        }
 
         Ok((quotient_wrapped, remainder))
     }
@@ -140,13 +514,16 @@ impl DivideAndModuloExpr {
 
 #[cfg(test)]
 mod tests {
-    use super::DivideAndModuloExpr;
+    use super::{
+        DivideAndModuloExpr, DivideAndModuloExprUtilities, StandardDivideAndModuloExprUtilities,
+    };
     use crate::{
         base::{
             database::{Column, ColumnRef, ColumnType, Table, TableRef},
             map::indexmap,
             polynomial::MultilinearExtension,
-            scalar::test_scalar::TestScalar,
+            proof::ProofError,
+            scalar::{test_scalar::TestScalar, Scalar},
         },
         sql::{
             proof::{
@@ -157,8 +534,260 @@ mod tests {
         },
     };
     use bumpalo::Bump;
+    use mockall::automock;
     use sqlparser::ast::Ident;
     use std::collections::VecDeque;
+
+    #[automock]
+    trait MockableDivideAndModuloExprFunctionality {
+        fn divide_columns(&self, lhs: &[i128], rhs: &[i128]) -> (Vec<TestScalar>, Vec<TestScalar>);
+
+        fn modulo_columns(&self, lhs: &[i128], rhs: &[i128]) -> Vec<i128>;
+
+        fn get_in_range_column_from_quotient_and_rhs(
+            &self,
+            quotient: &[TestScalar],
+            rhs: &[TestScalar],
+        ) -> Vec<TestScalar>;
+    }
+
+    struct MockDivideAndModuloExprUtilities<F: MockableDivideAndModuloExprFunctionality> {
+        functions: F,
+    }
+
+    impl<F: MockableDivideAndModuloExprFunctionality> DivideAndModuloExprUtilities<TestScalar>
+        for MockDivideAndModuloExprUtilities<F>
+    {
+        fn divide_columns<'a>(
+            &self,
+            lhs: &Column<'a, TestScalar>,
+            rhs: &Column<'a, TestScalar>,
+            alloc: &'a Bump,
+        ) -> (Column<'a, TestScalar>, &'a [TestScalar]) {
+            if let (Column::Int128(a), Column::Int128(b)) = (lhs, rhs) {
+                let (quotient_wrapped, quotient) = self.functions.divide_columns(a, b);
+                let quotient_wrapped_slice = alloc.alloc_slice_copy(&quotient_wrapped);
+                let quotient_slice = alloc.alloc_slice_copy(&quotient);
+                (Column::Scalar(quotient_wrapped_slice), quotient_slice)
+            } else {
+                panic!("MockDivideAndModuloExprUtilities should only be used with int128 columns");
+            }
+        }
+
+        fn modulo_columns<'a>(
+            &self,
+            lhs: &Column<'a, TestScalar>,
+            rhs: &Column<'a, TestScalar>,
+            alloc: &'a Bump,
+        ) -> Column<'a, TestScalar> {
+            if let (Column::Int128(a), Column::Int128(b)) = (lhs, rhs) {
+                let remainder = self.functions.modulo_columns(a, b);
+                let remainder_slice = alloc.alloc_slice_copy(&remainder);
+                Column::Int128(remainder_slice)
+            } else {
+                panic!("MockDivideAndModuloExprUtilities should only be used with int128 columns");
+            }
+        }
+
+        fn get_in_range_column_from_quotient_and_rhs<'a>(
+            &self,
+            alloc: &'a Bump,
+            quotient: &'a [TestScalar],
+            rhs: Vec<TestScalar>,
+            _min_sqrt_scalar: TestScalar,
+        ) -> &'a [TestScalar] {
+            alloc.alloc_slice_copy(
+                &self
+                    .functions
+                    .get_in_range_column_from_quotient_and_rhs(quotient, &rhs),
+            )
+        }
+    }
+
+    fn default_divide_columns(lhs: &[i128], rhs: &[i128]) -> (Vec<TestScalar>, Vec<TestScalar>) {
+        let alloc = Bump::new();
+        let standard_utilities = StandardDivideAndModuloExprUtilities;
+        let (quotient_wrapped, quotient) = standard_utilities.divide_columns(
+            &Column::Int128::<TestScalar>(lhs),
+            &Column::Int128(rhs),
+            &alloc,
+        );
+        (quotient_wrapped.to_scalar(), quotient.to_vec())
+    }
+
+    fn default_modulo_columns(lhs: &[i128], rhs: &[i128]) -> Vec<i128> {
+        let alloc = Bump::new();
+        let standard_utilities = StandardDivideAndModuloExprUtilities;
+        standard_utilities
+            .modulo_columns(
+                &Column::Int128::<TestScalar>(lhs),
+                &Column::Int128(rhs),
+                &alloc,
+            )
+            .as_int128()
+            .unwrap()
+            .to_vec()
+    }
+
+    fn default_get_in_range_column_from_quotient_and_rhs(
+        quotient: &[TestScalar],
+        rhs: &[TestScalar],
+    ) -> Vec<TestScalar> {
+        let alloc = Bump::new();
+        let standard_utilities = StandardDivideAndModuloExprUtilities;
+        standard_utilities
+            .get_in_range_column_from_quotient_and_rhs(
+                &alloc,
+                quotient,
+                rhs.to_vec(),
+                TestScalar::from(ColumnType::Int128.sqrt_negative_min().unwrap()),
+            )
+            .to_vec()
+    }
+
+    #[derive(PartialEq, Debug)]
+    enum TestableConstraints {
+        /// q * b + r - a = 0
+        DivisionAlgorithm,
+        /// (r - b) * (r + b) * t - b = 0
+        DenominatorZeroIfRemainderAndDenominatorMagnitudeEqual,
+        /// (s - q)(s - b) = 0
+        BoundedValueIsQuotientOrDenominator,
+        /// b * u - q = 0
+        ZeroDenominatorDictatesQuotient,
+        /// (q′ - q) * (q + MIN) = 0
+        WrappedIsQuotientOrMin,
+        /// (q' - MIN) * (q + MIN) * v - (q' - MIN) = 0
+        WrappedIsMinIfQuotientIsNegativeMin,
+        /// sign(a) * r - sign(r) * r = 0
+        RemainderSignMatchesNumerator,
+        /// sign(r - b) * b + sign(r + b) * b - b = 0
+        RemainderBound,
+    }
+
+    fn get_failing_constraints(row: &[bool]) -> Vec<TestableConstraints> {
+        assert_eq!(row.len(), 8);
+        row.iter()
+            .enumerate()
+            .filter_map(|(i, include)| {
+                if *include {
+                    None
+                } else {
+                    Some(if i == 0 {
+                        TestableConstraints::DivisionAlgorithm
+                    } else if i == 1 {
+                        TestableConstraints::DenominatorZeroIfRemainderAndDenominatorMagnitudeEqual
+                    } else if i == 2 {
+                        TestableConstraints::BoundedValueIsQuotientOrDenominator
+                    } else if i == 3 {
+                        TestableConstraints::ZeroDenominatorDictatesQuotient
+                    } else if i == 4 {
+                        TestableConstraints::WrappedIsQuotientOrMin
+                    } else if i == 5 {
+                        TestableConstraints::WrappedIsMinIfQuotientIsNegativeMin
+                    } else if i == 6 {
+                        TestableConstraints::RemainderSignMatchesNumerator
+                    } else {
+                        TestableConstraints::RemainderBound
+                    })
+                }
+            })
+            .collect()
+    }
+
+    fn check_constraints(
+        divide_columns_return: Option<(Vec<TestScalar>, Vec<TestScalar>)>,
+        modulo_columns_return: Option<Vec<i128>>,
+        get_in_range_column_from_quotient_and_rhs_return: Option<Vec<TestScalar>>,
+        lhs: &[i128],
+        rhs: &[i128],
+        expected_failing_constraints: &[TestableConstraints],
+    ) {
+        let alloc = Bump::new();
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        if let Some(quotient) = divide_columns_return {
+            mock_functionality
+                .expect_divide_columns()
+                .return_const(quotient);
+        } else {
+            mock_functionality
+                .expect_divide_columns()
+                .returning(default_divide_columns);
+        }
+        if let Some(remainder) = modulo_columns_return {
+            mock_functionality
+                .expect_modulo_columns()
+                .return_const(remainder);
+        } else {
+            mock_functionality
+                .expect_modulo_columns()
+                .returning(default_modulo_columns);
+        }
+        if let Some(in_range_column) = get_in_range_column_from_quotient_and_rhs_return {
+            mock_functionality
+                .expect_get_in_range_column_from_quotient_and_rhs()
+                .return_const(in_range_column);
+        } else {
+            mock_functionality
+                .expect_get_in_range_column_from_quotient_and_rhs()
+                .returning(default_get_in_range_column_from_quotient_and_rhs);
+        }
+        let mock_utilities = MockDivideAndModuloExprUtilities {
+            functions: mock_functionality,
+        };
+        let table_ref: TableRef = "sxt.t".parse().unwrap();
+        let lhs_ident = Ident::from("lhs");
+        let rhs_ident = Ident::from("rhs");
+        let lhs_ref = ColumnRef::new(table_ref.clone(), lhs_ident.clone(), ColumnType::Int128);
+        let rhs_ref = ColumnRef::new(table_ref, rhs_ident.clone(), ColumnType::Int128);
+        let divide_and_modulo_expr = DivideAndModuloExpr::new(
+            Box::new(DynProofExpr::Column(ColumnExpr::new(lhs_ref))),
+            Box::new(DynProofExpr::Column(ColumnExpr::new(rhs_ref))),
+        );
+        let first_round_builder = FirstRoundBuilder::new(lhs.len());
+        let mut final_round_builder = FinalRoundBuilder::new(lhs.len(), VecDeque::new());
+        let table = Table::try_new(indexmap! {
+            lhs_ident.clone() => Column::Int128::<TestScalar>(lhs),
+            rhs_ident.clone() => Column::Int128::<TestScalar>(rhs),
+        })
+        .unwrap();
+        divide_and_modulo_expr
+            .final_round_evaluate_base(
+                &mut final_round_builder,
+                &alloc,
+                &table,
+                &mock_utilities,
+                &[],
+            )
+            .unwrap();
+        let mock_verification_builder = run_verify_for_each_row(
+            lhs.len(),
+            &first_round_builder,
+            &final_round_builder,
+            Vec::new(),
+            4,
+            |verification_builder, chi_eval, evaluation_point| {
+                let accessor = indexmap! {
+                    lhs_ident.clone() => lhs.inner_product(evaluation_point),
+                    rhs_ident.clone() => rhs.inner_product(evaluation_point)
+                };
+                divide_and_modulo_expr
+                    .verifier_evaluate(verification_builder, &accessor, chi_eval, &[])
+                    .unwrap();
+            },
+        );
+        let matrix = mock_verification_builder.get_identity_results();
+        let reduced_matrix = matrix.iter().map(|v| {
+            assert!(v[6..(v.len() - 2)].iter().all(|b| *b));
+            let mut vec = v[0..6].to_vec();
+            vec.extend(v[(v.len() - 2)..v.len()].iter());
+            vec
+        });
+        for row in reduced_matrix {
+            let failing_constraints = get_failing_constraints(&row);
+            assert_eq!(failing_constraints, expected_failing_constraints);
+        }
+    }
 
     #[test]
     fn we_can_verify_simple_expr() {
@@ -201,6 +830,264 @@ mod tests {
             },
         );
         let matrix = mock_verification_builder.get_identity_results();
-        assert!(matrix.into_iter().all(|v| v.into_iter().all(|b| b)));
+        let reduced_matrix = matrix.iter().map(|v| {
+            assert!(v[6..(v.len() - 2)].iter().all(|b| *b));
+            let mut vec = v[0..6].to_vec();
+            vec.extend(v[(v.len() - 2)..v.len()].iter());
+            vec
+        });
+        for row in reduced_matrix {
+            let failing_constraints = get_failing_constraints(&row);
+            assert_eq!(failing_constraints, []);
+        }
+    }
+
+    /// Shifting remainder by a very small amount will only fail the division algorithm
+    #[test]
+    fn we_can_reject_if_division_algorithm_fails() {
+        check_constraints(
+            None,
+            Some(vec![1i128, -4, 1, -1]),
+            None,
+            &[8i128, -12, 8, -8],
+            &[3i128, 7, -3, -3],
+            &[TestableConstraints::DivisionAlgorithm],
+        );
+    }
+
+    /// When the remainder is 0, shifting the remainder to have the same magnitude as the denominator can trick both the
+    /// division algorithm and the remainder bound. However, this should result in the failure of
+    /// `TestableConstraints::DenominatorZeroIfRemainderAndDenominatorMagnitudeEqual`
+    #[test]
+    fn we_can_reject_if_nonzero_remainder_magnitude_equals_denominator_magnitude() {
+        check_constraints(
+            Some((
+                [1, -1].map(TestScalar::from).to_vec(),
+                [1, -1].map(TestScalar::from).to_vec(),
+            )),
+            Some(vec![-4i128, -6]),
+            None,
+            &[-8i128, -12],
+            &[-4i128, 6],
+            &[TestableConstraints::DenominatorZeroIfRemainderAndDenominatorMagnitudeEqual],
+        );
+    }
+
+    /// There is a check to verify that quotient * denominator does not overflow the scalar field.
+    /// That check verifies that either quotient or denominator is less than a certain number.
+    /// This requires committing to a column of values composed of quotients and denominators.
+    /// Providing a value that is not either the quotient or denominator should fail
+    /// `TestableContraints::BoundedValueIsQuotientOrDenominator`
+    #[test]
+    fn we_can_reject_if_committed_in_range_column_is_not_quotient_or_denominator() {
+        let quotient = vec![TestScalar::from(1i128 << 126)];
+        let rhs_i128 = (1i128 << 126) + 1;
+        let overflow: i128 = (TestScalar::from(1i128 << 126) * TestScalar::from(rhs_i128))
+            .try_into()
+            .unwrap();
+        check_constraints(
+            Some((quotient.clone(), quotient)),
+            Some(vec![rhs_i128 - overflow]),
+            Some(vec![TestScalar::ONE]),
+            &[rhs_i128],
+            &[rhs_i128],
+            &[TestableConstraints::BoundedValueIsQuotientOrDenominator],
+        );
+    }
+
+    /// When the denominator is zero, the quotient must be zero. Lying about quotient in this scenario
+    /// is rejected easily by `TestableConstraints::ZeroDenominatorDictatesQuotient`
+    #[test]
+    fn we_can_reject_if_denominator_is_zero_but_quotient_is_not() {
+        let quotient = [10000, -10000, 10000, -10000]
+            .map(TestScalar::from)
+            .to_vec();
+        check_constraints(
+            Some((quotient.clone(), quotient)),
+            None,
+            None,
+            &[8i128, -12, -8, 12],
+            &[0i128, 0, 0, 0],
+            &[TestableConstraints::ZeroDenominatorDictatesQuotient],
+        );
+    }
+
+    /// If the wrapped version of quotient is completely incorrect and quotient is not -MIN, the constraint
+    /// `TestableConstraints::WrappedIsQuotientOrMin` will catch it.
+    #[test]
+    fn we_can_reject_if_quotient_wrapped_is_incorrect() {
+        check_constraints(
+            Some((
+                [-20i128, -20, 20, 20].map(TestScalar::from).to_vec(),
+                [2, -2, 2, -2].map(TestScalar::from).to_vec(),
+            )),
+            None,
+            None,
+            &[8i128, -12, -8, 12],
+            &[3i128, 5, -3, -5],
+            &[TestableConstraints::WrappedIsQuotientOrMin],
+        );
+    }
+
+    /// If the wrapped version of quotient is completely incorrect and quotient is -MIN, the constraint
+    /// `TestableConstraints::WrappedIsMinIfQuotientIsNegativeMin` will catch it.
+    #[test]
+    fn we_can_reject_if_quotient_is_negative_min_and_quotient_wrapped_is_incorrect() {
+        check_constraints(
+            Some((
+                vec![TestScalar::from(-20)],
+                vec![-TestScalar::from(i128::MIN)],
+            )),
+            None,
+            None,
+            &[i128::MIN],
+            &[-1i128],
+            &[TestableConstraints::WrappedIsMinIfQuotientIsNegativeMin],
+        );
+    }
+
+    /// A malicious prover can try to shift the quotient by 1, adjusting the remainder accordingly,
+    /// which still satisfies the division algorithm and stays within the bounds of the +/- denominator.
+    /// However, this necessarily requires that the remainder flip sign, violating `TestableConstraints::RemainderSignMatchesNumerator`
+    #[test]
+    fn we_can_reject_if_remainder_sign_matches_numerator_fails() {
+        let quotient = [3i128, -2, -3, 3].map(TestScalar::from).to_vec();
+        check_constraints(
+            Some((quotient.clone(), quotient)),
+            Some(vec![-1i128, 2, -1, 1]),
+            None,
+            &[8i128, -12, 8, -8],
+            &[3i128, 7, -3, -3],
+            &[TestableConstraints::RemainderSignMatchesNumerator],
+        );
+    }
+
+    /// A malicious prover can try to shift the remainder by the rhs, adjusting the quotient accordingly, so that the sign of
+    /// the remainder doesn't change. This still satisfies the division algorithm.
+    /// However, this necessarily requires that exactly one of `r - b` or `r + b` switches sign, violating `TestableConstraints::RemainderBound`
+    #[test]
+    fn we_can_reject_if_remainder_bound_fails() {
+        let quotient = [1i128, 0, -1, 1].map(TestScalar::from).to_vec();
+        check_constraints(
+            Some((quotient.clone(), quotient)),
+            Some(vec![5i128, -12, 5, -5]),
+            None,
+            &[8i128, -12, 8, -8],
+            &[3i128, 7, -3, -3],
+            &[TestableConstraints::RemainderBound],
+        );
+    }
+
+    /// A malicious prover can try to craft a scenario where the quotient and denominator are so big that their product
+    /// exceeds the max value of the `Scalar` type. This can satisfy the division algorithm and allow for tampering
+    /// of both the quotient and the remainder. The verifier checks to see that at least one of the quotient and
+    /// denominator is small enough that this doesn't happen.
+    #[test]
+    fn we_can_reject_if_quotient_and_rhs_are_too_high() {
+        let alloc = Bump::new();
+        let quotient = vec![TestScalar::from(1i128 << 126)];
+        let rhs_i128 = (1i128 << 126) + 1;
+        let overflow: i128 = (TestScalar::from(1i128 << 126) * TestScalar::from(rhs_i128))
+            .try_into()
+            .unwrap();
+        let lhs = &[rhs_i128];
+        let rhs = &[rhs_i128];
+        let mut mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        mock_functionality
+            .expect_divide_columns()
+            .return_const((quotient.clone(), quotient.clone()));
+        mock_functionality
+            .expect_modulo_columns()
+            .return_const(vec![rhs_i128 - overflow]);
+        mock_functionality
+            .expect_get_in_range_column_from_quotient_and_rhs()
+            .return_const(quotient);
+        let mock_utilities = MockDivideAndModuloExprUtilities {
+            functions: mock_functionality,
+        };
+        let table_ref: TableRef = "sxt.t".parse().unwrap();
+        let lhs_ident = Ident::from("lhs");
+        let rhs_ident = Ident::from("rhs");
+        let lhs_ref = ColumnRef::new(table_ref.clone(), lhs_ident.clone(), ColumnType::Int128);
+        let rhs_ref = ColumnRef::new(table_ref, rhs_ident.clone(), ColumnType::Int128);
+        let divide_and_modulo_expr = DivideAndModuloExpr::new(
+            Box::new(DynProofExpr::Column(ColumnExpr::new(lhs_ref))),
+            Box::new(DynProofExpr::Column(ColumnExpr::new(rhs_ref))),
+        );
+        let first_round_builder = FirstRoundBuilder::new(lhs.len());
+        let mut final_round_builder = FinalRoundBuilder::new(lhs.len(), VecDeque::new());
+        let table = Table::try_new(indexmap! {
+            lhs_ident.clone() => Column::Int128::<TestScalar>(lhs),
+            rhs_ident.clone() => Column::Int128::<TestScalar>(rhs),
+        })
+        .unwrap();
+        divide_and_modulo_expr
+            .final_round_evaluate_base(
+                &mut final_round_builder,
+                &alloc,
+                &table,
+                &mock_utilities,
+                &[],
+            )
+            .unwrap();
+        let mock_verification_builder = run_verify_for_each_row(
+            1,
+            &first_round_builder,
+            &final_round_builder,
+            Vec::new(),
+            4,
+            |verification_builder, chi_eval, evaluation_point| {
+                let accessor = indexmap! {
+                    lhs_ident.clone() => lhs.inner_product(evaluation_point),
+                    rhs_ident.clone() => rhs.inner_product(evaluation_point)
+                };
+                let err = divide_and_modulo_expr
+                    .verifier_evaluate(verification_builder, &accessor, chi_eval, &[])
+                    .unwrap_err();
+                assert!(matches!(
+                    err,
+                    ProofError::VerificationError {
+                        error: "Intermediate value out of range"
+                    }
+                ));
+            },
+        );
+        let matrix = mock_verification_builder.get_identity_results();
+        let reduced_matrix = matrix.iter().map(|v| {
+            assert!(v[6..(v.len() - 2)].iter().all(|b| *b));
+            let mut vec = v[0..6].to_vec();
+            vec.extend(v[(v.len() - 2)..v.len()].iter());
+            vec
+        });
+        for row in reduced_matrix {
+            let failing_constraints = get_failing_constraints(&row);
+            assert_eq!(failing_constraints, []);
+        }
+    }
+
+    #[should_panic(
+        expected = "MockDivideAndModuloExprUtilities should only be used with int128 columns"
+    )]
+    #[test]
+    fn we_currently_cannot_use_anything_other_than_i128_for_mocking_divide() {
+        let alloc = Bump::new();
+        let mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        let mock_utilities = MockDivideAndModuloExprUtilities {
+            functions: mock_functionality,
+        };
+        mock_utilities.divide_columns(&Column::BigInt(&[]), &Column::BigInt(&[]), &alloc);
+    }
+
+    #[should_panic(
+        expected = "MockDivideAndModuloExprUtilities should only be used with int128 columns"
+    )]
+    #[test]
+    fn we_currently_cannot_use_anything_other_than_i128_for_mocking_modulo() {
+        let alloc = Bump::new();
+        let mock_functionality = MockMockableDivideAndModuloExprFunctionality::new();
+        let mock_utilities = MockDivideAndModuloExprUtilities {
+            functions: mock_functionality,
+        };
+        mock_utilities.modulo_columns(&Column::BigInt(&[]), &Column::BigInt(&[]), &alloc);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,5 +1,4 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
-#[cfg(test)]
 mod divide_and_modulo_expr;
 mod filter_base;
 pub(crate) use filter_base::{final_round_evaluate_filter, verify_evaluate_filter};

--- a/docs/protocols/divide_modulo.tex
+++ b/docs/protocols/divide_modulo.tex
@@ -1,0 +1,61 @@
+\documentclass[11pt]{article}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage[margin=1in]{geometry}
+\usepackage{graphicx}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{hyperref}
+\usepackage{microtype}
+\usepackage{todonotes}
+\DeclareMathOperator{\nonneg}{nonneg}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,
+  citecolor=blue,
+  urlcolor=blue
+}
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt}
+
+\title{Divide and Modulo}
+\author{Space and Time Inc}
+\date{March 2025}
+
+\begin{document}
+\maketitle
+
+\noindent Let $A=(a_{i})$ and $B=(b_{i})$ be columns of signed integers. We need to prove that $Q=(q'_{i})$ is the quotient of $N$ and $D$ and $R=(r_{i})$ is the remainder of $N$ and $D$. \\
+There are a couple abnormalities to our definitions of quotient and remainder:
+\begin{itemize}
+    \item For division by 0, the quotient is defined as 0, and the remainder is defined to be the numerator.
+    \item If the numerator is the minimum value for the unsigned int type and the denominator is $-1$, the quotient is defined to be the minimum value for the unsigned int type and the remainder is $0$.
+    \item The remainder is not necessarily positive. It will match the sign of the numerator, unless the remainder is $0$.
+\end{itemize}
+
+\section{Summary}
+\begin{itemize}
+    \item Plan values: None
+    \item Inputs: $N$, $D$
+    \item Outputs: $Q$, $R$
+    \item Hints: $s$, $t$, $u$, $v$.
+\end{itemize}
+
+\section{Details}
+
+The $6$ constraints are:
+
+\begin{align*}
+    q\cdot b + r &\equiv a\tag{1}\\
+    r\cdot \nonneg(r)&\equiv r\cdot \nonneg(a)\tag{2}\\
+    \nonneg(r-b)\cdot b + \nonneg(r+b)\cdot b &\equiv b \tag{3.1}\\
+    (r-b)\cdot (r+b)\cdot t + b&\equiv 0\tag{3.2}\\
+    (s-q)(s-b)&\equiv 0\tag{4.1}\\
+    [-\sqrt{-MIN},-\sqrt{MIN}]&\supset s\tag{4.2}\\
+    [-MIN,MAX]&\supset q'\tag{4.3}\\
+    b \cdot u &= q\\
+    (q'-q)\cdot (q+MIN)&\equiv 0\tag{6.1}\\
+    (q+MIN)\cdot v-(q'-MIN)&\equiv 0\tag{6.2}\\
+\end{align*}
+\end{document}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The constraints for div and mod expr need to be added. This will allow it to be a fully secure gadget.

# What changes are included in this PR?

All the constraints for div-and-mod-expr.

# Are these changes tested?
Yes. There is a tamperproof test for each constraint, demonstrating that each constraint is necessary.
