### PR TITLE
refactor: simplify range check syntax

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -104,10 +104,9 @@ pub(crate) fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
     let alpha = builder.consume_post_result_challenge();
 
     // avoids usize to u8 cast
-    let mut word_value_table = [0u8; 256];
+    let word_val_table = alloc.alloc_slice_fill_iter(0u8..=255);
     let mut inv_word_values_plus_alpha_table = [S::ZERO; 256];
     for i in 0u8..=255 {
-        word_value_table[i as usize] = i;
         inv_word_values_plus_alpha_table[i as usize] = S::from(&i);
     }
     let inv_word_vals_plus_alpha_table: &mut [S] = alloc
@@ -134,7 +133,7 @@ pub(crate) fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
         alloc,
         alpha,
         builder,
-        alloc.alloc_slice_copy(&word_value_table), // give this an explicit lifetime for MLE commitment
+        word_val_table, // give this an explicit lifetime for MLE commitment
         inv_word_vals_plus_alpha_table,
     );
 

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -105,14 +105,8 @@ pub(crate) fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
 
     // avoids usize to u8 cast
     let word_val_table = alloc.alloc_slice_fill_iter(0u8..=255);
-    let mut inv_word_values_plus_alpha_table = [S::ZERO; 256];
-    for i in 0u8..=255 {
-        inv_word_values_plus_alpha_table[i as usize] = S::from(&i);
-    }
-    let inv_word_vals_plus_alpha_table: &mut [S] = alloc
-        .alloc_slice_fill_with(inv_word_values_plus_alpha_table.len(), |i| {
-            inv_word_values_plus_alpha_table[i]
-        });
+    let inv_word_vals_plus_alpha_table: &mut [S] =
+        alloc.alloc_slice_fill_iter((0..256).map(S::from));
     // Add alpha, batch invert, etc.
     slice_ops::add_const::<S, S>(inv_word_vals_plus_alpha_table, alpha);
     slice_ops::batch_inversion(inv_word_vals_plus_alpha_table);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

There are a few places in range check that could be written more succinctly.

# What changes are included in this PR?

Reduction of code.

# Are these changes tested?
Yes
