### PR TITLE
perf: avoid creation of intermediate vector when calling `slice_ops::inner_product`

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -35,7 +35,7 @@ where
     &'a T: Into<S>,
 {
     fn inner_product(&self, evaluation_vec: &[S]) -> S {
-        slice_ops::inner_product(evaluation_vec, &slice_ops::slice_cast(self))
+        slice_ops::inner_product(evaluation_vec, self)
     }
 
     fn mul_add(&self, res: &mut [S], multiplier: &S) {

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -9,13 +9,15 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIter
 
 /// This operation takes the inner product of two slices. In other words, it does `a[0] * b[0] + a[1] * b[1] + ... + a[n] * b[n]`.
 /// If one of the slices is longer than the other, the extra elements are ignored/considered to be 0.
-pub fn inner_product<F>(a: &[F], b: &[F]) -> F
+pub fn inner_product<'a, F, T>(a: &[F], b: &'a [T]) -> F
 where
     F: Sync + Send + Mul<Output = F> + Sum + Copy,
+    &'a T: Into<F>,
+    T: Sync,
 {
     if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
         .zip(b)
-        .map(|(&a, &b)| a * b)
+        .map(|(&a, b)| a * b.into())
         .sum()
 }
 

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -110,17 +110,17 @@ fn test_inner_product_with_bytes_some_edge_cases() {
 
 #[test]
 fn test_inner_product() {
-    let a = vec![1, 2, 3, 4];
-    let b = vec![2, 3, 4, 5];
-    assert_eq!(40, inner_product(&a, &b));
+    let a = [1, 2, 3, 4].map(TestScalar::from).to_vec();
+    let b = [2, 3, 4, 5].map(TestScalar::from).to_vec();
+    assert_eq!(TestScalar::from(40), inner_product(&a, &b));
 }
 
 /// test inner products of different lengths
 #[test]
 fn test_inner_product_different_lengths() {
-    let a = vec![1, 2, 3, 4];
-    let b = vec![2, 3, 4, 5, 6];
-    assert_eq!(40, inner_product(&a, &b));
+    let a = [1, 2, 3, 4].map(TestScalar::from).to_vec();
+    let b = [2, 3, 4, 5, 6].map(TestScalar::from).to_vec();
+    assert_eq!(TestScalar::from(40), inner_product(&a, &b));
 }
 
 /// test inner producr with scalar


### PR DESCRIPTION
# Rationale for this change
This work is similar to the work done in PR https://github.com/spaceandtimefdn/sxt-proof-of-sql/pull/852. The `slice_ops::inner_product` requires a call to `slice_ops::slice_cast` before calling it. This creates a temporary vector. This is not necessary for the calculation.

The temporary vector is not adding a lot of time, but non-parallel benchmarks show that we can shave off a few milliseconds. See the `MultilinearExtension slice_cast` calls in the benchmark below.
![image](https://github.com/user-attachments/assets/9df6f8df-8328-4455-887b-5defb4a16c3e)

The biggest gain can be seen in the `FirstRoundBuilder::evaluate_pcs_proof_mles`.

Before, `8.04ms`
![image](https://github.com/user-attachments/assets/6b5a3321-95e9-4e13-997a-07d3cbdd1014)

After, `1.94ms`
![image](https://github.com/user-attachments/assets/760e2c5f-d8c6-4b14-8963-b093d10d8077)


# What changes are included in this PR?
- `slice_ops::inner_product` is updated to avoid callers needing to create a temporary vector

# Are these changes tested?
Yes