### PR TITLE
ci: increase test optimization level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,9 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)
 missing_errors_doc = "allow"
 pedantic = { level = "warn", priority = -1 }
 
+[profile.test]
+opt-level = 3
+
 [patch.crates-io]
 # patch for sqlparser no_std compatibility with the serde feature enabled.
 # required until sqlparser releases a similar update and proof-of-sql upgrades to it.


### PR DESCRIPTION
# Rationale for this change

This is a reattempt of #610 now that #621 is merged.

# Are these changes tested?
No, we will have to wait for this change to be merged before the cache kicks in.