### PR TITLE
perf: `flattened_ml_extensions` should be parallel if using `Rayon`

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -6,7 +6,7 @@ use num_traits::Zero;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 /// Interface for operating on multilinear extension's in-place
-pub trait MultilinearExtension<S: Scalar>: Debug {
+pub trait MultilinearExtension<S: Scalar>: Debug + Sync {
     /// Given an evaluation vector, compute the evaluation of the multilinear
     /// extension
     fn inner_product(&self, evaluation_vec: &[S]) -> S;


### PR DESCRIPTION
# Rationale for this change
During benchmarking for the `Filter` query, it was identified that the `flattened_ml_extensions` method in the `make_symcheck_state` module could benefit from using parallelism if the `Rayon` crate was being used. This PR add the `if_rayon` macro to the `flatten_ml_extensions` method.

Before, `31.54ms`
![image](https://github.com/user-attachments/assets/e4aa2d2d-14be-445e-82a7-651726a8ca96)

After, `9.91ms`, `3.18x` performance improvement of the `flatten_ml_extensions` method.
![image](https://github.com/user-attachments/assets/846ce3c1-8eb6-4b3f-981d-83547fd359af)

# What changes are included in this PR?
- `Sync` is added to the `MultilinearExtension` trait
- The `flattened_ml_extensions` method in the `make_symcheck_state` module now uses the `if_rayon` macro

# Are these changes tested?
Yes
