### PR TITLE
feat(sol): add singleton chi eval to verification builder

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -174,7 +174,7 @@ uint256 constant VK_TAU_HY_REAL = 0x2bad9a374aec49d329ec66e8f530f68509313450580c
 uint256 constant VK_TAU_HY_IMAG = 0x219edfceee1723de674f5b2f6fdb69d9e32dd53b15844956a630d3c7cdaa6ed9;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 13;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 14;
 /// @dev Offset of the pointer to the challenge queue in the verification builder.
 uint256 constant BUILDER_CHALLENGES_OFFSET = 0x20 * 0;
 /// @dev Offset of the pointer to the first round MLEs in the verification builder.
@@ -201,6 +201,8 @@ uint256 constant BUILDER_TABLE_CHI_EVALUATIONS_OFFSET = 0x20 * 10;
 uint256 constant BUILDER_FIRST_ROUND_COMMITMENTS_OFFSET = 0x20 * 11;
 /// @dev Offset of the pointer to the final round commitments in the verification builder.
 uint256 constant BUILDER_FINAL_ROUND_COMMITMENTS_OFFSET = 0x20 * 12;
+/// @dev Offset of the singleton chi evaluation in the verification builder.
+uint256 constant BUILDER_SINGLETON_CHI_EVALUATION_OFFSET = 0x20 * 13;
 
 /// @dev The initial transcript state. This is the hash of the empty string.
 uint256 constant INITIAL_TRANSCRIPT_STATE = 0x7c26f909f37b2c61df0bb3b19f76296469cb4d07b582a215c4e2b1f7a05527c3;

--- a/solidity/src/builder/VerificationBuilder.pre.sol
+++ b/solidity/src/builder/VerificationBuilder.pre.sol
@@ -23,6 +23,7 @@ library VerificationBuilder {
         uint256[] tableChiEvaluations;
         uint256 firstRoundCommitmentsPtr;
         uint256 finalRoundCommitmentsPtr;
+        uint256 singletonChiEvaluation;
     }
 
     /// @notice Allocates and reserves a block of memory for a verification builder
@@ -849,6 +850,42 @@ library VerificationBuilder {
                 }
             }
             builder_check_aggregate_evaluation(__builder)
+        }
+    }
+
+    /// @notice Sets the singleton chi evaluation in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_singleton_chi_evaluation(builder_ptr, value)
+    /// ```
+    /// @param __builder The builder struct
+    /// @param __value The singleton chi evaluation value
+    function __setSingletonChiEvaluation(Builder memory __builder, uint256 __value) internal pure {
+        assembly {
+            function builder_set_singleton_chi_evaluation(builder_ptr, value) {
+                mstore(add(builder_ptr, BUILDER_SINGLETON_CHI_EVALUATION_OFFSET), value)
+            }
+            builder_set_singleton_chi_evaluation(__builder, __value)
+        }
+    }
+
+    /// @notice Gets the singleton chi evaluation from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_singleton_chi_evaluation(builder_ptr) -> value
+    /// ```
+    /// @param __builder The builder struct
+    /// @return __value The singleton chi evaluation value
+    function __getSingletonChiEvaluation(Builder memory __builder) internal pure returns (uint256 __value) {
+        assembly {
+            function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
+                value := mload(add(builder_ptr, BUILDER_SINGLETON_CHI_EVALUATION_OFFSET))
+            }
+            __value := builder_get_singleton_chi_evaluation(__builder)
         }
     }
 }

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -239,6 +239,10 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_set_singleton_chi_evaluation(builder_ptr, value) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_set_table_chi_evaluations(builder_ptr, values_ptr) {
                 revert(0, 0)
             }
@@ -543,6 +547,9 @@ library Verifier {
 
                 compute_evaluations(evaluation_point_ptr, builder_get_table_chi_evaluations(builder_ptr))
                 compute_evaluations(evaluation_point_ptr, builder_get_chi_evaluations(builder_ptr))
+                builder_set_singleton_chi_evaluation(
+                    builder_ptr, compute_truncated_lagrange_basis_sum(1, add(evaluation_point_ptr, WORD_SIZE), num_vars)
+                )
 
                 builder_set_row_multipliers_evaluation(
                     builder_ptr,

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -85,7 +85,7 @@ contract ConstantsTest is Test {
     }
 
     function testVerificationBuilderOffsetsAreValid() public pure {
-        uint256[13] memory offsets = [
+        uint256[14] memory offsets = [
             BUILDER_CHALLENGES_OFFSET,
             BUILDER_FIRST_ROUND_MLES_OFFSET,
             BUILDER_FINAL_ROUND_MLES_OFFSET,
@@ -98,7 +98,8 @@ contract ConstantsTest is Test {
             BUILDER_COLUMN_EVALUATIONS_OFFSET,
             BUILDER_TABLE_CHI_EVALUATIONS_OFFSET,
             BUILDER_FIRST_ROUND_COMMITMENTS_OFFSET,
-            BUILDER_FINAL_ROUND_COMMITMENTS_OFFSET
+            BUILDER_FINAL_ROUND_COMMITMENTS_OFFSET,
+            BUILDER_SINGLETON_CHI_EVALUATION_OFFSET
         ];
         uint256 offsetsLength = offsets.length;
         assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);

--- a/solidity/test/builder/VerificationBuilder.t.pre.sol
+++ b/solidity/test/builder/VerificationBuilder.t.pre.sol
@@ -922,6 +922,30 @@ contract VerificationBuilderTest is Test {
         }
     }
 
+    function testSetSingletonChiEvaluation() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setSingletonChiEvaluation(builder, 42);
+        assert(builder.singletonChiEvaluation == 42);
+    }
+
+    function testFuzzSetSingletonChiEvaluation(uint256 value) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setSingletonChiEvaluation(builder, value);
+        assert(builder.singletonChiEvaluation == value);
+    }
+
+    function testGetSingletonChiEvaluation() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.singletonChiEvaluation = 42;
+        assert(VerificationBuilder.__getSingletonChiEvaluation(builder) == 42);
+    }
+
+    function testFuzzGetSingletonChiEvaluation(uint256 value) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.singletonChiEvaluation = value;
+        assert(VerificationBuilder.__getSingletonChiEvaluation(builder) == value);
+    }
+
     function testCheckAggregateEvaluationZero() public pure {
         VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
         builder.aggregateEvaluation = 0;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
In order to port `EmptyExec` and the monotonic proof gadget used in joins to Solidity we need to have singleton chi eval added.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See title.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.