### PR TITLE
feat: byte matrix

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_distribution.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_distribution.rs
@@ -18,7 +18,6 @@ pub struct ByteDistribution {
 
 impl ByteDistribution {
     /// Creates the `ByteDistribution` for a column of data.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub fn new<S: Scalar, T: Into<S> + Copy>(data: &[T]) -> Self {
         let bit_masks = data.iter().copied().map(Into::<S>::into).map(make_bit_mask);
         let (vary_mask, constant_mask) = (0u8..32)
@@ -51,7 +50,6 @@ impl ByteDistribution {
 
     /// Returns the starting indices (`0, 8, ..., 248` are the possible values) of all varying byte columns.
     #[expect(clippy::missing_panics_doc)]
-    #[cfg_attr(not(test), expect(dead_code))]
     pub fn varying_byte_indices(&self) -> impl Iterator<Item = u8> + '_ {
         BitIter::from(self.vary_mask)
             .iter()

--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -1,0 +1,106 @@
+use super::ByteDistribution;
+use crate::base::{bit::bit_mask_utils::make_bit_mask, scalar::Scalar};
+use alloc::vec::Vec;
+use bnum::types::U256;
+use bumpalo::Bump;
+use core::ops::Shr;
+
+/// Calculates the byte matrix for a column of data
+/// The `Vec<&'a [u8]>` values are the bytes of the columns that vary.
+/// The `ByteDistribution` indicate which columns are constant and what those constant values are.
+#[expect(clippy::missing_panics_doc)]
+#[cfg_attr(not(test), expect(dead_code))]
+pub fn compute_varying_byte_matrix<'a, S: Scalar>(
+    column_data: &[S],
+    alloc: &'a Bump,
+) -> (Vec<&'a [u8]>, ByteDistribution) {
+    let dist = ByteDistribution::new::<S, S>(column_data);
+    let byte_matrix = dist
+        .varying_byte_indices()
+        .map(|start_index| {
+            alloc.alloc_slice_fill_iter(column_data.iter().map(|row| {
+                let bit_mask = make_bit_mask(*row);
+                // This will not panic because & 255 guarantees the value is at most 255
+                (bit_mask.shr(start_index) & U256::from(255u8))
+                    .try_into()
+                    .unwrap()
+            })) as &[_]
+        })
+        .collect();
+    (byte_matrix, dist)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::base::{
+        byte::{byte_matrix_utils::compute_varying_byte_matrix, ByteDistribution},
+        scalar::{test_scalar::TestScalar, Scalar},
+    };
+    use bumpalo::Bump;
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_small_scalars() {
+        let alloc = Bump::new();
+        let scalars: Vec<TestScalar> = [1, 2, 3, 255, 256, 257]
+            .iter()
+            .map(TestScalar::from)
+            .collect();
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        let expected_word_columns = vec![vec![1, 2, 3, 255, 0, 1], vec![0, 0, 0, 0, 1, 1]];
+        assert_eq!(varying_columns, expected_word_columns);
+    }
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_large_scalars() {
+        let alloc = Bump::new();
+        let scalars = vec![
+            TestScalar::MAX_SIGNED,
+            TestScalar::from(u64::MAX),
+            -TestScalar::ONE,
+        ];
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+        assert_eq!(byte_distribution, expected_byte_distribution);
+
+        let expected_word_columns = vec![
+            [246, 255, 255],
+            [233, 255, 255],
+            [122, 255, 255],
+            [46, 255, 255],
+            [141, 255, 255],
+            [49, 255, 255],
+            [9, 255, 255],
+            [44, 255, 255],
+            [107, 0, 255],
+            [206, 0, 255],
+            [123, 0, 255],
+            [81, 0, 255],
+            [239, 0, 255],
+            [124, 0, 255],
+            [111, 0, 255],
+            [10, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [0, 0, 255],
+            [136, 128, 127],
+        ];
+
+        assert_eq!(varying_columns, expected_word_columns);
+    }
+}

--- a/crates/proof-of-sql/src/base/byte/mod.rs
+++ b/crates/proof-of-sql/src/base/byte/mod.rs
@@ -1,1 +1,3 @@
 mod byte_distribution;
+pub mod byte_matrix_utils;
+pub use byte_distribution::*;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We want to be able to break a column of data into its byte matrix.

# What changes are included in this PR?

New function `compute_varying_byte_matrix`.

# Are these changes tested?
Yes
