### PR TITLE
ci: switch to cargo nextest on code coverage

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,102 @@
+[store]
+dir = "target/nextest"
+
+[profile.default]
+default-filter = "all()"
+retries = 0
+threads-required = 1
+
+[[profile.default.overrides]]
+filter = 'test(/proof_primitive::dory::/)'
+threads-required = 2
+priority = -90
+
+[[profile.default.overrides]]
+filter = 'test(/proof_primitive::hyperkzg::/)'
+threads-required = 2
+priority = -60
+
+[[profile.default.overrides]]
+filter = 'test(/proof-of-sql::integration_tests/)'
+threads-required = 2
+priority = -85
+
+[[profile.default.overrides]]
+filter = 'test(/proof-of-sql::timestamp_integration_tests/)'
+threads-required = 2
+priority = -85
+
+[[profile.default.overrides]]
+filter = 'test(/proof-of-sql::decimal_integration_tests/)'
+threads-required = 2
+priority = -85
+
+[[profile.default.overrides]]
+filter = 'test(/proof-of-sql::e2e_tests/)'
+threads-required = 4
+priority = -100
+
+[[profile.default.overrides]]
+filter = 'test(/sql::proof_exprs::/)'
+threads-required = 2
+priority = -30
+
+[[profile.default.overrides]]
+filter = 'test(/sql::proof_gadgets::/)'
+threads-required = 2
+priority = -40
+
+[[profile.default.overrides]]
+filter = 'test(/sql::proof_plans::/)'
+threads-required = 2
+priority = -50
+
+[profile.ci]
+default-filter = "all()"
+retries = 0
+threads-required = 16
+
+[[profile.ci.overrides]]
+filter = 'test(/proof_primitive::dory::/)'
+threads-required = 16
+priority = -90
+
+[[profile.ci.overrides]]
+filter = 'test(/proof_primitive::hyperkzg::/)'
+threads-required = 16
+priority = -60
+
+[[profile.ci.overrides]]
+filter = 'test(/proof-of-sql::integration_tests/)'
+threads-required = 16
+priority = -85
+
+[[profile.ci.overrides]]
+filter = 'test(/proof-of-sql::timestamp_integration_tests/)'
+threads-required = 16
+priority = -85
+
+[[profile.ci.overrides]]
+filter = 'test(/proof-of-sql::decimal_integration_tests/)'
+threads-required = 16
+priority = -85
+
+[[profile.ci.overrides]]
+filter = 'test(/proof-of-sql::e2e_tests/)'
+threads-required = 16
+priority = -100
+
+[[profile.ci.overrides]]
+filter = 'test(/sql::proof_exprs::/)'
+threads-required = 16
+priority = -30
+
+[[profile.ci.overrides]]
+filter = 'test(/sql::proof_gadgets::/)'
+threads-required = 16
+priority = -40
+
+[[profile.ci.overrides]]
+filter = 'test(/sql::proof_plans::/)'
+threads-required = 16
+priority = -50

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -174,10 +174,11 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y clang lld
       - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
       - name: Clean Previous Coverage Artifacts
         run: cargo llvm-cov clean --workspace
       - name: Run Tests to Generate Coverage Data (All Features)
-        run: cargo llvm-cov --no-report --all-features
+        run: cargo llvm-cov nextest --profile ci --no-report --all-features
       #- name: Run Tests to Generate Coverage Data (Rayon Only)
       #  run: cargo llvm-cov --no-report --no-default-features --features="rayon"
       #- name: Run Tests to Generate Coverage Data (Blitzar Only)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -50,23 +50,34 @@ fn test_random_ipa_with_length_1() {
     );
 }
 
-#[test]
-fn test_random_ipa_with_various_lengths() {
+fn test_random_ipa_with_various_lengths(setup_p: (usize, usize)) {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let setup_setup = [(4, 4), (4, 3), (6, 2)];
-    for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
-        for length in lengths {
-            test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
-                length,
-                0,
-                &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
-            );
-        }
+    let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    for length in lengths {
+        test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
+            length,
+            0,
+            &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
+            &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+        );
     }
+}
+
+#[test]
+fn test_random_ipa_with_various_lengths_4_4() {
+    test_random_ipa_with_various_lengths((4, 4));
+}
+
+#[test]
+fn test_random_ipa_with_various_lengths_4_3() {
+    test_random_ipa_with_various_lengths((4, 3));
+}
+
+#[test]
+fn test_random_ipa_with_various_lengths_6_2() {
+    test_random_ipa_with_various_lengths((6, 2));
 }
 
 #[test]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
