### PR TITLE
fix!: make `DynProofPlan` serialize the same as `EVMProofPlan`

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
@@ -108,7 +108,7 @@ fn we_can_verify_a_simple_filter_using_the_evm() {
     let plan = query.proof_expr();
 
     let verifiable_result = VerifiableQueryResult::<HyperKZGCommitmentEvaluationProof>::new(
-        &EVMProofPlan::new(plan.clone()),
+        plan,
         &accessor,
         &&ps[..],
         &[],

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -35,6 +35,17 @@ pub struct EVMProofPlan {
     inner: DynProofPlan,
 }
 
+impl From<DynProofPlan> for EVMProofPlan {
+    fn from(plan: DynProofPlan) -> Self {
+        Self { inner: plan }
+    }
+}
+impl From<EVMProofPlan> for DynProofPlan {
+    fn from(plan: EVMProofPlan) -> Self {
+        plan.inner
+    }
+}
+
 impl EVMProofPlan {
     /// Create a new `EVMProofPlan` from a `DynProofPlan`.
     #[must_use]

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -26,6 +26,10 @@ use sqlparser::ast::Ident;
 /// The query plan for proving a query
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 #[enum_dispatch::enum_dispatch]
+#[serde(
+    from = "crate::sql::evm_proof_plan::EVMProofPlan",
+    into = "crate::sql::evm_proof_plan::EVMProofPlan"
+)]
 pub enum DynProofPlan {
     /// Source [`ProofPlan`] for (sub)queries without table source such as `SELECT "No table here" as msg;`
     Empty(EmptyExec),


### PR DESCRIPTION
# Rationale for this change

Different plan serializations lead to different proofs. The prover must ensure that it uses to the same serialization that the verifier uses.

# What changes are included in this PR?

`DynProofPlan` now serializes the same as `EVMProofPlan` to avoid this complication

# Are these changes tested?
Yes