### PR TITLE
chore(sol): update transcript

### DIFF
--- a/solidity/src/base/Transcript.sol
+++ b/solidity/src/base/Transcript.sol
@@ -90,4 +90,27 @@ library Transcript {
         }
         __resultTranscript = __transcript;
     }
+
+    /// @notice Append an array to the transcript, and update the state of the transcript.
+    /// @dev This is achieved by hashing the current transcript state with the array data.
+    /// The operation is done in place by temporarily swapping the array length with the transcript state.
+    /// @param __transcript The current state of the transcript
+    /// @param __data The array to append
+    /// @return __resultTranscript The updated state of the transcript
+    function __appendArray(uint256[1] memory __transcript, uint256[] memory __data)
+        internal
+        pure
+        returns (uint256[1] memory __resultTranscript)
+    {
+        assembly {
+            function append_array(transcript_ptr, array_ptr) {
+                let array_len := mload(array_ptr)
+                mstore(array_ptr, mload(transcript_ptr))
+                mstore(transcript_ptr, keccak256(array_ptr, mul(add(array_len, 1), WORD_SIZE)))
+                mstore(array_ptr, array_len)
+            }
+            append_array(__transcript, __data)
+        }
+        __resultTranscript = __transcript;
+    }
 }

--- a/solidity/test/base/Transcript.t.sol
+++ b/solidity/test/base/Transcript.t.sol
@@ -116,4 +116,39 @@ library TranscriptTest {
         uint256 expectedState = uint256(keccak256(abi.encodePacked(start, data)));
         assert(state[0] == expectedState);
     }
+
+    function testAppendArray() public pure {
+        uint256[1] memory transcript = [uint256(0x123)];
+        uint256[] memory data = new uint256[](3);
+        data[0] = 0xabc;
+        data[1] = 0xdef;
+        data[2] = 0x789;
+        uint256 expectedState = uint256(keccak256(abi.encodePacked(transcript, data)));
+
+        transcript = Transcript.__appendArray(transcript, data);
+
+        // Verify data is preserved
+        assert(data.length == 3);
+        assert(data[0] == 0xabc);
+        assert(data[1] == 0xdef);
+        assert(data[2] == 0x789);
+
+        // Verify state changed
+        assert(transcript[0] == expectedState);
+    }
+
+    function testFuzzAppendArray(uint256[1] memory transcript, uint256[] memory array) public pure {
+        uint256 len = array.length;
+        uint256[] memory originalArray = array;
+
+        uint256 expectedState = uint256(keccak256(abi.encodePacked(transcript, array)));
+        transcript = Transcript.__appendArray(transcript, array);
+
+        // Verify data preserved
+        assert(array.length == len);
+        for (uint256 i = 0; i < len; ++i) {
+            assert(array[i] == originalArray[i]);
+        }
+        assert(transcript[0] == expectedState);
+    }
 }


### PR DESCRIPTION
# Rationale for this change

Some updates to the solidity transcript implementation are needed for upcoming PRs.

# What changes are included in this PR?

See individual commits:

* [refactor(sol): make draw_challenges return length-prefixed array](https://github.com/spaceandtimelabs/sxt-proof-of-sql/pull/670/commits/2cf60597f1fb6c819676813175bb17a03c75b080)

    Previously, `draw_challenges` would allocate memory of length `count`,
    fill that memory with `count` challenges,
    and return a pointer to the first challenge.
    This commit changes this so that it allocates an extra word,
    starts the memory with a value of `count`,
    and returns a pointer to that first value.
    
    This aligns with the solidity memory layout for arrays.
    While it is slightly less efficient, it is helpful for keeping the stack small.
    Although, future optimizations may wish to revert this.

* [feat(sol): add append_array](https://github.com/spaceandtimelabs/sxt-proof-of-sql/pull/670/commits/eddd9c0e66a04390442c94b875fa80877bc721b8)

    Adds an in-memory array to the transcript. This is similar to `append_calldata`, but is memory instead.

# Are these changes tested?
Yes