### PR TITLE
chore: bump nova-snark version with patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,5 @@ pedantic = { level = "warn", priority = -1 }
 # patch for sqlparser no_std compatibility with the serde feature enabled.
 # required until sqlparser releases a similar update and proof-of-sql upgrades to it.
 sqlparser = { git = "https://github.com/tlovell-sxt/datafusion-sqlparser-rs.git", rev = "a828cbea22cf19bb6b4596f902bdd6f4d14a00b8" }
+# patch for nova-snark that enables more compact proofs
+nova-snark = { git = "https://github.com/microsoft/Nova.git", rev = "45a3678d809c0efd92eadd0326a63314edfc5c2d" }

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
@@ -31,8 +31,10 @@ impl Engine for HyperKZGEngine {
     type Base = nova_snark::provider::bn256_grumpkin::bn256::Base;
     type Scalar = NovaScalar;
     type GE = nova_snark::provider::bn256_grumpkin::bn256::Point;
-    type RO = nova_snark::provider::poseidon::PoseidonRO<Self::Base, Self::Scalar>;
+    type RO = nova_snark::provider::poseidon::PoseidonRO<Self::Base>;
     type ROCircuit = nova_snark::provider::poseidon::PoseidonROCircuit<Self::Base>;
+    type RO2 = nova_snark::provider::poseidon::PoseidonRO<Self::Scalar>;
+    type RO2Circuit = nova_snark::provider::poseidon::PoseidonROCircuit<Self::Scalar>;
     type TE = Keccak256Transcript;
     type CE = nova_snark::provider::hyperkzg::CommitmentEngine<Self>;
 }


### PR DESCRIPTION
# Rationale for this change

The github repo for `nova-snark` has some recent changes that we rely on for EVM verification. We need to bump to that specific git revision

# What changes are included in this PR?

See above

# Are these changes tested?
Yes