### PR TITLE
feat!: bump to 1.87.0

### DIFF
--- a/crates/proof-of-sql-parser/src/sqlparser.rs
+++ b/crates/proof-of-sql-parser/src/sqlparser.rs
@@ -9,11 +9,10 @@ use crate::{
 };
 use alloc::{
     boxed::Box,
-    format,
     string::{String, ToString},
     vec,
 };
-use core::fmt::Display;
+use core::fmt::{Display, Write};
 use sqlparser::ast::{
     BinaryOperator, DataType, Expr, Function, FunctionArg, FunctionArgExpr, GroupByExpr, Ident,
     ObjectName, Offset, OffsetRows, OrderByExpr, Query, Select, SelectItem, SetExpr, TableFactor,
@@ -77,7 +76,7 @@ impl From<Literal> for Expr {
                     bytes
                         .iter()
                         .fold(String::with_capacity(bytes.len() * 2), |mut acc, byte| {
-                            acc.push_str(&format!("{byte:02x}"));
+                            write!(&mut acc, "{byte:02x}").unwrap();
                             acc
                         });
                 Expr::Value(Value::HexStringLiteral(hex_string))

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -87,13 +87,13 @@ pub enum PlannerError {
     #[snafu(display("Logical expression {:?} is not supported", expr))]
     UnsupportedLogicalExpression {
         /// Unsupported logical expression
-        expr: Expr,
+        expr: Box<Expr>,
     },
     /// Returned when a `LogicalPlan` is not supported
     #[snafu(display("LogicalPlan is not supported"))]
     UnsupportedLogicalPlan {
         /// Unsupported `LogicalPlan`
-        plan: LogicalPlan,
+        plan: Box<LogicalPlan>,
     },
     /// Returned when the `LogicalPlan` is not resolved
     #[snafu(display("LogicalPlan is not resolved"))]

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -132,7 +132,9 @@ pub fn expr_to_proof_expr(
                 }
             }
         }
-        _ => Err(PlannerError::UnsupportedLogicalExpression { expr: expr.clone() }),
+        _ => Err(PlannerError::UnsupportedLogicalExpression {
+            expr: Box::new(expr.clone()),
+        }),
     }
 }
 

--- a/crates/proof-of-sql-planner/src/proof_plan_with_postprocessing.rs
+++ b/crates/proof-of-sql-planner/src/proof_plan_with_postprocessing.rs
@@ -54,7 +54,9 @@ pub fn logical_plan_to_proof_plan_with_postprocessing(
                         Some(postprocessing),
                     ))
                 }
-                _ => Err(PlannerError::UnsupportedLogicalPlan { plan: plan.clone() }),
+                _ => Err(PlannerError::UnsupportedLogicalPlan {
+                    plan: Box::new(plan.clone()),
+                }),
             }
         }
     }

--- a/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
+++ b/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
@@ -31,10 +31,10 @@ impl VisitorMut for UppercaseColumnVisitor {
 
 /// Returns the sqlparser statement with all of its column/table identifiers uppercased.
 pub fn statement_with_uppercase_identifiers(mut statement: Statement) -> Statement {
-    statement.visit(&mut UppercaseColumnVisitor);
+    let _ = statement.visit(&mut UppercaseColumnVisitor);
 
     // uppercase all tables
-    visit_relations_mut(&mut statement, |object_name| {
+    let _ = visit_relations_mut(&mut statement, |object_name| {
         object_name.0.iter_mut().for_each(|ident| {
             ident.value = ident.value.to_uppercase();
         });

--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -65,13 +65,13 @@ pub trait ArrayRefExt {
     ///
     /// Parameters:
     /// - `alloc`: used to allocate a slice of data when necessary
-    ///    (vide [`StringArray`] into `Column::HashedBytes((_,_))`.
+    ///   (vide [`StringArray`] into `Column::HashedBytes((_,_))`.
     ///
     /// - `range`: used to get a subslice out of [`ArrayRef`].
     ///
     /// - `scals`: scalar representation of each element in the [`ArrayRef`].
-    ///    Some types don't require this slice (see [`Column::BigInt`]). But for types requiring it,
-    ///    `scals` must be provided and have a length equal to `range.len()`.
+    ///   Some types don't require this slice (see [`Column::BigInt`]). But for types requiring it,
+    ///   `scals` must be provided and have a length equal to `range.len()`.
     ///
     /// Note: this function must not be called from unsupported or nullable arrays as it will panic.
     fn to_column<'a, S: Scalar>(
@@ -90,7 +90,7 @@ impl ArrayRefExt for ArrayRef {
     /// - `alloc`: Reference to a `Bump` allocator used for memory allocation during the conversion.
     /// - `range`: Reference to a `Range<usize>` specifying the slice of the array to convert.
     /// - `precomputed_scals`: Optional reference to a slice of `TestScalars` values.
-    ///    `VarChar` columns store hashes to their values as scalars, which can be provided here.
+    ///   `VarChar` columns store hashes to their values as scalars, which can be provided here.
     ///
     /// # Supported types
     /// - For `DataType::Int64` and `DataType::Decimal128(38, 0)`, it slices the array

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -42,7 +42,7 @@ fn we_can_access_the_columns_of_a_table() {
     match accessor.get_column(&table_ref_1, &"b".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     let data2 = owned_table([
         bigint("a", [1, 2, 3, 4]),
@@ -63,17 +63,17 @@ fn we_can_access_the_columns_of_a_table() {
     match accessor.get_column(&table_ref_1, &"a".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![1, 2, 3]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"b".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"c128".into()) {
         Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     let col_slice: Vec<_> = vec!["a", "bc", "d", "e"];
     let col_scalars: Vec<_> = ["a", "bc", "d", "e"]
@@ -86,7 +86,7 @@ fn we_can_access_the_columns_of_a_table() {
             assert_eq!(scals.to_vec(), col_scalars);
         }
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"scalar".into()) {
         Column::Scalar(col) => assert_eq!(
@@ -99,17 +99,17 @@ fn we_can_access_the_columns_of_a_table() {
             ]
         ),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"boolean".into()) {
         Column::Boolean(col) => assert_eq!(col.to_vec(), vec![true, false, true, false]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"time".into()) {
         Column::TimestampTZ(_, _, col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
-    };
+    }
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/database/slice_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_operation.rs
@@ -239,7 +239,7 @@ pub(super) fn repeat_slice<S: Clone>(slice: &[S], n: usize) -> impl Iterator<Ite
 pub(super) fn repeat_elementwise<S: Clone>(slice: &[S], n: usize) -> impl Iterator<Item = S> + '_ {
     slice
         .iter()
-        .flat_map(move |s| core::iter::repeat(s).take(n).cloned())
+        .flat_map(move |s| core::iter::repeat_n(s, n).cloned())
 }
 
 /// Apply a slice to a slice of indexes.

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -54,7 +54,7 @@ fn we_can_access_the_columns_of_a_table() {
     match accessor.get_column(&table_ref_1, &"b".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     let data2 = table([
         borrowed_bigint("a", [1, 2, 3, 4], &alloc),
@@ -76,17 +76,17 @@ fn we_can_access_the_columns_of_a_table() {
     match accessor.get_column(&table_ref_1, &"a".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![1, 2, 3]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"b".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"c128".into()) {
         Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     let col_slice: Vec<_> = vec!["a", "bc", "d", "e"];
     let col_scalars: Vec<_> = ["a", "bc", "d", "e"]
@@ -99,7 +99,7 @@ fn we_can_access_the_columns_of_a_table() {
             assert_eq!(scals.to_vec(), col_scalars);
         }
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"scalar".into()) {
         Column::Scalar(col) => assert_eq!(
@@ -112,17 +112,17 @@ fn we_can_access_the_columns_of_a_table() {
             ]
         ),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"boolean".into()) {
         Column::Boolean(col) => assert_eq!(col.to_vec(), vec![true, false, true, false]),
         _ => panic!("Invalid column type"),
-    };
+    }
 
     match accessor.get_column(&table_ref_2, &"time".into()) {
         Column::TimestampTZ(_, _, col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
-    };
+    }
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -165,7 +165,7 @@ pub fn u256_varint_size(zig_x: U256) -> usize {
 
     // we must at least return 1. because even for
     // the 0 scalar case, we need one byte for the encoding
-    max(1, (zigzag_size as usize + 6) / 7)
+    max(1, (zigzag_size as usize).div_ceil(7))
 }
 
 /// This function returns the varint encoding size for the given scalar slice

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -158,7 +158,7 @@ impl VarInt for bool {
 impl VarInt for u64 {
     fn required_space(self) -> usize {
         let bits = 64 - self.leading_zeros() as usize;
-        core::cmp::max(1, (bits + 6) / 7)
+        core::cmp::max(1, bits.div_ceil(7))
     }
 
     #[inline]

--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -13,13 +13,11 @@ pub trait BigDecimalExt {
 }
 impl BigDecimalExt for BigDecimal {
     /// Get the precision of the fixed-point representation of this intermediate decimal.
-    #[must_use]
     fn precision(&self) -> u64 {
         self.normalized().digits()
     }
 
     /// Get the scale of the fixed-point representation of this intermediate decimal.
-    #[must_use]
     fn scale(&self) -> i64 {
         self.normalized().fractional_digit_count()
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -194,7 +194,7 @@ pub fn create_blitzar_metadata_tables(
     let single_entry_in_blitzar_output_bit_table: Vec<u32> = committable_columns
         .iter()
         .map(|column| column.column_type().bit_size())
-        .chain(iter::repeat(BYTE_SIZE).take(ones_columns_lengths.len()))
+        .chain(core::iter::repeat_n(BYTE_SIZE, ones_columns_lengths.len()))
         .collect();
 
     // Create the full bit table vector to be used by Blitzar's vlen_msm algorithm.

--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
@@ -56,7 +56,7 @@ pub fn eval_vmv_re_prove(
 /// Note: there are several typos in the paper here.
 /// * The paper uses `C'` and `T_vec_prime` interchangeably. They are the same thing.
 /// * The paper uses `s1 = L` and `s2 = R` as the arguments to Dory-Innerproduct. This is backwards.
-///     We should have `E_1 = s2 * v1` and `E_2 = s1 * v2`, which is the case if we use `s1 = R` and `s2 = L`.
+///   We should have `E_1 = s2 * v1` and `E_2 = s1 * v2`, which is the case if we use `s1 = R` and `s2 = L`.
 ///
 /// Note: the paper has the prover send `E_2` to the verifier. We opt to simply have the verifier compute `E_2` from y, which is known.
 pub fn eval_vmv_re_verify(

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -334,10 +334,10 @@ pub fn bit_table_and_scalars_for_packed_msm(
     let bit_table_sub_commits_sum = bit_table.iter().sum::<u32>() as usize;
 
     // Add offsets to handle signed values to the bit table.
-    bit_table.extend(
-        iter::repeat(u32::try_from(BYTE_SIZE).expect("BYTE_SIZE fits in u32"))
-            .take(OFFSET_SIZE + committable_columns.len()),
-    );
+    bit_table.extend(core::iter::repeat_n(
+        u32::try_from(BYTE_SIZE).expect("BYTE_SIZE fits in u32"),
+        OFFSET_SIZE + committable_columns.len(),
+    ));
     let bit_table_full_sum_in_bytes = bit_table.iter().sum::<u32>() as usize / BYTE_SIZE;
 
     // Create the packed_scalar array.

--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -9,7 +9,7 @@ use core::iter;
 #[cfg(feature = "std")]
 use std::{
     fs::File,
-    io::{BufReader, BufWriter, Error, ErrorKind, Read, Write},
+    io::{BufReader, BufWriter, Error, Read, Write},
     path::Path,
 };
 
@@ -68,7 +68,7 @@ impl PublicParameters {
         // Serialize the PublicParameters struct into the file
         let mut serialized_data = Vec::new();
         self.serialize_with_mode(&mut serialized_data, Compress::No)
-            .map_err(|e| Error::new(ErrorKind::Other, format!("{e}")))?;
+            .map_err(|e| Error::other(format!("{e}")))?;
 
         // Write serialized bytes to the file
         writer.write_all(&serialized_data)?;
@@ -92,7 +92,7 @@ impl PublicParameters {
             Compress::No,
             Validate::Yes,
         )
-        .map_err(|e| Error::new(ErrorKind::Other, format!("{e}")))
+        .map_err(|e| Error::other(format!("{e}")))
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -8,7 +8,7 @@ use num_traits::One;
 #[cfg(feature = "std")]
 use std::{
     fs::File,
-    io::{BufReader, BufWriter, Error, ErrorKind, Read, Write},
+    io::{BufReader, BufWriter, Error, Read, Write},
     path::Path,
 };
 
@@ -280,7 +280,7 @@ impl VerifierSetup {
         // Serialize the PublicParameters struct into the file
         let mut serialized_data = Vec::new();
         self.serialize_with_mode(&mut serialized_data, Compress::No)
-            .map_err(|e| Error::new(ErrorKind::Other, format!("{e}")))?;
+            .map_err(|e| Error::other(format!("{e}")))?;
 
         // Write serialized bytes to the file
         writer.write_all(&serialized_data)?;
@@ -302,7 +302,7 @@ impl VerifierSetup {
 
         // Deserialize the data into a PublicParameters instance
         Self::deserialize_with_mode(&mut &serialized_data[..], Compress::No, Validate::No)
-            .map_err(|e| Error::new(ErrorKind::Other, format!("{e}")))
+            .map_err(|e| Error::other(format!("{e}")))
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/matrix_structure.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/matrix_structure.rs
@@ -48,7 +48,7 @@ pub(crate) const fn row_start_index(row: usize) -> usize {
 
 /// Returns the (row, column) in the matrix where the data with the given index belongs.
 pub(crate) const fn row_and_column_from_index(index: usize) -> (usize, usize) {
-    let width_of_row = 1 << (((2 * index + 1).ilog2() + 1) / 2);
+    let width_of_row = 1 << (2 * index + 1).ilog2().div_ceil(2);
     let row = index / width_of_row + width_of_row / 2;
     let column = index % width_of_row;
     (row, column)
@@ -160,14 +160,14 @@ mod tests {
         let mut expected_widths = Vec::new();
 
         // First three rows are defined by the dynamic Dory structure.
-        expected_widths.extend(std::iter::repeat(1).take(1));
-        expected_widths.extend(std::iter::repeat(2).take(2));
+        expected_widths.extend(std::iter::repeat_n(1, 1));
+        expected_widths.extend(std::iter::repeat_n(2, 2));
 
         // The rest of the rows are defined by the pattern 3*2^n rows of length 4*2^n.
         for n in 0..n {
             let repeat_count = 3 * 2_usize.pow(n);
             let value = 4 * 2_usize.pow(n);
-            expected_widths.extend(std::iter::repeat(value).take(repeat_count));
+            expected_widths.extend(std::iter::repeat_n(value, repeat_count));
         }
 
         // Verify the widths.

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/test_cases.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/test_cases.rs
@@ -1,5 +1,4 @@
 use crate::base::{polynomial::CompositePolynomial, scalar::Scalar};
-use core::iter;
 use itertools::Itertools;
 
 pub struct SumcheckTestCase<S: Scalar> {
@@ -29,7 +28,7 @@ impl<S: Scalar> SumcheckTestCase<S> {
         let polynomial = CompositePolynomial::<S>::rand(
             num_vars,
             max_multiplicands,
-            iter::repeat(length).take(num_multiplicands),
+            std::iter::repeat_n(length, num_multiplicands),
             products_vec,
             rng,
         );

--- a/crates/proof-of-sql/utils/generate-parameters/main.rs
+++ b/crates/proof-of-sql/utils/generate-parameters/main.rs
@@ -80,7 +80,7 @@ fn main() {
         args.target,
     );
         std::process::exit(-1)
-    };
+    }
 }
 
 fn generate_parameters(args: &Args) {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.87.0"


### PR DESCRIPTION
- **rust-toolchain.toml**  
  - Bumped the Rust channel from `1.85.0` to **`1.87.0`**, ensuring the project now compiles with Rust 1.87’s toolchain.

- **GitHub Actions workflows**  
  - Updated all `actions/setup-rust` steps to install **Rust 1.87.0** instead of 1.85.0, so CI uses the new compiler.

- **Cargo.toml (workspace root)**  
  - Raised any MSRV-related comments or metadata from `1.85` to **`1.87`** to match the new toolchain.  
  - No other dependency versions were changed—this commit only moves the minimum Rust version forward. 

- **clippy.toml**  
  - (Indirectly) Since Clippy now ships with Rust 1.87, the CI config no longer pins an older Clippy; it inherits the version that comes with 1.87.0. No manual flags were added or removed.