### PR TITLE
feat(sol): lagrange basis utilities

### DIFF
--- a/solidity/src/base/LagrangeBasisEvaluation.pre.sol
+++ b/solidity/src/base/LagrangeBasisEvaluation.pre.sol
@@ -14,7 +14,7 @@ library LagrangeBasisEvaluation {
     /// @param __x The point at which to evaluate the Lagrange basis.
     /// @return __result The sum of the Lagrange basis polynomials evaluated at the given point.
     /// @dev Let \\(\chi_i(x)\\) be the \\(i\\)th Lagrange basis polynomial.
-    /// That is, \\[\chi_i(x) = \prod_{j=0}^{\nu-1} (1-x_j)^{1-b_j}x_j^{b_j},\\]
+    /// That is, \\[\chi_i(x) = \prod_{j=0}^{\infty} (1-x_j)^{1-b_j}x_j^{b_j},\\]
     /// where \\(b_j\\) is the \\(j\\)th bit of \\(i\\).
     /// @dev This function computes \\[ \sum_{i=0}^{\ell-1}\chi_i(x_0,\ldots,x_{\nu-1},0,\ldots),\\]
     /// where \\(\ell = \texttt{length}\\) and \\(\nu = \texttt{num_vars} = \texttt{__x.length}\\).
@@ -80,7 +80,7 @@ library LagrangeBasisEvaluation {
                 let num_vars := mload(evaluation_point_ptr)
                 for { let len := 1 } num_vars { num_vars := sub(num_vars, 1) } {
                     let x := mod(mload(add(evaluation_point_ptr, mul(num_vars, WORD_SIZE))), MODULUS)
-                    let one_minux_x := sub(MODULUS_PLUS_ONE, x)
+                    let one_minus_x := sub(MODULUS_PLUS_ONE, x)
                     len := mul(len, 2)
                     if gt(len, length) { len := length }
                     for { let l := len } l {} {
@@ -88,7 +88,7 @@ library LagrangeBasisEvaluation {
                         let to_ptr := add(evaluations_ptr, mul(l, WORD_SIZE))
                         let from_ptr := add(evaluations_ptr, mul(shr(1, l), WORD_SIZE))
                         switch mod(l, 2)
-                        case 0 { mstore(to_ptr, mulmod(mload(from_ptr), one_minux_x, MODULUS)) }
+                        case 0 { mstore(to_ptr, mulmod(mload(from_ptr), one_minus_x, MODULUS)) }
                         case 1 { mstore(to_ptr, mulmod(mload(from_ptr), x, MODULUS)) }
                     }
                 }
@@ -97,6 +97,32 @@ library LagrangeBasisEvaluation {
             __evaluations := compute_evaluation_vec(__length, __evaluationPoint)
             __evaluations := sub(__evaluations, WORD_SIZE)
             mstore(__evaluations, __length)
+        }
+    }
+
+    /// @notice Computes evaluations of Lagrange basis polynomials for a given evaluation point and array.
+    /// @notice This is a wrapper around the `compute_evaluations` Yul function. Note that the function
+    /// does not return the evaluations, but rather modifies the input array in place.
+    /// @param __evaluationPoint The evaluation point at which to compute the evaluations.
+    /// @param __array The array of lengths to evaluate.
+    /// @dev This could likely be batched more efficiently. For now, we just naively compute the evaluations for each length.
+    function __computeEvaluations(uint256[] memory __evaluationPoint, uint256[] memory __array) internal pure {
+        assembly {
+            // IMPORT-YUL LagrangeBasisEvaluation.pre.sol
+            function compute_truncated_lagrange_basis_sum(length, x_ptr, num_vars) -> result {
+                revert(0, 0)
+            }
+            function compute_evaluations(evaluation_point_ptr, array_ptr) {
+                let num_vars := mload(evaluation_point_ptr)
+                let x := add(evaluation_point_ptr, WORD_SIZE)
+                let array_len := mload(array_ptr)
+                array_ptr := add(array_ptr, WORD_SIZE)
+                for {} array_len { array_len := sub(array_len, 1) } {
+                    mstore(array_ptr, compute_truncated_lagrange_basis_sum(mload(array_ptr), x, num_vars))
+                    array_ptr := add(array_ptr, WORD_SIZE)
+                }
+            }
+            compute_evaluations(__evaluationPoint, __array)
         }
     }
 
@@ -126,7 +152,7 @@ library LagrangeBasisEvaluation {
     /// \\[\begin{aligned}
     /// g(\ell, X_{\nu+1},Y_{\nu+1},\nu+1)&=(1-x_\nu)\cdot(1-y_\nu)\cdot g(\ell, X_\nu,Y_\nu,\nu)\\\\
     /// g(\ell+2^\nu, X_{\nu+1},Y_{\nu+1},\nu+1)&=(1-x_\nu)\cdot(1-y_\nu)\cdot h(X_\nu, Y_\nu, \nu)+x_\nu\cdot y_\nu\cdot g(\ell, X_\nu,Y_\nu,\nu)\\\\
-    /// h(X_\nu, Y_\nu, \nu)&=((1-x_\nu)\cdot(1-y_\nu)+x_\nu\cdot y_\nu)\cdot h(X_\nu, Y_\nu, \nu)
+    /// h(X_{\nu+1}, Y_{\nu+1}, \nu+1)&=((1-x_\nu)\cdot(1-y_\nu)+x_\nu\cdot y_\nu)\cdot h(X_\nu, Y_\nu, \nu)
     /// \end{aligned}\\]
     /// For \\(\ell \geq 2^{\nu}\\), we have that \\(g(\ell,X_\nu,Y_\nu,\nu)=h(X_\nu,Y_\nu,\nu)\\).
     function __computeTruncatedLagrangeBasisInnerProduct(uint256 __length, uint256[] memory __x, uint256[] memory __y)

--- a/solidity/test/base/LagrangeBasisEvaluation.t.pre.sol
+++ b/solidity/test/base/LagrangeBasisEvaluation.t.pre.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import "../../src/base/Constants.sol";
-import {LagrangeBasisEvaluation} from "./../../src/base/LagrangeBasisEvaluation.sol";
+import {LagrangeBasisEvaluation} from "./../../src/base/LagrangeBasisEvaluation.pre.sol";
 import {F, FF} from "./FieldUtil.sol";
 
 /// A library for efficiently computing sums over Lagrange basis polynomials evaluated at points.
@@ -88,13 +88,13 @@ contract LagrangeBasisEvaluationTest is Test {
         assert(LagrangeBasisEvaluation.__computeTruncatedLagrangeBasisInnerProduct(0, a, b) == 0);
     }
 
-    uint256 private constant MAX_FUZZ_POINT_LENGTH = 5;
-    uint256 private constant EXTRA_FUZZ_LENGTH = 10;
+    uint256 private constant _MAX_FUZZ_POINT_LENGTH = 5;
+    uint256 private constant _EXTRA_FUZZ_LENGTH = 10;
 
     function testFuzzComputeTruncatedLagrangeBasisSum(uint256[] memory rand) public pure {
         uint256 numVars = rand.length;
-        if (numVars > MAX_FUZZ_POINT_LENGTH) {
-            numVars = MAX_FUZZ_POINT_LENGTH;
+        if (numVars > _MAX_FUZZ_POINT_LENGTH) {
+            numVars = _MAX_FUZZ_POINT_LENGTH;
         }
         uint256[] memory point = new uint256[](numVars);
         for (uint256 i = 0; i < numVars; ++i) {
@@ -102,7 +102,7 @@ contract LagrangeBasisEvaluationTest is Test {
         }
 
         FF sum = F.ZERO;
-        for (uint256 i = 0; i < (1 << numVars) + EXTRA_FUZZ_LENGTH; ++i) {
+        for (uint256 i = 0; i < (1 << numVars) + _EXTRA_FUZZ_LENGTH; ++i) {
             FF product = F.ONE;
             for (uint256 j = 0; j < numVars; ++j) {
                 FF term = F.from(point[j]);
@@ -121,8 +121,8 @@ contract LagrangeBasisEvaluationTest is Test {
 
     function testFuzzComputeTruncatedLagrangeBasisInnerProduct(uint256[] memory rand) public pure {
         uint256 numVars = rand.length / 2;
-        if (numVars > MAX_FUZZ_POINT_LENGTH) {
-            numVars = MAX_FUZZ_POINT_LENGTH;
+        if (numVars > _MAX_FUZZ_POINT_LENGTH) {
+            numVars = _MAX_FUZZ_POINT_LENGTH;
         }
         uint256[] memory a = new uint256[](numVars);
         uint256[] memory b = new uint256[](numVars);
@@ -132,7 +132,7 @@ contract LagrangeBasisEvaluationTest is Test {
         }
 
         FF sum = F.ZERO;
-        for (uint256 i = 0; i < (1 << numVars) + EXTRA_FUZZ_LENGTH; ++i) {
+        for (uint256 i = 0; i < (1 << numVars) + _EXTRA_FUZZ_LENGTH; ++i) {
             FF product = F.ONE;
             for (uint256 j = 0; j < numVars; ++j) {
                 FF aTerm = F.from(a[j]);
@@ -203,6 +203,90 @@ contract LagrangeBasisEvaluationTest is Test {
             for (uint256 i = 0; i < length; ++i) {
                 assert(evaluations[i] == expectedEvaluations[i]);
             }
+        }
+    }
+
+    function testSimpleComputeEvaluations() public pure {
+        uint256[] memory point = new uint256[](3);
+        point[0] = 2;
+        point[1] = 3;
+        point[2] = 5;
+        FF a = F.from(point[0]);
+        FF b = F.from(point[1]);
+        FF c = F.from(point[2]);
+        FF[] memory expectedEvaluations = new FF[](8);
+        expectedEvaluations[0] = ((F.ONE - a) * (F.ONE - b) * (F.ONE - c));
+        expectedEvaluations[1] = (a * (F.ONE - b) * (F.ONE - c));
+        expectedEvaluations[2] = ((F.ONE - a) * b * (F.ONE - c));
+        expectedEvaluations[3] = (a * b * (F.ONE - c));
+        expectedEvaluations[4] = ((F.ONE - a) * (F.ONE - b) * c);
+        expectedEvaluations[5] = (a * (F.ONE - b) * c);
+        expectedEvaluations[6] = ((F.ONE - a) * b * c);
+        expectedEvaluations[7] = (a * b * c);
+
+        FF[] memory expectedSums = new FF[](12);
+        for (uint256 i = 0; i < 8; ++i) {
+            for (uint256 j = 0; j < i; ++j) {
+                expectedSums[i] = expectedSums[i] + expectedEvaluations[j];
+            }
+        }
+
+        for (uint256 i = 8; i < 12; ++i) {
+            expectedSums[i] = F.ONE;
+        }
+
+        uint256[] memory evaluations = new uint256[](12);
+        for (uint256 i = 0; i < 12; ++i) {
+            evaluations[i] = i;
+        }
+
+        LagrangeBasisEvaluation.__computeEvaluations(point, evaluations);
+
+        for (uint256 i = 0; i < 12; ++i) {
+            assert(evaluations[i] == expectedSums[i].into());
+        }
+    }
+
+    // solhint-disable-next-line code-complexity
+    function testFuzzComputeEvaluations(uint256[] memory point) public pure {
+        uint256 numVars = point.length;
+        // If the point is too long, we will run out of memory
+        vm.assume(numVars < _MAX_FUZZ_POINT_LENGTH + 1);
+        uint256 maxEvaluationLength = 1 << numVars;
+        uint256 maxLength = maxEvaluationLength + _EXTRA_FUZZ_LENGTH;
+        FF[] memory expectedEvaluations = new FF[](maxEvaluationLength);
+        for (uint256 i = 0; i < maxEvaluationLength; ++i) {
+            FF product = F.ONE;
+            for (uint256 j = 0; j < numVars; ++j) {
+                FF term = F.from(point[j]);
+                if ((i >> j) & 1 == 0) {
+                    term = F.ONE - term;
+                }
+                product = product * term;
+            }
+            expectedEvaluations[i] = product;
+        }
+
+        FF[] memory expectedSums = new FF[](maxLength);
+        for (uint256 i = 0; i < maxEvaluationLength; ++i) {
+            for (uint256 j = 0; j < i; ++j) {
+                expectedSums[i] = expectedSums[i] + expectedEvaluations[j];
+            }
+        }
+
+        for (uint256 i = maxEvaluationLength; i < maxLength; ++i) {
+            expectedSums[i] = F.ONE;
+        }
+
+        uint256[] memory evaluations = new uint256[](maxLength);
+        for (uint256 i = 0; i < maxLength; ++i) {
+            evaluations[i] = i;
+        }
+
+        LagrangeBasisEvaluation.__computeEvaluations(point, evaluations);
+
+        for (uint256 i = 0; i < maxLength; ++i) {
+            assert(evaluations[i] == expectedSums[i].into());
         }
     }
 }


### PR DESCRIPTION
# Rationale for this change

A few helper methods are needed for the complete verifier. This splits some of the code from #705 into a separate file and adds unit tests.

# What changes are included in this PR?

`compute_evaluation_vec` and `compute_evaluations` are added to the `LagrangeBasisEvaluation` module

# Are these changes tested?
Yes