### PR TITLE
perf(sol): reduce `log2_up` gas

### DIFF
--- a/solidity/src/base/MathUtil.sol
+++ b/solidity/src/base/MathUtil.sol
@@ -15,7 +15,38 @@ library MathUtil {
             function log2_up(value) -> exponent {
                 if value { value := sub(value, 1) }
                 exponent := 1
-                for {} shr(exponent, value) {} { exponent := add(exponent, 1) }
+                if gt(value, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) {
+                    exponent := add(exponent, 128)
+                    value := shr(128, value)
+                }
+                if gt(value, 0xFFFFFFFFFFFFFFFF) {
+                    exponent := add(exponent, 64)
+                    value := shr(64, value)
+                }
+                if gt(value, 0xFFFFFFFF) {
+                    exponent := add(exponent, 32)
+                    value := shr(32, value)
+                }
+                if gt(value, 0xFFFF) {
+                    exponent := add(exponent, 16)
+                    value := shr(16, value)
+                }
+                if gt(value, 0xFF) {
+                    exponent := add(exponent, 8)
+                    value := shr(8, value)
+                }
+                if gt(value, 0xF) {
+                    exponent := add(exponent, 4)
+                    value := shr(4, value)
+                }
+                if gt(value, 0x3) {
+                    exponent := add(exponent, 2)
+                    value := shr(2, value)
+                }
+                if gt(value, 0x1) {
+                    exponent := add(exponent, 1)
+                    value := shr(1, value)
+                }
             }
             __exponent := log2_up(__value)
         }

--- a/solidity/test/base/MathUtil.t.sol
+++ b/solidity/test/base/MathUtil.t.sol
@@ -25,6 +25,16 @@ library MathUtilTest {
         /* solhint-enable gas-strict-inequalities */
     }
 
+    function testLog2UpEdgeCases() public pure {
+        for (uint256 exponent = 1; exponent < 256; ++exponent) {
+            uint256 value = 1 << exponent;
+            assert(MathUtil.__log2Up(value) == exponent);
+            assert(MathUtil.__log2Up(value - 1) == exponent);
+            assert(MathUtil.__log2Up(value + 1) == exponent + 1);
+        }
+        assert(MathUtil.__log2Up(uint256(int256(-1))) == 256);
+    }
+
     function testFuzzLog2Up(uint256 value) public pure {
         uint256 exponent = MathUtil.__log2Up(value);
         if (value < 2) {


### PR DESCRIPTION
# Rationale for this change

Gas is expensive. We should use less of it.

# What changes are included in this PR?

`log2_up` is optimized to be $O(1)$ cost rather than $O(\log(value))$ cost. This has concrete gas improvements when value is at least 16. The typical situation will involve tables larger than 16 rows.

# Are these changes tested?
Yes, extra tests were added as well.