### PR TITLE
docs: add more comments to bit distribution

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -29,24 +29,36 @@ pub enum BitDistributionError {
 }
 
 impl BitDistribution {
+    /// Creates a new `BitDistribution` by analyzing the bit patterns in the provided data.
+    ///
+    /// This function examines each element in the data slice, converts them to bit masks,
+    /// and determines which bit positions vary across the dataset and which are constant.
     pub fn new<S: Scalar, T: Into<S> + Clone>(data: &[T]) -> Self {
+        // Convert each data element to a scalar and then to its bit mask representation
         let bit_masks = data.iter().cloned().map(Into::<S>::into).map(make_bit_mask);
+        // Calculate masks for bits that are consistently 1 (sign_mask) or consistently 0 (inverse_sign_mask)
+        // across all elements, normalizing negative representations first
         let (sign_mask, inverse_sign_mask) =
             bit_masks
                 .clone()
                 .fold((U256::MAX, U256::MAX), |acc, bit_mask| {
+                    // Normalize negative representations by flipping the sign bit
                     let bit_mask = if is_bit_mask_negative_representation(bit_mask) {
                         bit_mask ^ U256::MAX.shr(1)
                     } else {
                         bit_mask
                     };
+                    // Accumulate bits that are consistently 1 and consistently 0
                     (acc.0 & bit_mask, acc.1 & !bit_mask)
                 });
+        // Set the most significant bit if the sign varies across elements
         let vary_mask_bit = U256::from(
             !bit_masks
                 .map(is_bit_mask_negative_representation)
                 .all_equal(),
         ) << 255;
+        // Combine varying bit positions: bits that are neither consistently 1 nor consistently 0,
+        // plus the sign bit if it varies
         let vary_mask: U256 = !(sign_mask | inverse_sign_mask) | vary_mask_bit;
 
         Self {
@@ -55,20 +67,27 @@ impl BitDistribution {
         }
     }
 
+    /// Returns the mask identifying bit positions that vary across the dataset.
+    /// A bit is set to 1 if that position has different values across different elements.
     pub fn vary_mask(&self) -> U256 {
         U256::from(self.vary_mask)
     }
 
-    /// Identifies all columns that are the identical to the lead column.
+    /// Returns the mask identifying bit positions that are identical to the lead (sign) column.
+    /// The most significant bit is always set to indicate the sign column itself.
     pub fn leading_bit_mask(&self) -> U256 {
         U256::from(self.leading_bit_mask) | (U256::ONE.shl(255))
     }
 
-    /// Identifies all columns that are the identical to the inverse of the lead column.
+    /// Returns the mask identifying bit positions that are identical to the inverse of the lead column.
+    /// These are positions where the bit value is always opposite to the sign bit.
     pub fn leading_bit_inverse_mask(&self) -> U256 {
         (!self.vary_mask() ^ self.leading_bit_mask()) & U256::MAX.shr(1)
     }
 
+    /// Returns the number of bit positions that vary across the dataset.
+    /// This is calculated by counting the number of 1s in the `vary_mask`.
+    ///
     /// # Panics
     ///
     /// Panics if conversion from `ExpType` to `usize` fails
@@ -76,20 +95,29 @@ impl BitDistribution {
         self.vary_mask().count_ones() as usize
     }
 
-    /// Determines the lead (sign) bit.
+    /// Determines the evaluation of the lead (sign) bit based on the bit distribution.
+    ///
+    /// Returns:
+    /// - The last bit evaluation if the sign bit varies across elements
+    /// - Zero if the sign is constantly 0
+    /// - The chi evaluation if the sign is constantly 1
     pub fn leading_bit_eval<S: ScalarExt>(
         &self,
         bit_evals: &[S],
         chi_eval: S,
     ) -> Result<S, BitDistributionError> {
+        // Check if the sign bit varies (MSB of vary_mask is set)
         if U256::from(self.vary_mask) & (U256::ONE.shl(255)) != U256::ZERO {
+            // Sign varies, use the last bit evaluation
             bit_evals
                 .last()
                 .ok_or(BitDistributionError::NoLeadBit)
                 .copied()
         } else if U256::from(self.leading_bit_mask) & U256::ONE.shl(255) == U256::ZERO {
+            // Sign is constantly 0
             Ok(S::ZERO)
         } else {
+            // Sign is constantly 1
             Ok(chi_eval)
         }
     }
@@ -115,9 +143,12 @@ impl BitDistribution {
         (self.leading_bit_inverse_mask() >> 128) == (U256::MAX.shr(129))
     }
 
-    /// Iterate over each varying bit
+    /// Returns an iterator over the bit positions that vary across the dataset.
+    /// Each yielded value is the index (0-255) of a bit position that has different values
+    /// across different elements in the original data.
     #[expect(clippy::missing_panics_doc)]
     pub fn vary_mask_iter(&self) -> impl Iterator<Item = u8> + '_ {
+        // Iterate through each 64-bit chunk of the 256-bit vary_mask
         (0..4).flat_map(|i| {
             BitIter::from(self.vary_mask[i])
                 .iter()

--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
@@ -2,13 +2,28 @@ use crate::base::scalar::ScalarExt;
 use bnum::types::U256;
 use core::ops::Shl;
 
+/// Creates a bit mask representation for scalar values.
+///
+/// Sign handling for scalars can be tricky because scalars represent elements in
+/// a finite field, not traditional signed integers. The concept of "negative" numbers
+/// in a field is based on whether a value is greater than the midpoint of the field
+/// (`S::MAX_SIGNED`).
+///
+/// We use `U256::ONE.shl(255)` to transform the comparison with `S::MAX_SIGNED` into
+/// a simple check of the leading bit in U256. This transformation maps:
+/// - Values <= `S::MAX_SIGNED` to bit masks with MSB = 1 (representing "positive")
+/// - Values > `S::MAX_SIGNED` to bit masks with MSB = 0 (representing "negative")
+///
+/// For negative scalars, we map -x = |S| - x to 2^255 - x, since 2 * `S::MAX_SIGNED` + 1 = |S|.
 pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
     let x_as_u256 = x.into_u256_wrapping();
     if x > S::MAX_SIGNED {
+        // For "negative" scalars: map -x = |S| - x to 2^255 - x
         x_as_u256 - S::into_u256_wrapping(S::MAX_SIGNED) + (U256::ONE.shl(255))
             - S::into_u256_wrapping(S::MAX_SIGNED)
             - U256::ONE
     } else {
+        // For "positive" scalars: set the MSB by adding 2^255
         x_as_u256 + (U256::ONE.shl(255))
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
