### PR TITLE
chore: bump nova-snark version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ itertools = { version = "0.13.0", default-features = false, features = ["use_all
 lalrpop = { version = "0.22.0" }
 lalrpop-util = { version = "0.22.0", default-features = false }
 merlin = { version = "2" }
-nova-snark = { version = "0.40.0" }
+nova-snark = { version = "0.41.0" }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4.4", default-features = false }
 opentelemetry = { version = "0.23.0" }

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
@@ -18,8 +18,10 @@ impl Engine for HyperKZGEngine {
     type Base = nova_snark::provider::bn256_grumpkin::bn256::Base;
     type Scalar = NovaScalar;
     type GE = nova_snark::provider::bn256_grumpkin::bn256::Point;
-    type RO = nova_snark::provider::poseidon::PoseidonRO<Self::Base, Self::Scalar>;
+    type RO = nova_snark::provider::poseidon::PoseidonRO<Self::Base>;
     type ROCircuit = nova_snark::provider::poseidon::PoseidonROCircuit<Self::Base>;
+    type RO2 = nova_snark::provider::poseidon::PoseidonRO<Self::Scalar>;
+    type RO2Circuit = nova_snark::provider::poseidon::PoseidonROCircuit<Self::Scalar>;
     type TE = Keccak256Transcript;
     type CE = nova_snark::provider::hyperkzg::CommitmentEngine<Self>;
 }


### PR DESCRIPTION
# Rationale for this change

The github repo for `nova-snark` has some recent changes that we rely on for EVM verification. We need to bump to that specific git revision

# What changes are included in this PR?

See above

# Are these changes tested?
Yes