### PR TITLE
refactor: remove `verify_union` and `prove_union` from union code

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -175,8 +175,6 @@ impl ProverEvaluate for UnionExec {
         });
         let output_length = res.num_rows();
         // Produce the proof for the union
-        // Number of `ProofPlan`s should be a constant
-        assert_eq!(input_columns.len(), input_lengths.len());
         let c_stars = input_lengths
             .iter()
             .zip(input_columns.iter())


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

It's not ideal to have private functions in our proof plans and exprs that mutate the builder.

# What changes are included in this PR?

Stripping out the priavte functions `verify_union` and `prove_union`

# Are these changes tested?
Yes
