### PR TITLE
fix: enforce evaluation vec length

### DIFF
--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -53,6 +53,8 @@ uint32 constant ERR_UNSUPPORTED_PROOF = 0x6f1c50d9;
 uint32 constant ERR_UNSUPPORTED_PROOF_PLAN_VARIANT = 0xe5503cfa;
 /// @dev Error code for when a data type variant is unsupported.
 uint32 constant ERR_UNSUPPORTED_DATA_TYPE_VARIANT = 0xbd12560e;
+/// @dev Error code for when the evaluation length is too large.
+uint32 constant ERR_EVALUATION_LENGTH_TOO_LARGE = 0xb65e7142;
 
 library Errors {
     /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
@@ -106,6 +108,8 @@ library Errors {
     error UnsupportedProofPlanVariant();
     /// @notice Error thrown when a data type variant is unsupported.
     error UnsupportedDataTypeVariant();
+    /// @notice Error thrown when the evaluation length is too large.
+    error EvaluationLengthTooLarge();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -180,4 +180,11 @@ contract ErrorsTest is Test {
         vm.expectRevert(Errors.UnsupportedDataTypeVariant.selector);
         Errors.__err(ERR_UNSUPPORTED_DATA_TYPE_VARIANT);
     }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorEvaluationLengthTooLarge() public {
+        assert(Errors.EvaluationLengthTooLarge.selector == bytes4(ERR_EVALUATION_LENGTH_TOO_LARGE));
+        vm.expectRevert(Errors.EvaluationLengthTooLarge.selector);
+        Errors.__err(ERR_EVALUATION_LENGTH_TOO_LARGE);
+    }
 }

--- a/solidity/test/base/LagrangeBasisEvaluation.t.pre.sol
+++ b/solidity/test/base/LagrangeBasisEvaluation.t.pre.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import "../../src/base/Constants.sol";
+import {Errors} from "../../src/base/Errors.sol";
 import {LagrangeBasisEvaluation} from "./../../src/base/LagrangeBasisEvaluation.pre.sol";
 import {F, FF} from "./FieldUtil.sol";
 
@@ -152,7 +153,8 @@ contract LagrangeBasisEvaluationTest is Test {
         }
     }
 
-    function testSimpleComputeEvaluationVec() public pure {
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testSimpleComputeEvaluationVec() public {
         uint256[] memory point = new uint256[](3);
         point[0] = 2;
         point[1] = 3;
@@ -177,9 +179,13 @@ contract LagrangeBasisEvaluationTest is Test {
                 assert(evaluations[i] == expectedEvaluations[i]);
             }
         }
+        // Test revert for too large length
+        vm.expectRevert(Errors.EvaluationLengthTooLarge.selector);
+        LagrangeBasisEvaluation.__computeEvaluationVec(9, point);
     }
 
-    function testFuzzComputeEvaluationVec(uint256[] memory point) public pure {
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testFuzzComputeEvaluationVec(uint256[] memory point) public {
         uint256 numVars = point.length;
         // If the point is too long, we will run out of memory
         vm.assume(numVars < 10);
@@ -204,6 +210,9 @@ contract LagrangeBasisEvaluationTest is Test {
                 assert(evaluations[i] == expectedEvaluations[i]);
             }
         }
+        // Test revert for too large length
+        vm.expectRevert(Errors.EvaluationLengthTooLarge.selector);
+        LagrangeBasisEvaluation.__computeEvaluationVec(maxLength + 1, point);
     }
 
     function testSimpleComputeEvaluations() public pure {

--- a/solidity/test/verifier/ResultVerifier.t.pre.sol
+++ b/solidity/test/verifier/ResultVerifier.t.pre.sol
@@ -255,6 +255,9 @@ contract ResultVerifierTest is Test {
         vm.assume(nameData.length >= numberOfColumns);
         // solhint-disable-next-line gas-strict-inequalities
         vm.assume(data.length >= uint256(numberOfColumns) * uint256(numberOfRows));
+        vm.assume(evaluationPoint.length < 256);
+        // solhint-disable-next-line gas-strict-inequalities
+        vm.assume(1 << evaluationPoint.length >= numberOfRows);
 
         bytes[] memory columnNames = new bytes[](numberOfColumns);
         int64[][] memory table = new int64[][](numberOfColumns);


### PR DESCRIPTION
# Rationale for this change

If the result table is the power of 2 that is used by sumcheck, then a malicious prover could append anything extra onto the table.

# What changes are included in this PR?

* Add validation inside compute_evaluation_vec.

# Are these changes tested?
Yes