### PR TITLE
ci: release solidity code

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,3 +38,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+      - name: Conventional Changelog Action
+        if: github.ref_name == 'main'
+        id: conventional-changelog
+        uses: TriPSs/conventional-changelog-action@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-git-pull: true
+          skip-version-file: true
+          git-push: false
+          skip-on-empty: false # Always create commit
+      - name: Set VERSION for main branch
+        if: github.ref_name == 'main'
+        run: solidity/scripts/git_commit_proof_of_sql.sh ${{ steps.conventional-changelog.outputs.version }} evm-artifact

--- a/solidity/scripts/git_commit_proof_of_sql.sh
+++ b/solidity/scripts/git_commit_proof_of_sql.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/..
+find . -type f -name "*.post.sol" -delete
+scripts/install_deps.sh
+scripts/pre_forge.sh clean
+cd ./src
+
+# Variables
+REPO_URL="https://github.com/spaceandtimefdn/sxt-proof-of-sql"
+CLONE_DIR="temp-proof-of-sql"
+CLONED_PROOF_OF_SQL="$CLONE_DIR/sxt-proof-of-sql"
+BRANCH_NAME="#2"
+ERRORS_SOURCE_PATH="base/Errors.sol"
+CONSTANTS_SOURCE_PATH="base/Constants.sol"
+VERIFIER_SOURCE_PATH="verifier/Verifier.post.sol"
+ERRORS_TARGET_PATH="solidity/src/base/Errors.sol"
+CONSTANTS_TARGET_PATH="solidity/src/base/Constants.sol"
+VERIFIER_TARGET_PATH="solidity/src/verifier/Verifier.post.sol"
+COMMIT_MESSAGE="$1"
+
+# Checkout to the desired branch
+
+rm -rf $CLONE_DIR
+mkdir $CLONE_DIR
+cd $CLONE_DIR
+git clone -b $BRANCH_NAME $REPO_URL
+cd ../
+
+
+# Copy the contents of the local files to the target files
+cp $ERRORS_SOURCE_PATH $CLONED_PROOF_OF_SQL/$ERRORS_TARGET_PATH
+cp $CONSTANTS_SOURCE_PATH $CLONED_PROOF_OF_SQL/$CONSTANTS_TARGET_PATH
+cp $VERIFIER_SOURCE_PATH $CLONED_PROOF_OF_SQL/$VERIFIER_TARGET_PATH
+
+cd $CLONED_PROOF_OF_SQL
+
+# Add the modified files to the staging area
+git add $ERRORS_TARGET_PATH $CONSTANTS_TARGET_PATH $VERIFIER_TARGET_PATH
+
+# Commit the changes
+git commit -m "$COMMIT_MESSAGE"
+
+# Push the changes to the remote repository
+git push origin $BRANCH_NAME
+
+cd ../../
+
+# Delete the cloned repository
+rm -rf $CLONE_DIR


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
