### PR TITLE
chore(sol): add error variants

### DIFF
--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -30,6 +30,26 @@ uint32 constant ERR_UNSUPPORTED_LITERAL_VARIANT = 0xed9d5b00;
 uint32 constant ERR_INVALID_INDEX = 0x63df8171;
 /// @dev Error code for when a proof expression variant is unsupported.
 uint32 constant ERR_UNSUPPORTED_PROOF_EXPR_VARIANT = 0xb8a26620;
+/// @dev Error code for when PCS batch lengths don't match.
+uint32 constant ERR_PCS_BATCH_LENGTH_MISMATCH = 0x5a64ac85;
+/// @dev Error code for when result column counts don't match.
+uint32 constant ERR_RESULT_COLUMN_COUNT_MISMATCH = 0x4b08a100;
+/// @dev Error code for when a result column name is invalid.
+uint32 constant ERR_INVALID_RESULT_COLUMN_NAME = 0xc5a456b6;
+/// @dev Error code for when result column lengths are inconsistent.
+uint32 constant ERR_INCONSISTENT_RESULT_COLUMN_LENGTHS = 0x68c99843;
+/// @dev Error code for when the result is incorrect.
+uint32 constant ERR_INCORRECT_RESULT = 0x3ad072a3;
+/// @dev Error code for when HyperKZG proof size doesn't match.
+uint32 constant ERR_HYPER_KZG_PROOF_SIZE_MISMATCH = 0xbe285ccd;
+/// @dev Error code for when aggregate evaluation doesn't match.
+uint32 constant ERR_AGGREGATE_EVALUATION_MISMATCH = 0xf5c6cb38;
+/// @dev Error code for when proof type is unsupported.
+uint32 constant ERR_UNSUPPORTED_PROOF = 0x6f1c50d9;
+/// @dev Error code for when a proof plan variant is unsupported.
+uint32 constant ERR_UNSUPPORTED_PROOF_PLAN_VARIANT = 0xe5503cfa;
+/// @dev Error code for when a data type variant is unsupported.
+uint32 constant ERR_UNSUPPORTED_DATA_TYPE_VARIANT = 0xbd12560e;
 
 library Errors {
     /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
@@ -60,6 +80,26 @@ library Errors {
     error InvalidIndex();
     /// @notice Error thrown when a proof expression variant is unsupported.
     error UnsupportedProofExprVariant();
+    /// @notice Error thrown when PCS batch lengths don't match.
+    error PCSBatchLengthMismatch();
+    /// @notice Error thrown when result column counts don't match.
+    error ResultColumnCountMismatch();
+    /// @notice Error thrown when a result column name is invalid.
+    error InvalidResultColumnName();
+    /// @notice Error thrown when result column lengths are inconsistent.
+    error InconsistentResultColumnLengths();
+    /// @notice Error thrown when the result is incorrect.
+    error IncorrectResult();
+    /// @notice Error thrown when HyperKZG proof size doesn't match.
+    error HyperKZGProofSizeMismatch();
+    /// @notice Error thrown when aggregate evaluation doesn't match.
+    error AggregateEvaluationMismatch();
+    /// @notice Error thrown when proof type is unsupported.
+    error UnsupportedProof();
+    /// @notice Error thrown when a proof plan variant is unsupported.
+    error UnsupportedProofPlanVariant();
+    /// @notice Error thrown when a data type variant is unsupported.
+    error UnsupportedDataTypeVariant();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -103,4 +103,74 @@ contract ErrorsTest is Test {
         vm.expectRevert(Errors.UnsupportedProofExprVariant.selector);
         Errors.__err(ERR_UNSUPPORTED_PROOF_EXPR_VARIANT);
     }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorPCSBatchLengthMismatch() public {
+        assert(Errors.PCSBatchLengthMismatch.selector == bytes4(ERR_PCS_BATCH_LENGTH_MISMATCH));
+        vm.expectRevert(Errors.PCSBatchLengthMismatch.selector);
+        Errors.__err(ERR_PCS_BATCH_LENGTH_MISMATCH);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorResultColumnCountMismatch() public {
+        assert(Errors.ResultColumnCountMismatch.selector == bytes4(ERR_RESULT_COLUMN_COUNT_MISMATCH));
+        vm.expectRevert(Errors.ResultColumnCountMismatch.selector);
+        Errors.__err(ERR_RESULT_COLUMN_COUNT_MISMATCH);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorInvalidResultColumnName() public {
+        assert(Errors.InvalidResultColumnName.selector == bytes4(ERR_INVALID_RESULT_COLUMN_NAME));
+        vm.expectRevert(Errors.InvalidResultColumnName.selector);
+        Errors.__err(ERR_INVALID_RESULT_COLUMN_NAME);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorInconsistentResultColumnLengths() public {
+        assert(Errors.InconsistentResultColumnLengths.selector == bytes4(ERR_INCONSISTENT_RESULT_COLUMN_LENGTHS));
+        vm.expectRevert(Errors.InconsistentResultColumnLengths.selector);
+        Errors.__err(ERR_INCONSISTENT_RESULT_COLUMN_LENGTHS);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorIncorrectResult() public {
+        assert(Errors.IncorrectResult.selector == bytes4(ERR_INCORRECT_RESULT));
+        vm.expectRevert(Errors.IncorrectResult.selector);
+        Errors.__err(ERR_INCORRECT_RESULT);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorHyperKZGProofSizeMismatch() public {
+        assert(Errors.HyperKZGProofSizeMismatch.selector == bytes4(ERR_HYPER_KZG_PROOF_SIZE_MISMATCH));
+        vm.expectRevert(Errors.HyperKZGProofSizeMismatch.selector);
+        Errors.__err(ERR_HYPER_KZG_PROOF_SIZE_MISMATCH);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorAggregateEvaluationMismatch() public {
+        assert(Errors.AggregateEvaluationMismatch.selector == bytes4(ERR_AGGREGATE_EVALUATION_MISMATCH));
+        vm.expectRevert(Errors.AggregateEvaluationMismatch.selector);
+        Errors.__err(ERR_AGGREGATE_EVALUATION_MISMATCH);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorUnsupportedProof() public {
+        assert(Errors.UnsupportedProof.selector == bytes4(ERR_UNSUPPORTED_PROOF));
+        vm.expectRevert(Errors.UnsupportedProof.selector);
+        Errors.__err(ERR_UNSUPPORTED_PROOF);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorUnsupportedProofPlanVariant() public {
+        assert(Errors.UnsupportedProofPlanVariant.selector == bytes4(ERR_UNSUPPORTED_PROOF_PLAN_VARIANT));
+        vm.expectRevert(Errors.UnsupportedProofPlanVariant.selector);
+        Errors.__err(ERR_UNSUPPORTED_PROOF_PLAN_VARIANT);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorUnsupportedDataTypeVariant() public {
+        assert(Errors.UnsupportedDataTypeVariant.selector == bytes4(ERR_UNSUPPORTED_DATA_TYPE_VARIANT));
+        vm.expectRevert(Errors.UnsupportedDataTypeVariant.selector);
+        Errors.__err(ERR_UNSUPPORTED_DATA_TYPE_VARIANT);
+    }
 }


### PR DESCRIPTION
# Rationale for this change

We need more error variants in upcoming solidity PRs.

# What changes are included in this PR?

This PR adds the following error variants:

* PCSBatchLengthMismatch
* ResultColumnCountMismatch
* InvalidResultColumnName
* InconsistentResultColumnLengths
* IncorrectResult
* HyperKZGProofSizeMismatch
* AggregateEvaluationMismatch
* UnsupportedProof
* UnsupportedProofPlanVariant
* UnsupportedDataTypeVariant

# Are these changes tested?
Yes