### PR TITLE
ci: move code coverage to its own file and not make it block releases

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,46 @@
+name: CI-Code-Coverage
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  BLITZAR_BACKEND: cpu
+
+jobs:
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - name: Install Dependencies
+      run: sudo apt-get update && sudo apt-get install -y clang lld
+    - uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Clean Previous Coverage Artifacts
+      run: cargo llvm-cov clean --workspace
+    - name: Run Tests to Generate Coverage Data (All Features)
+      run: cargo llvm-cov --no-report --all-features --workspace --exclude proof-of-sql-benches --ignore-filename-regex evm_tests
+    #- name: Run Tests to Generate Coverage Data (Rayon Only)
+    #  run: cargo llvm-cov --no-report --no-default-features --features="rayon"
+    #- name: Run Tests to Generate Coverage Data (Blitzar Only)
+    #  run: cargo llvm-cov --no-report --no-default-features --features="blitzar"
+    #- name: Run Tests to Generate Coverage Data (std only)
+    #  run: cargo llvm-cov --no-report --no-default-features --features="std"
+    - name: Generate Final LCOV Report (Merged Coverage)
+      run: cargo llvm-cov report --lcov --ignore-filename-regex '[/\\]evm_tests\.rs$' --output-path lcov.info
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        files: lcov.info
+        fail_ci_if_error: true
+    - name: Enforce Coverage Threshold
+      run: cargo llvm-cov report --summary-only --fail-under-lines 94

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -164,37 +164,6 @@ jobs:
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
       - name: Run clippy
         run: cargo cl -- -D warnings
-
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang lld
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Clean Previous Coverage Artifacts
-        run: cargo llvm-cov clean --workspace
-      - name: Run Tests to Generate Coverage Data (All Features)
-        run: cargo llvm-cov --no-report --all-features --workspace --exclude proof-of-sql-benches --ignore-filename-regex evm_tests
-      #- name: Run Tests to Generate Coverage Data (Rayon Only)
-      #  run: cargo llvm-cov --no-report --no-default-features --features="rayon"
-      #- name: Run Tests to Generate Coverage Data (Blitzar Only)
-      #  run: cargo llvm-cov --no-report --no-default-features --features="blitzar"
-      #- name: Run Tests to Generate Coverage Data (std only)
-      #  run: cargo llvm-cov --no-report --no-default-features --features="std"
-      - name: Generate Final LCOV Report (Merged Coverage)
-        run: cargo llvm-cov report --lcov --ignore-filename-regex '[/\\]evm_tests\.rs$' --output-path lcov.info
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: lcov.info
-          fail_ci_if_error: true
-      - name: Enforce Coverage Threshold
-        run: cargo llvm-cov report --summary-only --fail-under-lines 94
         
   # Run cargo f --check
   format:


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here:  
https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr

---

## Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here:  
      https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md  
      (breaking changes use `!`)
- [x] I have run the CI check script with  
      ```bash
      source scripts/run_ci_checks.sh
      ```
- [x] I have run the clean commit check script with  
      ```bash
      source scripts/check_commits.sh
      ```  
      and the commit history follows the clean-commit guidelines:  
      https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated into this PR by simple rebase (or conflicts have been resolved appropriately).

---

# Rationale for this change
Moving code coverage into its own workflow decouples coverage reporting from the main lint-and-test pipeline, ensuring coverage checks no longer block release merges while still enforcing our minimum coverage threshold.

---

# What changes are included in this PR?
- **Add** `.github/workflows/code-coverage.yml`  
  - Defines a dedicated `CI-Code-Coverage` job that runs on pull request events and in merge groups  
  - Installs dependencies, generates coverage data with `cargo llvm-cov`, uploads to Codecov, and enforces a minimum coverage threshold
- **Update** `.github/workflows/lint-and-test.yml`  
  - **Remove** the embedded code coverage job so that linting and tests run independently of coverage

---

# Are these changes tested?
Yes. All existing lint-and-test jobs pass as before, and the new code coverage workflow executes successfully on pull requests without blocking releases.  
