### PR TITLE
feat(sol): support varchar and varbinary literals

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
@@ -130,11 +130,11 @@ fn we_can_verify_a_query_with_all_supported_types_using_the_evm() {
             varbinary(
                 "bin",
                 [
-                    b"\x00\x01\x02\x03\x04",
-                    b"\x00\x01\x02\x03\x04",
-                    b"\xFF\xFE\xFD\xFC\xFB",
-                    b"\xFF\xFE\xFD\xFC\xFB",
-                    b"\xFF\xFE\xFD\xFC\xFB",
+                    &b""[..],
+                    &b"\x00\x01\x02\x03\x04"[..],
+                    &b"\xFF\xFE\xFD\xFC\xFB"[..],
+                    &b"\xFF\xFE\xFD\xFC\xFB"[..],
+                    &b"\xFF\xFE\xFD\xFC\xFB"[..],
                 ],
             ),
         ]),
@@ -143,6 +143,7 @@ fn we_can_verify_a_query_with_all_supported_types_using_the_evm() {
     );
 
     let sql_list = [
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where bin = 0x",
         "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where bin = 0x0001020304",
         "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where lang = 'en'",
         "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where sxt = 'מרחב וזמן'",

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
@@ -116,18 +116,42 @@ fn we_can_verify_a_query_with_all_supported_types_using_the_evm() {
                     1_746_627_940,
                 ],
             ),
+            varchar("lang", ["en", "he", "hu", "ru", "hy"]),
+            varchar(
+                "sxt",
+                [
+                    "Space and Time",
+                    "מרחב וזמן",
+                    "Tér és idő",
+                    "Пространство и время",
+                    "Տարածություն և ժամանակ",
+                ],
+            ),
+            varbinary(
+                "bin",
+                [
+                    b"\x00\x01\x02\x03\x04",
+                    b"\x00\x01\x02\x03\x04",
+                    b"\xFF\xFE\xFD\xFC\xFB",
+                    b"\xFF\xFE\xFD\xFC\xFB",
+                    b"\xFF\xFE\xFD\xFC\xFB",
+                ],
+            ),
         ]),
         0,
         &ps[..],
     );
 
     let sql_list = [
-        "SELECT b, i8, i16, i32, i64, d, t from table where b",
-        "SELECT b, i8, i16, i32, i64, d, t from table where i8 = 0",
-        "SELECT b, i8, i16, i32, i64, d, t from table where i16 = 0",
-        "SELECT b, i8, i16, i32, i64, d, t from table where i32 = 1",
-        "SELECT b, i8, i16, i32, i64, d, t from table where i64 = 0",
-        "SELECT b, i8, i16, i32, i64, d, t from table where d = 1",
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where bin = 0x0001020304",
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where lang = 'en'",
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where sxt = 'מרחב וזמן'",
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where b",
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where i8 = 0",
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where i16 = 0",
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where i32 = 1",
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where i64 = 0",
+        "SELECT b, i8, i16, i32, i64, d, t, lang, sxt, bin from table where d = 1",
     ];
 
     for sql in sql_list {

--- a/solidity/slither.config.json
+++ b/solidity/slither.config.json
@@ -1,4 +1,4 @@
 {
-    "detectors_to_exclude": "assembly,naming-conventions",
+    "detectors_to_exclude": "assembly,naming-conventions,too-many-digits",
     "fail_on": "pedantic"
 }

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -115,10 +115,14 @@ uint32 constant DATA_TYPE_SMALLINT_VARIANT = 3;
 uint32 constant DATA_TYPE_INT_VARIANT = 4;
 /// @dev BigInt variant constant for column types
 uint32 constant DATA_TYPE_BIGINT_VARIANT = 5;
+/// @dev Varchar variant constant for column types
+uint32 constant DATA_TYPE_VARCHAR_VARIANT = 7;
 /// @dev Decimal75 variant constant for column types
 uint32 constant DATA_TYPE_DECIMAL75_VARIANT = 8;
 /// @dev Timestamp variant constant for column types
 uint32 constant DATA_TYPE_TIMESTAMP_VARIANT = 9;
+/// @dev Varbinary variant constant for column types
+uint32 constant DATA_TYPE_VARBINARY_VARIANT = 11;
 
 /// @dev Position of the free memory pointer in the context of the EVM memory.
 uint256 constant FREE_PTR = 0x40;

--- a/solidity/src/base/DataType.pre.sol
+++ b/solidity/src/base/DataType.pre.sol
@@ -37,6 +37,32 @@ library DataType {
             function case_const(lhs, rhs) {
                 revert(0, 0)
             }
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                let free_ptr := mload(FREE_PTR)
+                let len := shr(UINT64_PADDING_BITS, calldataload(result_ptr))
+                result_ptr := add(result_ptr, UINT64_SIZE)
+                // Special case for empty slices - return zero
+                if iszero(len) {
+                    entry := 0
+                    result_ptr_out := result_ptr
+                    leave
+                }
+                calldatacopy(free_ptr, result_ptr, len)
+                let hash_val := keccak256(free_ptr, len)
+                // ----- begin endian swap -----
+                // build `rev` by taking each byte of hash_val (big-endian)
+                // and placing it at the corresponding little-endian offset
+                let rev := 0
+                for { let i := 0 } lt(i, 32) { i := add(i, 1) } {
+                    // byte(i, hash_val) returns the i’th byte (0 = MSB)
+                    // shl(mul(8, i), …) shifts it to become little-endian
+                    rev := or(rev, shl(mul(8, i), byte(i, hash_val)))
+                }
+                // Apply the MODULUS_MASK to ensure value is in field
+                entry := and(rev, MODULUS_MASK)
+                mstore(FREE_PTR, add(free_ptr, len))
+                result_ptr_out := add(result_ptr, len)
+            }
             function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
                 result_ptr_out := result_ptr
                 switch data_type_variant
@@ -45,44 +71,58 @@ library DataType {
                     entry := shr(BOOLEAN_PADDING_BITS, calldataload(result_ptr))
                     if shr(1, entry) { err(ERR_INVALID_BOOLEAN) }
                     result_ptr_out := add(result_ptr, BOOLEAN_SIZE)
+                    entry := mod(entry, MODULUS)
                 }
                 case 2 {
                     case_const(2, DATA_TYPE_TINYINT_VARIANT)
                     entry :=
                         add(MODULUS, signextend(INT8_SIZE_MINUS_ONE, shr(INT8_PADDING_BITS, calldataload(result_ptr))))
                     result_ptr_out := add(result_ptr, INT8_SIZE)
+                    entry := mod(entry, MODULUS)
                 }
                 case 3 {
                     case_const(3, DATA_TYPE_SMALLINT_VARIANT)
                     entry :=
                         add(MODULUS, signextend(INT16_SIZE_MINUS_ONE, shr(INT16_PADDING_BITS, calldataload(result_ptr))))
                     result_ptr_out := add(result_ptr, INT16_SIZE)
+                    entry := mod(entry, MODULUS)
                 }
                 case 4 {
                     case_const(4, DATA_TYPE_INT_VARIANT)
                     entry :=
                         add(MODULUS, signextend(INT32_SIZE_MINUS_ONE, shr(INT32_PADDING_BITS, calldataload(result_ptr))))
                     result_ptr_out := add(result_ptr, INT32_SIZE)
+                    entry := mod(entry, MODULUS)
                 }
                 case 5 {
                     case_const(5, DATA_TYPE_BIGINT_VARIANT)
                     entry :=
                         add(MODULUS, signextend(INT64_SIZE_MINUS_ONE, shr(INT64_PADDING_BITS, calldataload(result_ptr))))
                     result_ptr_out := add(result_ptr, INT64_SIZE)
+                    entry := mod(entry, MODULUS)
+                }
+                case 7 {
+                    case_const(7, DATA_TYPE_VARCHAR_VARIANT)
+                    result_ptr_out, entry := read_binary(result_ptr)
                 }
                 case 8 {
                     case_const(8, DATA_TYPE_DECIMAL75_VARIANT)
                     entry := calldataload(result_ptr)
                     result_ptr_out := add(result_ptr, WORD_SIZE)
+                    entry := mod(entry, MODULUS)
                 }
                 case 9 {
                     case_const(9, DATA_TYPE_TIMESTAMP_VARIANT)
                     entry :=
                         add(MODULUS, signextend(INT64_SIZE_MINUS_ONE, shr(INT64_PADDING_BITS, calldataload(result_ptr))))
                     result_ptr_out := add(result_ptr, INT64_SIZE)
+                    entry := mod(entry, MODULUS)
+                }
+                case 11 {
+                    case_const(11, DATA_TYPE_VARBINARY_VARIANT)
+                    result_ptr_out, entry := read_binary(result_ptr)
                 }
                 default { err(ERR_UNSUPPORTED_DATA_TYPE_VARIANT) }
-                entry := mod(entry, MODULUS)
             }
             let __exprOutOffset
             __exprOutOffset, __entry := read_entry(__expr.offset, __dataTypeVariant)
@@ -128,6 +168,7 @@ library DataType {
                 case 3 { case_const(3, DATA_TYPE_SMALLINT_VARIANT) }
                 case 4 { case_const(4, DATA_TYPE_INT_VARIANT) }
                 case 5 { case_const(5, DATA_TYPE_BIGINT_VARIANT) }
+                case 7 { case_const(7, DATA_TYPE_VARCHAR_VARIANT) }
                 case 8 {
                     case_const(8, DATA_TYPE_DECIMAL75_VARIANT)
                     ptr_out := add(ptr_out, UINT8_SIZE) // Skip precision
@@ -138,6 +179,7 @@ library DataType {
                     ptr_out := add(ptr_out, UINT32_SIZE) // Skip timeunit
                     ptr_out := add(ptr_out, INT32_SIZE) // Skip timezone
                 }
+                case 11 { case_const(11, DATA_TYPE_VARBINARY_VARIANT) }
                 default { err(ERR_UNSUPPORTED_DATA_TYPE_VARIANT) }
             }
 

--- a/solidity/src/base/DataType.pre.sol
+++ b/solidity/src/base/DataType.pre.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 // This is licensed under the Cryptographic Open Software License 1.0
+// slither-disable write-after-write
 pragma solidity ^0.8.28;
 
 import "./Constants.sol";

--- a/solidity/src/base/DataType.pre.sol
+++ b/solidity/src/base/DataType.pre.sol
@@ -43,15 +43,14 @@ library DataType {
                 result_ptr := add(result_ptr, UINT64_SIZE)
 
                 // temps with their empty‐slice defaults
-                let e := 0
-                let rpo := result_ptr
+                entry := 0
 
                 // only run this when len != 0
                 if len {
                     calldatacopy(free_ptr, result_ptr, len)
                     let hash_val := keccak256(free_ptr, len)
 
-                    // [endian-swap steps as before…]
+                    // endian-swap steps
                     hash_val :=
                         or(
                             shr(128, and(hash_val, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000)),
@@ -78,15 +77,11 @@ library DataType {
                             shl(8, and(hash_val, 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF))
                         )
 
-                    e := and(hash_val, MODULUS_MASK)
-                    rpo := add(result_ptr, len)
-                    // bump the free pointer
-                    mstore(FREE_PTR, add(free_ptr, len))
+                    entry := and(hash_val, MODULUS_MASK)
                 }
 
                 // single assign to named returns
-                entry := e
-                result_ptr_out := rpo
+                result_ptr_out := add(result_ptr, len)
             }
 
             function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {

--- a/solidity/src/proof_exprs/AddExpr.pre.sol
+++ b/solidity/src/proof_exprs/AddExpr.pre.sol
@@ -114,6 +114,10 @@ library AddExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_exprs/AndExpr.pre.sol
+++ b/solidity/src/proof_exprs/AndExpr.pre.sol
@@ -114,6 +114,10 @@ library AndExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_exprs/CastExpr.pre.sol
+++ b/solidity/src/proof_exprs/CastExpr.pre.sol
@@ -65,6 +65,10 @@ library CastExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_exprs/EqualsExpr.pre.sol
+++ b/solidity/src/proof_exprs/EqualsExpr.pre.sol
@@ -140,6 +140,10 @@ library EqualsExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_exprs/LiteralExpr.pre.sol
+++ b/solidity/src/proof_exprs/LiteralExpr.pre.sol
@@ -52,6 +52,10 @@ library LiteralExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_exprs/MultiplyExpr.pre.sol
+++ b/solidity/src/proof_exprs/MultiplyExpr.pre.sol
@@ -114,6 +114,10 @@ library MultiplyExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_exprs/NotExpr.pre.sol
+++ b/solidity/src/proof_exprs/NotExpr.pre.sol
@@ -113,6 +113,10 @@ library NotExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_exprs/OrExpr.pre.sol
+++ b/solidity/src/proof_exprs/OrExpr.pre.sol
@@ -114,6 +114,10 @@ library OrExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_exprs/ProofExpr.pre.sol
+++ b/solidity/src/proof_exprs/ProofExpr.pre.sol
@@ -98,6 +98,10 @@ library ProofExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_exprs/SubtractExpr.pre.sol
+++ b/solidity/src/proof_exprs/SubtractExpr.pre.sol
@@ -114,6 +114,10 @@ library SubtractExpr {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_plans/FilterExec.pre.sol
+++ b/solidity/src/proof_plans/FilterExec.pre.sol
@@ -170,6 +170,10 @@ library FilterExec {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -149,6 +149,10 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/verifier/ResultVerifier.pre.sol
+++ b/solidity/src/verifier/ResultVerifier.pre.sol
@@ -51,6 +51,10 @@ library ResultVerifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -463,6 +463,10 @@ library Verifier {
             function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
 
             // IMPORT-YUL ../base/DataType.pre.sol
             function read_data_type(ptr) -> ptr_out, data_type {

--- a/solidity/test/base/DataType.t.pre.sol
+++ b/solidity/test/base/DataType.t.pre.sol
@@ -23,6 +23,18 @@ contract DataTypeTest is Test {
         }
     }
 
+    function testHashBytesToFieldEmpty() public pure {
+        bytes memory literalValue = "";
+        uint256 field = _hashBytesToField(literalValue);
+        assert(field == 0);
+    }
+
+    function testHashBytesToFieldNonEmpty() public pure {
+        bytes memory literalValue = "abc";
+        uint256 field = _hashBytesToField(literalValue);
+        assert(field == 0x056c2da18ff544ec36a0643ae3e6d1c067d6c826a87bd4c74fa945ea7a65034e);
+    }
+
     function testReadTrueBooleanEntryExpr() public pure {
         bytes memory exprIn = abi.encodePacked(uint8(1), hex"abcdef");
         bytes memory expectedExprOut = hex"abcdef";

--- a/solidity/test/base/DataType.t.pre.sol
+++ b/solidity/test/base/DataType.t.pre.sol
@@ -16,7 +16,7 @@ contract DataTypeTest is Test {
             // After endian swap, need to reverse keccak hash bytes
             bytes32 hash = keccak256(literalValue);
             uint256 rev = 0;
-            for (uint256 i = 0; i < 32; i++) {
+            for (uint256 i = 0; i < 32; ++i) {
                 rev = rev | (uint256(uint8(hash[i])) << (i * 8));
             }
             field = rev & MODULUS_MASK;

--- a/solidity/test/proof_exprs/LiteralExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/LiteralExpr.t.pre.sol
@@ -33,7 +33,7 @@ contract LiteralExprTest is Test {
     }
 
     function testFuzzInvalidLiteralVariant(uint32 variant) public {
-        vm.assume(variant > DATA_TYPE_TIMESTAMP_VARIANT);
+        vm.assume(variant > DATA_TYPE_VARBINARY_VARIANT);
         bytes memory exprIn = abi.encodePacked(variant, int64(2), hex"abcdef");
         vm.expectRevert(Errors.UnsupportedDataTypeVariant.selector);
         LiteralExpr.__literalExprEvaluate(exprIn, 3);


### PR DESCRIPTION
# Overview
This PR adds support for `VARCHAR` and `VARBINARY` literals in the Solidity‐based proof code, enabling variable-length string and binary data types in Proof-of-SQL.

# Changes
- **Constants.sol**  
  Added new data-type variant constants `DATA_TYPE_VARCHAR_VARIANT = 7` and `DATA_TYPE_VARBINARY_VARIANT = 11`

- **DataType.pre.sol**  
  Implemented `case 7` (varchar) and `case 11` (varbinary) in `__readEntry` to:
  1. Read a 64-bit length prefix  
  2. Copy the payload into EVM memory at `FREE_PTR`  
  3. Compute `keccak256` over that data  
  4. Update `FREE_PTR` and advance the result pointer  

- **DataType.t.pre.sol**  
  Added unit tests covering:
  - `testReadVarcharEntryExpr`, `testReadNonAsciiVarcharEntryExpr`, `testFuzzReadVarcharEntryExpr`  
  - `testReadVarbinaryEntryExpr`, `testFuzzReadVarbinaryEntryExpr`

- **LiteralExpr.t.pre.sol**  
  Extended the proof-expression tests to include parsing and proof generation of `VARCHAR` and `VARBINARY` literal expressions