### PR TITLE
feat: uppercase column visitor

### DIFF
--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -25,6 +25,8 @@ mod proof_plan_with_postprocessing;
 pub use proof_plan_with_postprocessing::{
     logical_plan_to_proof_plan_with_postprocessing, ProofPlanWithPostprocessing,
 };
+mod uppercase_column_visitor;
+pub use uppercase_column_visitor::{statement_with_uppercase_identifiers, uppercase_identifier};
 mod util;
 pub use util::column_fields_to_schema;
 pub(crate) use util::{

--- a/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
+++ b/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
@@ -1,0 +1,60 @@
+use sqlparser::ast::{visit_relations_mut, Expr, Ident, Statement, VisitMut, VisitorMut};
+use std::ops::ControlFlow;
+
+/// Returns an uppercased version of Ident
+/// Leaving this as public because the sdk also uses this function
+#[must_use]
+#[expect(clippy::needless_pass_by_value)]
+pub fn uppercase_identifier(ident: Ident) -> Ident {
+    let value = ident.value.to_uppercase();
+    Ident { value, ..ident }
+}
+
+struct UppercaseColumnVisitor;
+
+impl VisitorMut for UppercaseColumnVisitor {
+    type Break = ();
+
+    fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
+        match expr {
+            Expr::Identifier(ident) => *ident = uppercase_identifier(ident.clone()),
+            Expr::CompoundIdentifier(idents) => {
+                idents
+                    .iter_mut()
+                    .for_each(|ident| *ident = uppercase_identifier(ident.clone()));
+            }
+            _ => (),
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+/// Returns the sqlparser statement with all of its column/table identifiers uppercased.
+pub fn statement_with_uppercase_identifiers(mut statement: Statement) -> Statement {
+    statement.visit(&mut UppercaseColumnVisitor);
+
+    // uppercase all tables
+    visit_relations_mut(&mut statement, |object_name| {
+        object_name.0.iter_mut().for_each(|ident| {
+            ident.value = ident.value.to_uppercase();
+        });
+
+        ControlFlow::<()>::Continue(())
+    });
+
+    statement
+}
+
+#[cfg(test)]
+mod tests {
+    use super::statement_with_uppercase_identifiers;
+    use sqlparser::{dialect::GenericDialect, parser::Parser};
+
+    #[test]
+    fn we_can_capitalize_statement_idents() {
+        let statement = Parser::parse_sql(&GenericDialect{}, "SELECT a.thissum from (SELECT Sum(uppercase_Value) as thissum, COUNT(puppies) as coUNT fRoM NonSEnSE) as a").unwrap()[0].clone();
+        let statement = statement_with_uppercase_identifiers(statement);
+        let expected_statement = Parser::parse_sql(&GenericDialect{}, "SELECT A.THISSUM from (SELECT Sum(UPPERCASE_VALUE) as thissum, COUNT(PUPPIES) as coUNT fRoM NONSENSE) as a").unwrap()[0].clone();
+        assert_eq!(statement, expected_statement);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

`sqlparser::Statement` does not have a built in way to capitalize all the column and table idents, and we would like that functionality.

# What changes are included in this PR?

New function for capitalizing all the idents in a `Statement`.

# Are these changes tested?
Yes
