### PR TITLE
refactor: reduce num of local variables

### DIFF
--- a/solidity/src/base/Array.pre.sol
+++ b/solidity/src/base/Array.pre.sol
@@ -85,11 +85,9 @@ library Array {
                 source_ptr_out := source_ptr
             }
 
-            let __sourceOutOffset
-            __sourceOutOffset, __arrayTmp := read_uint64_array(__source.offset)
-            __sourceOut.offset := __sourceOutOffset
+            __sourceOut.offset, __arrayTmp := read_uint64_array(__source.offset)
             // slither-disable-next-line write-after-write
-            __sourceOut.length := sub(__source.length, sub(__sourceOutOffset, __source.offset))
+            __sourceOut.length := sub(__source.length, sub(__sourceOut.offset, __source.offset))
         }
         __array = __arrayTmp;
     }
@@ -133,11 +131,9 @@ library Array {
                 source_ptr_out := add(source_ptr, copy_size)
             }
 
-            let __sourceOutOffset
-            __sourceOutOffset, __arrayTmp := read_word_array(__source.offset)
-            __sourceOut.offset := __sourceOutOffset
+            __sourceOut.offset, __arrayTmp := read_word_array(__source.offset)
             // slither-disable-next-line write-after-write
-            __sourceOut.length := sub(__source.length, sub(__sourceOutOffset, __source.offset))
+            __sourceOut.length := sub(__source.length, sub(__sourceOut.offset, __source.offset))
         }
         __array = __arrayTmp;
     }
@@ -182,11 +178,9 @@ library Array {
                 source_ptr_out := add(source_ptr, copy_size)
             }
 
-            let __sourceOutOffset
-            __sourceOutOffset, __array := read_wordx2_array(__source.offset)
-            __sourceOut.offset := __sourceOutOffset
+            __sourceOut.offset, __array := read_wordx2_array(__source.offset)
             // slither-disable-next-line write-after-write
-            __sourceOut.length := sub(__source.length, sub(__sourceOutOffset, __source.offset))
+            __sourceOut.length := sub(__source.length, sub(__sourceOut.offset, __source.offset))
         }
 
         // __array is a flat array of uint256 values, so we need to convert it to an array of uint256[2],

--- a/solidity/src/base/DataType.pre.sol
+++ b/solidity/src/base/DataType.pre.sol
@@ -145,11 +145,9 @@ library DataType {
                 }
                 default { err(ERR_UNSUPPORTED_DATA_TYPE_VARIANT) }
             }
-            let __exprOutOffset
-            __exprOutOffset, __entry := read_entry(__expr.offset, __dataTypeVariant)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __entry := read_entry(__expr.offset, __dataTypeVariant)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
     }
 
@@ -204,11 +202,9 @@ library DataType {
                 default { err(ERR_UNSUPPORTED_DATA_TYPE_VARIANT) }
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __dataType := read_data_type(__expr.offset)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __dataType := read_data_type(__expr.offset)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
     }
 }

--- a/solidity/src/proof_exprs/AddExpr.pre.sol
+++ b/solidity/src/proof_exprs/AddExpr.pre.sol
@@ -163,11 +163,9 @@ library AddExpr {
                 expr_ptr_out := expr_ptr
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __eval := add_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := add_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/AndExpr.pre.sol
+++ b/solidity/src/proof_exprs/AndExpr.pre.sol
@@ -167,11 +167,9 @@ library AndExpr {
                 expr_ptr_out := expr_ptr
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __eval := and_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := and_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/CastExpr.pre.sol
+++ b/solidity/src/proof_exprs/CastExpr.pre.sol
@@ -157,11 +157,9 @@ library CastExpr {
                 expr_ptr_out, result_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __eval := cast_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := cast_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/ColumnExpr.pre.sol
+++ b/solidity/src/proof_exprs/ColumnExpr.pre.sol
@@ -59,11 +59,9 @@ library ColumnExpr {
 
                 expr_ptr_out := expr_ptr
             }
-            let __exprOutOffset
-            __exprOutOffset, __eval := column_expr_evaluate(__expr.offset, __builder)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := column_expr_evaluate(__expr.offset, __builder)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/EqualsExpr.pre.sol
+++ b/solidity/src/proof_exprs/EqualsExpr.pre.sol
@@ -199,11 +199,9 @@ library EqualsExpr {
                 expr_ptr_out := expr_ptr
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __eval := equals_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := equals_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/InequalityExpr.pre.sol
+++ b/solidity/src/proof_exprs/InequalityExpr.pre.sol
@@ -171,11 +171,9 @@ library InequalityExpr {
                 expr_ptr_out := expr_ptr
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __eval := inequality_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := inequality_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/LiteralExpr.pre.sol
+++ b/solidity/src/proof_exprs/LiteralExpr.pre.sol
@@ -79,11 +79,9 @@ library LiteralExpr {
                 eval := mulmod_bn254(eval, chi_eval)
                 expr_ptr_out := expr_ptr
             }
-            let __exprOutOffset
-            __exprOutOffset, __eval := literal_expr_evaluate(__expr.offset, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := literal_expr_evaluate(__expr.offset, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
     }
 }

--- a/solidity/src/proof_exprs/MultiplyExpr.pre.sol
+++ b/solidity/src/proof_exprs/MultiplyExpr.pre.sol
@@ -167,11 +167,9 @@ library MultiplyExpr {
                 expr_ptr_out := expr_ptr
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __eval := multiply_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := multiply_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/NotExpr.pre.sol
+++ b/solidity/src/proof_exprs/NotExpr.pre.sol
@@ -159,11 +159,9 @@ library NotExpr {
                 expr_ptr_out := expr_ptr
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __eval := not_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := not_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/OrExpr.pre.sol
+++ b/solidity/src/proof_exprs/OrExpr.pre.sol
@@ -169,11 +169,9 @@ library OrExpr {
                 expr_ptr_out := expr_ptr
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __eval := or_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := or_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/ProofExpr.pre.sol
+++ b/solidity/src/proof_exprs/ProofExpr.pre.sol
@@ -219,11 +219,9 @@ library ProofExpr {
                 }
                 default { err(ERR_UNSUPPORTED_PROOF_EXPR_VARIANT) }
             }
-            let __exprOutOffset
-            __exprOutOffset, __eval := proof_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := proof_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_exprs/SubtractExpr.pre.sol
+++ b/solidity/src/proof_exprs/SubtractExpr.pre.sol
@@ -163,11 +163,9 @@ library SubtractExpr {
                 expr_ptr_out := expr_ptr
             }
 
-            let __exprOutOffset
-            __exprOutOffset, __eval := subtract_expr_evaluate(__expr.offset, __builder, __chiEval)
-            __exprOut.offset := __exprOutOffset
+            __exprOut.offset, __eval := subtract_expr_evaluate(__expr.offset, __builder, __chiEval)
             // slither-disable-next-line write-after-write
-            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+            __exprOut.length := sub(__expr.length, sub(__exprOut.offset, __expr.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_plans/FilterExec.pre.sol
+++ b/solidity/src/proof_plans/FilterExec.pre.sol
@@ -290,11 +290,9 @@ library FilterExec {
                 plan_ptr_out := plan_ptr
             }
 
-            let __planOutOffset
-            __planOutOffset, __evaluations, __outputChiEvaluation := filter_exec_evaluate(__plan.offset, __builder)
-            __planOut.offset := __planOutOffset
+            __planOut.offset, __evaluations, __outputChiEvaluation := filter_exec_evaluate(__plan.offset, __builder)
             // slither-disable-next-line write-after-write
-            __planOut.length := sub(__plan.length, sub(__planOutOffset, __plan.offset))
+            __planOut.length := sub(__plan.length, sub(__planOut.offset, __plan.offset))
         }
         __evaluationsPtr = __evaluations;
         __builderOut = __builder;

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -225,11 +225,9 @@ library ProofPlan {
                 default { err(ERR_UNSUPPORTED_PROOF_PLAN_VARIANT) }
             }
 
-            let __planOutOffset
-            __planOutOffset, __evaluations, __outputChiEvaluation := proof_plan_evaluate(__plan.offset, __builder)
-            __planOut.offset := __planOutOffset
+            __planOut.offset, __evaluations, __outputChiEvaluation := proof_plan_evaluate(__plan.offset, __builder)
             // slither-disable-next-line write-after-write
-            __planOut.length := sub(__plan.length, sub(__planOutOffset, __plan.offset))
+            __planOut.length := sub(__plan.length, sub(__planOut.offset, __plan.offset))
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_plans/TableExec.pre.sol
+++ b/solidity/src/proof_plans/TableExec.pre.sol
@@ -104,11 +104,9 @@ library TableExec {
                 plan_ptr_out := plan_ptr
             }
 
-            let __planOutOffset
-            __planOutOffset, __evaluations, __outputChiEvaluation := table_exec_evaluate(__plan.offset, __builder)
-            __planOut.offset := __planOutOffset
+            __planOut.offset, __evaluations, __outputChiEvaluation := table_exec_evaluate(__plan.offset, __builder)
             // slither-disable-next-line write-after-write
-            __planOut.length := sub(__plan.length, sub(__planOutOffset, __plan.offset))
+            __planOut.length := sub(__plan.length, sub(__planOut.offset, __plan.offset))
         }
         __evaluationsPtr = __evaluations;
         __builderOut = __builder;

--- a/solidity/src/sumcheck/Sumcheck.pre.sol
+++ b/solidity/src/sumcheck/Sumcheck.pre.sol
@@ -106,12 +106,10 @@ library Sumcheck {
                 }
                 proof_ptr_out := proof_ptr
             }
-            let __proofOutOffset
-            __proofOutOffset, __evaluationPoint, __expectedEvaluation, __degree :=
+            __proofOut.offset, __evaluationPoint, __expectedEvaluation, __degree :=
                 verify_sumcheck_proof(__transcript, __proof.offset, __numVars)
-            __proofOut.offset := __proofOutOffset
             // slither-disable-next-line write-after-write
-            __proofOut.length := sub(__proof.length, sub(__proofOutOffset, __proof.offset))
+            __proofOut.length := sub(__proof.length, sub(__proofOut.offset, __proof.offset))
         }
     }
 }

--- a/solidity/src/verifier/PlanUtil.pre.sol
+++ b/solidity/src/verifier/PlanUtil.pre.sol
@@ -70,10 +70,9 @@ library PlanUtil {
                 plan_ptr_out := plan_ptr
             }
 
-            let __planOutOffset := skip_plan_names(__plan.offset)
-            __planOut.offset := __planOutOffset
+            __planOut.offset := skip_plan_names(__plan.offset)
             // slither-disable-next-line write-after-write
-            __planOut.length := sub(__plan.length, sub(__planOutOffset, __plan.offset))
+            __planOut.length := sub(__plan.length, sub(__planOut.offset, __plan.offset))
         }
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
