### PR TITLE
feat!: make filter more composable

### DIFF
--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -71,7 +71,7 @@ fn we_can_convert_an_ast_with_one_column() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_bigint(3)),
         ),
         vec![],
@@ -92,7 +92,7 @@ fn we_can_convert_an_ast_with_one_column_and_i128_data() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_bigint(3_i64)),
         ),
         vec![],
@@ -113,7 +113,7 @@ fn we_can_convert_an_ast_with_one_column_and_a_filter_by_a_string_literal() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_varchar("abc")),
         ),
         vec![],
@@ -162,7 +162,7 @@ fn we_dont_have_duplicate_filter_result_expressions() {
     let expected_ast = QueryExpr::new(
         filter(
             aliased_cols_expr_plan(&t, &[("a", "b"), ("a", "c")], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_bigint(3)),
         ),
         vec![],
@@ -185,7 +185,7 @@ fn we_can_convert_an_ast_with_two_columns() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a", "b"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "c", &accessor), const_bigint(123)),
         ),
         vec![],
@@ -212,7 +212,7 @@ fn we_can_convert_an_ast_with_two_columns_and_arithmetic() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a", "b"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(
                 column(&t, "c", &accessor),
                 subtract(
@@ -240,7 +240,7 @@ fn we_can_parse_all_result_columns_with_select_star() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["b", "a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_bigint(3)),
         ),
         vec![],
@@ -262,7 +262,7 @@ fn we_can_convert_an_ast_with_one_positive_cond() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "b", &accessor), const_bigint(4)),
         ),
         vec![],
@@ -284,7 +284,7 @@ fn we_can_convert_an_ast_with_one_not_equals_cond() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             not(equal(column(&t, "b", &accessor), const_bigint(4))),
         ),
         vec![],
@@ -306,7 +306,7 @@ fn we_can_convert_an_ast_with_one_negative_cond() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             lte(column(&t, "b", &accessor), const_bigint(-4)),
         ),
         vec![],
@@ -333,7 +333,7 @@ fn we_can_convert_an_ast_with_cond_and() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             and(
                 equal(column(&t, "b", &accessor), const_bigint(3)),
                 lte(column(&t, "c", &accessor), const_bigint(-2)),
@@ -363,7 +363,7 @@ fn we_can_convert_an_ast_with_cond_or() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             or(
                 equal(
                     multiply(column(&t, "b", &accessor), const_bigint(3)),
@@ -396,7 +396,7 @@ fn we_can_convert_an_ast_with_conds_or_not() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             or(
                 lte(column(&t, "b", &accessor), const_bigint(3)),
                 not(gte(column(&t, "c", &accessor), const_bigint(-2))),
@@ -436,7 +436,7 @@ fn we_can_convert_an_ast_with_conds_not_and_or() {
                     "boolean",
                 ),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             not(and(
                 or(
                     gte(column(&t, "f", &accessor), const_bigint(45)),
@@ -470,7 +470,7 @@ fn we_can_convert_an_ast_with_the_min_i128_filter_value_and_const() {
                 col_expr_plan(&t, "a", &accessor),
                 aliased_plan(const_int128(i128::MIN), "b"),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_int128(i128::MIN)),
         ),
         vec![],
@@ -498,7 +498,7 @@ fn we_can_convert_an_ast_with_the_max_i128_filter_value_and_const() {
                 col_expr_plan(&t, "a", &accessor),
                 aliased_plan(const_int128(i128::MAX), "ma"),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_int128(i128::MAX)),
         ),
         vec![],
@@ -530,7 +530,7 @@ fn we_can_convert_an_ast_using_an_aliased_column() {
                     "boolean",
                 ),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             gte(column(&t, "b", &accessor), const_bigint(4)),
         ),
         vec![],
@@ -575,7 +575,7 @@ fn we_can_convert_an_ast_with_a_schema() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_bigint(3)),
         ),
         vec![],
@@ -598,7 +598,7 @@ fn we_can_convert_an_ast_without_any_filter() {
                 col_expr_plan(&t, "a", &accessor),
                 aliased_plan(const_bigint(3), "b"),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![],
@@ -634,7 +634,7 @@ fn we_can_parse_order_by_with_a_single_column() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["b", "a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_bigint(3)),
         ),
         vec![orders(&[0_usize], &[true])],
@@ -660,7 +660,7 @@ fn we_can_parse_order_by_with_multiple_columns() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a", "b"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(
                 column(&t, "a", &accessor),
                 add(column(&t, "b", &accessor), const_bigint(3)),
@@ -693,7 +693,7 @@ fn we_can_parse_order_by_referencing_an_alias_associated_with_column_b_but_with_
                 aliased_col_expr_plan(&t, "salary", "s", &accessor),
                 aliased_col_expr_plan(&t, "name", "salary", &accessor),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "salary", &accessor), const_bigint(5)),
         ),
         vec![orders(&[1_usize], &[false])],
@@ -796,7 +796,7 @@ fn we_can_parse_order_by_queries_with_the_same_column_name_appearing_more_than_o
                     col_expr_plan(&t, "name", &accessor),
                     aliased_col_expr_plan(&t, "salary", "d", &accessor),
                 ],
-                tab(&t),
+                table_exec_from_accessor(&t, &accessor),
                 const_bool(true),
             ),
             vec![orders(&[index], &[true])],
@@ -822,7 +822,7 @@ fn we_can_parse_a_query_having_a_simple_limit_clause() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![slice(Some(3), Some(0))],
@@ -843,7 +843,7 @@ fn slice_is_still_applied_when_limit_is_u64_max_and_offset_is_zero() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![slice(Some(u64::MAX), Some(0))],
@@ -864,7 +864,7 @@ fn we_can_parse_a_query_having_a_simple_positive_offset_clause() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![slice(Some(u64::MAX), Some(7))],
@@ -885,7 +885,7 @@ fn we_can_parse_a_query_having_a_negative_offset_clause() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![slice(Some(u64::MAX), Some(-7))],
@@ -906,7 +906,7 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["a"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![slice(Some(55), Some(3))],
@@ -945,7 +945,7 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause_preceded_by_wher
                     "res",
                 ),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_bigint(-3)),
         ),
         vec![orders(&[0_usize], &[false]), slice(Some(55), Some(3))],
@@ -1094,7 +1094,7 @@ fn we_can_group_by_without_using_aggregate_functions() {
     let expected_ast = QueryExpr::new(
         filter(
             vec![col_expr_plan(&t, "department", &accessor)],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![
@@ -1140,7 +1140,7 @@ fn group_by_expressions_are_parsed_before_an_order_by_referencing_an_aggregate_a
                 col_expr_plan(&t, "salary", &accessor),
                 col_expr_plan(&t, "tax", &accessor),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![
@@ -1277,7 +1277,7 @@ fn we_can_parse_a_query_having_group_by_with_the_same_name_as_the_aggregation_ex
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["bonus", "department"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![group_by_postprocessing(
@@ -1307,7 +1307,7 @@ fn count_aggregate_functions_can_be_used_with_non_numeric_columns() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["bonus", "department"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![group_by_postprocessing(
@@ -1341,7 +1341,7 @@ fn count_all_uses_the_first_group_by_identifier_as_default_result_column() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["department", "salary"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "salary", &accessor), const_bigint(4)),
         ),
         vec![group_by_postprocessing(
@@ -1389,7 +1389,7 @@ fn we_can_use_the_same_result_columns_with_different_aliases_and_associate_it_wi
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["department"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![group_by_postprocessing(
@@ -1424,7 +1424,7 @@ fn we_can_use_multiple_group_by_clauses_with_multiple_agg_and_non_agg_exprs() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["bonus", "name", "salary", "tax"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![group_by_postprocessing(
@@ -1477,7 +1477,7 @@ fn we_can_parse_a_simple_add_mul_sub_div_arithmetic_expressions_in_the_result_ex
                     "af",
                 ),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![],
@@ -1536,7 +1536,7 @@ fn we_can_parse_multiple_arithmetic_expression_where_multiplication_has_preceden
                     "d",
                 ),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![],
@@ -1564,7 +1564,7 @@ fn we_can_parse_arithmetic_expression_within_aggregations_in_the_result_expr() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["c", "f"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![group_by_postprocessing(
@@ -1758,7 +1758,7 @@ fn group_by_with_bigint_column_is_valid() {
     let expected_query = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["salary"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![group_by_postprocessing(
@@ -1787,7 +1787,7 @@ fn group_by_with_decimal_column_is_valid() {
     let expected_query = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["salary"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![group_by_postprocessing(
@@ -1816,7 +1816,7 @@ fn group_by_with_varchar_column_is_valid() {
     let expected_query = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["name"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![group_by_postprocessing(
@@ -1847,7 +1847,7 @@ fn we_can_use_arithmetic_outside_agg_expressions_while_using_group_by() {
     let expected_query = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["salary", "tax"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![
@@ -1892,7 +1892,7 @@ fn we_can_use_arithmetic_outside_agg_expressions_without_using_group_by() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["bonus", "salary"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![
@@ -1939,7 +1939,7 @@ fn count_aggregation_always_have_integer_type() {
     let expected_ast = QueryExpr::new(
         filter(
             cols_expr_plan(&t, &["name", "salary", "tax"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![
@@ -2011,7 +2011,7 @@ fn select_wildcard_is_valid_with_group_by_exprs() {
                 .iter()
                 .map(|c| col_expr_plan(&t, c, &accessor))
                 .collect(),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         ),
         vec![group_by_postprocessing(&columns, &aliased_exprs)],
@@ -2112,7 +2112,11 @@ fn select_group_and_order_by_preserve_the_column_order_reference() {
                 .unwrap();
 
         let expected_query = QueryExpr::new(
-            filter(perm_col_plans, tab(&t), const_bool(true)),
+            filter(
+                perm_col_plans,
+                table_exec_from_accessor(&t, &accessor),
+                const_bool(true),
+            ),
             vec![
                 group_by_postprocessing(&group_cols_vec, &aliased_perm_cols),
                 orders(&[2_usize, 3, 0, 1], &ordering_vec),

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -43,7 +43,7 @@ fn we_can_prove_a_typical_add_subtract_query() {
             aliased_plan(add(column(&t, "b", &accessor), const_bigint(4)), "res"),
             col_expr_plan(&t, "d", &accessor),
         ],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(
             subtract(column(&t, "a", &accessor), column(&t, "b", &accessor)),
             const_bigint(3),
@@ -100,7 +100,7 @@ fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
             ),
             col_expr_plan(&t, "d", &accessor),
         ],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(
             subtract(
                 scaling_cast(
@@ -168,7 +168,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                     "f",
                 ),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             and(
                 equal(
                     column(&t, "b", &accessor),

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -43,7 +43,7 @@ fn we_can_prove_a_simple_and_query() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         and(
             equal(column(&t, "b", &accessor), const_scalar::<TestScalar, _>(1)),
             equal(
@@ -75,7 +75,7 @@ fn we_can_prove_a_simple_and_query_with_128_bits() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         and(
             equal(column(&t, "b", &accessor), const_scalar::<TestScalar, _>(1)),
             equal(
@@ -127,7 +127,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
         );
         let ast = filter(
             cols_expr_plan(&t, &["a", "d"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             and(
                 equal(
                     column(&t, "b", &accessor),

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    test_utility::{aliased_plan, cast, column, tab},
+    test_utility::{aliased_plan, cast, column},
     LiteralExpr,
 };
 use crate::{
@@ -18,7 +18,7 @@ use crate::{
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::{CastExpr, DynProofExpr},
-        proof_plans::test_utility::filter,
+        proof_plans::test_utility::{filter, table_exec_from_accessor},
         AnalyzeError,
     },
 };
@@ -67,7 +67,7 @@ fn we_can_prove_a_simple_cast_expr() {
                 "f_cast",
             ),
         ],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -141,7 +141,7 @@ fn we_can_prove_a_simple_cast_expr_from_int_to_other_numeric_type() {
                 "g_cast",
             ),
         ],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -36,7 +36,7 @@ fn we_can_prove_an_equality_query_with_no_rows() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res =
@@ -62,7 +62,7 @@ fn we_can_prove_another_equality_query_with_no_rows() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
     let verifiable_res =
@@ -89,7 +89,7 @@ fn we_can_prove_a_nested_equality_query_with_no_rows() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b", "c", "e"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(
             column(&t, "bool", &accessor),
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
@@ -122,7 +122,7 @@ fn we_can_prove_an_equality_query_with_a_single_selected_row() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["d", "a"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -148,7 +148,7 @@ fn we_can_prove_another_equality_query_with_a_single_selected_row() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["d", "a"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -174,7 +174,7 @@ fn we_can_prove_an_equality_query_with_a_single_non_selected_row() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -214,7 +214,7 @@ fn we_can_prove_an_equality_query_with_multiple_rows() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "c", "e"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -255,7 +255,7 @@ fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "c", "e"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(
             column(&t, "bool", &accessor),
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
@@ -299,7 +299,7 @@ fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "c", "e"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(column(&t, "b", &accessor), const_bigint(123_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -341,7 +341,7 @@ fn we_can_prove_an_equality_query_with_a_string_comparison() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "b", "e"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(column(&t, "c", &accessor), const_varchar("ghi")),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -390,7 +390,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
         );
         let ast = filter(
             cols_expr_plan(&t, &["a", "d"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(
                 column(&t, "b", &accessor),
                 const_varchar(filter_val.as_str()),
@@ -484,7 +484,7 @@ fn we_can_query_with_varbinary_equality() {
     // Build query plan: SELECT a, b FROM table WHERE b = [4,5,6,7]
     let ast = filter(
         cols_expr_plan(&t, &["a", "b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(column(&t, "b", &accessor), const_varbinary(&[4, 5, 6, 7])),
     );
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -38,7 +38,7 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         gte(
             DynProofExpr::try_new_scaling_cast(
                 column(&t, "a", &accessor),
@@ -81,7 +81,7 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(
             scaling_cast(
                 column(&t, "a", &accessor),
@@ -118,7 +118,7 @@ fn we_can_compare_a_constant_column() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -139,7 +139,7 @@ fn we_can_compare_a_varying_column_with_constant_sign() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -166,7 +166,7 @@ fn we_can_compare_columns_with_extreme_values() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["bigint_b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(
             lte(
                 lte(
@@ -206,7 +206,7 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "e", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -239,7 +239,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e", "f"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(
             column(&t, "f", &accessor),
             DynProofExpr::try_new_scaling_cast(
@@ -280,7 +280,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e", "f"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         gte(
             column(&t, "f", &accessor),
             DynProofExpr::try_new_scaling_cast(
@@ -324,7 +324,7 @@ fn we_can_compare_columns_returning_extreme_decimal_values() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -376,7 +376,7 @@ fn we_can_compare_two_columns() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -400,7 +400,7 @@ fn we_can_compare_a_varying_column_with_constant_absolute_value() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -424,7 +424,7 @@ fn we_can_compare_a_constant_column_of_negative_columns() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -448,7 +448,7 @@ fn we_can_compare_a_varying_column_with_negative_only_signs() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -469,7 +469,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), const_bigint(1)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -490,7 +490,7 @@ fn we_can_compare_column_with_greater_than_or_equal() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         gte(column(&t, "a", &accessor), const_bigint(1)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -515,7 +515,7 @@ fn we_can_run_nested_comparison() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(
             gte(column(&t, "a", &accessor), column(&t, "b", &accessor)),
             column(&t, "boolean", &accessor),
@@ -539,7 +539,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs_and_a_constant
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -560,7 +560,7 @@ fn we_can_compare_a_constant_column_of_zeros() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -581,7 +581,7 @@ fn the_sign_can_be_0_or_1_for_a_constant_column_of_zeros() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -621,7 +621,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
         );
         let ast = filter(
             cols_expr_plan(&t, &["a", "b"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             lte(column(&t, "a", &accessor), const_bigint(filter_val)),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -49,7 +49,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
         );
         let ast = filter(
             cols_expr_plan(&t, &["a", "b", "c"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(lit),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -98,7 +98,7 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         const_bool(true),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -118,7 +118,7 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         const_bool(false),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -53,7 +53,7 @@ fn we_can_prove_a_typical_multiply_query() {
             ),
             col_expr_plan(&t, "e", &accessor),
         ],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(
             multiply(column(&t, "d", &accessor), const_decimal75(2, 1, 39)),
             const_decimal75(3, 2, 819),
@@ -100,7 +100,7 @@ fn where_clause_can_wrap_around() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast: DynProofPlan = filter(
         cols_expr_plan(&t, &["a", "b", "c", "d", "e", "res"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         equal(
             multiply(
                 multiply(
@@ -181,7 +181,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                     "f",
                 ),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             and(
                 equal(
                     column(&t, "b", &accessor),

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -34,7 +34,7 @@ fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         not(equal(column(&t, "b", &accessor), const_bigint(1))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -75,7 +75,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
         );
         let ast = filter(
             cols_expr_plan(&t, &["a", "b"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             not(and(
                 equal(column(&t, "a", &accessor), const_bigint(filter_val_a)),
                 equal(

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -33,7 +33,7 @@ fn we_can_prove_a_simple_or_query() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         or(
             equal(column(&t, "b", &accessor), const_bigint(1)),
             equal(column(&t, "d", &accessor), const_varchar("g")),
@@ -61,7 +61,7 @@ fn we_can_prove_a_simple_or_query_with_variable_integer_types() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         or(
             equal(column(&t, "b", &accessor), const_bigint(1)),
             equal(column(&t, "d", &accessor), const_varchar("g")),
@@ -90,7 +90,7 @@ fn we_can_prove_an_or_query_where_both_lhs_and_rhs_are_true() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         or(
             equal(column(&t, "b", &accessor), const_bigint(1)),
             equal(column(&t, "d", &accessor), const_varchar("g")),
@@ -139,7 +139,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
         );
         let ast = filter(
             cols_expr_plan(&t, &["a", "d"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             or(
                 equal(
                     column(&t, "b", &accessor),

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
@@ -66,7 +66,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 aliased_placeholder(1, ColumnType::BigInt, "p1"),
                 aliased_placeholder(2, ColumnType::VarChar, "p2"),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             const_bool(true),
         );
         let params = vec![random_bigint_literal, random_varchar_literal];
@@ -114,7 +114,7 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         const_bool(true),
     );
     let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
@@ -140,7 +140,7 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         const_bool(false),
     );
     let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
@@ -179,7 +179,7 @@ fn we_cannot_prove_placeholder_expr_if_interpolate_fails() {
     let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         const_bool(true),
     );
     assert!(matches!(
@@ -196,7 +196,7 @@ fn we_cannot_verify_placeholder_expr_if_interpolate_fails() {
     let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         const_bool(true),
     );
     let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
@@ -226,7 +226,7 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
             aliased_placeholder(1, ColumnType::BigInt, "p1"),
             aliased_placeholder(2, ColumnType::VarChar, "p2"),
         ],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         const_bool(true),
     );
     let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
@@ -12,10 +12,10 @@ use crate::{
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::{
-            test_utility::{aliased_plan, column, scaling_cast, tab},
+            test_utility::{aliased_plan, column, scaling_cast},
             LiteralExpr,
         },
-        proof_plans::test_utility::filter,
+        proof_plans::test_utility::{filter, table_exec_from_accessor},
     },
 };
 use blitzar::proof::InnerProductProof;
@@ -78,7 +78,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
                 "f_cast",
             ),
         ],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -132,7 +132,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_decimal_to_decimal() {
                 "c_cast",
             ),
         ],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
@@ -168,7 +168,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_timestamp_to_timestamp() {
             ),
             "a_cast",
         )],
-        tab(&t),
+        table_exec_from_accessor(&t, &accessor),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -97,10 +97,14 @@ impl DynProofPlan {
     #[must_use]
     pub fn new_filter(
         aliased_results: Vec<AliasedDynProofExpr>,
-        input: TableExpr,
+        input: DynProofPlan,
         filter_expr: DynProofExpr,
     ) -> Self {
-        Self::Filter(FilterExec::new(aliased_results, input, filter_expr))
+        Self::Filter(FilterExec::new(
+            aliased_results,
+            Box::new(input),
+            filter_expr,
+        ))
     }
 
     /// Creates a new group by plan.

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -218,7 +218,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
                     "a",
                 ),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_int128(5)),
         ),
     );

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -67,7 +67,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
     let ast = slice_exec(
         filter(
             cols_expr_plan(&t, &["a", "b"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             where_clause,
         ),
         1,
@@ -104,7 +104,7 @@ fn we_can_get_an_empty_result_from_a_slice_on_an_empty_table_using_first_round_e
     let expr = slice_exec(
         filter(
             cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             where_clause,
         ),
         1,
@@ -158,7 +158,7 @@ fn we_can_get_an_empty_result_from_a_slice_using_first_round_evaluate() {
     let expr = slice_exec(
         filter(
             cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             where_clause,
         ),
         1,
@@ -210,7 +210,11 @@ fn we_can_get_no_columns_from_a_slice_with_empty_input_using_first_round_evaluat
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let expr = slice_exec(
-        filter(cols_expr_plan(&t, &[], &accessor), tab(&t), where_clause),
+        filter(
+            cols_expr_plan(&t, &[], &accessor),
+            table_exec_from_accessor(&t, &accessor),
+            where_clause,
+        ),
         2,
         None,
     );
@@ -247,7 +251,7 @@ fn we_can_get_the_correct_result_from_a_slice_using_first_round_evaluate() {
     let expr = slice_exec(
         filter(
             cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             where_clause,
         ),
         1,
@@ -303,7 +307,7 @@ fn we_can_prove_a_slice_exec() {
                     "bool",
                 ),
             ],
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             equal(column(&t, "a", &accessor), const_int128(105)),
         ),
         2,
@@ -349,7 +353,7 @@ fn we_can_prove_a_nested_slice_exec() {
                         "bool",
                     ),
                 ],
-                tab(&t),
+                table_exec_from_accessor(&t, &accessor),
                 equal(column(&t, "a", &accessor), const_int128(105)),
             ),
             1,
@@ -398,7 +402,7 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
                         "bool",
                     ),
                 ],
-                tab(&t),
+                table_exec_from_accessor(&t, &accessor),
                 equal(column(&t, "a", &accessor), const_int128(105)),
             ),
             1,
@@ -447,7 +451,7 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
                         "bool",
                     ),
                 ],
-                tab(&t),
+                table_exec_from_accessor(&t, &accessor),
                 equal(column(&t, "a", &accessor), const_int128(105)),
             ),
             6,

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -104,12 +104,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
         sort_merge_join(
             filter(
                 cols_expr_plan(&table_cats, &["id", "name"], &accessor),
-                tab(&table_cats),
+                table_exec_from_accessor(&table_cats, &accessor),
                 lte(column(&table_cats, "id", &accessor), const_int128(20)),
             ),
             filter(
                 cols_expr_plan(&table_cat_details, &["id", "human"], &accessor),
-                tab(&table_cat_details),
+                table_exec_from_accessor(&table_cat_details, &accessor),
                 not(equal(
                     column(&table_cat_details, "human", &accessor),
                     const_varchar("Gretta"),
@@ -197,12 +197,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
         sort_merge_join(
             filter(
                 cols_expr_plan(&table_cats, &["id", "name"], &accessor),
-                tab(&table_cats),
+                table_exec_from_accessor(&table_cats, &accessor),
                 lte(column(&table_cats, "id", &accessor), const_int128(20)),
             ),
             filter(
                 cols_expr_plan(&table_cat_human, &["id", "human", "state"], &accessor),
-                tab(&table_cat_human),
+                table_exec_from_accessor(&table_cat_human, &accessor),
                 not(equal(
                     column(&table_cat_human, "human", &accessor),
                     const_varchar("Gretta"),
@@ -219,7 +219,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
         ),
         filter(
             cols_expr_plan(&table_cat_vet, &["id", "hospital"], &accessor),
-            tab(&table_cat_vet),
+            table_exec_from_accessor(&table_cat_vet, &accessor),
             not(equal(
                 column(&table_cat_vet, "hospital", &accessor),
                 const_varchar("Clear Creek"),

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -51,7 +51,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_with_one_table() {
     let ast = union_exec(
         vec![filter(
             cols_expr_plan(&t, &["a0"], &accessor),
-            tab(&t),
+            table_exec_from_accessor(&t, &accessor),
             gte(column(&t, "a0", &accessor), const_int128(2_i128)),
         )],
         vec![column_field("a", ColumnType::BigInt)],
@@ -227,7 +227,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
                         slice_exec(
                             filter(
                                 cols_expr_plan(&t2, &["a2", "b2"], &accessor),
-                                tab(&t2),
+                                table_exec_from_accessor(&t2, &accessor),
                                 gte(column(&t2, "a2", &accessor), const_smallint(5_i16)),
                             ),
                             2,
@@ -238,7 +238,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
                                 aliased_plan(const_bigint(105_i64), "const"),
                                 col_expr_plan(&t3, "b3", &accessor),
                             ],
-                            tab(&t3),
+                            table_exec_from_accessor(&t3, &accessor),
                             equal(column(&t3, "a3", &accessor), const_int128(6_i128)),
                         ),
                         projection(


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
