### PR TITLE
feat(sol): add monotonic proof gadget

### DIFF
--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -59,6 +59,8 @@ uint32 constant ERR_EVALUATION_LENGTH_TOO_LARGE = 0xb65e7142;
 uint32 constant ERR_BIT_DECOMPOSITION_INVALID = 0xda443b2b;
 /// @dev Error code for when bits that shouldn't vary do vary.
 uint32 constant ERR_INVALID_VARYING_BITS = 0x76d56a3d;
+/// @dev Error code for when monotony check fails.
+uint32 constant ERR_MONOTONY_CHECK_FAILED = 0x976f97b8;
 
 library Errors {
     /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
@@ -118,6 +120,8 @@ library Errors {
     error BitDecompositionInvalid();
     /// @notice Error thrown when bits that shouldn't vary do vary.
     error InvalidVaryingBits();
+    /// @notice Error thrown when monotony check fails.
+    error MonotonyCheckFailed();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/src/proof_gadgets/Monotonic.pre.sol
+++ b/solidity/src/proof_gadgets/Monotonic.pre.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../base/Constants.sol";
+import "../base/Errors.sol";
+import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
+
+/// @title Monotonic
+/// @dev Library for verifying monotonic columns (increasing or decreasing, strictly or non-strictly)
+library Monotonic {
+    /// @notice Verifies that a column is monotonic (increasing or decreasing)
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// monotonic_verify(builder_ptr, alpha, beta, column_eval, chi_eval, strict, asc)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the verification builder
+    /// * `alpha` - a challenge
+    /// * `beta` - a challenge
+    /// * `column_eval` - the column evaluation
+    /// * `chi_eval` - the chi evaluation with length same as the column
+    /// * `strict` - whether monotonicity is strict (1) or non-strict (0)
+    /// * `asc` - whether monotonicity is ascending (1) or descending (0)
+    /// @param __builder The verification builder
+    /// @param __alpha a challenge
+    /// @param __beta a challenge
+    /// @param __columnEval the column evaluation
+    /// @param __chiEval The chi value for evaluation
+    /// @param __strict Whether monotonicity is strict (1) or non-strict (0)
+    /// @param __asc Whether monotonicity is ascending (1) or descending (0)
+    /// @return __builderOut The verification builder result
+    function __monotonicVerify( // solhint-disable-line gas-calldata-parameters
+        VerificationBuilder.Builder memory __builder,
+        uint256 __alpha,
+        uint256 __beta,
+        uint256 __columnEval,
+        uint256 __chiEval,
+        uint256 __strict,
+        uint256 __asc
+    ) internal pure returns (VerificationBuilder.Builder memory __builderOut) {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue_uint512(queue_ptr) -> upper, lower {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Array.pre.sol
+            function get_array_element(arr_ptr, index) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_final_round_mle(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_bit_distribution(builder_ptr) -> vary_mask, leading_bit_mask {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_chi_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_rho_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_identity_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_zerosum_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ./Shift.pre.sol
+            function compute_shift_identity_constraint(star, chi_plus_one, fold) -> constraint {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ./Shift.pre.sol
+            function compute_shift_fold(alpha, beta, eval, rho) -> fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ./Shift.pre.sol
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ./SignExpr.pre.sol
+            function sign_expr_evaluate(expr_eval, builder_ptr, chi_eval) -> result_eval {
+                revert(0, 0)
+            }
+
+            function monotonic_verify(builder_ptr, alpha, beta, column_eval, chi_eval, strict, asc) {
+                // 1. Verify that `shifted_column` is a shift of `column`
+                let shifted_column_eval := builder_consume_final_round_mle(builder_ptr)
+                let shifted_chi_eval := builder_consume_chi_evaluation(builder_ptr)
+
+                shift_evaluate(builder_ptr, alpha, beta, column_eval, shifted_column_eval, chi_eval, shifted_chi_eval)
+
+                // 2. Compute indicator evaluation based on strictness and direction
+                let ind_eval
+                switch eq(strict, asc)
+                case 1 {
+                    // (strict && asc) || (!strict && !asc): ind = shifted_column - column
+                    ind_eval := submod_bn254(shifted_column_eval, column_eval)
+                }
+                default {
+                    // (!strict && asc) || (strict && !asc): ind = column - shifted_column
+                    ind_eval := submod_bn254(column_eval, shifted_column_eval)
+                }
+
+                // 3. Verify the sign of `ind`
+                let sign_eval := sign_expr_evaluate(ind_eval, builder_ptr, shifted_chi_eval)
+                let singleton_chi_eval := builder_get_singleton_chi_evaluation(builder_ptr)
+
+                // 4. Check if sign_eval is in allowed evaluations
+                let is_valid := 0
+                switch strict
+                case 1 {
+                    // Strict monotonicity: sign(ind) == 1 for all but first and last element
+                    // Allowed evaluations: chi_eval, shifted_chi_eval - singleton_chi_eval, chi_eval - singleton_chi_eval
+                    if eq(sign_eval, chi_eval) { is_valid := 1 }
+                    if eq(sign_eval, submod_bn254(shifted_chi_eval, singleton_chi_eval)) { is_valid := 1 }
+                    if eq(sign_eval, submod_bn254(chi_eval, singleton_chi_eval)) { is_valid := 1 }
+                }
+                default {
+                    // Non-strict monotonicity: sign(ind) == 0 for all but first and last element
+                    // Allowed evaluations: singleton_chi_eval, shifted_chi_eval - chi_eval,
+                    // singleton_chi_eval + shifted_chi_eval - chi_eval, 0
+                    if eq(sign_eval, singleton_chi_eval) { is_valid := 1 }
+                    if eq(sign_eval, submod_bn254(shifted_chi_eval, chi_eval)) { is_valid := 1 }
+                    if eq(sign_eval, submod_bn254(addmod_bn254(singleton_chi_eval, shifted_chi_eval), chi_eval)) {
+                        is_valid := 1
+                    }
+                    if iszero(sign_eval) { is_valid := 1 }
+                }
+
+                if iszero(is_valid) { err(ERR_MONOTONY_CHECK_FAILED) }
+            }
+
+            monotonic_verify(__builder, __alpha, __beta, __columnEval, __chiEval, __strict, __asc)
+        }
+        __builderOut = __builder;
+    }
+}

--- a/solidity/src/proof_gadgets/Monotonic.pre.sol
+++ b/solidity/src/proof_gadgets/Monotonic.pre.sol
@@ -145,20 +145,24 @@ library Monotonic {
                 case 1 {
                     // Strict monotonicity: sign(ind) == 1 for all but first and last element
                     // Allowed evaluations: chi_eval, shifted_chi_eval - singleton_chi_eval, chi_eval - singleton_chi_eval
-                    if eq(sign_eval, chi_eval) { is_valid := 1 }
-                    if eq(sign_eval, submod_bn254(shifted_chi_eval, singleton_chi_eval)) { is_valid := 1 }
-                    if eq(sign_eval, submod_bn254(chi_eval, singleton_chi_eval)) { is_valid := 1 }
+                    is_valid :=
+                        or(
+                            or(eq(sign_eval, chi_eval), eq(sign_eval, submod_bn254(shifted_chi_eval, singleton_chi_eval))),
+                            eq(sign_eval, submod_bn254(chi_eval, singleton_chi_eval))
+                        )
                 }
                 default {
                     // Non-strict monotonicity: sign(ind) == 0 for all but first and last element
                     // Allowed evaluations: singleton_chi_eval, shifted_chi_eval - chi_eval,
                     // singleton_chi_eval + shifted_chi_eval - chi_eval, 0
-                    if eq(sign_eval, singleton_chi_eval) { is_valid := 1 }
-                    if eq(sign_eval, submod_bn254(shifted_chi_eval, chi_eval)) { is_valid := 1 }
-                    if eq(sign_eval, submod_bn254(addmod_bn254(singleton_chi_eval, shifted_chi_eval), chi_eval)) {
-                        is_valid := 1
-                    }
-                    if iszero(sign_eval) { is_valid := 1 }
+                    is_valid :=
+                        or(
+                            or(eq(sign_eval, singleton_chi_eval), eq(sign_eval, submod_bn254(shifted_chi_eval, chi_eval))),
+                            or(
+                                eq(sign_eval, submod_bn254(addmod_bn254(singleton_chi_eval, shifted_chi_eval), chi_eval)),
+                                iszero(sign_eval)
+                            )
+                        )
                 }
 
                 if iszero(is_valid) { err(ERR_MONOTONY_CHECK_FAILED) }

--- a/solidity/test/proof_gadgets/Monotonic.t.pre.sol
+++ b/solidity/test/proof_gadgets/Monotonic.t.pre.sol
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {Errors} from "../../src/base/Errors.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {Monotonic} from "../../src/proof_gadgets/Monotonic.pre.sol";
+
+contract MonotonicTest is Test {
+    function testStrictlyIncreasingColumn() public pure {
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+        uint256 alpha = 3;
+        uint256 beta = 8;
+        uint256[3] memory shiftedColumn = [uint256(0), MODULUS_MINUS_ONE, 1];
+        // cStar = 1 / (1 + alpha * (column + beta * (rho + chi)))
+        uint256[3] memory cStarEval = [
+            uint256(14923801958072233106077094826311778469464793909374568870703321036301687610648),
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            1
+        ];
+        // dStar = 1 / (1 + alpha * (shiftedColumn + beta * rhoPlusOne))
+        uint256[3] memory dStarEval = [
+            uint256(1),
+            14923801958072233106077094826311778469464793909374568870703321036301687610648,
+            21467315124303904544895513327079250567614742008100341375550161798372427563009
+        ];
+        uint256[3] memory sign = [uint256(1), 0, 1]; //Sign of [1, -2, 1];
+
+        builder.finalRoundMLEs = new uint256[](12);
+        for (uint8 i = 0; i < 3; ++i) {
+            builder.finalRoundMLEs[i * 4] = shiftedColumn[i];
+            builder.finalRoundMLEs[i * 4 + 1] = cStarEval[i];
+            builder.finalRoundMLEs[i * 4 + 2] = dStarEval[i];
+            builder.finalRoundMLEs[i * 4 + 3] = sign[i];
+        }
+
+        builder.constraintMultipliers = new uint256[](12);
+        for (uint8 i = 0; i < 12; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+        builder.rhoEvaluations = new uint256[](6);
+        builder.rhoEvaluations[0] = 0;
+        builder.rhoEvaluations[1] = 0;
+        builder.rhoEvaluations[2] = 1;
+        builder.rhoEvaluations[3] = 1;
+        builder.rhoEvaluations[4] = 0;
+        builder.rhoEvaluations[5] = 2;
+        builder.chiEvaluations = new uint256[](3);
+        builder.chiEvaluations[0] = 1; // shifted_chi_eval
+        builder.chiEvaluations[1] = 1;
+        builder.chiEvaluations[2] = 1;
+
+        uint256[] memory bitDistribution = new uint256[](6);
+        bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[1] = 1;
+        bitDistribution[2] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[3] = 1;
+        bitDistribution[4] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[5] = 1;
+        VerificationBuilder.__setBitDistributions(builder, bitDistribution);
+        uint256[3] memory chi = [uint256(1), 1, 0];
+        uint256[3] memory column = [MODULUS_MINUS_ONE, uint256(1), 0];
+
+        for (uint8 i = 0; i < 3; ++i) {
+            uint256 chiEval = chi[i];
+            if (i == 0) {
+                builder.singletonChiEvaluation = 1; // singleton_chi_eval for first test
+            } else {
+                builder.singletonChiEvaluation = 0;
+            }
+            Monotonic.__monotonicVerify({
+                __builder: builder,
+                __alpha: alpha,
+                __beta: beta,
+                __columnEval: column[i],
+                __chiEval: chiEval,
+                __strict: 1, // strict
+                __asc: 1 // ascending
+            });
+        }
+
+        assert(builder.aggregateEvaluation == 0);
+    }
+
+    function testNonStrictlyIncreasingColumn() public pure {
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+        uint256 alpha = 3;
+        uint256 beta = 8;
+        uint256[3] memory shiftedColumn = [uint256(0), 1, 1];
+        // cStar = 1 / (1 + alpha * (column + beta * (rho + chi)))
+        uint256[3] memory cStarEval = [
+            uint256(11725844395628183154774860220673540226008052357365732684124037957094183122652),
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            1
+        ];
+        // dStar = 1 / (1 + alpha * (shiftedColumn + beta * rhoPlusOne))
+        uint256[3] memory dStarEval = [
+            uint256(1),
+            11725844395628183154774860220673540226008052357365732684124037957094183122652,
+            21467315124303904544895513327079250567614742008100341375550161798372427563009
+        ];
+        uint256[3] memory trail = [uint256(1), 0, 1]; //Trailing bit of bit mask of [1, 0, -1];
+        uint256[3] memory sign = [uint256(1), 1, 0]; //Sign of [1, 0, -1];
+
+        builder.finalRoundMLEs = new uint256[](15);
+        for (uint8 i = 0; i < 3; ++i) {
+            builder.finalRoundMLEs[i * 5] = shiftedColumn[i];
+            builder.finalRoundMLEs[i * 5 + 1] = cStarEval[i];
+            builder.finalRoundMLEs[i * 5 + 2] = dStarEval[i];
+            builder.finalRoundMLEs[i * 5 + 3] = trail[i];
+            builder.finalRoundMLEs[i * 5 + 4] = sign[i];
+        }
+
+        builder.constraintMultipliers = new uint256[](15);
+        for (uint8 i = 0; i < 15; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+        builder.rhoEvaluations = new uint256[](6);
+        builder.rhoEvaluations[0] = 0;
+        builder.rhoEvaluations[1] = 0;
+        builder.rhoEvaluations[2] = 1;
+        builder.rhoEvaluations[3] = 1;
+        builder.rhoEvaluations[4] = 0;
+        builder.rhoEvaluations[5] = 2;
+        builder.chiEvaluations = new uint256[](3);
+        builder.chiEvaluations[0] = 1; // shifted_chi_eval
+        builder.chiEvaluations[1] = 1;
+        builder.chiEvaluations[2] = 1;
+
+        uint256[] memory bitDistribution = new uint256[](6);
+        bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000001;
+        bitDistribution[1] = 0;
+        bitDistribution[2] = 0x8000000000000000000000000000000000000000000000000000000000000001;
+        bitDistribution[3] = 0;
+        bitDistribution[4] = 0x8000000000000000000000000000000000000000000000000000000000000001;
+        bitDistribution[5] = 0;
+        VerificationBuilder.__setBitDistributions(builder, bitDistribution);
+        uint256[3] memory chi = [uint256(1), 1, 0];
+        uint256[3] memory column = [uint256(1), 1, 0];
+
+        for (uint8 i = 0; i < 3; ++i) {
+            uint256 chiEval = chi[i];
+            if (i == 0) {
+                builder.singletonChiEvaluation = 1; // singleton_chi_eval for first test
+            } else {
+                builder.singletonChiEvaluation = 0;
+            }
+            Monotonic.__monotonicVerify({
+                __builder: builder,
+                __alpha: alpha,
+                __beta: beta,
+                __columnEval: column[i],
+                __chiEval: chiEval,
+                __strict: 0, // non-strict
+                __asc: 1 // ascending
+            });
+        }
+
+        assert(builder.aggregateEvaluation == 0);
+    }
+
+    function testStrictlyDecreasingColumn() public pure {
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+        uint256 alpha = 3;
+        uint256 beta = 8;
+        uint256[3] memory shiftedColumn = [uint256(0), 1, MODULUS_MINUS_ONE];
+        // cStar = 1 / (1 + alpha * (column + beta * (rho + chi)))
+        uint256[3] memory cStarEval = [
+            uint256(11725844395628183154774860220673540226008052357365732684124037957094183122652),
+            4282482301012032108700383732767727734715984339211832806375735601721353836099,
+            1
+        ];
+        // dStar = 1 / (1 + alpha * (shiftedColumn + beta * rhoPlusOne))
+        uint256[3] memory dStarEval = [
+            uint256(1),
+            11725844395628183154774860220673540226008052357365732684124037957094183122652,
+            4282482301012032108700383732767727734715984339211832806375735601721353836099
+        ];
+        uint256[3] memory sign = [uint256(1), 0, 1]; //Sign of [1, -2, 1];
+
+        builder.finalRoundMLEs = new uint256[](12);
+        for (uint8 i = 0; i < 3; ++i) {
+            builder.finalRoundMLEs[i * 4] = shiftedColumn[i];
+            builder.finalRoundMLEs[i * 4 + 1] = cStarEval[i];
+            builder.finalRoundMLEs[i * 4 + 2] = dStarEval[i];
+            builder.finalRoundMLEs[i * 4 + 3] = sign[i];
+        }
+
+        builder.constraintMultipliers = new uint256[](12);
+        for (uint8 i = 0; i < 12; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+        builder.rhoEvaluations = new uint256[](6);
+        builder.rhoEvaluations[0] = 0;
+        builder.rhoEvaluations[1] = 0;
+        builder.rhoEvaluations[2] = 1;
+        builder.rhoEvaluations[3] = 1;
+        builder.rhoEvaluations[4] = 0;
+        builder.rhoEvaluations[5] = 2;
+        builder.chiEvaluations = new uint256[](3);
+        builder.chiEvaluations[0] = 1; // shifted_chi_eval
+        builder.chiEvaluations[1] = 1;
+        builder.chiEvaluations[2] = 1;
+
+        uint256[] memory bitDistribution = new uint256[](6);
+        bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[1] = 1;
+        bitDistribution[2] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[3] = 1;
+        bitDistribution[4] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[5] = 1;
+        VerificationBuilder.__setBitDistributions(builder, bitDistribution);
+        uint256[3] memory chi = [uint256(1), 1, 0];
+        uint256[3] memory column = [uint256(1), MODULUS_MINUS_ONE, 0];
+
+        for (uint8 i = 0; i < 3; ++i) {
+            uint256 chiEval = chi[i];
+            if (i == 0) {
+                builder.singletonChiEvaluation = 1; // singleton_chi_eval for first test
+            } else {
+                builder.singletonChiEvaluation = 0;
+            }
+            Monotonic.__monotonicVerify({
+                __builder: builder,
+                __alpha: alpha,
+                __beta: beta,
+                __columnEval: column[i],
+                __chiEval: chiEval,
+                __strict: 1, // strict
+                __asc: 0 // descending
+            });
+        }
+
+        assert(builder.aggregateEvaluation == 0);
+    }
+
+    function testNonStrictlyDecreasingColumn() public pure {
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+        uint256 alpha = 3;
+        uint256 beta = 8;
+        uint256[3] memory shiftedColumn = [uint256(0), 1, 1];
+        // cStar = 1 / (1 + alpha * (column + beta * (rho + chi)))
+        uint256[3] memory cStarEval = [
+            uint256(11725844395628183154774860220673540226008052357365732684124037957094183122652),
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            1
+        ];
+        // dStar = 1 / (1 + alpha * (shiftedColumn + beta * rhoPlusOne))
+        uint256[3] memory dStarEval = [
+            uint256(1),
+            11725844395628183154774860220673540226008052357365732684124037957094183122652,
+            21467315124303904544895513327079250567614742008100341375550161798372427563009
+        ];
+        uint256[3] memory trail = [uint256(1), 0, 1]; //Trailing bit of bit mask of [-1, 0, 1];
+        uint256[3] memory sign = [uint256(0), 1, 1]; //Sign of [-1, 0, 1];
+
+        builder.finalRoundMLEs = new uint256[](15);
+        for (uint8 i = 0; i < 3; ++i) {
+            builder.finalRoundMLEs[i * 5] = shiftedColumn[i];
+            builder.finalRoundMLEs[i * 5 + 1] = cStarEval[i];
+            builder.finalRoundMLEs[i * 5 + 2] = dStarEval[i];
+            builder.finalRoundMLEs[i * 5 + 3] = trail[i];
+            builder.finalRoundMLEs[i * 5 + 4] = sign[i];
+        }
+
+        builder.constraintMultipliers = new uint256[](15);
+        for (uint8 i = 0; i < 15; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+        builder.rhoEvaluations = new uint256[](6);
+        builder.rhoEvaluations[0] = 0;
+        builder.rhoEvaluations[1] = 0;
+        builder.rhoEvaluations[2] = 1;
+        builder.rhoEvaluations[3] = 1;
+        builder.rhoEvaluations[4] = 0;
+        builder.rhoEvaluations[5] = 2;
+        builder.chiEvaluations = new uint256[](3);
+        builder.chiEvaluations[0] = 1; // shifted_chi_eval
+        builder.chiEvaluations[1] = 1;
+        builder.chiEvaluations[2] = 1;
+
+        uint256[] memory bitDistribution = new uint256[](6);
+        bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000001;
+        bitDistribution[1] = 0;
+        bitDistribution[2] = 0x8000000000000000000000000000000000000000000000000000000000000001;
+        bitDistribution[3] = 0;
+        bitDistribution[4] = 0x8000000000000000000000000000000000000000000000000000000000000001;
+        bitDistribution[5] = 0;
+        VerificationBuilder.__setBitDistributions(builder, bitDistribution);
+        uint256[3] memory chi = [uint256(1), 1, 0];
+        uint256[3] memory column = [uint256(1), 1, 0];
+
+        for (uint8 i = 0; i < 3; ++i) {
+            uint256 chiEval = chi[i];
+            if (i == 0) {
+                builder.singletonChiEvaluation = 1; // singleton_chi_eval for first test
+            } else {
+                builder.singletonChiEvaluation = 0;
+            }
+            Monotonic.__monotonicVerify({
+                __builder: builder,
+                __alpha: alpha,
+                __beta: beta,
+                __columnEval: column[i],
+                __chiEval: chiEval,
+                __strict: 0, // non-strict
+                __asc: 0 // descending
+            });
+        }
+
+        assert(builder.aggregateEvaluation == 0);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testInvalidMonotonicColumn() public {
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+        uint256 alpha = 3;
+        uint256 beta = 8;
+        uint256[3] memory shiftedColumn = [uint256(0), MODULUS_MINUS_ONE, 1];
+        // cStar = 1 / (1 + alpha * (column + beta * (rho + chi)))
+        uint256[3] memory cStarEval = [
+            uint256(14923801958072233106077094826311778469464793909374568870703321036301687610648),
+            21467315124303904544895513327079250567614742008100341375550161798372427563009,
+            1
+        ];
+        // dStar = 1 / (1 + alpha * (shiftedColumn + beta * rhoPlusOne))
+        uint256[3] memory dStarEval = [
+            uint256(1),
+            14923801958072233106077094826311778469464793909374568870703321036301687610648,
+            21467315124303904544895513327079250567614742008100341375550161798372427563009
+        ];
+        uint256[3] memory sign = [uint256(1), 0, 1]; //Sign of [1, -2, 1];
+
+        builder.finalRoundMLEs = new uint256[](12);
+        for (uint8 i = 0; i < 3; ++i) {
+            builder.finalRoundMLEs[i * 4] = shiftedColumn[i];
+            builder.finalRoundMLEs[i * 4 + 1] = cStarEval[i];
+            builder.finalRoundMLEs[i * 4 + 2] = dStarEval[i];
+            builder.finalRoundMLEs[i * 4 + 3] = sign[i];
+        }
+
+        builder.constraintMultipliers = new uint256[](12);
+        for (uint8 i = 0; i < 12; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+        builder.rhoEvaluations = new uint256[](6);
+        builder.rhoEvaluations[0] = 0;
+        builder.rhoEvaluations[1] = 0;
+        builder.rhoEvaluations[2] = 1;
+        builder.rhoEvaluations[3] = 1;
+        builder.rhoEvaluations[4] = 0;
+        builder.rhoEvaluations[5] = 2;
+        builder.chiEvaluations = new uint256[](3);
+        builder.chiEvaluations[0] = 1; // shifted_chi_eval
+        builder.chiEvaluations[1] = 1;
+        builder.chiEvaluations[2] = 1;
+
+        uint256[] memory bitDistribution = new uint256[](6);
+        bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[1] = 1;
+        bitDistribution[2] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[3] = 1;
+        bitDistribution[4] = 0x8000000000000000000000000000000000000000000000000000000000000000;
+        bitDistribution[5] = 1;
+        VerificationBuilder.__setBitDistributions(builder, bitDistribution);
+        uint256[3] memory chi = [uint256(1), 1, 0];
+        uint256[3] memory column = [MODULUS_MINUS_ONE, uint256(1), 0];
+
+        vm.expectRevert(Errors.MonotonyCheckFailed.selector);
+        for (uint8 i = 0; i < 3; ++i) {
+            uint256 chiEval = chi[i];
+            if (i == 0) {
+                builder.singletonChiEvaluation = 1; // singleton_chi_eval for first test
+            } else {
+                builder.singletonChiEvaluation = 0;
+            }
+            Monotonic.__monotonicVerify({
+                __builder: builder,
+                __alpha: alpha,
+                __beta: beta,
+                __columnEval: column[i],
+                __chiEval: chiEval,
+                __strict: 0, // non-strict
+                __asc: 0 // descending
+            });
+        }
+    }
+}


### PR DESCRIPTION
# Rationale for this change
Add monotonic gadget to Solidity
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See above
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.