### PR TITLE
bench: update filter, complex filter, and group by queries

### DIFF
--- a/crates/proof-of-sql-benches/src/main.rs
+++ b/crates/proof-of-sql-benches/src/main.rs
@@ -90,8 +90,8 @@ enum CommitmentScheme {
 enum Query {
     /// All queries
     All,
-    /// Single column filter query
-    SingleColumnFilter,
+    /// Filter query
+    Filter,
     /// Multi column filter query
     MultiColumnFilter,
     /// Arithmetic query
@@ -117,7 +117,7 @@ impl Query {
     pub fn to_string(&self) -> &'static str {
         match self {
             Query::All => "All",
-            Query::SingleColumnFilter => "Single Column Filter",
+            Query::Filter => "Filter",
             Query::MultiColumnFilter => "Multi Column Filter",
             Query::Arithmetic => "Arithmetic",
             Query::GroupBy => "Group By",

--- a/crates/proof-of-sql-benches/src/main.rs
+++ b/crates/proof-of-sql-benches/src/main.rs
@@ -93,7 +93,7 @@ enum Query {
     /// Filter query
     Filter,
     /// Multi column filter query
-    MultiColumnFilter,
+    ComplexFilter,
     /// Arithmetic query
     Arithmetic,
     /// Group by query
@@ -118,7 +118,7 @@ impl Query {
         match self {
             Query::All => "All",
             Query::Filter => "Filter",
-            Query::MultiColumnFilter => "Multi Column Filter",
+            Query::ComplexFilter => "Complex Filter",
             Query::Arithmetic => "Arithmetic",
             Query::GroupBy => "Group By",
             Query::Aggregate => "Aggregate",

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -64,15 +64,15 @@ impl BaseEntry for Filter {
     }
 }
 
-/// Multi-column filter query.
-pub struct MultiColumnFilter;
-impl BaseEntry for MultiColumnFilter {
+/// Complex filter query.
+pub struct ComplexFilter;
+impl BaseEntry for ComplexFilter {
     fn title(&self) -> &'static str {
-        "Multi Column Filter"
+        "Complex Filter"
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT * FROM bench_table WHERE ((a = $1) OR (b = $2)) AND (c = $3)"
+        "SELECT * FROM bench_table WHERE (((a = $1) AND (b = $2)) OR ((c = $3) AND (d = $4)))"
     }
 
     fn columns(&self) -> Vec<ColumnDefinition> {
@@ -88,6 +88,7 @@ impl BaseEntry for MultiColumnFilter {
                 Some(|size| (size / 10).max(10) as i64),
             ),
             ("c", ColumnType::VarChar, None),
+            ("d", ColumnType::VarChar, None),
         ]
     }
 
@@ -96,6 +97,7 @@ impl BaseEntry for MultiColumnFilter {
             LiteralValue::BigInt(0),
             LiteralValue::BigInt(1),
             LiteralValue::VarChar("a".to_string()),
+            LiteralValue::VarChar("b".to_string()),
         ]
     }
 }
@@ -407,7 +409,7 @@ impl BaseEntry for Coin {
 pub fn all_queries() -> Vec<QueryEntry> {
     vec![
         Filter.entry(),
-        MultiColumnFilter.entry(),
+        ComplexFilter.entry(),
         Arithmetic.entry(),
         GroupBy.entry(),
         Aggregate.entry(),

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -37,11 +37,11 @@ pub trait BaseEntry {
     }
 }
 
-/// Single column filter query.
-pub struct SingleColumnFilter;
-impl BaseEntry for SingleColumnFilter {
+/// Filter query.
+pub struct Filter;
+impl BaseEntry for Filter {
     fn title(&self) -> &'static str {
-        "Single Column Filter"
+        "Filter"
     }
 
     fn sql(&self) -> &'static str {
@@ -406,7 +406,7 @@ impl BaseEntry for Coin {
 /// Retrieves all available queries.
 pub fn all_queries() -> Vec<QueryEntry> {
     vec![
-        SingleColumnFilter.entry(),
+        Filter.entry(),
         MultiColumnFilter.entry(),
         Arithmetic.entry(),
         GroupBy.entry(),

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -142,7 +142,7 @@ impl BaseEntry for GroupBy {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT a, COUNT(*) FROM bench_table WHERE (c = $1) and (a <= b) and (a > $2) GROUP BY a"
+        "SELECT SUM(a), COUNT(*) FROM bench_table WHERE a = $1 GROUP BY b"
     }
 
     fn columns(&self) -> Vec<ColumnDefinition> {
@@ -157,12 +157,11 @@ impl BaseEntry for GroupBy {
                 ColumnType::Int,
                 Some(|size| (size / 10).max(10) as i64),
             ),
-            ("c", ColumnType::Boolean, None),
         ]
     }
 
     fn params(&self) -> Vec<LiteralValue> {
-        vec![LiteralValue::Boolean(true), LiteralValue::Int(0)]
+        vec![LiteralValue::Int(0)]
     }
 }
 


### PR DESCRIPTION
# Rationale for this change
Recently the benchmarks were updated using a filter, complex filter, and group by query. This PR updates the `proof-of-sql-benches` crate to have those queries.

# What changes are included in this PR?
- The Single Column Filter query is renamed to Filter
- The Multi-Column Filter query is updated and renamed to Complex Filter
- The Group-By query is updated to a more realistic query 

# Are these changes tested?
Yes
