### PR TITLE
bench: add spans for filter query

### DIFF
--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -64,7 +64,11 @@ impl BaseEntry for Filter {
                     ColumnType::BigInt,
                     Some(|size| (size / 10).max(10) as i64),
                 ),
-                ("b", ColumnType::VarChar, None),
+                (
+                    "b",
+                    ColumnType::BigInt,
+                    Some(|size| (size / 10).max(10) as i64),
+                ),
             ],
         }]
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -142,6 +142,7 @@ pub fn first_round_evaluate_equals_zero<'a, S: Scalar>(
     alloc.alloc_slice_fill_with(table_length, |i| lhs[i] == S::zero())
 }
 
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn final_round_evaluate_equals_zero<'a, S: Scalar>(
     table_length: usize,
     builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -132,6 +132,7 @@ impl ProofExpr for EqualsExpr {
     clippy::missing_panics_doc,
     reason = "table_length is guaranteed to match lhs.len()"
 )]
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn first_round_evaluate_equals_zero<'a, S: Scalar>(
     table_length: usize,
     alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -128,10 +128,6 @@ impl ProofExpr for EqualsExpr {
     }
 }
 
-#[expect(
-    clippy::missing_panics_doc,
-    reason = "table_length is guaranteed to match lhs.len()"
-)]
 #[tracing::instrument(level = "debug", skip_all)]
 pub fn first_round_evaluate_equals_zero<'a, S: Scalar>(
     table_length: usize,

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -10,10 +10,6 @@ use core::{convert::TryInto, ops::Neg};
 use itertools::izip;
 use num_traits::{NumCast, PrimInt};
 
-#[expect(
-    clippy::missing_panics_doc,
-    reason = "lhs and rhs are guaranteed to have the same length by design, ensuring no panic occurs"
-)]
 /// Add or subtract two columns together.
 #[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn add_subtract_columns<'a, S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -15,6 +15,7 @@ use num_traits::{NumCast, PrimInt};
     reason = "lhs and rhs are guaranteed to have the same length by design, ensuring no panic occurs"
 )]
 /// Add or subtract two columns together.
+#[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn add_subtract_columns<'a, S: Scalar>(
     lhs: Column<'a, S>,
     rhs: Column<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -326,7 +326,7 @@ pub(super) fn verify_filter<S: Scalar>(
     Ok(())
 }
 
-#[expect(clippy::too_many_arguments, clippy::many_single_char_names)]
+#[expect(clippy::too_many_arguments)]
 #[tracing::instrument(level = "debug", skip_all)]
 pub(super) fn prove_filter<'a, S: Scalar + 'a>(
     builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -327,6 +327,7 @@ pub(super) fn verify_filter<S: Scalar>(
 }
 
 #[expect(clippy::too_many_arguments, clippy::many_single_char_names)]
+#[tracing::instrument(level = "debug", skip_all)]
 pub(super) fn prove_filter<'a, S: Scalar + 'a>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,


### PR DESCRIPTION
# Rationale for this change
This PR makes sure traces are placed around all critical sections of code used in the Filter query in the benchmarks. This will help us identify performance improvements that can be made.

# What changes are included in this PR?
- Traces and spans are added throughout the Filter query execution path.
- The Filter query in the benchmarks is updated to use `BigInt` column type.

# Are these changes tested?
Yes. Below is an example of the filter query on a laptop.
![image](https://github.com/user-attachments/assets/0f43ea42-0b97-4b2a-a62b-9862d7888cc0)
