### PR TITLE
feat(sol): add arithmetic utils

### DIFF
--- a/solidity/src/base/MathUtil.sol
+++ b/solidity/src/base/MathUtil.sol
@@ -2,6 +2,8 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
+import "../base/Constants.sol";
+
 /// @title Math Utilities Library
 /// @notice Provides functions to perform various math operations
 library MathUtil {
@@ -49,6 +51,48 @@ library MathUtil {
                 }
             }
             __exponent := log2_up(__value)
+        }
+    }
+
+    /// @notice Computes `addmod(lhs, rhs, MODULUS)`
+    /// @dev The sum of two uint256 values mod the order of bn254.
+    /// @param __lhs The left hand side
+    /// @param __rhs The right hand side
+    /// @return __sum The sum of the two sides with the appropriate modulus
+    function __addModBN254(uint256 __lhs, uint256 __rhs) internal pure returns (uint256 __sum) {
+        assembly {
+            function addmod_bn254(lhs, rhs) -> sum {
+                sum := addmod(lhs, rhs, MODULUS)
+            }
+            __sum := addmod_bn254(__lhs, __rhs)
+        }
+    }
+
+    /// @notice Computes `addmod(lhs, mulmod(rhs, MODULUS_MINUS_ONE, MODULUS), MODULUS)`
+    /// @dev The difference of two uint256 values mod the order of bn254.
+    /// @param __lhs The left hand side
+    /// @param __rhs The right hand side
+    /// @return __difference The difference of the two sides with the appropriate modulus
+    function __subModBN254(uint256 __lhs, uint256 __rhs) internal pure returns (uint256 __difference) {
+        assembly {
+            function submod_bn254(lhs, rhs) -> difference {
+                difference := addmod(lhs, mulmod(rhs, MODULUS_MINUS_ONE, MODULUS), MODULUS)
+            }
+            __difference := submod_bn254(__lhs, __rhs)
+        }
+    }
+
+    /// @notice Computes `mulmod(lhs, rhs, MODULUS)`
+    /// @dev The product of two uint256 values mod the order of bn254.
+    /// @param __lhs The left hand side
+    /// @param __rhs The right hand side
+    /// @return __product The product of the two sides with the appropriate modulus
+    function __mulModBN254(uint256 __lhs, uint256 __rhs) internal pure returns (uint256 __product) {
+        assembly {
+            function mulmod_bn254(lhs, rhs) -> product {
+                product := mulmod(lhs, rhs, MODULUS)
+            }
+            __product := mulmod_bn254(__lhs, __rhs)
         }
     }
 }

--- a/solidity/src/hyperkzg/HyperKZGBatch.pre.sol
+++ b/solidity/src/hyperkzg/HyperKZGBatch.pre.sol
@@ -49,6 +49,14 @@ library HyperKZGBatch {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Transcript.sol
             function draw_challenge(transcript_ptr) -> result {
                 revert(0, 0)
@@ -67,7 +75,7 @@ library HyperKZGBatch {
                         args_ptr, mload(commitments_ptr), mload(add(commitments_ptr, WORD_SIZE)), challenge
                     )
                     commitments_ptr := add(commitments_ptr, WORDX2_SIZE)
-                    batch_eval := addmod(batch_eval, mulmod(mload(evaluations_ptr), challenge, MODULUS), MODULUS)
+                    batch_eval := addmod_bn254(batch_eval, mulmod_bn254(mload(evaluations_ptr), challenge))
                     evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
                 }
                 batch_eval_out := mod(batch_eval, MODULUS)

--- a/solidity/src/hyperkzg/HyperKZGVerifier.pre.sol
+++ b/solidity/src/hyperkzg/HyperKZGVerifier.pre.sol
@@ -135,6 +135,18 @@ library HyperKZGVerifier {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Transcript.sol
             function append_calldata(transcript_ptr, offset, size) {
                 revert(0, 0)

--- a/solidity/src/proof_exprs/AddExpr.pre.sol
+++ b/solidity/src/proof_exprs/AddExpr.pre.sol
@@ -45,6 +45,18 @@ library AddExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -129,7 +141,7 @@ library AddExpr {
                 let rhs_eval
                 expr_ptr, rhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
-                result_eval := addmod(lhs_eval, rhs_eval, MODULUS)
+                result_eval := addmod_bn254(lhs_eval, rhs_eval)
                 expr_ptr_out := expr_ptr
             }
 

--- a/solidity/src/proof_exprs/AndExpr.pre.sol
+++ b/solidity/src/proof_exprs/AndExpr.pre.sol
@@ -45,6 +45,18 @@ library AndExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -131,11 +143,7 @@ library AndExpr {
 
                 result_eval := mod(builder_consume_final_round_mle(builder_ptr), MODULUS)
                 builder_produce_identity_constraint(
-                    builder_ptr,
-                    addmod(
-                        result_eval, mulmod(MODULUS_MINUS_ONE, mulmod(lhs_eval, rhs_eval, MODULUS), MODULUS), MODULUS
-                    ),
-                    2
+                    builder_ptr, submod_bn254(result_eval, mulmod_bn254(lhs_eval, rhs_eval)), 2
                 )
 
                 expr_ptr_out := expr_ptr

--- a/solidity/src/proof_exprs/CastExpr.pre.sol
+++ b/solidity/src/proof_exprs/CastExpr.pre.sol
@@ -44,6 +44,18 @@ library CastExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_exprs/EqualsExpr.pre.sol
+++ b/solidity/src/proof_exprs/EqualsExpr.pre.sol
@@ -71,6 +71,18 @@ library EqualsExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -155,22 +167,14 @@ library EqualsExpr {
                 let rhs_eval
                 expr_ptr, rhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
-                let diff_eval := addmod(lhs_eval, mulmod(MODULUS_MINUS_ONE, rhs_eval, MODULUS), MODULUS)
+                let diff_eval := submod_bn254(lhs_eval, rhs_eval)
                 let diff_star_eval := builder_consume_final_round_mle(builder_ptr)
                 result_eval := mod(builder_consume_final_round_mle(builder_ptr), MODULUS)
 
-                builder_produce_identity_constraint(builder_ptr, mulmod(result_eval, diff_eval, MODULUS), 2)
+                builder_produce_identity_constraint(builder_ptr, mulmod_bn254(result_eval, diff_eval), 2)
                 builder_produce_identity_constraint(
                     builder_ptr,
-                    addmod(
-                        chi_eval,
-                        mulmod(
-                            MODULUS_MINUS_ONE,
-                            addmod(mulmod(diff_eval, diff_star_eval, MODULUS), result_eval, MODULUS),
-                            MODULUS
-                        ),
-                        MODULUS
-                    ),
+                    submod_bn254(chi_eval, addmod_bn254(mulmod_bn254(diff_eval, diff_star_eval), result_eval)),
                     2
                 )
 

--- a/solidity/src/proof_exprs/LiteralExpr.pre.sol
+++ b/solidity/src/proof_exprs/LiteralExpr.pre.sol
@@ -39,6 +39,18 @@ library LiteralExpr {
         returns (bytes calldata __exprOut, uint256 __eval)
     {
         assembly {
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Errors.sol
             function err(code) {
                 revert(0, 0)
@@ -64,7 +76,7 @@ library LiteralExpr {
                 let literal_variant
                 expr_ptr, literal_variant := read_data_type(expr_ptr)
                 expr_ptr, eval := read_entry(expr_ptr, literal_variant)
-                eval := mulmod(eval, chi_eval, MODULUS)
+                eval := mulmod_bn254(eval, chi_eval)
                 expr_ptr_out := expr_ptr
             }
             let __exprOutOffset

--- a/solidity/src/proof_exprs/MultiplyExpr.pre.sol
+++ b/solidity/src/proof_exprs/MultiplyExpr.pre.sol
@@ -45,6 +45,18 @@ library MultiplyExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -131,11 +143,7 @@ library MultiplyExpr {
 
                 result_eval := mod(builder_consume_final_round_mle(builder_ptr), MODULUS)
                 builder_produce_identity_constraint(
-                    builder_ptr,
-                    addmod(
-                        result_eval, mulmod(MODULUS_MINUS_ONE, mulmod(lhs_eval, rhs_eval, MODULUS), MODULUS), MODULUS
-                    ),
-                    2
+                    builder_ptr, submod_bn254(result_eval, mulmod_bn254(lhs_eval, rhs_eval)), 2
                 )
 
                 expr_ptr_out := expr_ptr

--- a/solidity/src/proof_exprs/NotExpr.pre.sol
+++ b/solidity/src/proof_exprs/NotExpr.pre.sol
@@ -44,6 +44,18 @@ library NotExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -125,7 +137,7 @@ library NotExpr {
                 let input_eval
                 expr_ptr, input_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
-                result_eval := addmod(chi_eval, mulmod(MODULUS_MINUS_ONE, input_eval, MODULUS), MODULUS)
+                result_eval := submod_bn254(chi_eval, input_eval)
                 expr_ptr_out := expr_ptr
             }
 

--- a/solidity/src/proof_exprs/OrExpr.pre.sol
+++ b/solidity/src/proof_exprs/OrExpr.pre.sol
@@ -45,6 +45,18 @@ library OrExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -130,18 +142,9 @@ library OrExpr {
                 expr_ptr, rhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
                 let lhs_times_rhs_eval := builder_consume_final_round_mle(builder_ptr)
-                result_eval :=
-                    addmod(
-                        addmod(lhs_eval, rhs_eval, MODULUS), mulmod(MODULUS_MINUS_ONE, lhs_times_rhs_eval, MODULUS), MODULUS
-                    )
+                result_eval := submod_bn254(addmod_bn254(lhs_eval, rhs_eval), lhs_times_rhs_eval)
                 builder_produce_identity_constraint(
-                    builder_ptr,
-                    addmod(
-                        lhs_times_rhs_eval,
-                        mulmod(MODULUS_MINUS_ONE, mulmod(lhs_eval, rhs_eval, MODULUS), MODULUS),
-                        MODULUS
-                    ),
-                    2
+                    builder_ptr, submod_bn254(lhs_times_rhs_eval, mulmod_bn254(lhs_eval, rhs_eval)), 2
                 )
 
                 expr_ptr_out := expr_ptr

--- a/solidity/src/proof_exprs/ProofExpr.pre.sol
+++ b/solidity/src/proof_exprs/ProofExpr.pre.sol
@@ -61,6 +61,18 @@ library ProofExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_exprs/SubtractExpr.pre.sol
+++ b/solidity/src/proof_exprs/SubtractExpr.pre.sol
@@ -45,6 +45,18 @@ library SubtractExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -129,7 +141,7 @@ library SubtractExpr {
                 let rhs_eval
                 expr_ptr, rhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
-                result_eval := addmod(lhs_eval, mulmod(MODULUS_MINUS_ONE, rhs_eval, MODULUS), MODULUS)
+                result_eval := submod_bn254(lhs_eval, rhs_eval)
                 expr_ptr_out := expr_ptr
             }
 

--- a/solidity/src/proof_plans/FilterExec.pre.sol
+++ b/solidity/src/proof_plans/FilterExec.pre.sol
@@ -85,6 +85,18 @@ library FilterExec {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -201,13 +213,13 @@ library FilterExec {
                 for { let i := column_count } i { i := sub(i, 1) } {
                     let c
                     plan_ptr, c := proof_expr_evaluate(plan_ptr, builder_ptr, input_chi_eval)
-                    c_fold := addmod(mulmod(c_fold, beta, MODULUS), c, MODULUS)
+                    c_fold := addmod_bn254(mulmod_bn254(c_fold, beta), c)
                 }
 
                 d_fold := 0
                 for { let i := column_count } i { i := sub(i, 1) } {
                     let d := builder_consume_final_round_mle(builder_ptr)
-                    d_fold := addmod(mulmod(d_fold, beta, MODULUS), d, MODULUS)
+                    d_fold := addmod_bn254(mulmod_bn254(d_fold, beta), d)
 
                     mstore(evaluations_ptr, d)
                     evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
@@ -234,32 +246,20 @@ library FilterExec {
                 let output_chi_eval := builder_consume_chi_evaluation(builder_ptr)
 
                 builder_produce_zerosum_constraint(
+                    builder_ptr, submod_bn254(mulmod_bn254(c_star, selection_eval), d_star), 2
+                )
+                builder_produce_identity_constraint(
                     builder_ptr,
-                    addmod(mulmod(c_star, selection_eval, MODULUS), mulmod(MODULUS_MINUS_ONE, d_star, MODULUS), MODULUS),
+                    submod_bn254(mulmod_bn254(add(1, mulmod_bn254(alpha, c_fold)), c_star), input_chi_eval),
                     2
                 )
                 builder_produce_identity_constraint(
                     builder_ptr,
-                    addmod(
-                        mulmod(add(1, mulmod(alpha, c_fold, MODULUS)), c_star, MODULUS),
-                        mulmod(MODULUS_MINUS_ONE, input_chi_eval, MODULUS),
-                        MODULUS
-                    ),
+                    submod_bn254(mulmod_bn254(add(1, mulmod_bn254(alpha, d_fold)), d_star), output_chi_eval),
                     2
                 )
                 builder_produce_identity_constraint(
-                    builder_ptr,
-                    addmod(
-                        mulmod(add(1, mulmod(alpha, d_fold, MODULUS)), d_star, MODULUS),
-                        mulmod(MODULUS_MINUS_ONE, output_chi_eval, MODULUS),
-                        MODULUS
-                    ),
-                    2
-                )
-                builder_produce_identity_constraint(
-                    builder_ptr,
-                    mulmod(mulmod(alpha, d_fold, MODULUS), addmod(output_chi_eval, MODULUS_MINUS_ONE, MODULUS), MODULUS),
-                    2
+                    builder_ptr, mulmod_bn254(mulmod_bn254(alpha, d_fold), submod_bn254(output_chi_eval, 1)), 2
                 )
                 plan_ptr_out := plan_ptr
             }

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -47,6 +47,18 @@ library ProofPlan {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/sumcheck/Sumcheck.pre.sol
+++ b/solidity/src/sumcheck/Sumcheck.pre.sol
@@ -36,6 +36,18 @@ library Sumcheck {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Transcript.sol
             function append_calldata(transcript_ptr, offset, size) {
                 revert(0, 0)
@@ -54,11 +66,11 @@ library Sumcheck {
                 for {} degree { degree := sub(degree, 1) } {
                     coefficient := calldataload(proof_ptr)
                     proof_ptr := add(proof_ptr, WORD_SIZE)
-                    round_evaluation := mulmod(round_evaluation, challenge, MODULUS)
-                    round_evaluation := addmod(round_evaluation, coefficient, MODULUS)
-                    actual_sum := addmod(actual_sum, coefficient, MODULUS)
+                    round_evaluation := mulmod_bn254(round_evaluation, challenge)
+                    round_evaluation := addmod_bn254(round_evaluation, coefficient)
+                    actual_sum := addmod_bn254(actual_sum, coefficient)
                 }
-                actual_sum := addmod(actual_sum, coefficient, MODULUS)
+                actual_sum := addmod_bn254(actual_sum, coefficient)
                 proof_ptr_out := proof_ptr
             }
 

--- a/solidity/src/verifier/ResultVerifier.pre.sol
+++ b/solidity/src/verifier/ResultVerifier.pre.sol
@@ -38,6 +38,14 @@ library ResultVerifier {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/SwitchUtil.pre.sol
             function case_const(lhs, rhs) {
                 revert(0, 0)
@@ -93,7 +101,7 @@ library ResultVerifier {
                     for { let i := 0 } sub(table_len, i) { i := add(i, 1) } {
                         let entry
                         result_ptr, entry := read_entry(result_ptr, data_type_variant)
-                        value := addmod(value, mulmod(entry, mload(add(eval_vec, mul(i, WORD_SIZE))), MODULUS), MODULUS)
+                        value := addmod_bn254(value, mulmod_bn254(entry, mload(add(eval_vec, mul(i, WORD_SIZE)))))
                     }
                     if value { err(ERR_INCORRECT_RESULT) }
                 }

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -74,6 +74,18 @@ library Verifier {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/LagrangeBasisEvaluation.pre.sol
             function compute_truncated_lagrange_basis_inner_product(length, x_ptr, y_ptr, num_vars) -> result {
                 revert(0, 0)
@@ -383,7 +395,7 @@ library Verifier {
                 let expected_evaluation, sumcheck_degree
                 proof_ptr, evaluation_point_ptr, expected_evaluation, sumcheck_degree :=
                     verify_sumcheck_proof(transcript_ptr, proof_ptr_init, num_vars)
-                builder_set_aggregate_evaluation(builder_ptr, mulmod(MODULUS_MINUS_ONE, expected_evaluation, MODULUS))
+                builder_set_aggregate_evaluation(builder_ptr, mulmod_bn254(MODULUS_MINUS_ONE, expected_evaluation))
                 builder_set_max_degree(builder_ptr, sumcheck_degree)
             }
             // IMPORT-YUL ../base/LagrangeBasisEvaluation.pre.sol

--- a/solidity/test/base/MathUtil.t.sol
+++ b/solidity/test/base/MathUtil.t.sol
@@ -2,6 +2,7 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
+import "../../src/base/Constants.sol";
 import {MathUtil} from "../../src/base/MathUtil.sol";
 
 library MathUtilTest {
@@ -47,5 +48,14 @@ library MathUtilTest {
             assert(exponent == 256);
             assert((1 << 255) < value);
         }
+    }
+
+    function testWeCanComputeAddAndMultiplicationModulus() public pure {
+        assert(MathUtil.__addModBN254(1, 2) == 3);
+        assert(MathUtil.__addModBN254(MODULUS_MINUS_ONE, 2) == 1);
+        assert(MathUtil.__subModBN254(2, 1) == 1);
+        assert(MathUtil.__subModBN254(1, 2) == MODULUS_MINUS_ONE);
+        assert(MathUtil.__mulModBN254(1, 2) == 2);
+        assert(MathUtil.__mulModBN254(MODULUS_MINUS_ONE, 2) == MODULUS_MINUS_ONE - 1);
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

There's loads of places where code like `addmod(lhs, rhs, MODULUS)` is repeated. There's no need to constantly indicate the mod is `MODULUS`, so it's would be far more succinct to have arithmetic functions that apply the modulus.

# What changes are included in this PR?

New add, sub, and mul functions.

# Are these changes tested?
Yes
