### PR TITLE
refactor: remove unnecessary vec from range check verification

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -375,7 +375,7 @@ pub(crate) fn verifier_evaluate_range_check<S: Scalar>(
     // Additionally, we'll collect all (wᵢ + α)⁻¹ evaluations in `w_plus_alpha_inv_evals`
     // to use later for the ZeroSum argument.
     let mut sum = S::ZERO;
-    let mut w_plus_alpha_inv_evals = Vec::with_capacity(31);
+    let mut row_sum_eval = S::ZERO;
 
     // Process 31 columns (one per byte in a 248-bit decomposition).
     // Each iteration handles:
@@ -407,8 +407,8 @@ pub(crate) fn verifier_evaluate_range_check<S: Scalar>(
         // Add wᵢ * 256ⁱ to our running sum to ensure the entire column is in range
         sum += w_eval * power;
 
-        // Collect the inverse factor for the final ZeroSum argument
-        w_plus_alpha_inv_evals.push(words_inv);
+        // Sum over all (wᵢ + α)⁻¹ evaluations to get row_sum_eval
+        row_sum_eval += words_inv;
     }
 
     // Ensure the sum of the scalars (interpreted in base 256) matches
@@ -437,12 +437,6 @@ pub(crate) fn verifier_evaluate_range_check<S: Scalar>(
 
     // The final-round MLE evaluation for word count
     let count_eval = builder.try_consume_final_round_mle_evaluation()?;
-
-    // Sum over all (wᵢ + α)⁻¹ evaluations to get row_sum_eval
-    let mut row_sum_eval = S::ZERO;
-    for inv_eval in &w_plus_alpha_inv_evals {
-        row_sum_eval += *inv_eval;
-    }
 
     // Compute count_eval * (word_vals + α)⁻¹
     let count_value_product_eval = count_eval * word_vals_plus_alpha_inv;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a slight improvement in the verification of range check

# What changes are included in this PR?

Removing a vec that is unneeded

# Are these changes tested?
Yes
