### PR TITLE
ci: add allow dirty flag to crate publishing script

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -26,6 +26,6 @@ for crate in "${CRATES[@]}"; do
     echo "The version ${NEW_VERSION} for ${crate} is already on crates.io. Skipping publish."
   else
     echo "${crate}@${NEW_VERSION} not found, publishing..."
-    cargo publish -p "${crate}" --token "${CRATES_TOKEN}"
+    cargo publish -p "${crate}" --token "${CRATES_TOKEN}" --allow-dirty
   fi
 done


### PR DESCRIPTION
# Rationale for this change
Semantic release updates `Cargo.toml` during the release process. Our release process publish script has failed since we upgraded to Rust version 1.87. There does not appear to be any other indication of people experiencing this online, but we suspect adding the `--allow-dirty` flag to the `cargo publish` call will allow us to work around the issue.

Re-running the release script in Github's Actions UI has succeeded in 3 of the 4 failing jobs. One job has not succeeded: https://github.com/spaceandtimefdn/sxt-proof-of-sql/actions/runs/15476798627/job/43576240647.

This issue is likely related to https://github.com/rust-lang/cargo/pull/15276.

# What changes are included in this PR?
- `--allow-dirty` is added to the publish script

# Are these changes tested?
No, I can only think to run the release process to test this?