### PR TITLE
feat(sol): add chi to proof plan output

### DIFF
--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -328,7 +328,7 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_plans/FilterExec.pre.sol
-            function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr {
+            function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../sumcheck/Sumcheck.pre.sol
@@ -345,7 +345,7 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_plans/ProofPlan.pre.sol
-            function proof_plan_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr {
+            function proof_plan_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
 
@@ -562,7 +562,8 @@ library Verifier {
                 )
 
                 plan_ptr := skip_plan_names(plan_ptr)
-                plan_ptr, evaluations_ptr := proof_plan_evaluate(plan_ptr, builder_ptr)
+                let output_chi_eval
+                plan_ptr, evaluations_ptr, output_chi_eval := proof_plan_evaluate(plan_ptr, builder_ptr)
                 builder_check_aggregate_evaluation(builder_ptr)
             }
 

--- a/solidity/test/proof_plans/FilterExec.t.pre.sol
+++ b/solidity/test/proof_plans/FilterExec.t.pre.sol
@@ -45,7 +45,8 @@ contract FilterExecTest is Test {
         builder.tableChiEvaluations[0] = 801;
 
         uint256[] memory evals;
-        (plan, builder, evals) = FilterExec.__filterExecEvaluate(plan, builder);
+        uint256 outputChiEval;
+        (plan, builder, evals, outputChiEval) = FilterExec.__filterExecEvaluate(plan, builder);
 
         FF cFold = FF.wrap(502 * 502) * FF.wrap(102 * 801) + FF.wrap(502) * FF.wrap(103 * 801) + FF.wrap(104 * 801);
         FF dFold = FF.wrap(502 * 502) * FF.wrap(202) + FF.wrap(502) * FF.wrap(203) + FF.wrap(204);
@@ -189,7 +190,8 @@ contract FilterExecTest is Test {
         uint256[] memory expectedResultEvaluations = _computeFilterExecResultEvaluations(builder, inputsLength);
 
         uint256[] memory evals;
-        (plan, builder, evals) = FilterExec.__filterExecEvaluate(plan, builder);
+        uint256 outputChiEval;
+        (plan, builder, evals, outputChiEval) = FilterExec.__filterExecEvaluate(plan, builder);
 
         uint256 evalsLength = evals.length;
         assert(evalsLength == expectedResultEvaluations.length);

--- a/solidity/test/proof_plans/ProofPlan.t.pre.sol
+++ b/solidity/test/proof_plans/ProofPlan.t.pre.sol
@@ -47,7 +47,8 @@ contract ProofPlanTest is Test {
         builder.tableChiEvaluations[0] = 801;
 
         uint256[] memory evals;
-        (plan, builder, evals) = ProofPlan.__proofPlanEvaluate(plan, builder);
+        uint256 outputChiEval;
+        (plan, builder, evals, outputChiEval) = ProofPlan.__proofPlanEvaluate(plan, builder);
 
         FF cFold = FF.wrap(502 * 502) * FF.wrap(102 * 801) + FF.wrap(502) * FF.wrap(103 * 801) + FF.wrap(104 * 801);
         FF dFold = FF.wrap(502 * 502) * FF.wrap(202) + FF.wrap(502) * FF.wrap(203) + FF.wrap(204);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We will need the chi output for projection.

# What changes are included in this PR?

Adding chi to the output of proof plan and filter.

# Are these changes tested?
Yes
