### PR TITLE
perf: use `S::ZERO` for vector initialization in `compute_entrywise_multipliers`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
@@ -20,6 +20,7 @@ impl<'a, S: Scalar> SumcheckRandomScalars<'a, S> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn compute_entrywise_multipliers(&self) -> Vec<S> {
         let mut v = vec![Default::default(); self.table_length];
         compute_evaluation_vector(&mut v, self.entrywise_point);

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
@@ -22,7 +22,7 @@ impl<'a, S: Scalar> SumcheckRandomScalars<'a, S> {
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn compute_entrywise_multipliers(&self) -> Vec<S> {
-        let mut v = vec![Default::default(); self.table_length];
+        let mut v = vec![S::ZERO; self.table_length];
         compute_evaluation_vector(&mut v, self.entrywise_point);
         v
     }


### PR DESCRIPTION
# Rationale for this change
When benchmarking the `Filter` query, the initialization of the vector `v` when computing entrywise multipliers was taking longer than expected. This PR updates the `Default::default()` initializer to `S::ZERO`, which showed a `1.35x` performance improvement during benchmarks.

Before, `18.71ms`
![image](https://github.com/user-attachments/assets/a438705f-c93c-412c-b339-b310c25846ae)

After, `13.82ms`, `1.35x` improvement
![image](https://github.com/user-attachments/assets/ef8e1334-c81e-40b1-91bb-3c5c7f0a14d7)

# What changes are included in this PR?
- Tracing is added to `compute_entrywise_multipliers`
- `Default:::default()` is updated to `S::ZERO`

# Are these changes tested?
Yes