### PR TITLE
refactor!: update Rust proof to be Solidity compatible

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -24,6 +24,8 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 /// Supported types for [`OwnedColumn`]
 pub enum OwnedColumn<S: Scalar> {
+    /// i64 columns
+    BigInt(Vec<i64>),
     /// Boolean columns
     Boolean(Vec<bool>),
     /// u8 columns
@@ -34,8 +36,6 @@ pub enum OwnedColumn<S: Scalar> {
     SmallInt(Vec<i16>),
     /// i32 columns
     Int(Vec<i32>),
-    /// i64 columns
-    BigInt(Vec<i64>),
     /// String columns
     VarChar(Vec<String>),
     /// Variable length binary columns

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) enum Expr {
     Column(ColumnExpr),
-    Equals(EqualsExpr),
     Literal(LiteralExpr),
+    Equals(EqualsExpr),
 }
 impl Expr {
     /// Try to create an `Expr` from a `DynProofExpr`.

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -74,10 +74,10 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
         .chain([])
         .chain(&0_u32.to_be_bytes()) //   FilterExec
         .chain(&0_usize.to_be_bytes()) //   table_number
-        .chain(&1_u32.to_be_bytes()) //     where_clause - EqualsExpr
+        .chain(&2_u32.to_be_bytes()) //     where_clause - EqualsExpr
         .chain(&0_u32.to_be_bytes()) //       lhs - ColumnExpr
         .chain(&1_usize.to_be_bytes()) //       column_number
-        .chain(&2_u32.to_be_bytes()) //       rhs - LiteralExpr
+        .chain(&1_u32.to_be_bytes()) //       rhs - LiteralExpr
         .chain(&0_u32.to_be_bytes()) //         type
         .chain(&5_i64.to_be_bytes()) //         value
         .chain(&1_usize.to_be_bytes()) //   results.len()
@@ -131,10 +131,10 @@ fn we_can_deserialize_proof_plan_for_simple_filter() {
         .chain([])
         .chain(&0_u32.to_be_bytes()) //   FilterExec
         .chain(&0_usize.to_be_bytes()) //   table_number
-        .chain(&1_u32.to_be_bytes()) //     where_clause - EqualsExpr
+        .chain(&2_u32.to_be_bytes()) //     where_clause - EqualsExpr
         .chain(&0_u32.to_be_bytes()) //       lhs - ColumnExpr
         .chain(&1_usize.to_be_bytes()) //       column_number
-        .chain(&2_u32.to_be_bytes()) //       rhs - LiteralExpr
+        .chain(&1_u32.to_be_bytes()) //       rhs - LiteralExpr
         .chain(&0_u32.to_be_bytes()) //         type
         .chain(&5_i64.to_be_bytes()) //         value
         .chain(&1_usize.to_be_bytes()) //   results.len()

--- a/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
+++ b/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
@@ -136,9 +136,9 @@ mod tests {
         ];
 
         let scalars = vec![
-            TestScalar::from(201),
             TestScalar::from(202),
             TestScalar::from(203),
+            TestScalar::from(201),
         ];
         let random_scalars = SumcheckRandomScalars::new(&scalars, 2, 1);
 
@@ -215,13 +215,13 @@ mod tests {
         ];
 
         let scalars = vec![
-            TestScalar::from(201),
-            TestScalar::from(202),
-            TestScalar::from(203),
             TestScalar::from(204),
             TestScalar::from(205),
             TestScalar::from(206),
             TestScalar::from(207),
+            TestScalar::from(201),
+            TestScalar::from(202),
+            TestScalar::from(203),
         ];
         let random_scalars = SumcheckRandomScalars::new(&scalars, 6, 3);
 

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
@@ -10,7 +10,9 @@ pub struct SumcheckRandomScalars<'a, S: Scalar> {
 
 impl<'a, S: Scalar> SumcheckRandomScalars<'a, S> {
     pub fn new(scalars: &'a [S], table_length: usize, num_sumcheck_variables: usize) -> Self {
-        let (entrywise_point, subpolynomial_multipliers) = scalars.split_at(num_sumcheck_variables);
+        let num_subpolynomial_multipliers = scalars.len() - num_sumcheck_variables;
+        let (subpolynomial_multipliers, entrywise_point) =
+            scalars.split_at(num_subpolynomial_multipliers);
         Self {
             entrywise_point,
             subpolynomial_multipliers,


### PR DESCRIPTION
# Rationale for this change

This is the final refactoring change that enables EVM compatibility

# What changes are included in this PR?

* Transcript updates
* Reordering of `enum`s for serialization.

# Are these changes tested?
Yes, by existing tests