### PR TITLE
refactor(sol): expose filter code to slice

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -116,15 +116,16 @@ where
 
         let output_chi_eval = builder.try_consume_chi_evaluation()?.0;
 
+        let c_fold_eval = alpha * fold_vals(beta, &columns_evals);
+        let d_fold_eval = alpha * fold_vals(beta, &filtered_columns_evals);
+
         verify_filter(
             builder,
-            alpha,
-            beta,
+            c_fold_eval,
+            d_fold_eval,
             input_chi_eval,
             output_chi_eval,
-            &columns_evals,
             selection_eval,
-            &filtered_columns_evals,
         )?;
         Ok(TableEvaluation::new(
             filtered_columns_evals,
@@ -278,19 +279,15 @@ impl ProverEvaluate for FilterExec {
     }
 }
 
-#[expect(clippy::too_many_arguments, clippy::similar_names)]
+#[expect(clippy::similar_names)]
 pub(super) fn verify_filter<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
-    alpha: S,
-    beta: S,
+    c_fold_eval: S,
+    d_fold_eval: S,
     chi_n_eval: S,
     chi_m_eval: S,
-    c_evals: &[S],
     s_eval: S,
-    d_evals: &[S],
 ) -> Result<(), ProofError> {
-    let c_fold_eval = alpha * fold_vals(beta, c_evals);
-    let d_fold_eval = alpha * fold_vals(beta, d_evals);
     let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;
     let d_star_eval = builder.try_consume_final_round_mle_evaluation()?;
 

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -12,8 +12,11 @@ use crate::{
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::proof::{
-        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+        },
+        proof_plans::fold_vals,
     },
     utils::log,
 };
@@ -95,15 +98,16 @@ where
         let alpha = builder.try_consume_post_result_challenge()?;
         let beta = builder.try_consume_post_result_challenge()?;
 
+        let c_fold_eval = alpha * fold_vals(beta, columns_evals);
+        let d_fold_eval = alpha * fold_vals(beta, &filtered_columns_evals);
+
         verify_filter(
             builder,
-            alpha,
-            beta,
+            c_fold_eval,
+            d_fold_eval,
             input_table_eval.chi_eval(),
             output_chi_eval,
-            columns_evals,
             selection_eval,
-            &filtered_columns_evals,
         )?;
         Ok(TableEvaluation::new(
             filtered_columns_evals,

--- a/solidity/src/proof_plans/GroupByExec.pre.sol
+++ b/solidity/src/proof_plans/GroupByExec.pre.sol
@@ -237,6 +237,10 @@ library GroupByExec {
             {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_plans/FilterExec.pre.sol
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                revert(0, 0)
+            }
             // IMPORT-YUL FilterExec.pre.sol
             function filter_exec_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/src/proof_plans/ProjectionExec.pre.sol
+++ b/solidity/src/proof_plans/ProjectionExec.pre.sol
@@ -136,6 +136,10 @@ library ProjectionExec {
             function empty_exec_evaluate(builder_ptr) -> evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_plans/FilterExec.pre.sol
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                revert(0, 0)
+            }
             // IMPORT-YUL FilterExec.pre.sol
             function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -211,6 +211,10 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL FilterExec.pre.sol
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
             function compute_filter_folds(plan_ptr, builder_ptr, input_chi_eval, beta) ->
                 plan_ptr_out,
                 c_fold,

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -408,6 +408,10 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_plans/FilterExec.pre.sol
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/FilterExec.pre.sol
             function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Filter and slice use the same constraints, with different setups. So we want to expose a solidity function for the constraints.

# What changes are included in this PR?

Abstracting filter code so that slice can use it.

# Are these changes tested?
Yes