### PR TITLE
test: add post result challenges to mock verification builder

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -226,6 +226,7 @@ fn we_can_verify_a_simple_proof() {
         4,
         &first_round_builder,
         &final_round_builder,
+        Vec::new(),
         3,
         |verification_builder, chi_eval, evaluation_point| {
             let accessor = indexmap! {
@@ -277,6 +278,7 @@ fn we_can_reject_a_simple_tampered_proof() {
         3,
         Vec::new(),
         final_round_mles,
+        Vec::new(),
         Vec::new(),
         Vec::new(),
     );

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -188,6 +188,7 @@ mod tests {
             lhs.len(),
             &first_round_builder,
             &final_round_builder,
+            Vec::new(),
             4,
             |verification_builder, chi_eval, evaluation_point| {
                 let accessor = indexmap! {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
@@ -166,6 +166,7 @@ mod tests {
             3,
             &first_round_builder,
             &final_round_builder,
+            Vec::new(),
             3,
             |verification_builder, chi_eval, evaluation_point| {
                 verify_permutation_check(


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Because range check uses post result challenges, it will be helpful to add functionality to the mock verification builder for them.

# What changes are included in this PR?

Adding functionality for post result challenges in the `MockVerificationBuilder`.

# Are these changes tested?
Yes
