### PR TITLE
docs: add protocol for multicolumn monotonicity

### DIFF
--- a/docs/protocols/multi-column-monotonicity.tex
+++ b/docs/protocols/multi-column-monotonicity.tex
@@ -1,0 +1,48 @@
+\documentclass[11pt]{article}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage[margin=1in]{geometry}
+\usepackage{graphicx}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{hyperref}
+\usepackage{microtype}
+\usepackage{todonotes}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,
+  citecolor=blue,
+  urlcolor=blue
+}
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt}
+
+\title{Monotonicity}
+\author{Makeinfinite Labs}
+\date{May 2025}
+
+\begin{document}
+\maketitle
+
+\noindent Let $A=(a_{ij})$ be a table with $R$ rows and $N$ columns. We need to prove that $A$ is sorted on columns $(c_{i_k}, w_k)$ for $k \in [0, K)$. Strictness is $s$. That is, $A$ needs to increase in $c_{i_0}$ if $w_0 = 1$ and decrease in $c_{i_0}$ if $w_0 = -1$. Then tie breaker is $c_{i_1}$ for rows with the same $c_{i_0}$. So on and so on.\\
+Note that if $s$ is on it is implied that $A$ is distinct on columns $c_{i_0}, \cdots c_{i_{K-1}}$ which is needed for joins, groupbys etc.\\
+
+\section{Summary}
+\begin{itemize}
+    \item Plan values: $(c_{i_k}, w_k)$ for $k \in [0, K)$ and strictness $s$.
+    \item Inputs: $A$
+    \item Hints: $d$, $e_k$, $s_k$, $t$.
+\end{itemize}
+
+\section{Details}
+We set $A'$ be the shifted version of $A$. The following holds:\\
+\begin{itemize}
+    \item $A'$ is a shift of $A$, $D = (A' - A)\mathbf{1_{[0, R)}}$
+    \item Let $k = 0, e_{-1} = \mathbf{1}, t:=\mathbf{0}$.
+    \item Do sign check on $c_{i_k}e_{k-1}w_k$ with result $s_k$. $t:=t+s_k$. Note that all checks are strict with the possible exception of if $k = K - 1$ and we don't require strict order. Also break if $k = K - 1$.
+    \item Take $e_k = e_{k-1}\mathbf{1}_{d_k = 0}$. If $e_k = \mathbf{0}$, break. Otherwise return to 3.
+    \item Verify that $t = \mathbf{1}$.
+\end{itemize}
+
+\end{document}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
