### PR TITLE
fix: stop script if YAML file is missing

### DIFF
--- a/scripts/run_posql_examples.sh
+++ b/scripts/run_posql_examples.sh
@@ -13,6 +13,7 @@ if [ ! -f "$YAML_FILE" ]; then
   echo "Error: $YAML_FILE not found."
   echo "Please run this script from the repository root or update YAML_FILE accordingly."
   echo "Exiting with status 0, no commands executed."
+  exit 0
 
 fi
 


### PR DESCRIPTION
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change  
The script warned about a missing YAML file but kept running, which could cause issues if later steps expected the file to exist.  

# What changes are included in this PR?  
Added `exit 0` after the error message to stop execution when the file is missing.  

# Are these changes tested?  
Yes, manually tested by running the script with and without the file present.  
