### PR TITLE
feat: binary serde standard functions

### DIFF
--- a/crates/proof-of-sql/src/base/mod.rs
+++ b/crates/proof-of-sql/src/base/mod.rs
@@ -14,7 +14,11 @@ pub(crate) mod polynomial;
 /// Module for Proof of SQL datetime types.
 pub mod posql_time;
 pub(crate) mod proof;
+mod standard_binary_serde;
 pub use proof::{PlaceholderError, PlaceholderResult};
+pub use standard_binary_serde::{
+    try_standard_binary_deserialization, try_standard_binary_serialization,
+};
 pub(crate) mod ref_into;
 /// This module contains the `Scalar` trait as well as the main, generic, implementations of it.
 pub mod scalar;

--- a/crates/proof-of-sql/src/base/proof/transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript.rs
@@ -1,4 +1,4 @@
-use crate::base::scalar::Scalar;
+use crate::base::{scalar::Scalar, try_standard_binary_serialization};
 use alloc::vec::Vec;
 use zerocopy::{AsBytes, FromBytes};
 
@@ -41,14 +41,9 @@ pub trait Transcript {
     /// # Panics
     /// - Panics if `postcard::to_allocvec(message)` fails to serialize the message.
     fn extend_serialize_as_le(&mut self, message: &(impl serde::Serialize + ?Sized)) {
-        self.extend_as_le_from_refs([bincode::serde::encode_to_vec(
-            message,
-            bincode::config::legacy()
-                .with_fixed_int_encoding()
-                .with_big_endian(),
-        )
-        .unwrap()
-        .as_slice()]);
+        self.extend_as_le_from_refs([try_standard_binary_serialization(message)
+            .unwrap()
+            .as_slice()]);
     }
     /// Appends a type that implements [`ark_serialize::CanonicalSerialize`] by appending the raw bytes (i.e. assuming the message is littleendian)
     ///

--- a/crates/proof-of-sql/src/base/standard_binary_serde.rs
+++ b/crates/proof-of-sql/src/base/standard_binary_serde.rs
@@ -1,0 +1,54 @@
+use alloc::vec::Vec;
+use bincode::{
+    config::Config,
+    error::{DecodeError, EncodeError},
+};
+use serde::{Deserialize, Serialize};
+
+fn standard_binary_config() -> impl Config {
+    bincode::config::legacy()
+        .with_fixed_int_encoding()
+        .with_big_endian()
+}
+
+/// The standard serialization we use for our proof types
+pub fn try_standard_binary_serialization(
+    value_to_be_serialized: impl Serialize,
+) -> Result<Vec<u8>, EncodeError> {
+    bincode::serde::encode_to_vec(value_to_be_serialized, standard_binary_config())
+}
+
+/// The standard deserialization we use for our proof types
+pub fn try_standard_binary_deserialization<D: for<'a> Deserialize<'a>>(
+    value_to_be_deserialized: &[u8],
+) -> Result<(D, usize), DecodeError> {
+    bincode::serde::decode_from_slice(value_to_be_deserialized, standard_binary_config())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{try_standard_binary_deserialization, try_standard_binary_serialization};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+    struct SerdeTestType {
+        a: String,
+        b: bool,
+        c: i32,
+    }
+
+    #[test]
+    fn round_trip() {
+        let obj = SerdeTestType {
+            a: "test".to_string(),
+            b: false,
+            c: 123,
+        };
+        let serialized = try_standard_binary_serialization(obj.clone()).unwrap();
+        let (deserialized, _): (SerdeTestType, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+        assert_eq!(obj, deserialized);
+        let reserialized = try_standard_binary_serialization(deserialized).unwrap();
+        assert_eq!(serialized, reserialized);
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -218,6 +218,7 @@ mod tests {
     use super::*;
     #[cfg(feature = "hyperkzg_proof")]
     use crate::base::database::OwnedColumn;
+    use crate::base::{try_standard_binary_deserialization, try_standard_binary_serialization};
     #[cfg(feature = "hyperkzg_proof")]
     use crate::proof_primitive::hyperkzg::nova_commitment_key_to_hyperkzg_public_setup;
     #[cfg(feature = "hyperkzg_proof")]
@@ -262,28 +263,22 @@ mod tests {
 
     #[test]
     fn we_can_serialize_and_deserialize_hyperkzg_commitment_generator() {
-        let bincode_config = bincode::config::legacy()
-            .with_fixed_int_encoding()
-            .with_big_endian();
         let commitment: HyperKZGCommitment = (&G1Affine::generator()).into();
-        let bytes = bincode::serde::encode_to_vec(commitment, bincode_config).unwrap();
+        let bytes = try_standard_binary_serialization(commitment).unwrap();
         assert_eq!(bytes, [&[0u8; 31][..], &[1], &[0; 31], &[2]].concat());
 
         let (deserialized_commitment, _): (HyperKZGCommitment, _) =
-            bincode::serde::decode_from_slice(&bytes[..], bincode_config).unwrap();
+            try_standard_binary_deserialization(&bytes[..]).unwrap();
         assert_eq!(deserialized_commitment.commitment, G1Affine::generator());
     }
     #[test]
     fn we_can_serialize_and_deserialize_hyperkzg_commitment_identity() {
-        let bincode_config = bincode::config::legacy()
-            .with_fixed_int_encoding()
-            .with_big_endian();
         let commitment: HyperKZGCommitment = (&G1Affine::identity()).into();
-        let bytes = bincode::serde::encode_to_vec(commitment, bincode_config).unwrap();
+        let bytes = try_standard_binary_serialization(commitment).unwrap();
         assert_eq!(bytes, [&[0u8; 31][..], &[0], &[0; 31], &[0]].concat());
 
         let (deserialized_commitment, _): (HyperKZGCommitment, _) =
-            bincode::serde::decode_from_slice(&bytes[..], bincode_config).unwrap();
+            try_standard_binary_deserialization(&bytes[..]).unwrap();
         assert_eq!(deserialized_commitment.commitment, G1Affine::identity());
     }
     #[test]
@@ -292,14 +287,11 @@ mod tests {
 
         let mut rng = ark_std::test_rng();
 
-        let bincode_config = bincode::config::legacy()
-            .with_fixed_int_encoding()
-            .with_big_endian();
         for _ in 0..100 {
             let commitment: HyperKZGCommitment = (&G1Affine::rand(&mut rng)).into();
-            let bytes = bincode::serde::encode_to_vec(commitment, bincode_config).unwrap();
+            let bytes = try_standard_binary_serialization(commitment).unwrap();
             let (deserialized_commitment, _): (HyperKZGCommitment, _) =
-                bincode::serde::decode_from_slice(&bytes[..], bincode_config).unwrap();
+                try_standard_binary_deserialization(&bytes[..]).unwrap();
             assert_eq!(deserialized_commitment.commitment, commitment.commitment);
         }
     }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Just for the sake of clarity, and some conciseness, it would be helpful to have functions that serialize and deserialize our objects using a standard config.

# What changes are included in this PR?

New functions `try_standard_binary_serialization` and `try_standard_binary_deserialization`.

# Are these changes tested?
Yes
