### PR TITLE
chore: pin nova version in powers-of-tau-util

### DIFF
--- a/crates/powers-of-tau-util/Cargo.toml
+++ b/crates/powers-of-tau-util/Cargo.toml
@@ -10,7 +10,7 @@ license-file.workspace = true
 ark-bn254 = { version = "0.5.0" }
 ark-serialize = { version = "0.5.0" }
 blitzar = { version = "4.3.0" }
-nova-snark = { git = "https://github.com/microsoft/Nova.git" }
+nova-snark = { git = "https://github.com/microsoft/Nova.git", rev = "4386a91" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Rationale for this change

Since we are relying on the nova git repo in the `powers-of-tau-util` crate, any breaking changes in the repo can potentially cause CI/other failures.

# What changes are included in this PR?

* Pinned the version of `nova-snark` to a particular commit.

# Are these changes tested?

Yes