### PR TITLE
ci: close stale PRs beyond 30 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+name: Mark and Close Stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * 5'  # Run at midnight every Friday
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  actions: write
+  contents: write # only for delete-branch option
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and Close Stale PRs
+        uses: actions/stale@v9
+        with:
+          # PR specific settings
+          stale-pr-message: 'This PR has been marked as stale due to 30 days of inactivity. It will be closed in 7 days if no further activity occurs.'
+          close-pr-message: 'This PR has been closed due to inactivity. Feel free to reopen if you wish to continue working on it.'
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'no-stale,dependencies,security'
+          exempt-draft-pr: true
+          
+          # Issue specific settings - disabled by default
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          
+          # General settings
+          operations-per-run: 100
+          ascending: true  # Older PRs are processed first
+          remove-stale-when-updated: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,8 @@ The most relevant fields in the issue are: `assignees`, `projects`, `milestone`,
 
 Before you submit your Pull Request (PR) consider the following guidelines:
 
+> **IMPORTANT:** Please note that PRs without activity for 30 days will be automatically closed as stale. If your PR is closed due to inactivity but you would like to continue working on it, please feel free to reopen it when you're ready to continue.
+
 1. Make your changes in a new git branch:
 
    In case you haven't generated a new branch yet, use the following command to create a new branch from the main:


### PR DESCRIPTION
- Uses the `actions/stale@v9` action to mark pull requests inactive after 30 days and close them 7 days later
- Configures custom messages, labels, and exemptions (e.g. drafts, dependency/security PRs)
- Grants only the minimum permissions needed (write on PRs and issues)
- Updates the CONTRIBUTING guide to explain the new stale-and-close policy to contributors