### PR TITLE
refactor: move monotonic to shift

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -23,10 +23,22 @@ pub(crate) fn first_round_evaluate_shift<S: Scalar>(
 }
 
 /// Perform final round evaluation of downward shift.
+pub(crate) fn final_round_evaluate_shift<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    column: &'a [S],
+    shifted_column: &'a [S],
+){
+    final_round_evaluate_shift_base(builder, alloc, alpha, beta, column, shifted_column)
+}
+
+/// Perform final round evaluation of downward shift.
 ///
 /// # Panics
 /// Panics if `column.len() != shifted_column.len() - 1` which should always hold for shifts.
-pub(crate) fn final_round_evaluate_shift<'a, S: Scalar>(
+fn final_round_evaluate_shift_base<'a, S: Scalar>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     alpha: S,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -29,9 +29,17 @@ pub(crate) fn final_round_evaluate_shift<'a, S: Scalar>(
     alpha: S,
     beta: S,
     column: &'a [S],
-    shifted_column: &'a [S],
-){
-    final_round_evaluate_shift_base(builder, alloc, alpha, beta, column, shifted_column)
+) -> &'a [S] {
+    let shifted_column = alloc.alloc_slice_fill_with(column.len() + 1, |i| {
+        if i == 0 {
+            S::ZERO
+        } else {
+            column[i - 1]
+        }
+    });
+    builder.produce_intermediate_mle(shifted_column as &[_]);
+    final_round_evaluate_shift_base(builder, alloc, alpha, beta, column, shifted_column);
+    shifted_column
 }
 
 /// Perform final round evaluation of downward shift.
@@ -115,10 +123,10 @@ pub(crate) fn verify_shift<S: Scalar>(
     alpha: S,
     beta: S,
     column_eval: S,
-    shifted_column_eval: S,
     chi_n_eval: S,
     chi_n_plus_1_eval: S,
-) -> Result<(), ProofError> {
+) -> Result<S, ProofError> {
+    let shifted_column_eval = builder.try_consume_final_round_mle_evaluation()?;
     let rho_n_eval = builder.try_consume_rho_evaluation()?;
     let rho_n_plus_1_eval = builder.try_consume_rho_evaluation()?;
     let c_fold_eval = alpha * fold_vals(beta, &[rho_n_eval + chi_n_eval, column_eval]);
@@ -147,12 +155,12 @@ pub(crate) fn verify_shift<S: Scalar>(
         2,
     )?;
 
-    Ok(())
+    Ok(shifted_column_eval)
 }
 
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
-    use super::{final_round_evaluate_shift, first_round_evaluate_shift, verify_shift};
+    use super::{final_round_evaluate_shift_base, first_round_evaluate_shift, verify_shift};
     use crate::{
         base::{
             database::{
@@ -234,7 +242,7 @@ mod tests {
             builder.produce_intermediate_mle(alloc_candidate_column as &[_]);
             let alpha = builder.consume_post_result_challenge();
             let beta = builder.consume_post_result_challenge();
-            final_round_evaluate_shift(
+            final_round_evaluate_shift_base(
                 builder,
                 alloc,
                 alpha,
@@ -279,7 +287,6 @@ mod tests {
             let beta = builder.try_consume_post_result_challenge()?;
             // Get the columns
             let column_eval = builder.try_consume_final_round_mle_evaluation()?;
-            let candidate_shift_eval = builder.try_consume_final_round_mle_evaluation()?;
             let chi_n_eval = builder.try_consume_chi_evaluation()?;
             let chi_n_plus_1_eval = builder.try_consume_chi_evaluation()?;
             // Evaluate the verifier
@@ -288,7 +295,6 @@ mod tests {
                 alpha,
                 beta,
                 column_eval,
-                candidate_shift_eval,
                 chi_n_eval,
                 chi_n_plus_1_eval,
             )?;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The logic for calculating a shifted column is being done by the monotonic gadget, which is not where it should be.

# What changes are included in this PR?

Moving shift logic to shift, where it belongs.

# Are these changes tested?
Yes.
