### PR TITLE
fix: correct membership comments

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
@@ -154,14 +154,14 @@ pub(crate) fn verify_membership_check<S: Scalar>(
         2,
     )?;
 
-    // c_star + c_fold * c_star - chi_n = 0
+    // c_star + c_fold * c_star * alpha - chi_n = 0
     builder.try_produce_sumcheck_subpolynomial_evaluation(
         SumcheckSubpolynomialType::Identity,
         (S::ONE + alpha * c_fold_eval) * c_star_eval - chi_n_eval,
         2,
     )?;
 
-    // d_star + d_fold * d_star - chi_m = 0
+    // d_star + d_fold * d_star * alpha - chi_m = 0
     builder.try_produce_sumcheck_subpolynomial_evaluation(
         SumcheckSubpolynomialType::Identity,
         (S::ONE + alpha * d_fold_eval) * d_star_eval - chi_m_eval,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

There's a slight mistake in membership verification comments

# What changes are included in this PR?

Correcting comments

# Are these changes tested?
Nothing to test
