### PR TITLE
fix!: bit distribution serialization

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -8,14 +8,31 @@ use core::{
     ops::{Shl, Shr},
 };
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+fn serialize_limbs<S: Serializer>(limbs: &[u64; 4], serializer: S) -> Result<S::Ok, S::Error> {
+    [limbs[3], limbs[2], limbs[1], limbs[0]].serialize(serializer)
+}
+
+fn deserialize_to_limbs<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u64; 4], D::Error> {
+    let limbs = <[u64; 4]>::deserialize(deserializer)?;
+    Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
+}
 
 /// Describe the distribution of bit values in a table column
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct BitDistribution {
     /// Identifies all columns that are not either identical to or the inverse of the leading column (the sign column). The lead bit indicates if the sign column is constant
+    #[serde(
+        serialize_with = "serialize_limbs",
+        deserialize_with = "deserialize_to_limbs"
+    )]
     pub(crate) vary_mask: [u64; 4],
     /// Identifies all columns that are the identical to the lead column. The lead bit indicates the sign of the last row of data (only relevant if the sign is constant)
+    #[serde(
+        serialize_with = "serialize_limbs",
+        deserialize_with = "deserialize_to_limbs"
+    )]
     pub(crate) leading_bit_mask: [u64; 4],
 }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

In order for the solidity to more easily read the serialized proof, we need to flip the limbs on the bit distribution fields.

# What changes are included in this PR?

Changing the serialization of `BitDistribution`.

# Are these changes tested?
Yes
