### PR TITLE
refactor!: strip out uint8

### DIFF
--- a/crates/proof-of-sql-planner/src/postprocessing/expression_evaluation.rs
+++ b/crates/proof-of-sql-planner/src/postprocessing/expression_evaluation.rs
@@ -63,7 +63,6 @@ fn evaluate_literal<S: Scalar>(
         ScalarValue::Int16(Some(i)) => Ok(OwnedColumn::SmallInt(vec![*i; len])),
         ScalarValue::Int32(Some(i)) => Ok(OwnedColumn::Int(vec![*i; len])),
         ScalarValue::Int64(Some(i)) => Ok(OwnedColumn::BigInt(vec![*i; len])),
-        ScalarValue::UInt8(Some(i)) => Ok(OwnedColumn::Uint8(vec![*i; len])),
         ScalarValue::Utf8(Some(s)) => Ok(OwnedColumn::VarChar(vec![s.clone(); len])),
         ScalarValue::Binary(Some(b)) => Ok(OwnedColumn::VarBinary(vec![b.clone(); len])),
         ScalarValue::TimestampSecond(Some(v), None) => Ok(OwnedColumn::TimestampTZ(

--- a/crates/proof-of-sql-planner/src/postprocessing/expression_evaluation_test.rs
+++ b/crates/proof-of-sql-planner/src/postprocessing/expression_evaluation_test.rs
@@ -65,12 +65,6 @@ fn we_can_evaluate_a_literal() {
     let expected_column = OwnedColumn::BigInt(vec![i64::MIN; 5]);
     assert_eq!(actual_column, expected_column);
 
-    // 255 as a uint8
-    let expr = Expr::Literal(ScalarValue::UInt8(Some(255_u8)));
-    let actual_column = evaluate_expr(&table, &expr).unwrap();
-    let expected_column = OwnedColumn::Uint8(vec![255_u8; 5]);
-    assert_eq!(actual_column, expected_column);
-
     // Is Proof of SQL in production?
     let expr = Expr::Literal(ScalarValue::Boolean(Some(true)));
     let actual_column = evaluate_expr(&table, &expr).unwrap();

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -66,7 +66,6 @@ pub(crate) fn scalar_value_to_literal_value(value: ScalarValue) -> PlannerResult
         ScalarValue::Int16(Some(v)) => Ok(LiteralValue::SmallInt(v)),
         ScalarValue::Int32(Some(v)) => Ok(LiteralValue::Int(v)),
         ScalarValue::Int64(Some(v)) => Ok(LiteralValue::BigInt(v)),
-        ScalarValue::UInt8(Some(v)) => Ok(LiteralValue::Uint8(v)),
         ScalarValue::Utf8(Some(v)) => Ok(LiteralValue::VarChar(v)),
         ScalarValue::Binary(Some(v)) => Ok(LiteralValue::VarBinary(v)),
         ScalarValue::TimestampSecond(Some(v), None) => Ok(LiteralValue::TimeStampTZ(
@@ -296,13 +295,6 @@ mod tests {
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::BigInt(1)
-        );
-
-        // UInt8
-        let value = ScalarValue::UInt8(Some(1));
-        assert_eq!(
-            scalar_value_to_literal_value(value).unwrap(),
-            LiteralValue::Uint8(1)
         );
 
         // Utf8

--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -9,7 +9,7 @@ use arrow::{
     array::{
         Array, ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Decimal256Array, Int16Array,
         Int32Array, Int64Array, Int8Array, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
     },
     datatypes::{i256, DataType, TimeUnit as ArrowTimeUnit},
 };
@@ -132,15 +132,6 @@ impl ArrayRefExt for ArrayRef {
                         .ok_or(ArrowArrayToColumnConversionError::ArrayContainsNulls)?;
                     let values = alloc.alloc_slice_fill_with(range.len(), |i| boolean_slice[i]);
                     Ok(Column::Boolean(values))
-                } else {
-                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
-                        datatype: self.data_type().clone(),
-                    })
-                }
-            }
-            DataType::UInt8 => {
-                if let Some(array) = self.as_any().downcast_ref::<UInt8Array>() {
-                    Ok(Column::Uint8(&array.values()[range.start..range.end]))
                 } else {
                     Err(ArrowArrayToColumnConversionError::UnsupportedType {
                         datatype: self.data_type().clone(),

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -11,7 +11,6 @@ impl From<&ColumnType> for DataType {
     fn from(column_type: &ColumnType) -> Self {
         match column_type {
             ColumnType::Boolean => DataType::Boolean,
-            ColumnType::Uint8 => DataType::UInt8,
             ColumnType::TinyInt => DataType::Int8,
             ColumnType::SmallInt => DataType::Int16,
             ColumnType::Int => DataType::Int32,
@@ -44,7 +43,6 @@ impl TryFrom<DataType> for ColumnType {
     fn try_from(data_type: DataType) -> Result<Self, Self::Error> {
         match data_type {
             DataType::Boolean => Ok(ColumnType::Boolean),
-            DataType::UInt8 => Ok(ColumnType::Uint8),
             DataType::Int8 => Ok(ColumnType::TinyInt),
             DataType::Int16 => Ok(ColumnType::SmallInt),
             DataType::Int32 => Ok(ColumnType::Int),

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -25,7 +25,7 @@ use arrow::{
     array::{
         ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Decimal256Array, Int16Array,
         Int32Array, Int64Array, Int8Array, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
     },
     datatypes::{i256, DataType, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
     error::ArrowError,
@@ -75,7 +75,6 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
     fn from(value: OwnedColumn<S>) -> Self {
         match value {
             OwnedColumn::Boolean(col) => Arc::new(BooleanArray::from(col)),
-            OwnedColumn::Uint8(col) => Arc::new(UInt8Array::from(col)),
             OwnedColumn::TinyInt(col) => Arc::new(Int8Array::from(col)),
             OwnedColumn::SmallInt(col) => Arc::new(Int16Array::from(col)),
             OwnedColumn::Int(col) => Arc::new(Int32Array::from(col)),
@@ -159,14 +158,6 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .iter()
                     .collect::<Option<Vec<bool>>>()
                     .ok_or(OwnedArrowConversionError::NullNotSupportedYet)?,
-            )),
-            DataType::UInt8 => Ok(Self::Uint8(
-                value
-                    .as_any()
-                    .downcast_ref::<UInt8Array>()
-                    .unwrap()
-                    .values()
-                    .to_vec(),
             )),
             DataType::Int8 => Ok(Self::TinyInt(
                 value

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -203,8 +203,6 @@ pub struct ColumnBoundsMismatch {
 pub enum ColumnBounds {
     /// Column does not have order.
     NoOrder,
-    /// The bounds of a `Uint8` column.
-    Uint8(Bounds<u8>),
     /// The bounds of a `TinyInt` column.
     TinyInt(Bounds<i8>),
     /// The bounds of a `SmallInt` column.
@@ -227,7 +225,6 @@ impl ColumnBounds {
     pub fn from_column(column: &CommittableColumn) -> ColumnBounds {
         match column {
             CommittableColumn::TinyInt(ints) => ColumnBounds::TinyInt(Bounds::from_iter(*ints)),
-            CommittableColumn::Uint8(ints) => ColumnBounds::Uint8(Bounds::from_iter(*ints)),
             CommittableColumn::SmallInt(ints) => ColumnBounds::SmallInt(Bounds::from_iter(*ints)),
             CommittableColumn::Int(ints) => ColumnBounds::Int(Bounds::from_iter(*ints)),
             CommittableColumn::BigInt(ints) => ColumnBounds::BigInt(Bounds::from_iter(*ints)),
@@ -249,9 +246,6 @@ impl ColumnBounds {
     pub fn try_union(self, other: Self) -> Result<Self, ColumnBoundsMismatch> {
         match (self, other) {
             (ColumnBounds::NoOrder, ColumnBounds::NoOrder) => Ok(ColumnBounds::NoOrder),
-            (ColumnBounds::Uint8(bounds_a), ColumnBounds::Uint8(bounds_b)) => {
-                Ok(ColumnBounds::Uint8(bounds_a.union(bounds_b)))
-            }
             (ColumnBounds::TinyInt(bounds_a), ColumnBounds::TinyInt(bounds_b)) => {
                 Ok(ColumnBounds::TinyInt(bounds_a.union(bounds_b)))
             }
@@ -284,9 +278,6 @@ impl ColumnBounds {
     pub fn try_difference(self, other: Self) -> Result<Self, ColumnBoundsMismatch> {
         match (self, other) {
             (ColumnBounds::NoOrder, ColumnBounds::NoOrder) => Ok(self),
-            (ColumnBounds::Uint8(bounds_a), ColumnBounds::Uint8(bounds_b)) => {
-                Ok(ColumnBounds::Uint8(bounds_a.difference(bounds_b)))
-            }
             (ColumnBounds::TinyInt(bounds_a), ColumnBounds::TinyInt(bounds_b)) => {
                 Ok(ColumnBounds::TinyInt(bounds_a.difference(bounds_b)))
             }

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -44,8 +44,7 @@ impl ColumnCommitmentMetadata {
         bounds: ColumnBounds,
     ) -> Result<ColumnCommitmentMetadata, InvalidColumnCommitmentMetadata> {
         match (column_type, bounds) {
-            (ColumnType::Uint8, ColumnBounds::Uint8(_))
-            | (ColumnType::TinyInt, ColumnBounds::TinyInt(_))
+            (ColumnType::TinyInt, ColumnBounds::TinyInt(_))
             | (ColumnType::SmallInt, ColumnBounds::SmallInt(_))
             | (ColumnType::Int, ColumnBounds::Int(_))
             | (ColumnType::BigInt, ColumnBounds::BigInt(_))

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -25,8 +25,6 @@ use blitzar::sequence::Sequence;
 pub enum CommittableColumn<'a> {
     /// Borrowed Bool column, mapped to `bool`.
     Boolean(&'a [bool]),
-    /// Borrowed `Byte` column, mapped to `u8`.
-    Uint8(&'a [u8]),
     /// Borrowed `TinyInt` column, mapped to `i8`.
     TinyInt(&'a [i8]),
     /// Borrowed `SmallInt` column, mapped to `i16`.
@@ -54,7 +52,6 @@ impl CommittableColumn<'_> {
     #[must_use]
     pub fn len(&self) -> usize {
         match self {
-            CommittableColumn::Uint8(col) => col.len(),
             CommittableColumn::TinyInt(col) => col.len(),
             CommittableColumn::SmallInt(col) => col.len(),
             CommittableColumn::Int(col) => col.len(),
@@ -84,7 +81,6 @@ impl CommittableColumn<'_> {
 impl<'a> From<&CommittableColumn<'a>> for ColumnType {
     fn from(value: &CommittableColumn<'a>) -> Self {
         match value {
-            CommittableColumn::Uint8(_) => ColumnType::Uint8,
             CommittableColumn::TinyInt(_) => ColumnType::TinyInt,
             CommittableColumn::SmallInt(_) => ColumnType::SmallInt,
             CommittableColumn::Int(_) => ColumnType::Int,
@@ -106,7 +102,6 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
     fn from(value: &Column<'a, S>) -> Self {
         match value {
             Column::Boolean(bools) => CommittableColumn::Boolean(bools),
-            Column::Uint8(ints) => CommittableColumn::Uint8(ints),
             Column::TinyInt(ints) => CommittableColumn::TinyInt(ints),
             Column::SmallInt(ints) => CommittableColumn::SmallInt(ints),
             Column::Int(ints) => CommittableColumn::Int(ints),
@@ -140,7 +135,6 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
     fn from(value: &'a OwnedColumn<S>) -> Self {
         match value {
             OwnedColumn::Boolean(bools) => CommittableColumn::Boolean(bools),
-            OwnedColumn::Uint8(ints) => CommittableColumn::Uint8(ints),
             OwnedColumn::TinyInt(ints) => (ints as &[_]).into(),
             OwnedColumn::SmallInt(ints) => (ints as &[_]).into(),
             OwnedColumn::Int(ints) => (ints as &[_]).into(),
@@ -174,12 +168,6 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 CommittableColumn::TimestampTZ(*tu, *tz, times as &[_])
             }
         }
-    }
-}
-
-impl<'a> From<&'a [u8]> for CommittableColumn<'a> {
-    fn from(value: &'a [u8]) -> Self {
-        CommittableColumn::Uint8(value)
     }
 }
 impl<'a> From<&'a [i8]> for CommittableColumn<'a> {
@@ -224,7 +212,6 @@ impl<'a> From<&'a [bool]> for CommittableColumn<'a> {
 impl<'a, 'b> From<&'a CommittableColumn<'b>> for Sequence<'a> {
     fn from(value: &'a CommittableColumn<'b>) -> Self {
         match value {
-            CommittableColumn::Uint8(ints) => Sequence::from(*ints),
             CommittableColumn::TinyInt(ints) => Sequence::from(*ints),
             CommittableColumn::SmallInt(ints) => Sequence::from(*ints),
             CommittableColumn::Int(ints) => Sequence::from(*ints),
@@ -513,18 +500,6 @@ mod tests {
         assert_eq!(bool_committable_column.len(), 3);
         assert!(!bool_committable_column.is_empty());
         assert_eq!(bool_committable_column.column_type(), ColumnType::Boolean);
-    }
-
-    #[test]
-    fn we_can_get_length_of_uint8_column() {
-        // empty case
-        let bool_committable_column = CommittableColumn::Uint8(&[]);
-        assert_eq!(bool_committable_column.len(), 0);
-        assert!(bool_committable_column.is_empty());
-
-        let bool_committable_column = CommittableColumn::Uint8(&[12, 34, 56]);
-        assert_eq!(bool_committable_column.len(), 3);
-        assert!(!bool_committable_column.is_empty());
     }
 
     #[test]
@@ -845,30 +820,6 @@ mod tests {
         // nonempty case
         let values = [12, 34, 56];
         let committable_column = CommittableColumn::BigInt(&values);
-
-        let sequence_actual = Sequence::from(&committable_column);
-        let sequence_expected = Sequence::from(values.as_slice());
-        let mut commitment_buffer = [CompressedRistretto::default(); 2];
-        compute_curve25519_commitments(
-            &mut commitment_buffer,
-            &[sequence_actual, sequence_expected],
-            0,
-        );
-        assert_eq!(commitment_buffer[0], commitment_buffer[1]);
-    }
-
-    #[test]
-    fn we_can_commit_to_uint8_column_through_committable_column() {
-        // empty case
-        let committable_column = CommittableColumn::Uint8(&[]);
-        let sequence = Sequence::from(&committable_column);
-        let mut commitment_buffer = [CompressedRistretto::default()];
-        compute_curve25519_commitments(&mut commitment_buffer, &[sequence], 0);
-        assert_eq!(commitment_buffer[0], CompressedRistretto::default());
-
-        // nonempty case
-        let values = [12, 34, 56];
-        let committable_column = CommittableColumn::Uint8(&values);
 
         let sequence_actual = Sequence::from(&committable_column);
         let sequence_expected = Sequence::from(values.as_slice());

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -122,9 +122,6 @@ impl Commitment for NaiveCommitment {
                     CommittableColumn::Boolean(bool_vec) => {
                         bool_vec.iter().map(core::convert::Into::into).collect()
                     }
-                    CommittableColumn::Uint8(u8_vec) => {
-                        u8_vec.iter().map(core::convert::Into::into).collect()
-                    }
                     CommittableColumn::TinyInt(tiny_int_vec) => {
                         tiny_int_vec.iter().map(core::convert::Into::into).collect()
                     }

--- a/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
@@ -46,41 +46,6 @@ pub trait ArithmeticOp {
             });
         }
         match (&lhs, &rhs) {
-            // We can cast a u8 into any of the signed types without incident. However, we cannot cast
-            // a signed type into a u8 without potentially losing data. Therefore, we need a way to check
-            // that a signed type is greater than zero before we can cast it into a u8.
-            (OwnedColumn::Uint8(_), OwnedColumn::TinyInt(_)) => {
-                Err(ColumnOperationError::SignedCastingError {
-                    left_type: ColumnType::Uint8,
-                    right_type: ColumnType::TinyInt,
-                })
-            }
-            (OwnedColumn::Uint8(lhs), OwnedColumn::Uint8(rhs)) => {
-                Ok(OwnedColumn::Uint8(try_slice_binary_op(lhs, rhs, Self::op)?))
-            }
-            (OwnedColumn::Uint8(lhs), OwnedColumn::SmallInt(rhs)) => Ok(OwnedColumn::SmallInt(
-                try_slice_binary_op_left_upcast(lhs, rhs, Self::op)?,
-            )),
-            (OwnedColumn::Uint8(lhs), OwnedColumn::Int(rhs)) => Ok(OwnedColumn::Int(
-                try_slice_binary_op_left_upcast(lhs, rhs, Self::op)?,
-            )),
-            (OwnedColumn::Uint8(lhs), OwnedColumn::BigInt(rhs)) => Ok(OwnedColumn::BigInt(
-                try_slice_binary_op_left_upcast(lhs, rhs, Self::op)?,
-            )),
-            (OwnedColumn::Uint8(lhs), OwnedColumn::Int128(rhs)) => Ok(OwnedColumn::Int128(
-                try_slice_binary_op_left_upcast(lhs, rhs, Self::op)?,
-            )),
-            (OwnedColumn::Uint8(lhs_values), OwnedColumn::Decimal75(_, _, rhs_values)) => {
-                let (new_precision, new_scale, new_values) =
-                    Self::decimal_op(lhs_values, rhs_values, lhs.column_type(), rhs.column_type())?;
-                Ok(OwnedColumn::Decimal75(new_precision, new_scale, new_values))
-            }
-            (OwnedColumn::TinyInt(_), OwnedColumn::Uint8(_)) => {
-                Err(ColumnOperationError::SignedCastingError {
-                    left_type: ColumnType::TinyInt,
-                    right_type: ColumnType::Uint8,
-                })
-            }
             (OwnedColumn::TinyInt(lhs), OwnedColumn::TinyInt(rhs)) => Ok(OwnedColumn::TinyInt(
                 try_slice_binary_op(lhs, rhs, Self::op)?,
             )),

--- a/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
@@ -56,41 +56,6 @@ pub trait ComparisonOp {
             });
         }
         let result = match (&lhs, &rhs) {
-            (OwnedColumn::Uint8(_), OwnedColumn::TinyInt(_)) => {
-                Err(ColumnOperationError::SignedCastingError {
-                    left_type: ColumnType::Uint8,
-                    right_type: ColumnType::TinyInt,
-                })
-            }
-            (OwnedColumn::Uint8(lhs), OwnedColumn::Uint8(rhs)) => {
-                Ok(slice_binary_op(lhs, rhs, Self::op))
-            }
-            (OwnedColumn::Uint8(lhs), OwnedColumn::SmallInt(rhs)) => {
-                Ok(slice_binary_op_left_upcast(lhs, rhs, Self::op))
-            }
-            (OwnedColumn::Uint8(lhs), OwnedColumn::Int(rhs)) => {
-                Ok(slice_binary_op_left_upcast(lhs, rhs, Self::op))
-            }
-            (OwnedColumn::Uint8(lhs), OwnedColumn::BigInt(rhs)) => {
-                Ok(slice_binary_op_left_upcast(lhs, rhs, Self::op))
-            }
-            (OwnedColumn::Uint8(lhs), OwnedColumn::Int128(rhs)) => {
-                Ok(slice_binary_op_left_upcast(lhs, rhs, Self::op))
-            }
-            (OwnedColumn::Uint8(lhs_values), OwnedColumn::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::decimal_op_left_upcast(
-                    lhs_values,
-                    rhs_values,
-                    lhs.column_type(),
-                    rhs.column_type(),
-                ))
-            }
-            (OwnedColumn::TinyInt(_), OwnedColumn::Uint8(_)) => {
-                return Err(ColumnOperationError::SignedCastingError {
-                    left_type: ColumnType::TinyInt,
-                    right_type: ColumnType::Uint8,
-                })
-            }
             (OwnedColumn::TinyInt(lhs), OwnedColumn::TinyInt(rhs)) => {
                 Ok(slice_binary_op(lhs, rhs, Self::op))
             }

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -30,13 +30,6 @@ where
             )?;
             Ok(Column::TinyInt(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
-        ColumnType::Uint8 => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_uint8().expect("Column types should match"),
-                indexes,
-            )?;
-            Ok(Column::Uint8(alloc.alloc_slice_copy(&raw_values) as &[_]))
-        }
         ColumnType::SmallInt => {
             let raw_values = apply_slice_to_indexes(
                 column.as_smallint().expect("Column types should match"),

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -23,12 +23,6 @@ pub trait RepetitionOp {
                     iter.next().expect("Iterator should have enough elements")
                 }) as &[_])
             }
-            ColumnType::Uint8 => {
-                let mut iter = Self::op(column.as_uint8().expect("Column types should match"), n);
-                Column::Uint8(alloc.alloc_slice_fill_with(len, |_| {
-                    iter.next().expect("Iterator should have enough elements")
-                }) as &[_])
-            }
             ColumnType::TinyInt => {
                 let mut iter = Self::op(column.as_tinyint().expect("Column types should match"), n);
                 Column::TinyInt(alloc.alloc_slice_fill_with(len, |_| {
@@ -208,10 +202,6 @@ mod tests {
             result.as_boolean().unwrap(),
             &[false, false, true, true, false, false]
         );
-
-        let column: Column<TestScalar> = Column::Uint8(&[3u8, 5u8, 2u8]);
-        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
-        assert_eq!(result.as_uint8().unwrap(), &[3u8, 3u8, 5u8, 5u8, 2u8, 2u8]);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -206,11 +206,9 @@ pub fn try_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult
             | ColumnType::BigInt,
         )
         | (ColumnType::TimestampTZ(_, _), ColumnType::BigInt)
-        | (ColumnType::Uint8, ColumnType::Uint8)
         | (ColumnType::TinyInt, ColumnType::TinyInt) => true,
         (
             ColumnType::TinyInt
-            | ColumnType::Uint8
             | ColumnType::SmallInt
             | ColumnType::Int
             | ColumnType::Int128
@@ -242,7 +240,6 @@ pub fn try_scale_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperation
     match (from, to) {
         (
             ColumnType::TinyInt
-            | ColumnType::Uint8
             | ColumnType::SmallInt
             | ColumnType::Int
             | ColumnType::Int128
@@ -1100,7 +1097,6 @@ mod test {
             assert_eq!(remainder, (numerator, numerator));
         }
         let ineligible_columns = [
-            ColumnType::Uint8,
             ColumnType::Scalar,
             ColumnType::Boolean,
             ColumnType::VarBinary,
@@ -1140,7 +1136,6 @@ mod test {
     fn we_cannot_cast_integers_to_decimal_with_lower_precision() {
         for from in [
             ColumnType::TinyInt,
-            ColumnType::Uint8,
             ColumnType::SmallInt,
             ColumnType::Int,
             ColumnType::BigInt,
@@ -1158,7 +1153,6 @@ mod test {
     fn we_can_cast_integers_and_decimal_to_decimal() {
         for from in [
             ColumnType::TinyInt,
-            ColumnType::Uint8,
             ColumnType::SmallInt,
             ColumnType::Int,
             ColumnType::BigInt,
@@ -1191,12 +1185,6 @@ mod test {
 
     #[test]
     fn we_can_cast_integers_to_signed_integers() {
-        try_cast_types(ColumnType::Uint8, ColumnType::Uint8).unwrap();
-        try_cast_types(ColumnType::Uint8, ColumnType::TinyInt).unwrap_err();
-        try_cast_types(ColumnType::Uint8, ColumnType::SmallInt).unwrap();
-        try_cast_types(ColumnType::Uint8, ColumnType::Int).unwrap();
-        try_cast_types(ColumnType::Uint8, ColumnType::BigInt).unwrap();
-        try_cast_types(ColumnType::Uint8, ColumnType::Int128).unwrap();
         try_cast_types(ColumnType::TinyInt, ColumnType::TinyInt).unwrap();
         try_cast_types(ColumnType::TinyInt, ColumnType::SmallInt).unwrap();
         try_cast_types(ColumnType::TinyInt, ColumnType::Int).unwrap();
@@ -1248,7 +1236,6 @@ mod test {
     #[test]
     fn we_can_properly_determine_if_types_are_scale_castable() {
         for from in [
-            ColumnType::Uint8,
             ColumnType::TinyInt,
             ColumnType::SmallInt,
             ColumnType::Int,

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -43,9 +43,6 @@ pub fn filter_column_by_index<'a, S: Scalar>(
         Column::Boolean(col) => {
             Column::Boolean(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
-        Column::Uint8(col) => {
-            Column::Uint8(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
-        }
         Column::TinyInt(col) => {
             Column::TinyInt(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -154,7 +154,6 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
     indexes: &[usize],
 ) -> &'a [S] {
     match column {
-        Column::Uint8(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::TinyInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
@@ -187,8 +186,6 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
 ) -> &'a [Option<S>] {
     match column {
         Column::Boolean(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Uint8(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-
         Column::TinyInt(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
@@ -224,8 +221,6 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
 ) -> &'a [Option<S>] {
     match column {
         Column::Boolean(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Uint8(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-
         Column::TinyInt(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -17,8 +17,6 @@ use serde::{Deserialize, Serialize};
 pub enum LiteralValue {
     /// Boolean literals
     Boolean(bool),
-    /// u8 literals
-    Uint8(u8),
     /// i8 literals
     TinyInt(i8),
     /// i16 literals
@@ -53,7 +51,6 @@ impl LiteralValue {
     pub fn column_type(&self) -> ColumnType {
         match self {
             Self::Boolean(_) => ColumnType::Boolean,
-            Self::Uint8(_) => ColumnType::Uint8,
             Self::TinyInt(_) => ColumnType::TinyInt,
             Self::SmallInt(_) => ColumnType::SmallInt,
             Self::Int(_) => ColumnType::Int,
@@ -71,7 +68,6 @@ impl LiteralValue {
     pub(crate) fn to_scalar<S: Scalar>(&self) -> S {
         match self {
             Self::Boolean(b) => b.into(),
-            Self::Uint8(i) => i.into(),
             Self::TinyInt(i) => i.into(),
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -22,7 +22,6 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
         .iter()
         .map(|col| match col {
             Column::Boolean(col) => col[i].cmp(&col[j]),
-            Column::Uint8(col) => col[i].cmp(&col[j]),
             Column::TinyInt(col) => col[i].cmp(&col[j]),
             Column::SmallInt(col) => col[i].cmp(&col[j]),
             Column::Int(col) => col[i].cmp(&col[j]),
@@ -70,9 +69,6 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
         .zip(right.iter())
         .map(|(left_col, right_col)| match (left_col, right_col) {
             (Column::Boolean(left_col), Column::Boolean(right_col)) => {
-                left_col[left_row_index].cmp(&right_col[right_row_index])
-            }
-            (Column::Uint8(left_col), Column::Uint8(right_col)) => {
                 left_col[left_row_index].cmp(&right_col[right_row_index])
             }
             (Column::TinyInt(left_col), Column::TinyInt(right_col)) => {
@@ -137,7 +133,6 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
         .map(|(col, is_asc)| {
             let ordering = match col {
                 OwnedColumn::Boolean(col) => col[i].cmp(&col[j]),
-                OwnedColumn::Uint8(col) => col[i].cmp(&col[j]),
                 OwnedColumn::TinyInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::SmallInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::Int(col) => col[i].cmp(&col[j]),

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -93,7 +93,6 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
         {
             OwnedColumn::Boolean(col) => Column::Boolean(col),
             OwnedColumn::TinyInt(col) => Column::TinyInt(col),
-            OwnedColumn::Uint8(col) => Column::Uint8(col),
             OwnedColumn::SmallInt(col) => Column::SmallInt(col),
             OwnedColumn::Int(col) => Column::Int(col),
             OwnedColumn::BigInt(col) => Column::BigInt(col),

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -51,27 +51,6 @@ pub fn owned_table<S: Scalar>(
     OwnedTable::try_from_iter(iter).unwrap()
 }
 
-/// Creates a (Ident, `OwnedColumn`) pair for a uint8 column.
-/// This is primarily intended for use in conjunction with [`owned_table`].
-/// # Example
-/// ```
-/// use proof_of_sql::base::{database::owned_table_utility::*};
-/// # use proof_of_sql::base::scalar::MontScalar;
-/// # pub type MyScalar = MontScalar<ark_curve25519::FrConfig>;
-/// let result = owned_table::<MyScalar>([
-///     uint8("a", [1_u8, 2, 3]),
-/// ]);
-///```
-pub fn uint8<S: Scalar>(
-    name: impl Into<Ident>,
-    data: impl IntoIterator<Item = impl Into<u8>>,
-) -> (Ident, OwnedColumn<S>) {
-    (
-        name.into(),
-        OwnedColumn::Uint8(data.into_iter().map(Into::into).collect()),
-    )
-}
-
 /// Creates a (Ident, `OwnedColumn`) pair for a tinyint column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -70,29 +70,6 @@ pub fn table_with_row_count<'a, S: Scalar>(
     Table::try_from_iter_with_options(iter, TableOptions::new(Some(row_count))).unwrap()
 }
 
-/// Creates a (Ident, `Column`) pair for a uint8 column.
-/// This is primarily intended for use in conjunction with [`table`].
-/// # Example
-/// ```
-/// use bumpalo::Bump;
-/// use proof_of_sql::base::{database::table_utility::*};
-/// # use proof_of_sql::base::scalar::MontScalar;
-/// # pub type MyScalar = MontScalar<ark_curve25519::FrConfig>;
-/// let alloc = Bump::new();
-/// let result = table::<MyScalar>([
-///     borrowed_uint8("a", [1_u8, 2, 3], &alloc),
-/// ]);
-///```
-pub fn borrowed_uint8<S: Scalar>(
-    name: impl Into<Ident>,
-    data: impl IntoIterator<Item = impl Into<u8>>,
-    alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
-    let transformed_data: Vec<u8> = data.into_iter().map(Into::into).collect();
-    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
-    (name.into(), Column::Uint8(alloc_data))
-}
-
 /// Creates a (Ident, `Column`) pair for a tinyint column.
 /// This is primarily intended for use in conjunction with [`table`].
 /// # Example

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -53,16 +53,6 @@ pub fn column_union<'a, S: Scalar>(
                 iter.next().expect("Iterator should have enough elements")
             }) as &[_])
         }
-        ColumnType::Uint8 => {
-            let mut iter = columns
-                .iter()
-                .flat_map(|col| col.as_uint8().expect("Column types should match"))
-                .copied();
-
-            Column::Uint8(alloc.alloc_slice_fill_with(len, |_| {
-                iter.next().expect("Iterator should have enough elements")
-            }) as &[_])
-        }
         ColumnType::TinyInt => {
             let mut iter = columns
                 .iter()

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -103,7 +103,6 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
             | Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
-            Column::Uint8(c) => c.inner_product(evaluation_vec),
             Column::TinyInt(c) => c.inner_product(evaluation_vec),
             Column::SmallInt(c) => c.inner_product(evaluation_vec),
             Column::Int(c) => c.inner_product(evaluation_vec),
@@ -121,7 +120,6 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             | Column::Decimal75(_, _, c) => {
                 c.mul_add(res, multiplier);
             }
-            Column::Uint8(c) => c.mul_add(res, multiplier),
             Column::TinyInt(c) => c.mul_add(res, multiplier),
             Column::SmallInt(c) => c.mul_add(res, multiplier),
             Column::Int(c) => c.mul_add(res, multiplier),
@@ -137,7 +135,6 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
             | Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
-            Column::Uint8(c) => c.to_sumcheck_term(num_vars),
             Column::TinyInt(c) => c.to_sumcheck_term(num_vars),
             Column::SmallInt(c) => c.to_sumcheck_term(num_vars),
             Column::Int(c) => c.to_sumcheck_term(num_vars),
@@ -153,7 +150,6 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
             | Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
-            Column::Uint8(c) => MultilinearExtension::<S>::id(c),
             Column::TinyInt(c) => MultilinearExtension::<S>::id(c),
             Column::SmallInt(c) => MultilinearExtension::<S>::id(c),
             Column::Int(c) => MultilinearExtension::<S>::id(c),

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -37,7 +37,6 @@ pub const fn min_as_f(column_type: ColumnType) -> F {
         ColumnType::BigInt | ColumnType::TimestampTZ(_, _) => MontFp!("-9223372036854775808"),
         ColumnType::Int128 => MontFp!("-170141183460469231731687303715884105728"),
         ColumnType::Decimal75(_, _)
-        | ColumnType::Uint8
         | ColumnType::Scalar
         | ColumnType::VarChar
         | ColumnType::VarBinary
@@ -110,9 +109,6 @@ fn copy_column_data_to_slice(
 ) {
     match column {
         CommittableColumn::Boolean(column) => {
-            scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
-        }
-        CommittableColumn::Uint8(column) => {
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
         CommittableColumn::TinyInt(column) => {

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -66,7 +66,6 @@ fn compute_dory_commitment(
 ) -> DoryCommitment {
     match committable_column {
         CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Uint8(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TinyInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::SmallInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Int(column) => compute_dory_commitment_impl(column, offset, setup),

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -75,7 +75,6 @@ fn compute_dory_commitment(
 ) -> DynamicDoryCommitment {
     match committable_column {
         CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Uint8(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TinyInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::SmallInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Int(column) => compute_dory_commitment_impl(column, offset, setup),

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -367,17 +367,6 @@ pub fn bit_table_and_scalars_for_packed_msm(
         .iter()
         .enumerate()
         .for_each(|(i, column)| match column {
-            CommittableColumn::Uint8(column) => {
-                pack_bit(
-                    column,
-                    &mut packed_scalars,
-                    cumulative_bit_sum_table[i],
-                    offset,
-                    committable_columns[i].column_type().byte_size(),
-                    bit_table_full_sum_in_bytes,
-                    num_matrix_commitment_columns,
-                );
-            }
             CommittableColumn::TinyInt(column) => {
                 pack_bit(
                     column,

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -141,7 +141,6 @@ fn compute_commitments_impl(
             CommittableColumn::Boolean(vals) => {
                 compute_commitment_generic_impl(setup, offset, vals)
             }
-            CommittableColumn::Uint8(vals) => compute_commitment_generic_impl(setup, offset, vals),
             CommittableColumn::TinyInt(vals) => {
                 compute_commitment_generic_impl(setup, offset, vals)
             }

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
@@ -75,9 +75,6 @@ mod tests {
                 CommittableColumn::Boolean(vals) => {
                     expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
                 }
-                CommittableColumn::Uint8(vals) => {
-                    expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
-                }
                 CommittableColumn::TinyInt(vals) => {
                     expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
                 }
@@ -170,7 +167,6 @@ mod tests {
         let committable_columns = vec![
             CommittableColumn::TinyInt(&[0; 0]),
             CommittableColumn::SmallInt(&[0; 0]),
-            CommittableColumn::Uint8(&[0; 0]),
             CommittableColumn::Int(&[0; 0]),
             CommittableColumn::BigInt(&[0; 0]),
             CommittableColumn::Int128(&[0; 0]),
@@ -197,7 +193,6 @@ mod tests {
 
         let committable_columns = vec![
             CommittableColumn::BigInt(&[0, 1]),
-            CommittableColumn::Uint8(&[2, 3]),
             CommittableColumn::Int(&[4, 5, 10]),
             CommittableColumn::SmallInt(&[6, 7]),
             CommittableColumn::Int128(&[8, 9]),

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -145,8 +145,6 @@ impl EVMColumnExpr {
 pub(crate) enum EVMLiteralExpr {
     /// Boolean literals
     Boolean(bool),
-    /// u8 literals
-    Uint8(u8),
     /// i8 literals
     TinyInt(i8),
     /// i16 literals
@@ -178,7 +176,6 @@ impl EVMLiteralExpr {
     pub(crate) fn from_proof_expr(expr: &LiteralExpr) -> Self {
         match expr.value() {
             LiteralValue::Boolean(value) => EVMLiteralExpr::Boolean(*value),
-            LiteralValue::Uint8(value) => EVMLiteralExpr::Uint8(*value),
             LiteralValue::TinyInt(value) => EVMLiteralExpr::TinyInt(*value),
             LiteralValue::SmallInt(value) => EVMLiteralExpr::SmallInt(*value),
             LiteralValue::Int(value) => EVMLiteralExpr::Int(*value),
@@ -208,7 +205,6 @@ impl EVMLiteralExpr {
     pub(crate) fn to_proof_expr(&self) -> LiteralExpr {
         match self {
             EVMLiteralExpr::Boolean(value) => LiteralExpr::new(LiteralValue::Boolean(*value)),
-            EVMLiteralExpr::Uint8(value) => LiteralExpr::new(LiteralValue::Uint8(*value)),
             EVMLiteralExpr::TinyInt(value) => LiteralExpr::new(LiteralValue::TinyInt(*value)),
             EVMLiteralExpr::SmallInt(value) => LiteralExpr::new(LiteralValue::SmallInt(*value)),
             EVMLiteralExpr::Int(value) => LiteralExpr::new(LiteralValue::Int(*value)),
@@ -597,13 +593,6 @@ mod tests {
     // EVMLiteralExpr
     #[test]
     fn we_can_put_an_integer_literal_expr_in_evm() {
-        // Test Uint8
-        let evm_literal_expr =
-            EVMLiteralExpr::from_proof_expr(&LiteralExpr::new(LiteralValue::Uint8(42)));
-        assert_eq!(evm_literal_expr, EVMLiteralExpr::Uint8(42));
-        let roundtripped = evm_literal_expr.to_proof_expr();
-        assert_eq!(*roundtripped.value(), LiteralValue::Uint8(42));
-
         // Test TinyInt
         let evm_literal_expr =
             EVMLiteralExpr::from_proof_expr(&LiteralExpr::new(LiteralValue::TinyInt(-42)));

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -107,7 +107,6 @@ impl ProvableQueryResult {
             for entry in evaluation_vec.iter().take(output_length) {
                 let (x, sz) = match field.data_type() {
                     ColumnType::Boolean => decode_and_convert::<bool, S>(&self.data[offset..]),
-                    ColumnType::Uint8 => decode_and_convert::<u8, S>(&self.data[offset..]),
                     ColumnType::TinyInt => decode_and_convert::<i8, S>(&self.data[offset..]),
                     ColumnType::SmallInt => decode_and_convert::<i16, S>(&self.data[offset..]),
                     ColumnType::Int => decode_and_convert::<i32, S>(&self.data[offset..]),
@@ -166,11 +165,6 @@ impl ProvableQueryResult {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
                         Ok((field.name(), OwnedColumn::Boolean(col)))
-                    }
-                    ColumnType::Uint8 => {
-                        let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
-                        offset += num_read;
-                        Ok((field.name(), OwnedColumn::Uint8(col)))
                     }
                     ColumnType::TinyInt => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -32,7 +32,6 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
     fn num_bytes(&self, length: u64) -> usize {
         match self {
             Column::Boolean(col) => col.num_bytes(length),
-            Column::Uint8(col) => col.num_bytes(length),
             Column::TinyInt(col) => col.num_bytes(length),
             Column::SmallInt(col) => col.num_bytes(length),
             Column::Int(col) => col.num_bytes(length),
@@ -47,7 +46,6 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
     fn write(&self, out: &mut [u8], length: u64) -> usize {
         match self {
             Column::Boolean(col) => col.write(out, length),
-            Column::Uint8(col) => col.write(out, length),
             Column::TinyInt(col) => col.write(out, length),
             Column::SmallInt(col) => col.write(out, length),
             Column::Int(col) => col.write(out, length),

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -104,7 +104,6 @@ fn append_single_row_to_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedColum
     let mut column = column.clone();
     match &mut column {
         OwnedColumn::Boolean(col) => col.push(false),
-        OwnedColumn::Uint8(col) => col.push(0),
         OwnedColumn::TinyInt(col) => col.push(0),
         OwnedColumn::SmallInt(col) => col.push(0),
         OwnedColumn::Int(col) => col.push(0),
@@ -139,7 +138,6 @@ pub fn tamper_first_row_of_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedCo
     let mut column = column.clone();
     match &mut column {
         OwnedColumn::Boolean(col) => col[0] ^= true,
-        OwnedColumn::Uint8(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::TinyInt(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::SmallInt(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::Int(col) => col[0] = col[0].wrapping_add(1),

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
@@ -7,7 +7,7 @@ use crate::{
         database::{
             owned_table_utility::{
                 bigint, boolean, decimal75, int, int128, owned_table, smallint, timestamptz,
-                tinyint, uint8,
+                tinyint,
             },
             table_utility::{borrowed_smallint, table},
             ColumnType, LiteralValue, OwnedTableTestAccessor, TableRef, TableTestAccessor,
@@ -91,7 +91,6 @@ fn we_can_prove_a_simple_cast_expr() {
 fn we_can_prove_a_simple_cast_expr_from_int_to_other_numeric_type() {
     let data = owned_table([
         tinyint("a", [1]),
-        uint8("b", [1]),
         smallint("c", [1i16]),
         int("d", [1i32]),
         bigint("e", [1i64]),
@@ -106,10 +105,6 @@ fn we_can_prove_a_simple_cast_expr_from_int_to_other_numeric_type() {
             aliased_plan(
                 cast(column(&t, "a", &accessor), ColumnType::SmallInt),
                 "a_cast",
-            ),
-            aliased_plan(
-                cast(column(&t, "b", &accessor), ColumnType::Uint8),
-                "b_cast",
             ),
             aliased_plan(
                 cast(column(&t, "c", &accessor), ColumnType::BigInt),
@@ -152,7 +147,6 @@ fn we_can_prove_a_simple_cast_expr_from_int_to_other_numeric_type() {
         .table;
     let expected_res = owned_table([
         smallint("a_cast", [1i16]),
-        uint8("b_cast", [1u8]),
         bigint("c_cast", [1i64]),
         int128("d_cast", [1i128]),
         decimal75("e_cast", 42, 0, [1]),

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
@@ -2,7 +2,7 @@ use crate::{
     base::{
         database::{
             owned_table_utility::{
-                bigint, decimal75, int, int128, owned_table, smallint, timestamptz, tinyint, uint8,
+                bigint, decimal75, int, int128, owned_table, smallint, timestamptz, tinyint,
             },
             ColumnType, LiteralValue, OwnedTableTestAccessor, TableRef,
         },
@@ -24,7 +24,6 @@ use blitzar::proof::InnerProductProof;
 fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
     let data = owned_table([
         tinyint("a", [1]),
-        uint8("b", [1]),
         smallint("c", [1i16]),
         int("d", [1i32]),
         bigint("e", [1i64]),
@@ -41,13 +40,6 @@ fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
                     ColumnType::Decimal75(Precision::new(4).unwrap(), 1),
                 ),
                 "a_cast",
-            ),
-            aliased_plan(
-                scaling_cast(
-                    column(&t, "b", &accessor),
-                    ColumnType::Decimal75(Precision::new(4).unwrap(), 1),
-                ),
-                "b_cast",
             ),
             aliased_plan(
                 scaling_cast(
@@ -89,7 +81,6 @@ fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
         .table;
     let expected_res = owned_table([
         decimal75("a_cast", 4, 1, [10]),
-        decimal75("b_cast", 4, 1, [10]),
         decimal75("c_cast", 6, 1, [10]),
         decimal75("d_cast", 11, 1, [10]),
         decimal75("e_cast", 20, 1, [10]),

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
@@ -54,12 +54,6 @@ macro_rules! handle_column_with_match {
                     .expect("column_type() is TinyInt, but as_tinyint() was None");
                 $fn_name($builder, slice, $alloc);
             }
-            ColumnType::Uint8 => {
-                let slice = $col
-                    .as_uint8()
-                    .expect("column_type() is Uint8, but as_uint8() was None");
-                $fn_name($builder, slice, $alloc);
-            }
             ColumnType::Int128 => {
                 let slice = $col
                     .as_int128()
@@ -211,7 +205,6 @@ mod tests {
     #[test]
     fn we_can_prove_ranges_on_mixed_column_types() {
         let data = owned_table([
-            uint8("uint8", [0, u8::MAX]),
             tinyint("tinyint", [0, i8::MAX]),
             smallint("smallint", [0, i16::MAX]),
             int("int", [0, i32::MAX]),
@@ -244,7 +237,6 @@ mod tests {
         let accessor =
             OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
 
-        check_range(t.clone(), "uint8", ColumnType::Uint8, &accessor);
         check_range(t.clone(), "tinyint", ColumnType::TinyInt, &accessor);
         check_range(t.clone(), "smallint", ColumnType::SmallInt, &accessor);
         check_range(t.clone(), "int", ColumnType::Int, &accessor);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
