### PR TITLE
feat: add various verification builder getters and setters

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -110,7 +110,7 @@ uint256 constant VK_TAU_HY_REAL = 0x1a44ae9f94f7e4a96d8ea5f1d1a67f22e292e9f58cdd
 uint256 constant VK_TAU_HY_IMAG = 0x01ea86d896eddc7a6edac41e80a9e9059440e9b3baf2186fad830ae001a1482a;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 11;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 13;
 /// @dev Offset of the pointer to the challenge queue in the verification builder.
 uint256 constant BUILDER_CHALLENGES_OFFSET = 0x20 * 0;
 /// @dev Offset of the pointer to the first round MLEs in the verification builder.
@@ -133,3 +133,10 @@ uint256 constant BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET = 0x20 * 8;
 uint256 constant BUILDER_COLUMN_EVALUATIONS_OFFSET = 0x20 * 9;
 /// @dev Offset of the pointer to the table chi evaluations in the verification builder.
 uint256 constant BUILDER_TABLE_CHI_EVALUATIONS_OFFSET = 0x20 * 10;
+/// @dev Offset of the pointer to the first round commitments in the verification builder.
+uint256 constant BUILDER_FIRST_ROUND_COMMITMENTS_OFFSET = 0x20 * 11;
+/// @dev Offset of the pointer to the final round commitments in the verification builder.
+uint256 constant BUILDER_FINAL_ROUND_COMMITMENTS_OFFSET = 0x20 * 12;
+
+/// @dev The initial transcript state. This is the hash of the empty string.
+uint256 constant INITIAL_TRANSCRIPT_STATE = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;

--- a/solidity/src/builder/VerificationBuilder.pre.sol
+++ b/solidity/src/builder/VerificationBuilder.pre.sol
@@ -21,6 +21,8 @@ library VerificationBuilder {
         uint256 rowMultipliersEvaluation;
         uint256[] columnEvaluations;
         uint256[] tableChiEvaluations;
+        uint256 firstRoundCommitmentsPtr;
+        uint256 finalRoundCommitmentsPtr;
     }
 
     /// @notice Allocates and reserves a block of memory for a verification builder
@@ -125,6 +127,28 @@ library VerificationBuilder {
         }
     }
 
+    /// @notice Gets the first round MLE values from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_first_round_mles(builder_ptr) -> values_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `values_ptr` - pointer to the array in memory
+    /// @param __builder The builder struct
+    /// @return __values The first round MLE values array
+    function __getFirstRoundMLEs(Builder memory __builder) internal pure returns (uint256[] memory __values) {
+        assembly {
+            function builder_get_first_round_mles(builder_ptr) -> values_ptr {
+                values_ptr := mload(add(builder_ptr, BUILDER_FIRST_ROUND_MLES_OFFSET))
+            }
+            __values := builder_get_first_round_mles(__builder)
+        }
+    }
+
     /// @notice Consumes a first round MLE evaluation from the verification builder
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function
@@ -178,6 +202,28 @@ library VerificationBuilder {
                 mstore(add(builder_ptr, BUILDER_FINAL_ROUND_MLES_OFFSET), values_ptr)
             }
             builder_set_final_round_mles(__builder, __values)
+        }
+    }
+
+    /// @notice Gets the final round MLE values from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_final_round_mles(builder_ptr) -> values_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `values_ptr` - pointer to the array in memory
+    /// @param __builder The builder struct
+    /// @return __values The final round MLE values array
+    function __getFinalRoundMLEs(Builder memory __builder) internal pure returns (uint256[] memory __values) {
+        assembly {
+            function builder_get_final_round_mles(builder_ptr) -> values_ptr {
+                values_ptr := mload(add(builder_ptr, BUILDER_FINAL_ROUND_MLES_OFFSET))
+            }
+            __values := builder_get_final_round_mles(__builder)
         }
     }
 
@@ -378,6 +424,28 @@ library VerificationBuilder {
         }
     }
 
+    /// @notice Gets the aggregate evaluation from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_aggregate_evaluation(builder_ptr) -> value
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `value` - the aggregate evaluation value
+    /// @param __builder The builder struct
+    /// @return __value The aggregate evaluation value
+    function __getAggregateEvaluation(Builder memory __builder) internal pure returns (uint256 __value) {
+        assembly {
+            function builder_get_aggregate_evaluation(builder_ptr) -> value {
+                value := mload(add(builder_ptr, BUILDER_AGGREGATE_EVALUATION_OFFSET))
+            }
+            __value := builder_get_aggregate_evaluation(__builder)
+        }
+    }
+
     /// @notice Sets the row multipliers evaluation in the verification builder
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function
@@ -488,6 +556,28 @@ library VerificationBuilder {
         }
     }
 
+    /// @notice Gets the column evaluations array from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_column_evaluations(builder_ptr) -> values_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `values_ptr` - pointer to the array in memory
+    /// @param __builder The builder struct
+    /// @return __values The column evaluation values array
+    function __getColumnEvaluations(Builder memory __builder) internal pure returns (uint256[] memory __values) {
+        assembly {
+            function builder_get_column_evaluations(builder_ptr) -> values_ptr {
+                values_ptr := mload(add(builder_ptr, BUILDER_COLUMN_EVALUATIONS_OFFSET))
+            }
+            __values := builder_get_column_evaluations(__builder)
+        }
+    }
+
     /// @notice Gets a column evaluation by column number
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function
@@ -578,6 +668,162 @@ library VerificationBuilder {
                 value := get_array_element(add(builder_ptr, BUILDER_TABLE_CHI_EVALUATIONS_OFFSET), table_num)
             }
             __value := builder_get_table_chi_evaluation(__builder, __tableNum)
+        }
+    }
+
+    /// @notice Sets the first round commitments in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_first_round_commitments(builder_ptr, values_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `values_ptr` - memory pointer to the first round commitments array
+    /// @param __builder The builder struct
+    /// @param __valuesPtr Memory pointer to first round commitments array
+    function __setFirstRoundCommitments(Builder memory __builder, uint256 __valuesPtr) internal pure {
+        assembly {
+            function builder_set_first_round_commitments(builder_ptr, values_ptr) {
+                mstore(add(builder_ptr, BUILDER_FIRST_ROUND_COMMITMENTS_OFFSET), values_ptr)
+            }
+            builder_set_first_round_commitments(__builder, __valuesPtr)
+        }
+    }
+
+    /// @notice Gets the first round commitments pointer from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_first_round_commitments(builder_ptr) -> values_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `values_ptr` - memory pointer to the first round commitments array
+    /// @param __builder The builder struct
+    /// @return __valuesPtr Memory pointer to first round commitments array
+    function __getFirstRoundCommitments(Builder memory __builder) internal pure returns (uint256 __valuesPtr) {
+        assembly {
+            function builder_get_first_round_commitments(builder_ptr) -> values_ptr {
+                values_ptr := mload(add(builder_ptr, BUILDER_FIRST_ROUND_COMMITMENTS_OFFSET))
+            }
+            __valuesPtr := builder_get_first_round_commitments(__builder)
+        }
+    }
+
+    /// @notice Sets the final round commitments in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_final_round_commitments(builder_ptr, values_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `values_ptr` - memory pointer to the final round commitments array
+    /// @param __builder The builder struct
+    /// @param __valuesPtr Memory pointer to final round commitments array
+    function __setFinalRoundCommitments(Builder memory __builder, uint256 __valuesPtr) internal pure {
+        assembly {
+            function builder_set_final_round_commitments(builder_ptr, values_ptr) {
+                mstore(add(builder_ptr, BUILDER_FINAL_ROUND_COMMITMENTS_OFFSET), values_ptr)
+            }
+            builder_set_final_round_commitments(__builder, __valuesPtr)
+        }
+    }
+
+    /// @notice Gets the final round commitments pointer from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_final_round_commitments(builder_ptr) -> values_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `values_ptr` - memory pointer to the final round commitments array
+    /// @param __builder The builder struct
+    /// @return __valuesPtr Memory pointer to final round commitments array
+    function __getFinalRoundCommitments(Builder memory __builder) internal pure returns (uint256 __valuesPtr) {
+        assembly {
+            function builder_get_final_round_commitments(builder_ptr) -> values_ptr {
+                values_ptr := mload(add(builder_ptr, BUILDER_FINAL_ROUND_COMMITMENTS_OFFSET))
+            }
+            __valuesPtr := builder_get_final_round_commitments(__builder)
+        }
+    }
+
+    /// @notice Sets the bit distributions in the verification builder. Errors if the length is non-zero.
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_bit_distributions(builder_ptr, values_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `values_ptr` - pointer to the array in memory
+    /// @dev Always reverts with Errors.UnsupportedProof if length is non-zero
+    /// @param __builder The builder struct
+    /// @param __values The bit distributions array
+    function __setBitDistributions(Builder memory __builder, uint256[] memory __values) internal pure {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            function builder_set_bit_distributions(builder_ptr, values_ptr) {
+                if mload(values_ptr) { err(ERR_UNSUPPORTED_PROOF) }
+            }
+            builder_set_bit_distributions(__builder, __values)
+        }
+    }
+
+    /// @notice Gets the chi column evaluations array from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_chi_evaluations(builder_ptr) -> values_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `values_ptr` - pointer to the array in memory
+    /// @param __builder The builder struct
+    /// @return __values The chi evaluations array
+    function __getChiEvaluations(Builder memory __builder) internal pure returns (uint256[] memory __values) {
+        assembly {
+            function builder_get_chi_evaluations(builder_ptr) -> values_ptr {
+                values_ptr := mload(add(builder_ptr, BUILDER_CHI_EVALUATIONS_OFFSET))
+            }
+            __values := builder_get_chi_evaluations(__builder)
+        }
+    }
+
+    /// @notice Gets the table chi evaluations array from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_table_chi_evaluations(builder_ptr) -> values_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `values_ptr` - pointer to the array in memory
+    /// @param __builder The builder struct
+    /// @return __values The table chi evaluations array
+    function __getTableChiEvaluations(Builder memory __builder) internal pure returns (uint256[] memory __values) {
+        assembly {
+            function builder_get_table_chi_evaluations(builder_ptr) -> values_ptr {
+                values_ptr := mload(add(builder_ptr, BUILDER_TABLE_CHI_EVALUATIONS_OFFSET))
+            }
+            __values := builder_get_table_chi_evaluations(__builder)
         }
     }
 }

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -54,7 +54,7 @@ contract ConstantsTest is Test {
     }
 
     function testVerificationBuilderOffsetsAreValid() public pure {
-        uint256[11] memory offsets = [
+        uint256[13] memory offsets = [
             BUILDER_CHALLENGES_OFFSET,
             BUILDER_FIRST_ROUND_MLES_OFFSET,
             BUILDER_FINAL_ROUND_MLES_OFFSET,
@@ -65,7 +65,9 @@ contract ConstantsTest is Test {
             BUILDER_AGGREGATE_EVALUATION_OFFSET,
             BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET,
             BUILDER_COLUMN_EVALUATIONS_OFFSET,
-            BUILDER_TABLE_CHI_EVALUATIONS_OFFSET
+            BUILDER_TABLE_CHI_EVALUATIONS_OFFSET,
+            BUILDER_FIRST_ROUND_COMMITMENTS_OFFSET,
+            BUILDER_FINAL_ROUND_COMMITMENTS_OFFSET
         ];
         uint256 offsetsLength = offsets.length;
         assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);
@@ -76,5 +78,9 @@ contract ConstantsTest is Test {
                 assert(offsets[i] != offsets[j]); // Offsets must be unique
             }
         }
+    }
+
+    function testInitialTranscriptStateIsHashOfNothing() public pure {
+        assert(INITIAL_TRANSCRIPT_STATE == uint256(keccak256(hex"")));
     }
 }

--- a/solidity/test/builder/VerificationBuilder.t.pre.sol
+++ b/solidity/test/builder/VerificationBuilder.t.pre.sol
@@ -143,6 +143,31 @@ contract VerificationBuilderTest is Test {
         }
     }
 
+    function testGetFirstRoundMLEs() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        builder.firstRoundMLEs = values;
+        uint256[] memory result = VerificationBuilder.__getFirstRoundMLEs(builder);
+        assert(result.length == 3);
+        assert(result[0] == 0x12345678);
+        assert(result[1] == 0x23456789);
+        assert(result[2] == 0x3456789A);
+    }
+
+    function testFuzzGetFirstRoundMLEs(uint256[] memory values) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.firstRoundMLEs = values;
+        uint256[] memory result = VerificationBuilder.__getFirstRoundMLEs(builder);
+        assert(result.length == values.length);
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(result[i] == values[i]);
+        }
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testConsumeZeroFirstRoundMLEs() public {
         VerificationBuilder.Builder memory builder;
@@ -207,6 +232,31 @@ contract VerificationBuilderTest is Test {
         uint256 valuesLength = values.length;
         for (uint256 i = 0; i < valuesLength; ++i) {
             assert(builder.finalRoundMLEs[i] == values[i]);
+        }
+    }
+
+    function testGetFinalRoundMLEs() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        builder.finalRoundMLEs = values;
+        uint256[] memory result = VerificationBuilder.__getFinalRoundMLEs(builder);
+        assert(result.length == 3);
+        assert(result[0] == 0x12345678);
+        assert(result[1] == 0x23456789);
+        assert(result[2] == 0x3456789A);
+    }
+
+    function testFuzzGetFinalRoundMLEs(uint256[] memory values) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.finalRoundMLEs = values;
+        uint256[] memory result = VerificationBuilder.__getFinalRoundMLEs(builder);
+        assert(result.length == values.length);
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(result[i] == values[i]);
         }
     }
 
@@ -435,6 +485,18 @@ contract VerificationBuilderTest is Test {
         assert(builder.aggregateEvaluation == value);
     }
 
+    function testGetAggregateEvaluation() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.aggregateEvaluation = 42;
+        assert(VerificationBuilder.__getAggregateEvaluation(builder) == 42);
+    }
+
+    function testFuzzGetAggregateEvaluation(uint256 value) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.aggregateEvaluation = value;
+        assert(VerificationBuilder.__getAggregateEvaluation(builder) == value);
+    }
+
     function testSetRowMultipliersEvaluation() public pure {
         VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
         VerificationBuilder.__setRowMultipliersEvaluation(builder, 42);
@@ -623,6 +685,31 @@ contract VerificationBuilderTest is Test {
         }
     }
 
+    function testGetColumnEvaluations() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        builder.columnEvaluations = values;
+        uint256[] memory result = VerificationBuilder.__getColumnEvaluations(builder);
+        assert(result.length == 3);
+        assert(result[0] == 0x12345678);
+        assert(result[1] == 0x23456789);
+        assert(result[2] == 0x3456789A);
+    }
+
+    function testFuzzGetColumnEvaluations(uint256[] memory values) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.columnEvaluations = values;
+        uint256[] memory result = VerificationBuilder.__getColumnEvaluations(builder);
+        assert(result.length == values.length);
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(result[i] == values[i]);
+        }
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testGetColumnEvaluationInvalidIndex() public {
         VerificationBuilder.Builder memory builder;
@@ -711,6 +798,127 @@ contract VerificationBuilderTest is Test {
         uint256 valuesLength = values.length;
         for (uint256 i = 0; i < valuesLength; ++i) {
             assert(VerificationBuilder.__getTableChiEvaluation(builder, i) == values[i]);
+        }
+    }
+
+    function testSetFirstRoundCommitments() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256 valuesPtr = 0x123456;
+        VerificationBuilder.__setFirstRoundCommitments(builder, valuesPtr);
+        assert(builder.firstRoundCommitmentsPtr == valuesPtr);
+    }
+
+    function testFuzzSetFirstRoundCommitments(uint256 valuesPtr) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setFirstRoundCommitments(builder, valuesPtr);
+        assert(builder.firstRoundCommitmentsPtr == valuesPtr);
+    }
+
+    function testGetFirstRoundCommitments() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.firstRoundCommitmentsPtr = 0x123456;
+        assert(VerificationBuilder.__getFirstRoundCommitments(builder) == 0x123456);
+    }
+
+    function testFuzzGetFirstRoundCommitments(uint256 valuesPtr) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.firstRoundCommitmentsPtr = valuesPtr;
+        assert(VerificationBuilder.__getFirstRoundCommitments(builder) == valuesPtr);
+    }
+
+    function testSetFinalRoundCommitments() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256 valuesPtr = 0x123456;
+        VerificationBuilder.__setFinalRoundCommitments(builder, valuesPtr);
+        assert(builder.finalRoundCommitmentsPtr == valuesPtr);
+    }
+
+    function testFuzzSetFinalRoundCommitments(uint256 valuesPtr) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setFinalRoundCommitments(builder, valuesPtr);
+        assert(builder.finalRoundCommitmentsPtr == valuesPtr);
+    }
+
+    function testGetFinalRoundCommitments() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.finalRoundCommitmentsPtr = 0x123456;
+        assert(VerificationBuilder.__getFinalRoundCommitments(builder) == 0x123456);
+    }
+
+    function testFuzzGetFinalRoundCommitments(uint256 valuesPtr) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.finalRoundCommitmentsPtr = valuesPtr;
+        assert(VerificationBuilder.__getFinalRoundCommitments(builder) == valuesPtr);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testSetBitDistributions() public {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory emptyValues = new uint256[](0);
+        // Empty array should not revert
+        VerificationBuilder.__setBitDistributions(builder, emptyValues);
+
+        uint256[] memory values = new uint256[](1);
+        values[0] = 0x12345678;
+        vm.expectRevert(Errors.UnsupportedProof.selector);
+        VerificationBuilder.__setBitDistributions(builder, values);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testFuzzSetBitDistributions(uint256[] memory values) public {
+        vm.assume(values.length > 0);
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        vm.expectRevert(Errors.UnsupportedProof.selector);
+        VerificationBuilder.__setBitDistributions(builder, values);
+    }
+
+    function testGetChiEvaluations() public pure {
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        builder.chiEvaluations = values;
+        uint256[] memory result = VerificationBuilder.__getChiEvaluations(builder);
+        assert(result.length == 3);
+        assert(result[0] == 0x12345678);
+        assert(result[1] == 0x23456789);
+        assert(result[2] == 0x3456789A);
+    }
+
+    function testFuzzGetChiEvaluations(uint256[] memory values) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.chiEvaluations = values;
+        uint256[] memory result = VerificationBuilder.__getChiEvaluations(builder);
+        assert(result.length == values.length);
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(result[i] == values[i]);
+        }
+    }
+
+    function testGetTableChiEvaluations() public pure {
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        builder.tableChiEvaluations = values;
+        uint256[] memory result = VerificationBuilder.__getTableChiEvaluations(builder);
+        assert(result.length == 3);
+        assert(result[0] == 0x12345678);
+        assert(result[1] == 0x23456789);
+        assert(result[2] == 0x3456789A);
+    }
+
+    function testFuzzGetTableChiEvaluations(uint256[] memory values) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.tableChiEvaluations = values;
+        uint256[] memory result = VerificationBuilder.__getTableChiEvaluations(builder);
+        assert(result.length == values.length);
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(result[i] == values[i]);
         }
     }
 }


### PR DESCRIPTION
# Rationale for this change

A variety of getters and setters are needed for upcoming PRs. This PR adds them all at once.

# What changes are included in this PR?

The following function are added:

* `builder_get_first_round_mles`
* `builder_get_final_round_mles`
* `builder_get_aggregate_evaluation`
* `builder_get_column_evaluations`
* `builder_set_first_round_commitments`
* `builder_get_first_round_commitments`
* `builder_set_final_round_commitments`
* `builder_get_final_round_commitments`
* `builder_set_bit_distributions`
* `builder_get_chi_evaluations`
* `builder_get_table_chi_evaluations`

# Are these changes tested?

Yes