### PR TITLE
bench: add JOIN query to benchmarks

### DIFF
--- a/crates/proof-of-sql-benches/src/main.rs
+++ b/crates/proof-of-sql-benches/src/main.rs
@@ -110,6 +110,8 @@ enum Query {
     SumCount,
     /// Coin query
     Coin,
+    /// Join query
+    Join,
 }
 
 impl Query {
@@ -127,6 +129,7 @@ impl Query {
             Query::ComplexCondition => "Complex Condition",
             Query::SumCount => "Sum Count",
             Query::Coin => "Coin",
+            Query::Join => "Join",
         }
     }
 }
@@ -423,7 +426,16 @@ fn bench_hyperkzg(cli: &Cli, queries: &[QueryEntry]) {
 
         (prover_setup, vk)
     } else {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"bench", cli.table_size);
+        let table_size = if queries
+            .iter()
+            .any(|query| query.0 == Query::Join.to_string())
+        {
+            cli.table_size * 2
+        } else {
+            cli.table_size
+        };
+
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"bench", table_size);
         let (_, vk) = EvaluationEngine::setup(&ck);
         let prover_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
         (prover_setup, vk)

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -441,6 +441,45 @@ impl BaseEntry for Coin {
     }
 }
 
+/// Join query.
+pub struct Join;
+impl BaseEntry for Join {
+    fn title(&self) -> &'static str {
+        "Join"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT bench_table.a, bench_table_2.a
+         FROM bench_table
+         JOIN bench_table_2 on bench_table.a=bench_table_2.a"
+    }
+
+    fn tables(&self) -> Vec<TableDefinition> {
+        vec![
+            TableDefinition {
+                name: "bench_table",
+                columns: vec![(
+                    "a",
+                    ColumnType::BigInt,
+                    Some(|size| (size / 10 * size).max(10) as i64),
+                )],
+            },
+            TableDefinition {
+                name: "bench_table_2",
+                columns: vec![(
+                    "a",
+                    ColumnType::BigInt,
+                    Some(|size| (size / 10 * size).max(10) as i64),
+                )],
+            },
+        ]
+    }
+
+    fn params(&self) -> Vec<LiteralValue> {
+        vec![LiteralValue::BigInt(0)]
+    }
+}
+
 /// Retrieves all available queries.
 pub fn all_queries() -> Vec<QueryEntry> {
     vec![
@@ -454,6 +493,7 @@ pub fn all_queries() -> Vec<QueryEntry> {
         ComplexCondition.entry(),
         SumCount.entry(),
         Coin.entry(),
+        Join.entry(),
     ]
 }
 


### PR DESCRIPTION
# Rationale for this change
This PR adds a `JOIN` query to the benchmarks and ensures the `HyperKZG` setup has enough generators to handle the table size.

# What changes are included in this PR?
- A `JOIN` query is added to the benchmarks
- The HyperKZG setup doubles the setup table size if running the `JOIN` query

# Are these changes tested?
Yes