### PR TITLE
feat: join in planner

### DIFF
--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -3,6 +3,7 @@ use crate::base::map::IndexMap;
 use alloc::vec::Vec;
 use sqlparser::ast::Ident;
 /// A simple in-memory `SchemaAccessor` for testing intermediate AST -> Provable AST conversion.
+#[derive(Clone)]
 pub struct TestSchemaAccessor {
     schemas: IndexMap<TableRef, IndexMap<Ident, ColumnType>>,
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -46,7 +46,7 @@ pub(crate) use union_exec::UnionExec;
 mod union_exec_test;
 
 mod sort_merge_join_exec;
-pub(crate) use sort_merge_join_exec::SortMergeJoinExec;
+pub use sort_merge_join_exec::SortMergeJoinExec;
 #[cfg(all(test, feature = "blitzar"))]
 mod sort_merge_join_exec_test;
 

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -59,6 +59,7 @@ impl SortMergeJoinExec {
     /// - The join column index is out of bounds
     /// - The number of join columns is different
     /// - The number of result idents is different from the expected number of columns
+    #[must_use]
     pub fn new(
         left: Box<DynProofPlan>,
         right: Box<DynProofPlan>,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We need to support joins in the planner

# What changes are included in this PR?

New planner code for converting a logical plan to dyn proof plan including joins

# Are these changes tested?
Yes
