### PR TITLE
fix(sol): explicitly initialize yul variables with 0

### DIFF
--- a/solidity/src/hyperkzg/HyperKZGHelpers.pre.sol
+++ b/solidity/src/hyperkzg/HyperKZGHelpers.pre.sol
@@ -83,6 +83,7 @@ library HyperKZGHelpers {
     {
         assembly {
             function bivariate_evaluation(v_ptr, q, d, ell) -> b {
+                b := 0
                 let v_stack := add(v_ptr, mul(WORDX3_SIZE, ell))
                 for {} ell { ell := sub(ell, 1) } {
                     // tmp = v2i

--- a/solidity/src/proof_plans/FilterExec.pre.sol
+++ b/solidity/src/proof_plans/FilterExec.pre.sol
@@ -156,12 +156,14 @@ library FilterExec {
                 mstore(evaluations_ptr, column_count)
                 evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
 
+                c_fold := 0
                 for { let i := column_count } i { i := sub(i, 1) } {
                     let c
                     plan_ptr, c := proof_expr_evaluate(plan_ptr, builder_ptr, input_chi_eval)
                     c_fold := addmod(mulmod(c_fold, beta, MODULUS), c, MODULUS)
                 }
 
+                d_fold := 0
                 for { let i := column_count } i { i := sub(i, 1) } {
                     let d := builder_consume_final_round_mle(builder_ptr)
                     d_fold := addmod(mulmod(d_fold, beta, MODULUS), d, MODULUS)


### PR DESCRIPTION
# Rationale for this change

While the solidity documentation says Yul initializes unset variables to 0, it isn't clear on the behavior of returned variables.
https://docs.soliditylang.org/en/v0.8.29/yul.html#variable-declarations

# What changes are included in this PR?

Regardless of the behavior, for clarity purposes, we add explicit initialization.