### PR TITLE
fix!: update post sol

### DIFF
--- a/solidity/src/verifier/Verifier.post.sol
+++ b/solidity/src/verifier/Verifier.post.sol
@@ -752,19 +752,10 @@ library Verifier {
             // IMPORTED-YUL ../proof_exprs/LiteralExpr.pre.sol::literal_expr_evaluate
             function exclude_coverage_start_literal_expr_evaluate() {} // solhint-disable-line no-empty-blocks
             function literal_expr_evaluate(expr_ptr, chi_eval) -> expr_ptr_out, eval {
-                let literal_variant := shr(UINT32_PADDING_BITS, calldataload(expr_ptr))
-                expr_ptr := add(expr_ptr, UINT32_SIZE)
-
-                switch literal_variant
-                case 0 {
-                    case_const(0, LITERAL_BIGINT_VARIANT)
-                    eval :=
-                        add(signextend(INT64_SIZE_MINUS_ONE, shr(INT64_PADDING_BITS, calldataload(expr_ptr))), MODULUS)
-                    expr_ptr := add(expr_ptr, INT64_SIZE)
-                }
-                default { err(ERR_UNSUPPORTED_LITERAL_VARIANT) }
+                let literal_variant
+                expr_ptr, literal_variant := read_data_type(expr_ptr)
+                expr_ptr, eval := read_entry(expr_ptr, literal_variant)
                 eval := mulmod(eval, chi_eval, MODULUS)
-
                 expr_ptr_out := expr_ptr
             }
             function exclude_coverage_stop_literal_expr_evaluate() {} // solhint-disable-line no-empty-blocks
@@ -995,6 +986,11 @@ library Verifier {
                         mulmod(MODULUS_MINUS_ONE, output_chi_eval, MODULUS),
                         MODULUS
                     ),
+                    2
+                )
+                builder_produce_identity_constraint(
+                    builder_ptr,
+                    mulmod(mulmod(alpha, d_fold, MODULUS), addmod(output_chi_eval, MODULUS_MINUS_ONE, MODULUS), MODULUS),
                     2
                 )
                 plan_ptr_out := plan_ptr
@@ -1247,6 +1243,7 @@ library Verifier {
                 mstore(FREE_PTR, add(evaluations_ptr, mul(length, WORD_SIZE)))
                 mstore(evaluations_ptr, 1)
                 let num_vars := mload(evaluation_point_ptr)
+                if gt(length, shl(num_vars, 1)) { err(ERR_EVALUATION_LENGTH_TOO_LARGE) }
                 for { let len := 1 } num_vars { num_vars := sub(num_vars, 1) } {
                     let x := mod(mload(add(evaluation_point_ptr, mul(num_vars, WORD_SIZE))), MODULUS)
                     let one_minus_x := sub(MODULUS_PLUS_ONE, x)
@@ -1263,6 +1260,33 @@ library Verifier {
                 }
             }
             function exclude_coverage_stop_compute_evaluation_vec() {} // solhint-disable-line no-empty-blocks
+
+            // IMPORTED-YUL ../base/DataType.pre.sol::read_entry
+            function exclude_coverage_start_read_entry() {} // solhint-disable-line no-empty-blocks
+            function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
+                result_ptr_out := result_ptr
+                switch data_type_variant
+                case 5 {
+                    case_const(5, DATA_TYPE_BIGINT_VARIANT)
+                    entry :=
+                        add(MODULUS, signextend(INT64_SIZE_MINUS_ONE, shr(INT64_PADDING_BITS, calldataload(result_ptr))))
+                    result_ptr_out := add(result_ptr, INT64_SIZE)
+                    entry := mod(entry, MODULUS)
+                }
+                default { err(ERR_UNSUPPORTED_DATA_TYPE_VARIANT) }
+            }
+            function exclude_coverage_stop_read_entry() {} // solhint-disable-line no-empty-blocks
+
+            // IMPORTED-YUL ../base/DataType.pre.sol::read_data_type
+            function exclude_coverage_start_read_data_type() {} // solhint-disable-line no-empty-blocks
+            function read_data_type(ptr) -> ptr_out, data_type {
+                data_type := shr(UINT32_PADDING_BITS, calldataload(ptr))
+                ptr_out := add(ptr, UINT32_SIZE)
+                switch data_type
+                case 5 { case_const(5, DATA_TYPE_BIGINT_VARIANT) }
+                default { err(ERR_UNSUPPORTED_DATA_TYPE_VARIANT) }
+            }
+            function exclude_coverage_stop_read_data_type() {} // solhint-disable-line no-empty-blocks
 
             // IMPORTED-YUL ResultVerifier.pre.sol::verify_result_evaluations
             function exclude_coverage_start_verify_result_evaluations() {} // solhint-disable-line no-empty-blocks
@@ -1283,15 +1307,11 @@ library Verifier {
 
                     let value := mload(evaluations_ptr)
                     evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
-                    let column_variant := shr(UINT32_PADDING_BITS, calldataload(result_ptr))
-                    result_ptr := add(result_ptr, UINT32_SIZE)
 
+                    let data_type_variant
+                    result_ptr, data_type_variant := read_data_type(result_ptr)
                     let column_length := shr(UINT64_PADDING_BITS, calldataload(result_ptr))
                     result_ptr := add(result_ptr, UINT64_SIZE)
-
-                    switch column_variant
-                    case 0 { case_const(0, COLUMN_BIGINT_VARIANT) }
-                    default { err(ERR_UNSUPPORTED_LITERAL_VARIANT) }
 
                     if first {
                         first := 0
@@ -1303,16 +1323,7 @@ library Verifier {
                     value := mulmod(MODULUS_MINUS_ONE, value, MODULUS)
                     for { let i := 0 } sub(table_len, i) { i := add(i, 1) } {
                         let entry
-                        switch column_variant
-                        case 0 {
-                            case_const(0, COLUMN_BIGINT_VARIANT)
-                            entry :=
-                                add(
-                                    MODULUS,
-                                    signextend(INT64_SIZE_MINUS_ONE, shr(INT64_PADDING_BITS, calldataload(result_ptr)))
-                                )
-                            result_ptr := add(result_ptr, INT64_SIZE)
-                        }
+                        result_ptr, entry := read_entry(result_ptr, data_type_variant)
                         value := addmod(value, mulmod(entry, mload(add(eval_vec, mul(i, WORD_SIZE))), MODULUS), MODULUS)
                     }
                     if value { err(ERR_INCORRECT_RESULT) }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
