### PR TITLE
fix: logic error in YAML check script

### DIFF
--- a/scripts/run_posql_examples.sh
+++ b/scripts/run_posql_examples.sh
@@ -36,7 +36,7 @@ cargo_commands=$(
 if [ -z "$cargo_commands" ]; then
   echo "No cargo commands were found in the 'examples:' job block."
   echo "Nothing to run."
-
+  exit 0
 fi
 
 echo "Commands extracted from the 'examples:' job:"


### PR DESCRIPTION
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.


# What changes are included in this PR?

hey, just a quick fix: there was a logic issue in the script that could cause it to keep running even when there's nothing relevant in the YAML. I’ve added an `exit 0` to cleanly stop execution early in that case.

prevents unnecessary looping and avoids triggering a "blank" run.

# Are these changes tested?
tested locally with multiple YAML scenarios — confirmed that the script now exits early when appropriate and proceeds normally when matches are found.
