### PR TITLE
feat: add `GroupByExec` in solidity

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -112,6 +112,8 @@ uint32 constant FILTER_EXEC_VARIANT = 0;
 uint32 constant EMPTY_EXEC_VARIANT = 1;
 /// @dev Table variant constant for proof plans
 uint32 constant TABLE_EXEC_VARIANT = 2;
+/// @dev Group By variant constant for proof plans
+uint32 constant GROUP_BY_EXEC_VARIANT = 5;
 
 /// @dev Boolean variant constant for column types
 uint32 constant DATA_TYPE_BOOLEAN_VARIANT = 0;

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -63,6 +63,8 @@ uint32 constant ERR_INVALID_VARYING_BITS = 0x76d56a3d;
 uint32 constant ERR_MONOTONY_CHECK_FAILED = 0x976f97b8;
 /// @dev Error thrown when there is an internal error.
 uint32 constant ERR_INTERNAL = 0xfe835e35;
+/// @dev Error code for unprovable group by error.
+uint32 constant ERR_UNPROVABLE_GROUP_BY = 0x6bd33da2;
 
 library Errors {
     /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
@@ -126,6 +128,8 @@ library Errors {
     error MonotonyCheckFailed();
     /// @notice Error thrown when there is an internal error.
     error InternalError();
+    /// @notice Error thrown for unprovable group by error.
+    error UnprovableGroupBy();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/src/proof_plans/GroupByExec.pre.sol
+++ b/solidity/src/proof_plans/GroupByExec.pre.sol
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../base/Constants.sol";
+import "../base/Errors.sol";
+import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
+
+/// @title GroupByExec
+/// @dev Library for handling group by execution plans
+library GroupByExec {
+    /// @notice Evaluates a group by execution plan
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// group_by_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `plan_ptr` - calldata pointer to the group by execution plan
+    /// * `builder_ptr` - memory pointer to the verification builder
+    /// ##### Return Values
+    /// * `plan_ptr_out` - pointer to the remaining plan after consuming the group by execution plan
+    /// * `evaluations_ptr` - pointer to the evaluations
+    /// * `output_chi_eval` - pointer to the evaluation of a column of 1s with same length as output
+    /// @notice Evaluates expressions for group by operation and verifies the aggregation constraints
+    /// @notice ##### Constraints
+    /// * Inputs: \\(G_1,\ldots,G_\ell=\texttt{g_in}\\), \\(A_1,\ldots,A_m=\texttt{sum_in}\\),
+    ///   and \\(S=\texttt{sel_in}\\) with input characteristic \\(\chi_{[0,n)}=\texttt{input_chi_eval}\\).
+    /// * Outputs: \\(G_1',\ldots,G_\ell'=\texttt{g_out}\\), \\(A_1',\ldots,A_m'=\texttt{sum_out}\\),
+    ///   and \\(C=\texttt{count_out}\\) with output characteristic \\(\chi_{[0,m')}=\texttt{output_chi_eval}\\).
+    /// * Challenges: \\(\alpha=\texttt{alpha}\\), \\(\beta=\texttt{beta}\\)
+    /// * Helpers:
+    ///   \\(g_{in,fold} \=\texttt{g_in_fold} :\equiv \alpha \sum_{j=1}^{\ell} G_j \beta^{\ell-j}\\)
+    ///   \\(g_{out,fold} \=\texttt{g_out_fold} :\equiv \alpha \sum_{j=1}^{\ell} G_j' \beta^{\ell-j}\\)
+    ///   \\(sum_{in,fold} \=\texttt{sum_in_fold} :\equiv \chi_{[0,n)} + \beta \sum_{j=1}^{m} A_j \beta^{m-j}\\)
+    ///   \\(sum_{out,fold} \=\texttt{sum_out_fold} :\equiv C + \beta \sum_{j=1}^{m} A_j' \beta^{m-j}\\)
+    ///   \\(G^\star = \texttt{g_in_star}\\) and \\(G^{\star'} = \texttt{g_out_star}\\)
+    /// * Constraints:
+    /// \\[\begin{aligned}
+    /// G^\star \cdot S \cdot sum_{in,fold} - G^{\star'} \cdot sum_{out,fold} &\overset{\sum}{=} 0\\\\
+    /// G^\star + G^\star \cdot g_{in,fold} - \chi_{[0,n)} &\equiv 0\\\\
+    /// G^{\star'} + G^{\star'} \cdot g_{out,fold} - \chi_{[0,m')} &\equiv 0\\\\
+    /// \end{aligned}\\]
+    /// Note: the notation \\(A\overset{\sum}{=}B\\) is used to indicate the zero-sum constraint.
+    /// @dev Evaluates a group by execution plan
+    /// @param __plan The group by execution plan data
+    /// @param __builder The verification builder
+    /// @return __planOut The remaining plan after processing
+    /// @return __builderOut The verification builder result
+    /// @return __evaluationsPtr The evaluations pointer
+    /// @return __outputChiEvaluation The output chi evaluation
+    function __groupByExecEvaluate( // solhint-disable-line gas-calldata-parameters
+    bytes calldata __plan, VerificationBuilder.Builder memory __builder)
+        external
+        pure
+        returns (
+            bytes calldata __planOut,
+            VerificationBuilder.Builder memory __builderOut,
+            uint256[] memory __evaluationsPtr,
+            uint256 __outputChiEvaluation
+        )
+    {
+        uint256[] memory __evaluations;
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue_uint512(queue_ptr) -> upper, lower {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_challenge(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_final_round_mle(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_chi_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_zerosum_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_identity_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_bit_distribution(builder_ptr) -> vary_mask, leading_bit_mask {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/SwitchUtil.pre.sol
+            function case_const(lhs, rhs) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Array.pre.sol
+            function get_array_element(arr_ptr, index) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_column_evaluation(builder_ptr, column_num) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_rho_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/ColumnExpr.pre.sol
+            function column_expr_evaluate(expr_ptr, builder_ptr) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/LiteralExpr.pre.sol
+            function literal_expr_evaluate(expr_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/EqualsExpr.pre.sol
+            function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/InequalityExpr.pre.sol
+            function inequality_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/AddExpr.pre.sol
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/SubtractExpr.pre.sol
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/MultiplyExpr.pre.sol
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/AndExpr.pre.sol
+            function and_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/OrExpr.pre.sol
+            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/NotExpr.pre.sol
+            function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // slither-disable-start cyclomatic-complexity
+            // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
+            function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // slither-disable-end cyclomatic-complexity
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_data_type(ptr) -> ptr_out, data_type {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
+            function compute_shift_identity_constraint(star, chi_plus_one, fold) -> constraint {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
+            function compute_shift_fold(alpha, beta, eval, rho) -> fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
+            function fold_expr_evals(plan_ptr, builder_ptr, input_chi_eval, beta, column_count) -> plan_ptr_out, fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
+            function fold_column_expr_evals(plan_ptr, builder_ptr, beta, column_count) -> plan_ptr_out, fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
+            function fold_final_round_mles(builder_ptr, column_count, beta) -> fold, evaluations_ptr {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
+            function compute_filter_folds(plan_ptr, builder_ptr, input_chi_eval) ->
+                plan_ptr_out,
+                c_fold,
+                d_fold,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
+            function filter_exec_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_table_chi_evaluation(builder_ptr, table_num) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Monotonic.pre.sol
+            function monotonic_verify(builder_ptr, alpha, beta, column_eval, chi_eval, strict, asc) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/SignExpr.pre.sol
+            function sign_expr_evaluate(expr_eval, builder_ptr, chi_eval) -> result_eval {
+                revert(0, 0)
+            }
+
+            function get_and_check_group_by_input_columns(
+                plan_ptr, builder_ptr, alpha, beta, column_count, input_chi_eval
+            ) -> plan_ptr_out, g_star_selected_eval {
+                // Process group by columns
+                let g_in_fold
+                plan_ptr, g_in_fold := fold_column_expr_evals(plan_ptr, builder_ptr, beta, column_count)
+                g_in_fold := mulmod_bn254(g_in_fold, alpha)
+
+                // Where clause evaluation
+                let selection_eval
+                plan_ptr, selection_eval := proof_expr_evaluate(plan_ptr, builder_ptr, input_chi_eval)
+
+                // Get the g_in_star and g_out_star evaluations
+                let g_in_star_eval := builder_consume_final_round_mle(builder_ptr)
+
+                // First constraint: g_in_star + g_in_star * g_in_fold - input_chi_eval = 0
+                builder_produce_identity_constraint(
+                    builder_ptr,
+                    submod_bn254(addmod_bn254(g_in_star_eval, mulmod_bn254(g_in_star_eval, g_in_fold)), input_chi_eval),
+                    2
+                )
+                g_star_selected_eval := mulmod_bn254(g_in_star_eval, selection_eval)
+                plan_ptr_out := plan_ptr
+            }
+
+            function get_and_check_group_by_output_columns(
+                builder_ptr, alpha, beta, column_count, output_chi_eval, evaluations_ptr
+            ) -> g_out_star_eval, evaluations_ptr_out {
+                let g_out_fold := 0
+                for {} column_count { column_count := sub(column_count, 1) } {
+                    let mle := builder_consume_final_round_mle(builder_ptr)
+                    g_out_fold := addmod_bn254(mulmod_bn254(g_out_fold, beta), mle)
+                    mstore(evaluations_ptr, mle)
+                    evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
+                }
+                // Uniqueness constraint, currently only for single group by column using monotonicity
+                monotonic_verify(builder_ptr, alpha, beta, g_out_fold, output_chi_eval, 1, 1)
+                g_out_fold := mulmod_bn254(g_out_fold, alpha)
+                g_out_star_eval := builder_consume_final_round_mle(builder_ptr)
+                // Second constraint: g_out_star + g_out_star * g_out_fold - output_chi_eval = 0
+                builder_produce_identity_constraint(
+                    builder_ptr,
+                    submod_bn254(
+                        addmod_bn254(g_out_star_eval, mulmod_bn254(g_out_star_eval, g_out_fold)), output_chi_eval
+                    ),
+                    2
+                )
+                evaluations_ptr_out := evaluations_ptr
+            }
+
+            function get_and_check_sum_input_columns(
+                plan_ptr, builder_ptr, input_chi_eval, beta, column_count, g_star_selected_eval
+            ) -> plan_ptr_out, constraint_lhs {
+                let sum_in_fold
+                plan_ptr, sum_in_fold := fold_expr_evals(plan_ptr, builder_ptr, input_chi_eval, beta, column_count)
+                sum_in_fold := addmod_bn254(mulmod_bn254(sum_in_fold, beta), input_chi_eval)
+                constraint_lhs := mulmod_bn254(g_star_selected_eval, sum_in_fold)
+                plan_ptr_out := plan_ptr
+            }
+
+            function get_and_check_sum_output_columns(
+                builder_ptr, output_chi_eval, beta, column_count, g_out_star_eval, evaluations_ptr
+            ) -> constraint_rhs, evaluations_ptr_out {
+                let sum_out_fold
+                sum_out_fold := 0
+                for {} column_count { column_count := sub(column_count, 1) } {
+                    let mle := builder_consume_final_round_mle(builder_ptr)
+                    sum_out_fold := addmod_bn254(mulmod_bn254(sum_out_fold, beta), mle)
+                    mstore(evaluations_ptr, mle)
+                    evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
+                }
+                // Consume count column evaluation
+                let count_out_eval := builder_consume_final_round_mle(builder_ptr)
+                mstore(evaluations_ptr, count_out_eval)
+                evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
+                sum_out_fold := addmod_bn254(mulmod_bn254(sum_out_fold, beta), count_out_eval)
+                constraint_rhs := mulmod_bn254(g_out_star_eval, sum_out_fold)
+                evaluations_ptr_out := evaluations_ptr
+            }
+
+            function build_groupby_zerosum_constraint(
+                plan_ptr,
+                builder_ptr,
+                alpha,
+                beta,
+                input_chi_eval,
+                output_chi_eval,
+                g_star_selected_eval,
+                g_out_star_eval,
+                evaluations_ptr
+            ) -> plan_ptr_out, evaluations_ptr_out {
+                // Now read the number of sum columns
+                let column_count := shr(UINT64_PADDING_BITS, calldataload(plan_ptr))
+                plan_ptr := add(plan_ptr, UINT64_SIZE)
+                let constraint_lhs
+                plan_ptr, constraint_lhs :=
+                    get_and_check_sum_input_columns(
+                        plan_ptr, builder_ptr, input_chi_eval, beta, column_count, g_star_selected_eval
+                    )
+                let constraint_rhs
+                constraint_rhs, evaluations_ptr :=
+                    get_and_check_sum_output_columns(
+                        builder_ptr, output_chi_eval, beta, column_count, g_out_star_eval, evaluations_ptr
+                    )
+                // Third constraint: sum g_in_star * sel_in * sum_in_fold - g_out_star * sum_out_fold = 0
+                builder_produce_zerosum_constraint(builder_ptr, submod_bn254(constraint_lhs, constraint_rhs), 3)
+                plan_ptr_out := plan_ptr
+                evaluations_ptr_out := evaluations_ptr
+            }
+
+            function build_groupby_constraints(
+                plan_ptr, builder_ptr, alpha, beta, input_chi_eval, output_chi_eval, evaluations_ptr
+            ) -> plan_ptr_out, evaluations_ptr_out {
+                // Now read the number of group by columns
+                let groupby_column_count := shr(UINT64_PADDING_BITS, calldataload(plan_ptr))
+                if iszero(eq(groupby_column_count, 1)) { err(ERR_UNPROVABLE_GROUP_BY) }
+                plan_ptr := add(plan_ptr, UINT64_SIZE)
+                let g_star_selected_eval
+                let g_out_star_eval
+                plan_ptr, g_star_selected_eval :=
+                    get_and_check_group_by_input_columns(
+                        plan_ptr, builder_ptr, alpha, beta, groupby_column_count, input_chi_eval
+                    )
+                g_out_star_eval, evaluations_ptr :=
+                    get_and_check_group_by_output_columns(
+                        builder_ptr, alpha, beta, groupby_column_count, output_chi_eval, evaluations_ptr
+                    )
+                plan_ptr_out, evaluations_ptr_out :=
+                    build_groupby_zerosum_constraint(
+                        plan_ptr,
+                        builder_ptr,
+                        alpha,
+                        beta,
+                        input_chi_eval,
+                        output_chi_eval,
+                        g_star_selected_eval,
+                        g_out_star_eval,
+                        evaluations_ptr
+                    )
+            }
+
+            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) -> plan_ptr_out, evaluations_ptr {
+                // Table input
+                let input_chi_eval :=
+                    builder_get_table_chi_evaluation(builder_ptr, shr(UINT64_PADDING_BITS, calldataload(plan_ptr)))
+                plan_ptr := add(plan_ptr, UINT64_SIZE)
+                // Get chi evaluation
+                let output_chi_eval := builder_consume_chi_evaluation(builder_ptr)
+                // Read the number of result columns
+                let total_column_count := shr(UINT64_PADDING_BITS, calldataload(plan_ptr))
+                plan_ptr := add(plan_ptr, UINT64_SIZE)
+                evaluations_ptr := mload(FREE_PTR)
+                mstore(evaluations_ptr, total_column_count)
+                evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
+                plan_ptr, evaluations_ptr :=
+                    build_groupby_constraints(
+                        plan_ptr, builder_ptr, alpha, beta, input_chi_eval, output_chi_eval, evaluations_ptr
+                    )
+                // slither-disable-next-line write-after-write
+                evaluations_ptr := mload(FREE_PTR)
+                mstore(FREE_PTR, add(evaluations_ptr, add(WORD_SIZE, mul(total_column_count, WORD_SIZE))))
+                plan_ptr_out := plan_ptr
+            }
+
+            function group_by_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+                let alpha := builder_consume_challenge(builder_ptr)
+                let beta := builder_consume_challenge(builder_ptr)
+                plan_ptr, evaluations_ptr := check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta)
+                {
+                    // Skip the count alias (we don't need to parse it for verification)
+                    let count_alias
+                    plan_ptr, count_alias := read_binary(plan_ptr)
+                }
+                plan_ptr_out := plan_ptr
+            }
+
+            let __planOutOffset
+            __planOutOffset, __evaluations, __outputChiEvaluation := group_by_exec_evaluate(__plan.offset, __builder)
+            __planOut.offset := __planOutOffset
+            // slither-disable-next-line write-after-write
+            __planOut.length := sub(__plan.length, sub(__planOutOffset, __plan.offset))
+        }
+        __evaluationsPtr = __evaluations;
+        __builderOut = __builder;
+    }
+}

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -12,7 +12,10 @@ library ProofPlan {
     enum PlanVariant {
         Filter,
         Empty,
-        Table
+        Table,
+        Projection,
+        Slice,
+        GroupBy
     }
 
     /// @notice Evaluates a proof plan
@@ -69,11 +72,15 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/Queue.pre.sol
-            function dequeue_uint512(queue_ptr) -> value {
+            function dequeue_uint512(queue_ptr) -> upper, lower {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_challenge(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_bit_distribution(builder_ptr) -> vary_mask, leading_bit_mask {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
@@ -82,6 +89,14 @@ library ProofPlan {
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_chi_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_rho_evaluation(builder_ptr) -> value {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
@@ -144,10 +159,6 @@ library ProofPlan {
             function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
-            function builder_consume_bit_distribution(builder_ptr) -> vary_mask, leading_bit_mask {
-                revert(0, 0)
-            }
             // IMPORT-YUL ../proof_gadgets/SignExpr.pre.sol
             function sign_expr_evaluate(expr_eval, builder_ptr, chi_eval) -> result_eval {
                 revert(0, 0)
@@ -171,7 +182,24 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
+            function fold_column_expr_evals(plan_ptr, builder_ptr, beta, column_count) -> plan_ptr_out, fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
             function fold_final_round_mles(builder_ptr, beta, column_count) -> fold, evaluations_ptr {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
+            function compute_shift_identity_constraint(star, chi_plus_one, fold) -> constraint {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
+            function compute_shift_fold(alpha, beta, eval, rho) -> fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            {
                 revert(0, 0)
             }
             // IMPORT-YUL FilterExec.pre.sol
@@ -183,16 +211,68 @@ library ProofPlan {
             {
                 revert(0, 0)
             }
-            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
-            function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
-                revert(0, 0)
-            }
             // IMPORT-YUL EmptyExec.pre.sol
             function empty_exec_evaluate(builder_ptr) -> evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL FilterExec.pre.sol
             function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Monotonic.pre.sol
+            function monotonic_verify(builder_ptr, alpha, beta, column_eval, chi_eval, strict, asc) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function get_and_check_group_by_input_columns(
+                plan_ptr, builder_ptr, alpha, beta, column_count, input_chi_eval
+            ) -> plan_ptr_out, g_star_selected_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function get_and_check_group_by_output_columns(
+                builder_ptr, alpha, beta, column_count, output_chi_eval, evaluations_ptr
+            ) -> g_out_star_eval, evaluations_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function get_and_check_sum_input_columns(
+                plan_ptr, builder_ptr, input_chi_eval, beta, column_count, g_star_selected_eval
+            ) -> plan_ptr_out, constraint_lhs {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function get_and_check_sum_output_columns(
+                builder_ptr, output_chi_eval, beta, column_count, g_out_star_eval, evaluations_ptr
+            ) -> constraint_rhs, evaluations_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function build_groupby_zerosum_constraint(
+                plan_ptr,
+                builder_ptr,
+                alpha,
+                beta,
+                input_chi_eval,
+                output_chi_eval,
+                g_star_selected_eval,
+                g_out_star_eval,
+                evaluations_ptr
+            ) -> plan_ptr_out, evaluations_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function build_groupby_constraints(
+                plan_ptr, builder_ptr, alpha, beta, input_chi_eval, output_chi_eval, evaluations_ptr
+            ) -> plan_ptr_out, evaluations_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) -> plan_ptr_out, evaluations_ptr {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function group_by_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
@@ -229,6 +309,10 @@ library ProofPlan {
                 case 2 {
                     case_const(2, TABLE_EXEC_VARIANT)
                     plan_ptr_out, evaluations_ptr, output_chi_eval := table_exec_evaluate(plan_ptr, builder_ptr)
+                }
+                case 5 {
+                    case_const(5, GROUP_BY_EXEC_VARIANT)
+                    plan_ptr_out, evaluations_ptr, output_chi_eval := group_by_exec_evaluate(plan_ptr, builder_ptr)
                 }
                 default { err(ERR_UNSUPPORTED_PROOF_PLAN_VARIANT) }
             }

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -103,7 +103,7 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/Queue.pre.sol
-            function dequeue_uint512(queue_ptr) -> value {
+            function dequeue_uint512(queue_ptr) -> upper, lower {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/SwitchUtil.pre.sol
@@ -144,6 +144,14 @@ library Verifier {
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_get_chi_evaluations(builder_ptr) -> values_ptr {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_rho_evaluation(builder_ptr) -> value {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
@@ -251,6 +259,10 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_bit_distribution(builder_ptr) -> vary_mask, leading_bit_mask {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_check_aggregate_evaluation(builder_ptr) {
                 revert(0, 0)
             }
@@ -276,6 +288,27 @@ library Verifier {
             }
             // IMPORT-YUL ../hyperkzg/HyperKZGVerifier.pre.sol
             function verify_hyperkzg(proof_ptr, transcript_ptr, commitment_ptr, x, y) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
+            function compute_shift_identity_constraint(star, chi_plus_one, fold) -> constraint {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
+            function compute_shift_fold(alpha, beta, eval, rho) -> fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/Monotonic.pre.sol
+            function monotonic_verify(builder_ptr, alpha, beta, column_eval, chi_eval, strict, asc) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/SignExpr.pre.sol
+            function sign_expr_evaluate(expr_eval, builder_ptr, chi_eval) -> result_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/ColumnExpr.pre.sol
@@ -318,14 +351,6 @@ library Verifier {
             function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
-            function builder_consume_bit_distribution(builder_ptr) -> vary_mask, leading_bit_mask {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_gadgets/SignExpr.pre.sol
-            function sign_expr_evaluate(expr_eval, builder_ptr, chi_eval) -> result_eval {
-                revert(0, 0)
-            }
             // IMPORT-YUL ../proof_exprs/InequalityExpr.pre.sol
             function inequality_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
@@ -341,6 +366,10 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
+            function fold_column_expr_evals(plan_ptr, builder_ptr, beta, column_count) -> plan_ptr_out, fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
             function fold_final_round_mles(builder_ptr, beta, column_count) -> fold, evaluations_ptr {
                 revert(0, 0)
             }
@@ -353,10 +382,6 @@ library Verifier {
             {
                 revert(0, 0)
             }
-            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
-            function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
-                revert(0, 0)
-            }
             // IMPORT-YUL ../proof_plans/EmptyExec.pre.sol
             function empty_exec_evaluate(builder_ptr) -> evaluations_ptr, output_chi_eval {
                 revert(0, 0)
@@ -367,6 +392,58 @@ library Verifier {
             }
             // IMPORT-YUL ../proof_plans/TableExec.pre.sol
             function table_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function get_and_check_group_by_input_columns(
+                plan_ptr, builder_ptr, alpha, beta, column_count, input_chi_eval
+            ) -> plan_ptr_out, g_star_selected_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function get_and_check_group_by_output_columns(
+                builder_ptr, alpha, beta, column_count, output_chi_eval, evaluations_ptr
+            ) -> g_out_star_eval, evaluations_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function get_and_check_sum_input_columns(
+                plan_ptr, builder_ptr, input_chi_eval, beta, column_count, g_star_selected_eval
+            ) -> plan_ptr_out, constraint_lhs {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function get_and_check_sum_output_columns(
+                builder_ptr, output_chi_eval, beta, column_count, g_out_star_eval, evaluations_ptr
+            ) -> constraint_rhs, evaluations_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function build_groupby_zerosum_constraint(
+                plan_ptr,
+                builder_ptr,
+                alpha,
+                beta,
+                input_chi_eval,
+                output_chi_eval,
+                g_star_selected_eval,
+                g_out_star_eval,
+                evaluations_ptr
+            ) -> plan_ptr_out, evaluations_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function build_groupby_constraints(
+                plan_ptr, builder_ptr, alpha, beta, input_chi_eval, output_chi_eval, evaluations_ptr
+            ) -> plan_ptr_out, evaluations_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) -> plan_ptr_out, evaluations_ptr {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function group_by_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../sumcheck/Sumcheck.pre.sol

--- a/solidity/test/proof_plans/GroupByExec.t.pre.sol
+++ b/solidity/test/proof_plans/GroupByExec.t.pre.sol
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {Errors} from "../../src/base/Errors.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {GroupByExec} from "../../src/proof_plans/GroupByExec.pre.sol";
+
+contract GroupByExecTest is Test {
+    function testUnprovableGroupByExec() public {
+        bytes memory plan = abi.encodePacked(
+            uint64(0), // table_number
+            uint64(3), // total_column_count
+            uint64(2), // group_by_count
+            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause
+            abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(0)), // group_by_expr[0] - column 0
+            abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(1)), // group_by_expr[1] - column 1
+            uint64(0), // sum_count
+            uint64(7), // count_alias_length (unused in verification)
+            "count_0" // count_alias (unused in verification)
+        );
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.finalRoundMLEs = new uint256[](0);
+        builder.constraintMultipliers = new uint256[](0);
+        builder.challenges = new uint256[](2);
+        builder.challenges[0] = 501; // alpha
+        builder.challenges[1] = 502; // beta
+        builder.aggregateEvaluation = 0;
+        builder.rowMultipliersEvaluation = 601;
+        builder.chiEvaluations = new uint256[](1);
+        builder.chiEvaluations[0] = 701; // output_chi_eval
+        builder.tableChiEvaluations = new uint256[](1);
+        builder.tableChiEvaluations[0] = 801; // input_chi_eval
+        // Define column evaluations for ColumnExpr
+        builder.columnEvaluations = new uint256[](2);
+        builder.columnEvaluations[0] = 102;
+        builder.columnEvaluations[1] = 103;
+
+        uint256[] memory evals;
+        uint256 outputChiEval;
+        vm.expectRevert(Errors.UnprovableGroupBy.selector);
+        (plan, builder, evals, outputChiEval) = GroupByExec.__groupByExecEvaluate(plan, builder);
+    }
+
+    // Shared configuration for the builder in different tests
+    function _configureBuilderForGroupByExec(VerificationBuilder.Builder memory builder)
+        internal
+        pure
+        returns (VerificationBuilder.Builder memory configuredBuilder)
+    {
+        // table chi evals
+        builder.tableChiEvaluations = new uint256[](1);
+        builder.tableChiEvaluations[0] = 1;
+
+        // rho and chi evals
+        builder.rhoEvaluations = new uint256[](8);
+        builder.rhoEvaluations[0] = 0;
+        builder.rhoEvaluations[1] = 0;
+        builder.rhoEvaluations[2] = 1;
+        builder.rhoEvaluations[3] = 1;
+        builder.rhoEvaluations[4] = 0;
+        builder.rhoEvaluations[5] = 2;
+        builder.rhoEvaluations[6] = 0;
+        builder.rhoEvaluations[7] = 0;
+        builder.chiEvaluations = new uint256[](8);
+        builder.chiEvaluations[0] = 1; // output_chi_eval
+        builder.chiEvaluations[1] = 1; // shifted_output_chi_eval
+        builder.chiEvaluations[2] = 1;
+        builder.chiEvaluations[3] = 1;
+        builder.chiEvaluations[4] = 0;
+        builder.chiEvaluations[5] = 1;
+        builder.chiEvaluations[6] = 0;
+        builder.chiEvaluations[7] = 0;
+
+        // bit distributions
+        uint256[] memory bitDistribution = new uint256[](8);
+        bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[1] = 1;
+        bitDistribution[2] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[3] = 1;
+        bitDistribution[4] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[5] = 1;
+        bitDistribution[6] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[7] = 1;
+        VerificationBuilder.__setBitDistributions(builder, bitDistribution);
+
+        // challenges
+        builder.challenges = new uint256[](8);
+        builder.challenges[0] = 3; // alpha
+        builder.challenges[1] = 8; // beta
+        builder.challenges[2] = 3; // alpha
+        builder.challenges[3] = 8; // beta
+        builder.challenges[4] = 3; // alpha
+        builder.challenges[5] = 8; // beta
+        builder.challenges[6] = 3; // alpha
+        builder.challenges[7] = 8; // beta
+
+        // max degree and row multipliers
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+
+        // constraint multipliers
+        builder.constraintMultipliers = new uint256[](28); // 7 constraints times 4 rows
+        for (uint8 i = 0; i < 28; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+
+        // Aggregate evaluation
+        builder.aggregateEvaluation = 0;
+        configuredBuilder = builder;
+    }
+
+    function _configureForMinimalGroupByExec(VerificationBuilder.Builder memory builder)
+        internal
+        pure
+        returns (VerificationBuilder.Builder memory configuredBuilder)
+    {
+        // column evaluations
+        builder.columnEvaluations = new uint256[](1);
+
+        uint256[4] memory gOut = [MODULUS_MINUS_ONE, 1, 0, 0];
+        uint256[4] memory count = [uint256(2), 2, 0, 0];
+        // Check that (-1, 1) is strictly increasing hence the group by is valid
+        uint256[4] memory shiftedGOut = [uint256(0), MODULUS_MINUS_ONE, 1, 0];
+        // cStar = 1 / (1 + alpha * (column + beta * (rho + chi)))
+        uint256[4] memory cStarEval = [
+            uint256(14923801958072233106077094826311778469464793909374568870703321036301687610648),
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            1,
+            0
+        ];
+        // dStar = 1 / (1 + alpha * (shiftedColumn + beta * rhoPlusOne))
+        uint256[4] memory dStarEval = [
+            uint256(1),
+            14923801958072233106077094826311778469464793909374568870703321036301687610648,
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            0
+        ];
+        uint256[4] memory sign = [uint256(1), 0, 1, 0]; //Sign of [1, -2, 1];
+
+        // final round mles
+        builder.finalRoundMLEs = new uint256[](32); // 8 mles times 4 rows
+        {
+            uint256 inv4 = 16416182153879456416684804308942956316411273300312025757773653139931856371713;
+            uint256 invNegative2 = 10944121435919637611123202872628637544274182200208017171849102093287904247808;
+            uint256[4] memory gInStarColumn = [invNegative2, inv4, inv4, invNegative2];
+            uint256[4] memory gOutStarColumn = [invNegative2, inv4, 0, 0];
+
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.finalRoundMLEs[i * 8] = gInStarColumn[i];
+                builder.finalRoundMLEs[i * 8 + 1] = gOut[i];
+                // Monotonicity check
+                builder.finalRoundMLEs[i * 8 + 2] = shiftedGOut[i];
+                builder.finalRoundMLEs[i * 8 + 3] = cStarEval[i];
+                builder.finalRoundMLEs[i * 8 + 4] = dStarEval[i];
+                builder.finalRoundMLEs[i * 8 + 5] = sign[i];
+                // Continue with group by output
+                builder.finalRoundMLEs[i * 8 + 6] = gOutStarColumn[i];
+                builder.finalRoundMLEs[i * 8 + 7] = count[i];
+            }
+        }
+        configuredBuilder = builder;
+    }
+
+    function _configureForSimpleGroupByExec(VerificationBuilder.Builder memory builder)
+        internal
+        pure
+        returns (VerificationBuilder.Builder memory configuredBuilder)
+    {
+        // column evaluations
+        builder.columnEvaluations = new uint256[](2);
+
+        uint256[4] memory gOut = [MODULUS_MINUS_ONE, 1, 0, 0];
+        uint256[4] memory sumOut = [MODULUS - 2, 5, 0, 0];
+        uint256[4] memory count = [uint256(2), 2, 0, 0];
+        // Check that (-1, 1) is strictly increasing hence the group by is valid
+        uint256[4] memory shiftedGOut = [uint256(0), MODULUS_MINUS_ONE, 1, 0];
+        // cStar = 1 / (1 + alpha * (column + beta * (rho + chi)))
+        uint256[4] memory cStarEval = [
+            uint256(14923801958072233106077094826311778469464793909374568870703321036301687610648),
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            1,
+            0
+        ];
+        // dStar = 1 / (1 + alpha * (shiftedColumn + beta * rhoPlusOne))
+        uint256[4] memory dStarEval = [
+            uint256(1),
+            14923801958072233106077094826311778469464793909374568870703321036301687610648,
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            0
+        ];
+        uint256[4] memory sign = [uint256(1), 0, 1, 0]; //Sign of [1, -2, 1];
+
+        // final round mles
+        builder.finalRoundMLEs = new uint256[](36); // 9 mles times 4 rows
+        {
+            uint256 inv4 = 16416182153879456416684804308942956316411273300312025757773653139931856371713;
+            uint256 invNegative2 = 10944121435919637611123202872628637544274182200208017171849102093287904247808;
+            uint256[4] memory gInStarColumn = [invNegative2, inv4, inv4, invNegative2];
+            uint256[4] memory gOutStarColumn = [invNegative2, inv4, 0, 0];
+
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.finalRoundMLEs[i * 9] = gInStarColumn[i];
+                builder.finalRoundMLEs[i * 9 + 1] = gOut[i];
+                // Monotonicity check
+                builder.finalRoundMLEs[i * 9 + 2] = shiftedGOut[i];
+                builder.finalRoundMLEs[i * 9 + 3] = cStarEval[i];
+                builder.finalRoundMLEs[i * 9 + 4] = dStarEval[i];
+                builder.finalRoundMLEs[i * 9 + 5] = sign[i];
+                // Continue with group by output
+                builder.finalRoundMLEs[i * 9 + 6] = gOutStarColumn[i];
+                builder.finalRoundMLEs[i * 9 + 7] = sumOut[i];
+                builder.finalRoundMLEs[i * 9 + 8] = count[i];
+            }
+        }
+        configuredBuilder = builder;
+    }
+
+    function _configureForComplexGroupByExec(VerificationBuilder.Builder memory builder)
+        internal
+        pure
+        returns (VerificationBuilder.Builder memory configuredBuilder)
+    {
+        // column evaluations
+        builder.columnEvaluations = new uint256[](3);
+
+        uint256[4] memory gOut = [MODULUS_MINUS_ONE, 1, 0, 0];
+        uint256[4] memory sumOut0 = [MODULUS - 2, 5, 0, 0];
+        uint256[4] memory sumOut1 = [MODULUS - 5, 7, 0, 0];
+        uint256[4] memory count = [uint256(2), 2, 0, 0];
+        // Check that (-1, 1) is strictly increasing hence the group by is valid
+        uint256[4] memory shiftedGOut = [uint256(0), MODULUS_MINUS_ONE, 1, 0];
+        // cStar = 1 / (1 + alpha * (column + beta * (rho + chi)))
+        uint256[4] memory cStarEval = [
+            uint256(14923801958072233106077094826311778469464793909374568870703321036301687610648),
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            1,
+            0
+        ];
+        // dStar = 1 / (1 + alpha * (shiftedColumn + beta * rhoPlusOne))
+        uint256[4] memory dStarEval = [
+            uint256(1),
+            14923801958072233106077094826311778469464793909374568870703321036301687610648,
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            0
+        ];
+        uint256[4] memory sign = [uint256(1), 0, 1, 0]; //Sign of [1, -2, 1];
+
+        // final round mles
+        builder.finalRoundMLEs = new uint256[](40); // 10 mles times 4 rows
+        {
+            uint256 inv4 = 16416182153879456416684804308942956316411273300312025757773653139931856371713;
+            uint256 invNegative2 = 10944121435919637611123202872628637544274182200208017171849102093287904247808;
+            uint256[4] memory gInStarColumn = [invNegative2, inv4, inv4, invNegative2];
+            uint256[4] memory gOutStarColumn = [invNegative2, inv4, 0, 0];
+
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.finalRoundMLEs[i * 10] = gInStarColumn[i];
+                builder.finalRoundMLEs[i * 10 + 1] = gOut[i];
+                // Monotonicity check
+                builder.finalRoundMLEs[i * 10 + 2] = shiftedGOut[i];
+                builder.finalRoundMLEs[i * 10 + 3] = cStarEval[i];
+                builder.finalRoundMLEs[i * 10 + 4] = dStarEval[i];
+                builder.finalRoundMLEs[i * 10 + 5] = sign[i];
+                // Continue with group by output
+                builder.finalRoundMLEs[i * 10 + 6] = gOutStarColumn[i];
+                builder.finalRoundMLEs[i * 10 + 7] = sumOut0[i];
+                builder.finalRoundMLEs[i * 10 + 8] = sumOut1[i];
+                builder.finalRoundMLEs[i * 10 + 9] = count[i];
+            }
+        }
+        configuredBuilder = builder;
+    }
+
+    function testMinimalGroupByExec() public pure {
+        bytes memory plan = abi.encodePacked(
+            uint64(0), // table_number
+            uint64(2), // total_column_count
+            uint64(1), // group_by_count
+            uint64(0), // group_by_expr[0] - column 0
+            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause
+            uint64(0), // sum_count
+            uint64(7), // count_alias_length (unused in verification)
+            "count_0" // count_alias (unused in verification)
+        );
+        VerificationBuilder.Builder memory builder;
+        builder = _configureBuilderForGroupByExec(builder);
+        builder = _configureForMinimalGroupByExec(builder);
+        uint256[4] memory gIn = [MODULUS_MINUS_ONE, 1, 1, MODULUS_MINUS_ONE];
+        for (uint8 i = 0; i < 4; ++i) {
+            uint256[] memory evals;
+            uint256 outputChiEval;
+            bytes memory planOut;
+            if (i == 0) {
+                builder.singletonChiEvaluation = 1; // singleton_chi_eval for first test
+            } else {
+                builder.singletonChiEvaluation = 0;
+            }
+            builder.columnEvaluations[0] = gIn[i];
+            (planOut, builder, evals, outputChiEval) = GroupByExec.__groupByExecEvaluate(plan, builder);
+            assert(planOut.length == 0);
+        }
+        assert(builder.aggregateEvaluation == 0);
+    }
+
+    function testSimpleGroupByExec() public pure {
+        bytes memory plan = abi.encodePacked(
+            uint64(0), // table_number
+            uint64(3), // total_column_count
+            uint64(1), // group_by_count
+            uint64(0), // group_by_expr[0] - column 0
+            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause
+            uint64(1), // sum_count
+            abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(1)), // sum_expr[0] - column 1;
+            uint64(7), // count_alias_length (unused in verification)
+            "count_0" // count_alias (unused in verification)
+        );
+        VerificationBuilder.Builder memory builder;
+        builder = _configureBuilderForGroupByExec(builder);
+        builder = _configureForSimpleGroupByExec(builder);
+        uint256[4] memory gIn = [MODULUS_MINUS_ONE, 1, 1, MODULUS_MINUS_ONE];
+        uint256[4] memory sumIn = [MODULUS_MINUS_ONE, 2, 3, MODULUS_MINUS_ONE];
+        for (uint8 i = 0; i < 4; ++i) {
+            uint256[] memory evals;
+            uint256 outputChiEval;
+            bytes memory planOut;
+            if (i == 0) {
+                builder.singletonChiEvaluation = 1; // singleton_chi_eval for first test
+            } else {
+                builder.singletonChiEvaluation = 0;
+            }
+            builder.columnEvaluations[0] = gIn[i];
+            builder.columnEvaluations[1] = sumIn[i];
+            (planOut, builder, evals, outputChiEval) = GroupByExec.__groupByExecEvaluate(plan, builder);
+            assert(planOut.length == 0);
+        }
+        assert(builder.aggregateEvaluation == 0);
+    }
+
+    function testComplexGroupByExec() public pure {
+        bytes memory plan = abi.encodePacked(
+            uint64(0), // table_number
+            uint64(4), // total_column_count
+            uint64(1), // group_by_count
+            uint64(0), // group_by_expr[0] - column 0
+            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause
+            uint64(2), // sum_count
+            abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(1)), // sum_expr[0] - column 1;
+            abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(2)), // sum_expr[1] - column 2;
+            uint64(7), // count_alias_length (unused in verification)
+            "count_0" // count_alias (unused in verification)
+        );
+        VerificationBuilder.Builder memory builder;
+        builder = _configureBuilderForGroupByExec(builder);
+        builder = _configureForComplexGroupByExec(builder);
+        uint256[4] memory gIn = [MODULUS_MINUS_ONE, 1, 1, MODULUS_MINUS_ONE];
+        uint256[4] memory sumIn0 = [MODULUS_MINUS_ONE, 2, 3, MODULUS_MINUS_ONE];
+        uint256[4] memory sumIn1 = [MODULUS_MINUS_ONE, 5, 7, MODULUS_MINUS_ONE];
+        for (uint8 i = 0; i < 4; ++i) {
+            uint256[] memory evals;
+            uint256 outputChiEval;
+            bytes memory planOut;
+            if (i == 0) {
+                builder.singletonChiEvaluation = 1; // singleton_chi_eval for first test
+            } else {
+                builder.singletonChiEvaluation = 0;
+            }
+            builder.columnEvaluations[0] = gIn[i];
+            builder.columnEvaluations[1] = sumIn0[i];
+            builder.columnEvaluations[2] = sumIn1[i];
+            (planOut, builder, evals, outputChiEval) = GroupByExec.__groupByExecEvaluate(plan, builder);
+            assert(planOut.length == 0);
+        }
+    }
+}

--- a/solidity/test/proof_plans/ProofPlan.t.pre.sol
+++ b/solidity/test/proof_plans/ProofPlan.t.pre.sol
@@ -77,10 +77,161 @@ contract ProofPlanTest is Test {
         }
     }
 
+    function _configureBuilderForGroupByExec(VerificationBuilder.Builder memory builder)
+        internal
+        pure
+        returns (VerificationBuilder.Builder memory configuredBuilder)
+    {
+        // table chi evals
+        builder.tableChiEvaluations = new uint256[](1);
+        builder.tableChiEvaluations[0] = 1;
+
+        // rho and chi evals
+        builder.rhoEvaluations = new uint256[](8);
+        builder.rhoEvaluations[0] = 0;
+        builder.rhoEvaluations[1] = 0;
+        builder.rhoEvaluations[2] = 1;
+        builder.rhoEvaluations[3] = 1;
+        builder.rhoEvaluations[4] = 0;
+        builder.rhoEvaluations[5] = 2;
+        builder.rhoEvaluations[6] = 0;
+        builder.rhoEvaluations[7] = 0;
+        builder.chiEvaluations = new uint256[](8);
+        builder.chiEvaluations[0] = 1; // output_chi_eval
+        builder.chiEvaluations[1] = 1; // shifted_output_chi_eval
+        builder.chiEvaluations[2] = 1;
+        builder.chiEvaluations[3] = 1;
+        builder.chiEvaluations[4] = 0;
+        builder.chiEvaluations[5] = 1;
+        builder.chiEvaluations[6] = 0;
+        builder.chiEvaluations[7] = 0;
+
+        // bit distributions
+        uint256[] memory bitDistribution = new uint256[](8);
+        bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[1] = 1;
+        bitDistribution[2] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[3] = 1;
+        bitDistribution[4] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[5] = 1;
+        bitDistribution[6] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[7] = 1;
+        VerificationBuilder.__setBitDistributions(builder, bitDistribution);
+
+        // challenges
+        builder.challenges = new uint256[](8);
+        builder.challenges[0] = 3; // alpha
+        builder.challenges[1] = 8; // beta
+        builder.challenges[2] = 3; // alpha
+        builder.challenges[3] = 8; // beta
+        builder.challenges[4] = 3; // alpha
+        builder.challenges[5] = 8; // beta
+        builder.challenges[6] = 3; // alpha
+        builder.challenges[7] = 8; // beta
+
+        // max degree and row multipliers
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+
+        // constraint multipliers
+        builder.constraintMultipliers = new uint256[](28); // 7 constraints times 4 rows
+        for (uint8 i = 0; i < 28; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+
+        // Aggregate evaluation
+        builder.aggregateEvaluation = 0;
+        configuredBuilder = builder;
+    }
+
+    function _configureForMinimalGroupByExec(VerificationBuilder.Builder memory builder)
+        internal
+        pure
+        returns (VerificationBuilder.Builder memory configuredBuilder)
+    {
+        // column evaluations
+        builder.columnEvaluations = new uint256[](1);
+
+        uint256[4] memory gOut = [MODULUS_MINUS_ONE, 1, 0, 0];
+        uint256[4] memory count = [uint256(2), 2, 0, 0];
+        // Check that (-1, 1) is strictly increasing hence the group by is valid
+        uint256[4] memory shiftedGOut = [uint256(0), MODULUS_MINUS_ONE, 1, 0];
+        // cStar = 1 / (1 + alpha * (column + beta * (rho + chi)))
+        uint256[4] memory cStarEval = [
+            uint256(14923801958072233106077094826311778469464793909374568870703321036301687610648),
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            1,
+            0
+        ];
+        // dStar = 1 / (1 + alpha * (shiftedColumn + beta * rhoPlusOne))
+        uint256[4] memory dStarEval = [
+            uint256(1),
+            14923801958072233106077094826311778469464793909374568870703321036301687610648,
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            0
+        ];
+        uint256[4] memory sign = [uint256(1), 0, 1, 0]; //Sign of [1, -2, 1];
+
+        // final round mles
+        builder.finalRoundMLEs = new uint256[](32); // 8 mles times 4 rows
+        {
+            uint256 inv4 = 16416182153879456416684804308942956316411273300312025757773653139931856371713;
+            uint256 invNegative2 = 10944121435919637611123202872628637544274182200208017171849102093287904247808;
+            uint256[4] memory gInStarColumn = [invNegative2, inv4, inv4, invNegative2];
+            uint256[4] memory gOutStarColumn = [invNegative2, inv4, 0, 0];
+
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.finalRoundMLEs[i * 8] = gInStarColumn[i];
+                builder.finalRoundMLEs[i * 8 + 1] = gOut[i];
+                // Monotonicity check
+                builder.finalRoundMLEs[i * 8 + 2] = shiftedGOut[i];
+                builder.finalRoundMLEs[i * 8 + 3] = cStarEval[i];
+                builder.finalRoundMLEs[i * 8 + 4] = dStarEval[i];
+                builder.finalRoundMLEs[i * 8 + 5] = sign[i];
+                // Continue with group by output
+                builder.finalRoundMLEs[i * 8 + 6] = gOutStarColumn[i];
+                builder.finalRoundMLEs[i * 8 + 7] = count[i];
+            }
+        }
+        configuredBuilder = builder;
+    }
+
+    function testGroupByExecVariant() public pure {
+        bytes memory plan = abi.encodePacked(
+            GROUP_BY_EXEC_VARIANT,
+            uint64(0), // table_number
+            uint64(2), // total_column_count
+            uint64(1), // group_by_count
+            uint64(0), // group_by_expr[0] - column 0
+            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause
+            uint64(0), // sum_count
+            uint64(7), // count_alias_length (unused in verification)
+            "count_0" // count_alias (unused in verification)
+        );
+        VerificationBuilder.Builder memory builder;
+        uint256[4] memory gIn = [MODULUS_MINUS_ONE, 1, 1, MODULUS_MINUS_ONE];
+        builder = _configureBuilderForGroupByExec(builder);
+        builder = _configureForMinimalGroupByExec(builder);
+        for (uint8 i = 0; i < 4; ++i) {
+            uint256[] memory evals;
+            uint256 outputChiEval;
+            bytes memory planOut;
+            if (i == 0) {
+                builder.singletonChiEvaluation = 1; // singleton_chi_eval for first test
+            } else {
+                builder.singletonChiEvaluation = 0;
+            }
+            builder.columnEvaluations[0] = gIn[i];
+            (planOut, builder, evals, outputChiEval) = ProofPlan.__proofPlanEvaluate(plan, builder);
+            assert(planOut.length == 0);
+        }
+        assert(builder.aggregateEvaluation == 0);
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testUnsupportedVariant() public {
         VerificationBuilder.Builder memory builder;
-        bytes memory plan = abi.encodePacked(uint32(4), hex"abcdef");
+        bytes memory plan = abi.encodePacked(uint32(100), hex"abcdef");
         vm.expectRevert(Errors.UnsupportedProofPlanVariant.selector);
         ProofPlan.__proofPlanEvaluate(plan, builder);
     }
@@ -139,5 +290,6 @@ contract ProofPlanTest is Test {
         assert(uint32(ProofPlan.PlanVariant.Filter) == FILTER_EXEC_VARIANT);
         assert(uint32(ProofPlan.PlanVariant.Empty) == EMPTY_EXEC_VARIANT);
         assert(uint32(ProofPlan.PlanVariant.Table) == TABLE_EXEC_VARIANT);
+        assert(uint32(ProofPlan.PlanVariant.GroupBy) == GROUP_BY_EXEC_VARIANT);
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
