### PR TITLE
ci: usage of nextest instead of normal test to improve time

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Clean Previous Coverage Artifacts
         run: cargo llvm-cov clean --workspace
       - name: Run Tests to Generate Coverage Data (All Features)
-        run: cargo llvm-cov --no-report --all-features --workspace --exclude proof-of-sql-benches --ignore-filename-regex evm_tests
+        run: cargo llvm-cov nextest --no-report --all-features --workspace --exclude proof-of-sql-benches --ignore-filename-regex evm_tests
       #- name: Run Tests to Generate Coverage Data (Rayon Only)
       #  run: cargo llvm-cov --no-report --no-default-features --features="rayon"
       #- name: Run Tests to Generate Coverage Data (Blitzar Only)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -177,6 +177,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y clang lld
       - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
       - name: Clean Previous Coverage Artifacts
         run: cargo llvm-cov clean --workspace
       - name: Run Tests to Generate Coverage Data (All Features)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -83,8 +83,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y clang lld
-      - run: cargo install cargo-nextest --locked
-      - run: cargo nextest run --all-features
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --all-features --jobs=8
 
   testnorayon:
     name: Test Suite (without rayon)
@@ -94,8 +94,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y clang lld
-      - run: cargo install cargo-nextest --locked
-      - run: cargo nextest run --no-default-features --features="arrow blitzar"
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --no-default-features --features="arrow blitzar" --jobs=8
 
   testother:
     name: Test Suite (other)
@@ -112,8 +112,7 @@ jobs:
           export DEBIAN_FRONTEND=non-interactive
           sudo apt-get update
           sudo apt-get install -y clang lld
-      - name: Install nextest
-        run: cargo install cargo-nextest --locked
+      - uses: taiki-e/install-action@nextest
       - name: Dry run cargo test (proof-of-sql) (test feature only)
         run: cargo nextest run -p proof-of-sql --no-run --no-default-features --features="test"
       - name: Dry run cargo test (proof-of-sql) (arrow feature only)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y clang lld
-      - run: cargo install nextest --locked
+      - run: cargo install cargo-nextest --locked
       - run: cargo nextest run --all-features
 
   testnorayon:
@@ -94,7 +94,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y clang lld
-      - run: cargo install nextest --locked
+      - run: cargo install cargo-nextest --locked
       - run: cargo nextest run --no-default-features --features="arrow blitzar"
 
   testother:
@@ -113,7 +113,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang lld
       - name: Install nextest
-        run: cargo install nextest --locked
+        run: cargo install cargo-nextest --locked
       - name: Dry run cargo test (proof-of-sql) (test feature only)
         run: cargo nextest run -p proof-of-sql --no-run --no-default-features --features="test"
       - name: Dry run cargo test (proof-of-sql) (arrow feature only)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y clang lld
       - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --all-features --jobs=8
+      - run: cargo nextest run --all-features --jobs=$(nproc)
 
   testnorayon:
     name: Test Suite (without rayon)
@@ -95,7 +95,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y clang lld
       - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --no-default-features --features="arrow blitzar" --jobs=8
+      - run: cargo nextest run --no-default-features --features="arrow blitzar" --jobs=$(nproc)
 
   testother:
     name: Test Suite (other)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -83,7 +83,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y clang lld
-      - run: cargo test --all-features
+      - run: cargo install nextest --locked
+      - run: cargo nextest run --all-features
 
   testnorayon:
     name: Test Suite (without rayon)
@@ -93,7 +94,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y clang lld
-      - run: cargo test --no-default-features --features="arrow blitzar"
+      - run: cargo install nextest --locked
+      - run: cargo nextest run --no-default-features --features="arrow blitzar"
 
   testother:
     name: Test Suite (other)
@@ -110,18 +112,20 @@ jobs:
           export DEBIAN_FRONTEND=non-interactive
           sudo apt-get update
           sudo apt-get install -y clang lld
+      - name: Install nextest
+        run: cargo install nextest --locked
       - name: Dry run cargo test (proof-of-sql) (test feature only)
-        run: cargo test -p proof-of-sql --no-run --no-default-features --features="test"
+        run: cargo nextest run -p proof-of-sql --no-run --no-default-features --features="test"
       - name: Dry run cargo test (proof-of-sql) (arrow feature only)
-        run: cargo test -p proof-of-sql --no-run --no-default-features --features="arrow"
+        run: cargo nextest run  -p proof-of-sql --no-run --no-default-features --features="arrow"
       - name: Dry run cargo test (proof-of-sql) (blitzar feature only)
-        run: cargo test -p proof-of-sql --no-run --no-default-features --features="blitzar"
+        run: cargo nextest run -p proof-of-sql --no-run --no-default-features --features="blitzar"
       - name: Dry run cargo test (proof-of-sql) (std feature only)
-        run: cargo test -p proof-of-sql --no-run --no-default-features --features="std"
+        run: cargo nextest run  -p proof-of-sql --no-run --no-default-features --features="std"
       - name: Run cargo test (proof primitives - Dory) (std feature only - i.e. not using blitzar)
         run: |
-            cargo test proof_primitive::dory::dory_compute_commitments_test --no-default-features --features="std" && \
-            cargo test proof_primitive::dory::dynamic_dory_compute_commitments_test --no-default-features --features="std"
+            cargo nextest run  proof_primitive::dory::dory_compute_commitments_test --no-default-features --features="std" && \
+            cargo nextest run  proof_primitive::dory::dynamic_dory_compute_commitments_test --no-default-features --features="std"
 
   examples:
       name: Run Examples (Heavy)


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
