### PR TITLE
feat(sol): add `CastExpr` to solidity

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -1,14 +1,14 @@
 use super::{EVMProofPlanError, EVMProofPlanResult};
 use crate::{
     base::{
-        database::{ColumnRef, LiteralValue},
+        database::{ColumnRef, ColumnType, LiteralValue},
         map::IndexSet,
         math::{decimal::Precision, i256::I256},
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
     sql::proof_exprs::{
-        AddExpr, AndExpr, ColumnExpr, DynProofExpr, EqualsExpr, LiteralExpr, MultiplyExpr, NotExpr,
-        OrExpr, SubtractExpr,
+        AddExpr, AndExpr, CastExpr, ColumnExpr, DynProofExpr, EqualsExpr, LiteralExpr,
+        MultiplyExpr, NotExpr, OrExpr, SubtractExpr,
     },
 };
 use alloc::{boxed::Box, string::String, vec::Vec};
@@ -26,6 +26,7 @@ pub(crate) enum EVMDynProofExpr {
     And(EVMAndExpr),
     Or(EVMOrExpr),
     Not(EVMNotExpr),
+    Cast(EVMCastExpr),
 }
 impl EVMDynProofExpr {
     /// Try to create an `EVMDynProofExpr` from a `DynProofExpr`.
@@ -60,6 +61,9 @@ impl EVMDynProofExpr {
             }
             DynProofExpr::Not(not_expr) => {
                 EVMNotExpr::try_from_proof_expr(not_expr, column_refs).map(Self::Not)
+            }
+            DynProofExpr::Cast(cast_expr) => {
+                EVMCastExpr::try_from_proof_expr(cast_expr, column_refs).map(Self::Cast)
             }
             _ => Err(EVMProofPlanError::NotSupported),
         }
@@ -96,6 +100,9 @@ impl EVMDynProofExpr {
             }
             EVMDynProofExpr::Not(not_expr) => Ok(DynProofExpr::Not(
                 not_expr.try_into_proof_expr(column_refs)?,
+            )),
+            EVMDynProofExpr::Cast(cast_expr) => Ok(DynProofExpr::Cast(
+                cast_expr.try_into_proof_expr(column_refs)?,
             )),
         }
     }
@@ -533,6 +540,47 @@ impl EVMNotExpr {
         Ok(NotExpr::try_new(Box::new(
             self.expr.try_into_proof_expr(column_refs)?,
         ))?)
+    }
+}
+
+/// Represents a CAST expression.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct EVMCastExpr {
+    from_expr: Box<EVMDynProofExpr>,
+    to_type: ColumnType,
+}
+
+impl EVMCastExpr {
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn new(from_expr: EVMDynProofExpr, to_type: ColumnType) -> Self {
+        Self {
+            from_expr: Box::new(from_expr),
+            to_type,
+        }
+    }
+
+    /// Try to create an `EVMCastExpr` from a `CastExpr`.
+    pub(crate) fn try_from_proof_expr(
+        expr: &CastExpr,
+        column_refs: &IndexSet<ColumnRef>,
+    ) -> EVMProofPlanResult<Self> {
+        Ok(EVMCastExpr {
+            from_expr: Box::new(EVMDynProofExpr::try_from_proof_expr(
+                expr.get_from_expr(),
+                column_refs,
+            )?),
+            to_type: *expr.to_type(),
+        })
+    }
+
+    pub(crate) fn try_into_proof_expr(
+        &self,
+        column_refs: &IndexSet<ColumnRef>,
+    ) -> EVMProofPlanResult<CastExpr> {
+        Ok(CastExpr::try_new(
+            Box::new(self.from_expr.try_into_proof_expr(column_refs)?),
+            self.to_type,
+        )?)
     }
 }
 
@@ -1073,6 +1121,54 @@ mod tests {
         );
     }
 
+    // EVMCastExpr
+    #[test]
+    fn we_can_put_a_cast_expr_in_evm() {
+        let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
+        let ident_a = "a".into();
+        let ident_b = "b".into();
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
+
+        let cast_expr = CastExpr::try_new(
+            Box::new(DynProofExpr::new_column(column_ref_b.clone())),
+            ColumnType::BigInt,
+        )
+        .unwrap();
+
+        let evm_cast_expr = EVMCastExpr::try_from_proof_expr(
+            &cast_expr,
+            &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+        )
+        .unwrap();
+        assert_eq!(
+            evm_cast_expr,
+            EVMCastExpr {
+                from_expr: Box::new(EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 })),
+                to_type: ColumnType::BigInt,
+            }
+        );
+
+        // Roundtrip
+        let roundtripped_cast_expr = evm_cast_expr
+            .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+            .unwrap();
+        assert_eq!(roundtripped_cast_expr, cast_expr);
+    }
+
+    #[test]
+    fn we_cannot_get_a_cast_expr_from_evm_if_column_number_out_of_bounds() {
+        let evm_cast_expr = EVMCastExpr::new(
+            EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
+            ColumnType::BigInt,
+        );
+        let column_refs = IndexSet::<ColumnRef>::default();
+        assert_eq!(
+            evm_cast_expr.try_into_proof_expr(&column_refs).unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+    }
+
     // EVMDynProofExpr
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_equals_expr() {
@@ -1213,6 +1309,21 @@ mod tests {
             EVMDynProofExpr::Not(EVMNotExpr::new(EVMDynProofExpr::Column(EVMColumnExpr {
                 column_number: 0,
             })));
+        assert_eq!(evm, expected);
+        assert_eq!(evm.try_into_proof_expr(&indexset! { c }).unwrap(), expr);
+    }
+
+    #[test]
+    fn we_can_put_into_evm_a_dyn_proof_expr_cast_expr() {
+        let table_ref = TableRef::try_from("namespace.table").unwrap();
+        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Int);
+
+        let expr = cast(DynProofExpr::new_column(c.clone()), ColumnType::BigInt);
+        let evm = EVMDynProofExpr::try_from_proof_expr(&expr, &indexset! { c.clone() }).unwrap();
+        let expected = EVMDynProofExpr::Cast(EVMCastExpr {
+            from_expr: Box::new(EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 })),
+            to_type: ColumnType::BigInt,
+        });
         assert_eq!(evm, expected);
         assert_eq!(evm.try_into_proof_expr(&indexset! { c }).unwrap(), expr);
     }

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -546,16 +546,16 @@ impl EVMNotExpr {
 /// Represents a CAST expression.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct EVMCastExpr {
-    from_expr: Box<EVMDynProofExpr>,
     to_type: ColumnType,
+    from_expr: Box<EVMDynProofExpr>,
 }
 
 impl EVMCastExpr {
     #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn new(from_expr: EVMDynProofExpr, to_type: ColumnType) -> Self {
         Self {
-            from_expr: Box::new(from_expr),
             to_type,
+            from_expr: Box::new(from_expr),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -34,6 +34,16 @@ impl CastExpr {
                 right_type: to_type.to_string(),
             })
     }
+
+    /// Returns the from expression
+    pub fn get_from_expr(&self) -> &DynProofExpr {
+        &self.from_expr
+    }
+
+    /// Returns the to type
+    pub fn to_type(&self) -> &ColumnType {
+        &self.to_type
+    }
 }
 
 impl ProofExpr for CastExpr {

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -99,6 +99,8 @@ uint32 constant AND_EXPR_VARIANT = 6;
 uint32 constant OR_EXPR_VARIANT = 7;
 /// @dev Not variant constant for proof expressions
 uint32 constant NOT_EXPR_VARIANT = 8;
+/// @dev Cast variant constant for proof expressions
+uint32 constant CAST_EXPR_VARIANT = 9;
 
 /// @dev Filter variant constant for proof plans
 uint32 constant FILTER_EXEC_VARIANT = 0;

--- a/solidity/src/proof_exprs/AddExpr.pre.sol
+++ b/solidity/src/proof_exprs/AddExpr.pre.sol
@@ -93,6 +93,10 @@ library AddExpr {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_final_round_mle(builder_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_exprs/AndExpr.pre.sol
+++ b/solidity/src/proof_exprs/AndExpr.pre.sol
@@ -93,6 +93,10 @@ library AndExpr {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_final_round_mle(builder_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_exprs/CastExpr.pre.sol
+++ b/solidity/src/proof_exprs/CastExpr.pre.sol
@@ -118,9 +118,9 @@ library CastExpr {
             }
 
             function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
-                expr_ptr, result_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
                 let data_type
-                expr_ptr_out, data_type := read_data_type(expr_ptr)
+                expr_ptr, data_type := read_data_type(expr_ptr)
+                expr_ptr_out, result_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
             }
 
             let __exprOutOffset

--- a/solidity/src/proof_exprs/CastExpr.pre.sol
+++ b/solidity/src/proof_exprs/CastExpr.pre.sol
@@ -6,61 +6,34 @@ import "../base/Constants.sol";
 import "../base/Errors.sol";
 import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
 
-/// @title EqualsExpr
-/// @dev Library for handling equality comparison expressions between two proof expressions
-library EqualsExpr {
-    /// @notice Evaluates an equals expression by comparing two sub-expressions
+/// @title CastExpr
+/// @dev Library for handling casting a proof expression
+library CastExpr {
+    /// @notice Evaluates an cast expression by casting a sub-expression
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function
     /// ##### Signature
     /// ```yul
-    /// equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval
+    /// cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval
     /// ```
     /// ##### Parameters
     /// * `expr_ptr` - calldata pointer to the expression data
     /// * `builder_ptr` - memory pointer to the verification builder
     /// * `chi_eval` - the chi value for evaluation
     /// ##### Return Values
-    /// * `expr_ptr_out` - pointer to the remaining expression after consuming both sub-expressions
+    /// * `expr_ptr_out` - pointer to the remaining expression after consuming the sub-expression
     /// * `eval` - the evaluation result from the builder's final round MLE
-    /// @notice Evaluates two sub-expressions and produces identity constraints checking their equality
-    /// @notice ##### Constraints
-    /// * Inputs: \\(L=\texttt{lhs}\\), \\(R=\texttt{rhs}\\) with length \\(n\\), and thus \\(\chi_{[0,n)}=\texttt{chi}\\).
-    ///   Note: `proof_expr_evaluate` guarentees that the lengths of \\(L\\) and \\(R\\) are equal the lengths of `chi_{[0,n)}`.
-    /// * Outputs: \\(E=\texttt{result}\\) with length \\(n\\)
-    /// * Hints: \\(D^\star=\texttt{diff_star}\\)
-    /// * Helpers: \\(D :\equiv L - R=\texttt{diff}\\)
-    /// * Constraints:
-    /// \\[\begin{aligned}
-    /// E \cdot D &\equiv 0\\\\
-    /// \chi_{[0,n)} - (D\cdot D^\star + E) &\equiv 0
-    /// \end{aligned}\\]
-    /// @notice ##### Proof of Correctness
-    /// @notice **Theorem:** Given columns \\(L\\) and \\(R\\) of length \\(n\\),
-    /// \\[E[i] = \begin{cases} 1 & L[i] = R[i] \text{ and } i < n\\\\ 0 & \text{else}\end{cases}\\]
-    /// if and only if there exits a \\(D^\star\\) such that
-    /// \\[\begin{aligned}
-    /// E[i] \cdot D[i] &= 0\\\\
-    /// \chi_{[0,n)}[i] - (D[i]\cdot D^\star[i] + E[i]) &= 0
-    /// \end{aligned}\\]
-    /// for all \\(i\\), where \\(D[i] = L[i] - R[i]\\).
-    /// @notice **Completeness Proof:**
-    /// Setting \\[D^\star[i] = \begin{cases} (D[i])^{-1} & D[i] \neq 0\\\ 0 & \text{else}\end{cases}\\] satisfies the above equations.
-    /// @notice **Soundness Proof:**
-    /// * If \\(i<n\\) and \\(L[i] \neq R[i]\\), then \\(D[i] \neq 0\\) and \\(E[i] = 0\\) by the first equation.
-    /// * If \\(i<n\\) and \\(L[i] = R[i]\\), then \\(D[i] = 0\\) and \\(E[i] = \chi_{[0,n)}[i] = 1\\) by the second equation.
-    /// * If \\(i \geq n\\), then \\(L[i] = 0 = R[i]\\) and \\(E[i] = \chi_{[0,n)}[i] = 0\\) by the second equation.
+    /// @notice Evaluates a sub-expression and casts it
     /// ##### Proof Plan Encoding
-    /// The equals expression is encoded as follows:
-    /// 1. The left hand side expression
-    /// 2. The right hand side expression
-    /// @param __expr The equals expression data
+    /// The cast expression is encoded as follows:
+    /// 1. The input expression
+    /// @param __expr The cast expression data
     /// @param __builder The verification builder
     /// @param __chiEval The chi value for evaluation
     /// @return __exprOut The remaining expression after processing
     /// @return __builderOut The verification builder result
     /// @return __eval The evaluated result
-    function __equalsExprEvaluate( // solhint-disable-line gas-calldata-parameters
+    function __castExprEvaluate( // solhint-disable-line gas-calldata-parameters
     bytes calldata __expr, VerificationBuilder.Builder memory __builder, uint256 __chiEval)
         external
         pure
@@ -87,12 +60,24 @@ library EqualsExpr {
             function get_array_element(arr_ptr, index) -> value {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_data_type(ptr) -> ptr_out, data_type {
+                revert(0, 0)
+            }
             // IMPORT-YUL ColumnExpr.pre.sol
             function column_expr_evaluate(expr_ptr, builder_ptr) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL LiteralExpr.pre.sol
             function literal_expr_evaluate(expr_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL EqualsExpr.pre.sol
+            function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL AddExpr.pre.sol
@@ -119,10 +104,6 @@ library EqualsExpr {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL CastExpr.pre.sol
-            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
-                revert(0, 0)
-            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_final_round_mle(builder_ptr) -> value {
                 revert(0, 0)
@@ -135,46 +116,15 @@ library EqualsExpr {
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL ../base/DataType.pre.sol
-            function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../base/DataType.pre.sol
-            function read_data_type(ptr) -> ptr_out, data_type {
-                revert(0, 0)
-            }
 
-            function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
-                let lhs_eval
-                expr_ptr, lhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
-
-                let rhs_eval
-                expr_ptr, rhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
-
-                let diff_eval := addmod(lhs_eval, mulmod(MODULUS_MINUS_ONE, rhs_eval, MODULUS), MODULUS)
-                let diff_star_eval := builder_consume_final_round_mle(builder_ptr)
-                result_eval := mod(builder_consume_final_round_mle(builder_ptr), MODULUS)
-
-                builder_produce_identity_constraint(builder_ptr, mulmod(result_eval, diff_eval, MODULUS), 2)
-                builder_produce_identity_constraint(
-                    builder_ptr,
-                    addmod(
-                        chi_eval,
-                        mulmod(
-                            MODULUS_MINUS_ONE,
-                            addmod(mulmod(diff_eval, diff_star_eval, MODULUS), result_eval, MODULUS),
-                            MODULUS
-                        ),
-                        MODULUS
-                    ),
-                    2
-                )
-
-                expr_ptr_out := expr_ptr
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                expr_ptr, result_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
+                let data_type
+                expr_ptr_out, data_type := read_data_type(expr_ptr)
             }
 
             let __exprOutOffset
-            __exprOutOffset, __eval := equals_expr_evaluate(__expr.offset, __builder, __chiEval)
+            __exprOutOffset, __eval := cast_expr_evaluate(__expr.offset, __builder, __chiEval)
             __exprOut.offset := __exprOutOffset
             // slither-disable-next-line write-after-write
             __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))

--- a/solidity/src/proof_exprs/MultiplyExpr.pre.sol
+++ b/solidity/src/proof_exprs/MultiplyExpr.pre.sol
@@ -93,6 +93,10 @@ library MultiplyExpr {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_final_round_mle(builder_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_exprs/NotExpr.pre.sol
+++ b/solidity/src/proof_exprs/NotExpr.pre.sol
@@ -92,6 +92,10 @@ library NotExpr {
             function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_final_round_mle(builder_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_exprs/OrExpr.pre.sol
+++ b/solidity/src/proof_exprs/OrExpr.pre.sol
@@ -93,6 +93,10 @@ library OrExpr {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_final_round_mle(builder_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_exprs/ProofExpr.pre.sol
+++ b/solidity/src/proof_exprs/ProofExpr.pre.sol
@@ -18,7 +18,8 @@ library ProofExpr {
         Multiply,
         And,
         Or,
-        Not
+        Not,
+        Cast
     }
 
     /// @notice Evaluates a proof expression
@@ -128,6 +129,10 @@ library ProofExpr {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
 
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 let proof_expr_variant := shr(UINT32_PADDING_BITS, calldataload(expr_ptr))
@@ -169,6 +174,10 @@ library ProofExpr {
                 case 8 {
                     case_const(8, NOT_EXPR_VARIANT)
                     expr_ptr_out, eval := not_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
+                }
+                case 9 {
+                    case_const(9, CAST_EXPR_VARIANT)
+                    expr_ptr_out, eval := cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
                 }
                 default { err(ERR_UNSUPPORTED_PROOF_EXPR_VARIANT) }
             }

--- a/solidity/src/proof_exprs/SubtractExpr.pre.sol
+++ b/solidity/src/proof_exprs/SubtractExpr.pre.sol
@@ -93,6 +93,10 @@ library SubtractExpr {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_final_round_mle(builder_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_plans/FilterExec.pre.sol
+++ b/solidity/src/proof_plans/FilterExec.pre.sol
@@ -157,6 +157,10 @@ library FilterExec {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_exprs/CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -119,6 +119,10 @@ library ProofPlan {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_exprs/CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -294,6 +294,10 @@ library Verifier {
             function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_exprs/CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/test/proof_exprs/CastExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/CastExpr.t.pre.sol
@@ -13,7 +13,7 @@ contract CastExprTest is Test {
     function testSimpleCastExpr() public pure {
         VerificationBuilder.Builder memory builder;
         bytes memory expr = abi.encodePacked(
-            LITERAL_EXPR_VARIANT, DATA_TYPE_INT_VARIANT, int32(7), DATA_TYPE_BIGINT_VARIANT, hex"abcdef"
+            DATA_TYPE_BIGINT_VARIANT, LITERAL_EXPR_VARIANT, DATA_TYPE_INT_VARIANT, int32(7), hex"abcdef"
         );
         bytes memory expectedExprOut = hex"abcdef";
 
@@ -31,12 +31,12 @@ contract CastExprTest is Test {
     function testDecimalCastExpr() public pure {
         VerificationBuilder.Builder memory builder;
         bytes memory expr = abi.encodePacked(
-            LITERAL_EXPR_VARIANT,
-            DATA_TYPE_INT_VARIANT,
-            int32(7),
             DATA_TYPE_DECIMAL75_VARIANT,
             uint8(20),
             int8(0),
+            LITERAL_EXPR_VARIANT,
+            DATA_TYPE_INT_VARIANT,
+            int32(7),
             hex"abcdef"
         );
         bytes memory expectedExprOut = hex"abcdef";
@@ -55,12 +55,12 @@ contract CastExprTest is Test {
     function testTimestampCastExpr() public pure {
         VerificationBuilder.Builder memory builder;
         bytes memory expr = abi.encodePacked(
+            DATA_TYPE_BIGINT_VARIANT,
             LITERAL_EXPR_VARIANT,
             DATA_TYPE_TIMESTAMP_VARIANT,
             uint32(3),
             int32(0),
             int64(7),
-            DATA_TYPE_BIGINT_VARIANT,
             hex"abcdef"
         );
         bytes memory expectedExprOut = hex"abcdef";
@@ -83,7 +83,7 @@ contract CastExprTest is Test {
         bytes memory trailingExpr
     ) public pure {
         bytes memory expr = abi.encodePacked(
-            LITERAL_EXPR_VARIANT, DATA_TYPE_INT_VARIANT, inputValue, DATA_TYPE_BIGINT_VARIANT, trailingExpr
+            DATA_TYPE_BIGINT_VARIANT, LITERAL_EXPR_VARIANT, DATA_TYPE_INT_VARIANT, inputValue, trailingExpr
         );
 
         uint256 eval;
@@ -107,12 +107,12 @@ contract CastExprTest is Test {
         vm.assume(decimalPrecision > 9);
 
         bytes memory expr = abi.encodePacked(
-            LITERAL_EXPR_VARIANT,
-            DATA_TYPE_INT_VARIANT,
-            inputValue,
             DATA_TYPE_DECIMAL75_VARIANT,
             decimalPrecision,
             int8(0),
+            LITERAL_EXPR_VARIANT,
+            DATA_TYPE_INT_VARIANT,
+            inputValue,
             trailingExpr
         );
 
@@ -136,12 +136,12 @@ contract CastExprTest is Test {
         bytes memory trailingExpr
     ) public pure {
         bytes memory expr = abi.encodePacked(
+            DATA_TYPE_BIGINT_VARIANT,
             LITERAL_EXPR_VARIANT,
             DATA_TYPE_TIMESTAMP_VARIANT,
             timestampUnit,
             timestampOffset,
             timestampValue,
-            DATA_TYPE_BIGINT_VARIANT,
             trailingExpr
         );
 

--- a/solidity/test/proof_exprs/CastExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/CastExpr.t.pre.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {CastExpr} from "../../src/proof_exprs/CastExpr.pre.sol";
+//import {ProofExpr} from "../../src/proof_exprs/ProofExpr.pre.sol";
+import {F} from "../base/FieldUtil.sol";
+
+contract CastExprTest is Test {
+    function testSimpleCastExpr() public pure {
+        VerificationBuilder.Builder memory builder;
+        bytes memory expr = abi.encodePacked(
+            LITERAL_EXPR_VARIANT, DATA_TYPE_INT_VARIANT, int32(7), DATA_TYPE_BIGINT_VARIANT, hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = CastExpr.__castExprEvaluate(expr, builder, 10);
+
+        assert(eval == 70); // 7 * 10
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testDecimalCastExpr() public pure {
+        VerificationBuilder.Builder memory builder;
+        bytes memory expr = abi.encodePacked(
+            LITERAL_EXPR_VARIANT,
+            DATA_TYPE_INT_VARIANT,
+            int32(7),
+            DATA_TYPE_DECIMAL75_VARIANT,
+            uint8(20),
+            int8(0),
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = CastExpr.__castExprEvaluate(expr, builder, 10);
+
+        assert(eval == 70); // 7 * 10
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testTimestampCastExpr() public pure {
+        VerificationBuilder.Builder memory builder;
+        bytes memory expr = abi.encodePacked(
+            LITERAL_EXPR_VARIANT,
+            DATA_TYPE_TIMESTAMP_VARIANT,
+            uint32(3),
+            int32(0),
+            int64(7),
+            DATA_TYPE_BIGINT_VARIANT,
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = CastExpr.__castExprEvaluate(expr, builder, 10);
+
+        assert(eval == 70); // 7 * 10
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testFuzzCastExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        int32 inputValue,
+        bytes memory trailingExpr
+    ) public pure {
+        bytes memory expr = abi.encodePacked(
+            LITERAL_EXPR_VARIANT, DATA_TYPE_INT_VARIANT, inputValue, DATA_TYPE_BIGINT_VARIANT, trailingExpr
+        );
+
+        uint256 eval;
+        (expr, builder, eval) = CastExpr.__castExprEvaluate(expr, builder, chiEvaluation);
+
+        assert(eval == (F.from(inputValue) * F.from(chiEvaluation)).into());
+        assert(expr.length == trailingExpr.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+
+    function testFuzzDecimalCastExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        int32 inputValue,
+        uint8 decimalPrecision,
+        bytes memory trailingExpr
+    ) public pure {
+        vm.assume(decimalPrecision > 9);
+
+        bytes memory expr = abi.encodePacked(
+            LITERAL_EXPR_VARIANT,
+            DATA_TYPE_INT_VARIANT,
+            inputValue,
+            DATA_TYPE_DECIMAL75_VARIANT,
+            decimalPrecision,
+            int8(0),
+            trailingExpr
+        );
+
+        uint256 eval;
+        (expr, builder, eval) = CastExpr.__castExprEvaluate(expr, builder, chiEvaluation);
+
+        assert(eval == (F.from(inputValue) * F.from(chiEvaluation)).into());
+        assert(expr.length == trailingExpr.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+
+    function testFuzzTimestampCastExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        uint32 timestampUnit,
+        int32 timestampOffset,
+        int64 timestampValue,
+        bytes memory trailingExpr
+    ) public pure {
+        bytes memory expr = abi.encodePacked(
+            LITERAL_EXPR_VARIANT,
+            DATA_TYPE_TIMESTAMP_VARIANT,
+            timestampUnit,
+            timestampOffset,
+            timestampValue,
+            DATA_TYPE_BIGINT_VARIANT,
+            trailingExpr
+        );
+
+        uint256 eval;
+        (expr, builder, eval) = CastExpr.__castExprEvaluate(expr, builder, chiEvaluation);
+
+        assert(eval == (F.from(timestampValue) * F.from(chiEvaluation)).into());
+        assert(expr.length == trailingExpr.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+}

--- a/solidity/test/proof_exprs/ProofExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/ProofExpr.t.pre.sol
@@ -210,11 +210,31 @@ contract ProofExprTest is Test {
             NOT_EXPR_VARIANT, abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(0)), hex"abcdef"
         );
         bytes memory expectedExprOut = hex"abcdef";
-
         uint256 eval;
         (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 3);
 
         assert(eval == 3); // 1 * 3 - 0 * 3
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testCastExprVariant() public pure {
+        VerificationBuilder.Builder memory builder;
+        bytes memory expr = abi.encodePacked(
+            CAST_EXPR_VARIANT,
+            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_INT_VARIANT, int32(2)),
+            DATA_TYPE_BIGINT_VARIANT,
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 3);
+
+        assert(eval == 6); // 2 * 3
         assert(expr.length == expectedExprOut.length);
         uint256 exprOutLength = expr.length;
         for (uint256 i = 0; i < exprOutLength; ++i) {
@@ -240,5 +260,6 @@ contract ProofExprTest is Test {
         assert(uint32(ProofExpr.ExprVariant.And) == AND_EXPR_VARIANT);
         assert(uint32(ProofExpr.ExprVariant.Or) == OR_EXPR_VARIANT);
         assert(uint32(ProofExpr.ExprVariant.Not) == NOT_EXPR_VARIANT);
+        assert(uint32(ProofExpr.ExprVariant.Cast) == CAST_EXPR_VARIANT);
     }
 }

--- a/solidity/test/proof_exprs/ProofExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/ProofExpr.t.pre.sol
@@ -225,8 +225,8 @@ contract ProofExprTest is Test {
         VerificationBuilder.Builder memory builder;
         bytes memory expr = abi.encodePacked(
             CAST_EXPR_VARIANT,
-            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_INT_VARIANT, int32(2)),
             DATA_TYPE_BIGINT_VARIANT,
+            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_INT_VARIANT, int32(2)),
             hex"abcdef"
         );
         bytes memory expectedExprOut = hex"abcdef";


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
We need to allow casting in the Solidity verifier.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See title.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.