### PR TITLE
feat: add inequality expr to evm dyn proof expr

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -39,7 +39,7 @@ pub(crate) use and_expr::AndExpr;
 mod and_expr_test;
 
 mod inequality_expr;
-use inequality_expr::InequalityExpr;
+pub(crate) use inequality_expr::InequalityExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod inequality_expr_test;
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -31,6 +31,13 @@ pub fn equal(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_inequality()` returns an error.
+pub fn lt(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
+    DynProofExpr::try_new_inequality(left, right, true).unwrap()
+}
+
+/// # Panics
+/// Panics if:
+/// - `DynProofExpr::try_new_inequality()` returns an error.
 pub fn lte(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     not(DynProofExpr::try_new_inequality(left, right, false).unwrap())
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We want inequality in the evm code

# What changes are included in this PR?

Adding an Inequality variant to the `EVMDynProofExpr`

# Are these changes tested?
Yes
