### PR TITLE
feat(sol): add `proof_plan_evaluate`

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -59,6 +59,8 @@ uint32 constant LITERAL_EXPR_VARIANT = 1;
 uint32 constant EQUALS_EXPR_VARIANT = 2;
 /// @dev BigInt variant constant for literal expressions
 uint32 constant LITERAL_BIGINT_VARIANT = 0;
+/// @dev Filter variant constant for proof plans
+uint32 constant FILTER_EXEC_VARIANT = 0;
 
 /// @dev Position of the free memory pointer in the context of the EVM memory.
 uint256 constant FREE_PTR = 0x40;

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../base/Constants.sol";
+import "../base/Errors.sol";
+import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
+
+/// @title ProofPlan
+/// @dev Library for handling proof plans
+library ProofPlan {
+    enum PlanVariant {
+        Filter
+    }
+
+    /// @notice Evaluates a proof plan
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// proof_plan_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `plan_ptr` - calldata pointer to the proof plan
+    /// * `builder_ptr` - memory pointer to the verification builder
+    /// ##### Return Values
+    /// * `plan_ptr_out` - pointer to the remaining plan after consuming the proof plan
+    /// * `evaluations_ptr` - pointer to the evaluations
+    /// @dev Evaluates a proof plan by dispatching to the appropriate sub-plan evaluator
+    /// @param __plan The proof plan data
+    /// @param __builder The verification builder
+    /// @return __planOut The remaining plan after processing
+    /// @return __builderOut The updated verification builder
+    /// @return __evaluations The evaluations pointer
+    function __proofPlanEvaluate( // solhint-disable-line gas-calldata-parameters
+    bytes calldata __plan, VerificationBuilder.Builder memory __builder)
+        external
+        pure
+        returns (
+            bytes calldata __planOut,
+            VerificationBuilder.Builder memory __builderOut,
+            uint256[] memory __evaluations
+        )
+    {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_challenge(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_final_round_mle(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_chi_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_zerosum_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_identity_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/SwitchUtil.pre.sol
+            function case_const(lhs, rhs) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Array.pre.sol
+            function get_array_element(arr_ptr, index) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_column_evaluation(builder_ptr, column_num) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/ColumnExpr.pre.sol
+            function column_expr_evaluate(expr_ptr, builder_ptr) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/LiteralExpr.pre.sol
+            function literal_expr_evaluate(expr_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/EqualsExpr.pre.sol
+            function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
+            function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_table_chi_evaluation(builder_ptr, table_num) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
+            function compute_folds(plan_ptr, builder_ptr, input_chi_eval) ->
+                plan_ptr_out,
+                c_fold,
+                d_fold,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
+            function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr {
+                revert(0, 0)
+            }
+
+            function proof_plan_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr {
+                let proof_plan_variant := shr(UINT32_PADDING_BITS, calldataload(plan_ptr))
+                plan_ptr := add(plan_ptr, UINT32_SIZE)
+
+                switch proof_plan_variant
+                case 0 {
+                    case_const(0, FILTER_EXEC_VARIANT)
+                    plan_ptr_out, evaluations_ptr := filter_exec_evaluate(plan_ptr, builder_ptr)
+                }
+                default { err(ERR_UNSUPPORTED_PROOF_PLAN_VARIANT) }
+            }
+
+            let __planOutOffset
+            __planOutOffset, __evaluations := proof_plan_evaluate(__plan.offset, __builder)
+            __planOut.offset := __planOutOffset
+            // slither-disable-next-line write-after-write
+            __planOut.length := sub(__plan.length, sub(__planOutOffset, __plan.offset))
+        }
+        __builderOut = __builder;
+    }
+}

--- a/solidity/test/proof_plans/ProofPlan.t.pre.sol
+++ b/solidity/test/proof_plans/ProofPlan.t.pre.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {Errors} from "../../src/base/Errors.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {ProofPlan} from "../../src/proof_plans/ProofPlan.pre.sol";
+import {FF, F} from "../base/FieldUtil.sol";
+
+contract ProofPlanTest is Test {
+    function testFilterExecVariant() public pure {
+        bytes memory plan = abi.encodePacked(
+            FILTER_EXEC_VARIANT,
+            uint64(0), // table_number
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(101)), // where clause
+            abi.encodePacked( // select clause
+                uint64(3),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(102)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(103)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(104))
+            ),
+            hex"abcdef"
+        );
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.finalRoundMLEs = new uint256[](5);
+        builder.finalRoundMLEs[0] = 202;
+        builder.finalRoundMLEs[1] = 203;
+        builder.finalRoundMLEs[2] = 204;
+        builder.finalRoundMLEs[3] = 301;
+        builder.finalRoundMLEs[4] = 302;
+        builder.constraintMultipliers = new uint256[](3);
+        builder.constraintMultipliers[0] = 401;
+        builder.constraintMultipliers[1] = 402;
+        builder.constraintMultipliers[2] = 403;
+        builder.challenges = new uint256[](2);
+        builder.challenges[0] = 501;
+        builder.challenges[1] = 502;
+        builder.aggregateEvaluation = 0;
+        builder.rowMultipliersEvaluation = 601;
+        builder.chiEvaluations = new uint256[](1);
+        builder.chiEvaluations[0] = 701;
+        builder.tableChiEvaluations = new uint256[](1);
+        builder.tableChiEvaluations[0] = 801;
+
+        uint256[] memory evals;
+        (plan, builder, evals) = ProofPlan.__proofPlanEvaluate(plan, builder);
+
+        FF cFold = FF.wrap(502 * 502) * FF.wrap(102 * 801) + FF.wrap(502) * FF.wrap(103 * 801) + FF.wrap(104 * 801);
+        FF dFold = FF.wrap(502 * 502) * FF.wrap(202) + FF.wrap(502) * FF.wrap(203) + FF.wrap(204);
+
+        FF zeroSumConstraint0 = FF.wrap(301) * FF.wrap(101 * 801) - FF.wrap(302);
+        FF identityConstraint1 = (F.ONE + FF.wrap(501) * cFold) * FF.wrap(301) - FF.wrap(801);
+        FF identityConstraint2 = (F.ONE + FF.wrap(501) * dFold) * FF.wrap(302) - FF.wrap(701);
+
+        FF expectedAggregateEvaluation = zeroSumConstraint0 * FF.wrap(401) + identityConstraint1 * FF.wrap(402 * 601)
+            + identityConstraint2 * FF.wrap(403 * 601);
+
+        assert(evals.length == 3);
+        assert(evals[0] == 202);
+        assert(evals[1] == 203);
+        assert(evals[2] == 204);
+        assert(builder.aggregateEvaluation == expectedAggregateEvaluation.into());
+        assert(builder.finalRoundMLEs.length == 0);
+        assert(builder.constraintMultipliers.length == 0);
+
+        bytes memory expectedExprOut = hex"abcdef";
+        assert(plan.length == expectedExprOut.length);
+        uint256 exprOutLength = plan.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(plan[i] == expectedExprOut[i]);
+        }
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testUnsupportedVariant() public {
+        VerificationBuilder.Builder memory builder;
+        bytes memory plan = abi.encodePacked(uint32(1), hex"abcdef");
+        vm.expectRevert(Errors.UnsupportedProofPlanVariant.selector);
+        ProofPlan.__proofPlanEvaluate(plan, builder);
+    }
+
+    function testVariantsMatchEnum() public pure {
+        assert(uint32(ProofPlan.PlanVariant.Filter) == FILTER_EXEC_VARIANT);
+    }
+}


### PR DESCRIPTION
# Rationale for this change

We need a method to delegate work to the different Proof Plan variants.

# What changes are included in this PR?

Add the `proof_plan_evaluate` method which simply reads the variant and delegates to the appropriate plan evaluator.

# Are these changes tested?
Yes