### PR TITLE
fix!: use keccak instead of blake3 for varchar hashing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ arrow-csv = { version = "51.0.0" }
 bincode = { version = "2.0.0-rc.3", default-features = false }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
-blake3 = { version = "1.3.3", default-features = false }
 blitzar = { version = "4.3.0" }
 bnum = { version = "0.3.0" }
 bumpalo = { version = "3.11.0" }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -27,7 +27,6 @@ arrow = { workspace = true, optional = true }
 bincode = { workspace = true, features = ["serde", "alloc"] }
 bit-iter = { workspace = true }
 bigdecimal = { workspace = true }
-blake3 = { workspace = true }
 blitzar = { workspace = true, optional = true }
 bnum = { workspace = true }
 bumpalo = { workspace = true, features = ["collections"] }

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -1,4 +1,4 @@
-use crate::base::scalar::{Scalar, ScalarConversionError};
+use crate::base::scalar::{Scalar, ScalarConversionError, ScalarExt};
 use alloc::{
     format,
     string::{String, ToString},
@@ -17,7 +17,7 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 use num_bigint::BigInt;
-use num_traits::{Signed, Zero};
+use num_traits::Signed;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[derive(CanonicalSerialize, CanonicalDeserialize, TransparentWrapper)]
 /// A wrapper struct around a `Fp256<MontBackend<T, 4>>` that can easily implement the `Scalar` trait.
@@ -134,15 +134,7 @@ macro_rules! impl_from_for_mont_scalar_for_type_supported_by_from {
 /// Implement `From<&[u8]>` for `MontScalar`
 impl<T: MontConfig<4>> From<&[u8]> for MontScalar<T> {
     fn from(x: &[u8]) -> Self {
-        if x.is_empty() {
-            return Self::zero();
-        }
-
-        let hash = blake3::hash(x);
-        let mut bytes: [u8; 32] = hash.into();
-        bytes[31] &= 0b0000_1111_u8;
-
-        Self::from_le_bytes_mod_order(&bytes)
+        ScalarExt::from_byte_slice_via_hash(x)
     }
 }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We need to be using keccak instead of blak3.

# What changes are included in this PR?

Replacing usage of keccak with blak3.

# Are these changes tested?

