### PR TITLE
refactor: simplify sign expr verification

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -1,5 +1,8 @@
 use super::bit_mask_utils::{is_bit_mask_negative_representation, make_bit_mask};
-use crate::base::scalar::{Scalar, ScalarExt};
+use crate::base::{
+    proof::ProofError,
+    scalar::{Scalar, ScalarExt},
+};
 use ark_std::iterable::Iterable;
 use bit_iter::BitIter;
 use bnum::types::U256;
@@ -43,6 +46,19 @@ pub enum BitDistributionError {
     NoLeadBit,
     /// Failed to verify bit decomposition
     Verification,
+}
+
+impl From<BitDistributionError> for ProofError {
+    fn from(err: BitDistributionError) -> Self {
+        match err {
+            BitDistributionError::NoLeadBit => {
+                panic!("No lead bit available despite variable lead bit.")
+            }
+            BitDistributionError::Verification => ProofError::VerificationError {
+                error: "invalid bit_decomposition",
+            },
+        }
+    }
 }
 
 impl BitDistribution {

--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -110,20 +110,13 @@ impl BitDistribution {
     }
 
     /// Determines the lead (sign) bit.
-    pub fn leading_bit_eval<S: ScalarExt>(
-        &self,
-        bit_evals: &[S],
-        chi_eval: S,
-    ) -> Result<S, BitDistributionError> {
+    pub fn try_constant_leading_bit_eval<S: ScalarExt>(&self, chi_eval: S) -> Option<S> {
         if U256::from(self.vary_mask) & (U256::ONE.shl(255)) != U256::ZERO {
-            bit_evals
-                .last()
-                .ok_or(BitDistributionError::NoLeadBit)
-                .copied()
+            None
         } else if U256::from(self.leading_bit_mask) & U256::ONE.shl(255) == U256::ZERO {
-            Ok(S::ZERO)
+            Some(S::ZERO)
         } else {
-            Ok(chi_eval)
+            Some(chi_eval)
         }
     }
 

--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -160,7 +160,7 @@ fn we_can_get_u256_version_of_leading_bit_inverse_mask_for_large_number() {
 // leading_bit_inverse_mask function end
 
 #[test]
-fn we_can_get_leading_bit_eval_while_varying() {
+fn we_cannot_get_leading_bit_eval_from_dist_while_varying() {
     // ARRANGE
     let bit_distribution = BitDistribution {
         vary_mask: [0, 0, 0, 1 << 63],
@@ -168,12 +168,10 @@ fn we_can_get_leading_bit_eval_while_varying() {
     };
 
     // ACT
-    let bit_eval = bit_distribution
-        .leading_bit_eval(&[TestScalar::ONE], TestScalar::TWO)
-        .unwrap();
+    let bit_eval = bit_distribution.try_constant_leading_bit_eval(TestScalar::TWO);
 
     // ASSERT
-    assert_eq!(bit_eval, TestScalar::ONE);
+    assert!(bit_eval.is_none());
 }
 
 #[test]
@@ -186,7 +184,7 @@ fn we_can_get_leading_bit_eval_while_constant_and_zero() {
 
     // ACT
     let bit_eval = bit_distribution
-        .leading_bit_eval(&[TestScalar::ONE], TestScalar::TWO)
+        .try_constant_leading_bit_eval(TestScalar::TWO)
         .unwrap();
 
     // ASSERT
@@ -203,7 +201,7 @@ fn we_can_get_leading_bit_eval_while_constant_and_non_zero() {
 
     // ACT
     let bit_eval = bit_distribution
-        .leading_bit_eval(&[TestScalar::ONE], TestScalar::TWO)
+        .try_constant_leading_bit_eval(TestScalar::TWO)
         .unwrap();
 
     // ASSERT

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -121,10 +121,9 @@ pub fn verifier_evaluate_sign<S: Scalar>(
     let is_eval_correct_number_of_bits = bits_that_must_match_inverse_lead_bit
         & dist.leading_bit_inverse_mask()
         == bits_that_must_match_inverse_lead_bit;
-    (rhs == eval && is_eval_correct_number_of_bits)
-        .then_some(sign_eval)
-        .ok_or(BitDistributionError::Verification)?;
-    Ok(chi_eval - sign_eval)
+    Ok((rhs == eval && is_eval_correct_number_of_bits)
+        .then_some(chi_eval - sign_eval)
+        .ok_or(BitDistributionError::Verification)?)
 }
 
 fn prove_bits_are_binary<'a, S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -101,7 +101,15 @@ pub fn verifier_evaluate_sign<S: Scalar>(
         bit_evals.push(eval);
     }
 
-    let sign_eval = dist.leading_bit_eval(&bit_evals, chi_eval)?;
+    let sign_eval = dist.try_constant_leading_bit_eval(chi_eval).map_or_else(
+        || {
+            bit_evals
+                .last()
+                .ok_or(BitDistributionError::NoLeadBit)
+                .copied()
+        },
+        Ok,
+    )?;
     let mut rhs = sign_eval * S::from_wrapping(dist.leading_bit_mask())
         + (chi_eval - sign_eval) * S::from_wrapping(dist.leading_bit_inverse_mask())
         - chi_eval * S::from_wrapping(U256::ONE.shl(255));

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -108,7 +108,7 @@ pub fn verifier_evaluate_sign<S: Scalar>(
 /// This function checks the consistency of the bit evaluations with the expression evaluation.
 /// The column of data is restricted to an unsigned integer type of `num_bits_allowed` bits.
 fn verify_bit_decomposition<S: ScalarExt>(
-    expr_eval: S,
+    eval: S,
     chi_eval: S,
     bit_evals: &[S],
     dist: &BitDistribution,
@@ -135,7 +135,7 @@ fn verify_bit_decomposition<S: ScalarExt>(
     let is_eval_correct_number_of_bits = bits_that_must_match_inverse_lead_bit
         & dist.leading_bit_inverse_mask()
         == bits_that_must_match_inverse_lead_bit;
-    (rhs == expr_eval && is_eval_correct_number_of_bits)
+    (rhs == eval && is_eval_correct_number_of_bits)
         .then_some(sign_eval)
         .ok_or(BitDistributionError::Verification)
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -101,16 +101,8 @@ pub fn verifier_evaluate_sign<S: Scalar>(
         bit_evals.push(eval);
     }
 
-    verify_bit_decomposition(eval, chi_eval, &bit_evals, &dist, num_bits_allowed)
-        .map(|sign_eval| chi_eval - sign_eval)
-        .map_err(|err| match err {
-            BitDistributionError::NoLeadBit => {
-                panic!("No lead bit available despite variable lead bit.")
-            }
-            BitDistributionError::Verification => ProofError::VerificationError {
-                error: "invalid bit_decomposition",
-            },
-        })
+    let sign_eval = verify_bit_decomposition(eval, chi_eval, &bit_evals, &dist, num_bits_allowed)?;
+    Ok(chi_eval - sign_eval)
 }
 
 /// This function checks the consistency of the bit evaluations with the expression evaluation.

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -93,11 +93,13 @@ pub fn verifier_evaluate_sign<S: Scalar>(
     let mut bit_evals = Vec::with_capacity(num_varying_bits);
     for _ in 0..num_varying_bits {
         let eval = builder.try_consume_final_round_mle_evaluation()?;
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            eval - eval * eval,
+            2,
+        )?;
         bit_evals.push(eval);
     }
-
-    // establish that the bits are binary
-    verify_bits_are_binary(builder, &bit_evals)?;
 
     verify_bit_decomposition(eval, chi_eval, &bit_evals, &dist, num_bits_allowed)
         .map(|sign_eval| chi_eval - sign_eval)
@@ -125,20 +127,6 @@ fn prove_bits_are_binary<'a, S: Scalar>(
             ],
         );
     }
-}
-
-fn verify_bits_are_binary<S: Scalar>(
-    builder: &mut impl VerificationBuilder<S>,
-    bit_evals: &[S],
-) -> Result<(), ProofError> {
-    for bit_eval in bit_evals {
-        builder.try_produce_sumcheck_subpolynomial_evaluation(
-            SumcheckSubpolynomialType::Identity,
-            *bit_eval - *bit_eval * *bit_eval,
-            2,
-        )?;
-    }
-    Ok(())
 }
 
 /// This function checks the consistency of the bit evaluations with the expression evaluation.

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -113,22 +113,6 @@ pub fn verifier_evaluate_sign<S: Scalar>(
         })
 }
 
-fn prove_bits_are_binary<'a, S: Scalar>(
-    builder: &mut FinalRoundBuilder<'a, S>,
-    bits: &[&'a [bool]],
-) {
-    for &seq in bits {
-        builder.produce_intermediate_mle(seq);
-        builder.produce_sumcheck_subpolynomial(
-            SumcheckSubpolynomialType::Identity,
-            vec![
-                (S::one(), vec![Box::new(seq)]),
-                (-S::one(), vec![Box::new(seq), Box::new(seq)]),
-            ],
-        );
-    }
-}
-
 /// This function checks the consistency of the bit evaluations with the expression evaluation.
 /// The column of data is restricted to an unsigned integer type of `num_bits_allowed` bits.
 fn verify_bit_decomposition<S: ScalarExt>(
@@ -162,6 +146,22 @@ fn verify_bit_decomposition<S: ScalarExt>(
     (rhs == expr_eval && is_eval_correct_number_of_bits)
         .then_some(sign_eval)
         .ok_or(BitDistributionError::Verification)
+}
+
+fn prove_bits_are_binary<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    bits: &[&'a [bool]],
+) {
+    for &seq in bits {
+        builder.produce_intermediate_mle(seq);
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(seq)]),
+                (-S::one(), vec![Box::new(seq), Box::new(seq)]),
+            ],
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
