### PR TITLE
feat(sol): slice exec

### DIFF
--- a/crates/proof-of-sql-planner/tests/evm_tests.rs
+++ b/crates/proof-of-sql-planner/tests/evm_tests.rs
@@ -485,7 +485,7 @@ fn we_can_verify_a_simple_projection_exec_and_table_exec_using_the_evm() {
         &ps[..],
     );
     let statements =
-        Parser::parse_sql(&GenericDialect {}, "SELECT b FROM namespace.table").unwrap();
+        Parser::parse_sql(&GenericDialect {}, "SELECT a, b FROM namespace.table").unwrap();
     let plan = &sql_to_proof_plans(&statements, &accessor, &ConfigOptions::default()).unwrap()[0];
     let verifiable_result = VerifiableQueryResult::<HyperKZGCommitmentEvaluationProof>::new(
         &EVMProofPlan::new(plan.clone()),

--- a/crates/proof-of-sql-planner/tests/evm_tests.rs
+++ b/crates/proof-of-sql-planner/tests/evm_tests.rs
@@ -472,7 +472,7 @@ fn we_can_verify_a_complex_filter_using_the_evm() {
 #[ignore = "This test requires the forge binary to be present"]
 #[test]
 #[expect(clippy::missing_panics_doc)]
-fn we_can_verify_a_simple_table_exec_using_the_evm() {
+fn we_can_verify_a_simple_projection_exec_and_table_exec_using_the_evm() {
     let (ps, vk) = load_small_setup_for_testing();
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
@@ -487,25 +487,25 @@ fn we_can_verify_a_simple_table_exec_using_the_evm() {
     let statements =
         Parser::parse_sql(&GenericDialect {}, "SELECT b FROM namespace.table").unwrap();
     let plan = &sql_to_proof_plans(&statements, &accessor, &ConfigOptions::default()).unwrap()[0];
-    if let DynProofPlan::Projection(projection) = plan {
-        let plan = projection.input();
-        let verifiable_result = VerifiableQueryResult::<HyperKZGCommitmentEvaluationProof>::new(
-            &EVMProofPlan::new(plan.clone()),
-            &accessor,
-            &&ps[..],
-            &[],
-        )
+    let verifiable_result = VerifiableQueryResult::<HyperKZGCommitmentEvaluationProof>::new(
+        &EVMProofPlan::new(plan.clone()),
+        &accessor,
+        &&ps[..],
+        &[],
+    )
+    .unwrap();
+
+    verifiable_result
+        .clone()
+        .verify(&EVMProofPlan::new(plan.clone()), &accessor, &&vk, &[])
         .unwrap();
 
-        verifiable_result
-            .clone()
-            .verify(&EVMProofPlan::new(plan.clone()), &accessor, &&vk, &[])
-            .unwrap();
+    assert!(evm_verifier_all(plan, &verifiable_result, &accessor));
 
-        assert!(evm_verifier_all(plan, &verifiable_result, &accessor));
-    } else {
-        panic!("Plan should be a projection");
-    }
+    verifiable_result
+        .clone()
+        .verify(&EVMProofPlan::new(plan.clone()), &accessor, &&vk, &[])
+        .unwrap();
 }
 
 #[ignore = "This test requires the forge binary to be present"]

--- a/crates/proof-of-sql-planner/tests/evm_tests.rs
+++ b/crates/proof-of-sql-planner/tests/evm_tests.rs
@@ -560,3 +560,37 @@ fn we_can_verify_a_empty_exec_using_the_evm() {
 
     assert!(evm_verifier_all(plan, &verifiable_result, &accessor));
 }
+
+#[ignore = "This test requires the forge binary to be present"]
+#[test]
+#[expect(clippy::missing_panics_doc)]
+fn we_can_verify_simple_slice_exec_using_the_evm() {
+    let (ps, vk) = load_small_setup_for_testing();
+
+    let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
+        TableRef::new("namespace", "table"),
+        owned_table([bigint("a", [0, 3, -87, 6]), bigint("b", [3, -50, 1, 0])]),
+        0,
+        &ps[..],
+    );
+    let statements = Parser::parse_sql(
+        &GenericDialect {},
+        "SELECT a, b FROM namespace.table LIMIT 2 OFFSET 1",
+    )
+    .unwrap();
+    let plan = &sql_to_proof_plans(&statements, &accessor, &ConfigOptions::default()).unwrap()[0];
+    let verifiable_result = VerifiableQueryResult::<HyperKZGCommitmentEvaluationProof>::new(
+        &EVMProofPlan::new(plan.clone()),
+        &accessor,
+        &&ps[..],
+        &[],
+    )
+    .unwrap();
+
+    assert!(evm_verifier_all(plan, &verifiable_result, &accessor));
+
+    verifiable_result
+        .clone()
+        .verify(&EVMProofPlan::new(plan.clone()), &accessor, &&vk, &[])
+        .unwrap();
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -116,15 +116,16 @@ where
 
         let output_chi_eval = builder.try_consume_chi_evaluation()?;
 
+        let c_fold_eval = alpha * fold_vals(beta, &columns_evals);
+        let d_fold_eval = alpha * fold_vals(beta, &filtered_columns_evals);
+
         verify_filter(
             builder,
-            alpha,
-            beta,
+            c_fold_eval,
+            d_fold_eval,
             input_chi_eval,
             output_chi_eval,
-            &columns_evals,
             selection_eval,
-            &filtered_columns_evals,
         )?;
         Ok(TableEvaluation::new(
             filtered_columns_evals,
@@ -278,19 +279,15 @@ impl ProverEvaluate for FilterExec {
     }
 }
 
-#[expect(clippy::too_many_arguments, clippy::similar_names)]
+#[expect(clippy::similar_names)]
 pub(super) fn verify_filter<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
-    alpha: S,
-    beta: S,
+    c_fold_eval: S,
+    d_fold_eval: S,
     chi_n_eval: S,
     chi_m_eval: S,
-    c_evals: &[S],
     s_eval: S,
-    d_evals: &[S],
 ) -> Result<(), ProofError> {
-    let c_fold_eval = alpha * fold_vals(beta, c_evals);
-    let d_fold_eval = alpha * fold_vals(beta, d_evals);
     let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;
     let d_star_eval = builder.try_consume_final_round_mle_evaluation()?;
 

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -12,8 +12,11 @@ use crate::{
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::proof::{
-        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+        },
+        proof_plans::fold_vals,
     },
     utils::log,
 };
@@ -95,15 +98,16 @@ where
         let alpha = builder.try_consume_post_result_challenge()?;
         let beta = builder.try_consume_post_result_challenge()?;
 
+        let c_fold_eval = alpha * fold_vals(beta, columns_evals);
+        let d_fold_eval = alpha * fold_vals(beta, &filtered_columns_evals);
+
         verify_filter(
             builder,
-            alpha,
-            beta,
+            c_fold_eval,
+            d_fold_eval,
             input_table_eval.chi_eval(),
             output_chi_eval,
-            columns_evals,
             selection_eval,
-            &filtered_columns_evals,
         )?;
         Ok(TableEvaluation::new(
             filtered_columns_evals,

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -112,6 +112,8 @@ uint32 constant FILTER_EXEC_VARIANT = 0;
 uint32 constant EMPTY_EXEC_VARIANT = 1;
 /// @dev Table variant constant for proof plans
 uint32 constant TABLE_EXEC_VARIANT = 2;
+/// @dev Projection variant constant for proof plans
+uint32 constant PROJECTION_EXEC_VARIANT = 3;
 
 /// @dev Boolean variant constant for column types
 uint32 constant DATA_TYPE_BOOLEAN_VARIANT = 0;

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -114,6 +114,8 @@ uint32 constant EMPTY_EXEC_VARIANT = 1;
 uint32 constant TABLE_EXEC_VARIANT = 2;
 /// @dev Projection variant constant for proof plans
 uint32 constant PROJECTION_EXEC_VARIANT = 3;
+/// @dev Slice variant constant for proof plans
+uint32 constant SLICE_EXEC_VARIANT = 4;
 
 /// @dev Boolean variant constant for column types
 uint32 constant DATA_TYPE_BOOLEAN_VARIANT = 0;

--- a/solidity/src/proof_plans/FilterExec.pre.sol
+++ b/solidity/src/proof_plans/FilterExec.pre.sol
@@ -236,6 +236,24 @@ library FilterExec {
                 plan_ptr_out := plan_ptr
             }
 
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                let c_star := builder_consume_final_round_mle(builder_ptr)
+                let d_star := builder_consume_final_round_mle(builder_ptr)
+
+                builder_produce_zerosum_constraint(
+                    builder_ptr, submod_bn254(mulmod_bn254(c_star, selection_eval), d_star), 2
+                )
+                builder_produce_identity_constraint(
+                    builder_ptr, submod_bn254(mulmod_bn254(addmod_bn254(1, c_fold), c_star), input_chi_eval), 2
+                )
+                builder_produce_identity_constraint(
+                    builder_ptr, submod_bn254(mulmod_bn254(addmod_bn254(1, d_fold), d_star), output_chi_eval), 2
+                )
+                builder_produce_identity_constraint(
+                    builder_ptr, mulmod_bn254(d_fold, submod_bn254(output_chi_eval, 1)), 2
+                )
+            }
+
             // IMPORT-YUL TableExec.pre.sol
             function table_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
@@ -243,38 +261,30 @@ library FilterExec {
 
             function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 let alpha := builder_consume_challenge(builder_ptr)
-                let beta := builder_consume_challenge(builder_ptr)
+                let input_chi_eval, selection_eval, c_fold, d_fold
+                {
+                    let beta := builder_consume_challenge(builder_ptr)
 
-                let input_chi_eval :=
-                    builder_get_table_chi_evaluation(builder_ptr, shr(UINT64_PADDING_BITS, calldataload(plan_ptr)))
-                plan_ptr := add(plan_ptr, UINT64_SIZE)
+                    input_chi_eval :=
+                        builder_get_table_chi_evaluation(builder_ptr, shr(UINT64_PADDING_BITS, calldataload(plan_ptr)))
+                    plan_ptr := add(plan_ptr, UINT64_SIZE)
 
-                let selection_eval
-                plan_ptr, selection_eval := proof_expr_evaluate(plan_ptr, builder_ptr, input_chi_eval)
+                    plan_ptr, selection_eval := proof_expr_evaluate(plan_ptr, builder_ptr, input_chi_eval)
 
-                let c_fold, d_fold
-                plan_ptr, c_fold, d_fold, evaluations_ptr :=
-                    compute_filter_folds(plan_ptr, builder_ptr, input_chi_eval, beta)
-                let c_star := builder_consume_final_round_mle(builder_ptr)
-                let d_star := builder_consume_final_round_mle(builder_ptr)
+                    plan_ptr, c_fold, d_fold, evaluations_ptr :=
+                        compute_filter_folds(plan_ptr, builder_ptr, input_chi_eval, beta)
+                }
                 output_chi_eval := builder_consume_chi_evaluation(builder_ptr)
 
-                builder_produce_zerosum_constraint(
-                    builder_ptr, submod_bn254(mulmod_bn254(c_star, selection_eval), d_star), 2
-                )
-                builder_produce_identity_constraint(
+                verify_filter(
                     builder_ptr,
-                    submod_bn254(mulmod_bn254(add(1, mulmod_bn254(alpha, c_fold)), c_star), input_chi_eval),
-                    2
+                    mulmod_bn254(alpha, c_fold),
+                    mulmod_bn254(alpha, d_fold),
+                    input_chi_eval,
+                    output_chi_eval,
+                    selection_eval
                 )
-                builder_produce_identity_constraint(
-                    builder_ptr,
-                    submod_bn254(mulmod_bn254(add(1, mulmod_bn254(alpha, d_fold)), d_star), output_chi_eval),
-                    2
-                )
-                builder_produce_identity_constraint(
-                    builder_ptr, mulmod_bn254(mulmod_bn254(alpha, d_fold), submod_bn254(output_chi_eval, 1)), 2
-                )
+
                 plan_ptr_out := plan_ptr
             }
 

--- a/solidity/src/proof_plans/ProjectionExec.pre.sol
+++ b/solidity/src/proof_plans/ProjectionExec.pre.sol
@@ -75,6 +75,10 @@ library ProjectionExec {
             function mulmod_bn254(lhs, rhs) -> product {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function compute_fold(beta, evals) -> fold {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -115,8 +119,28 @@ library ProjectionExec {
             function builder_get_column_evaluation(builder_ptr, column_num) -> value {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
+            function fold_expr_evals(plan_ptr, builder_ptr, input_chi_eval, beta, column_count) -> plan_ptr_out, fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
+            function fold_final_round_mles(builder_ptr, beta, column_count) -> fold, evaluations_ptr {
+                revert(0, 0)
+            }
             // IMPORT-YUL FilterExec.pre.sol
-            function compute_folds(plan_ptr, builder_ptr, input_chi_eval) ->
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL SliceExec.pre.sol
+            function skip_unused_slice_fields(plan_ptr) -> plan_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL SliceExec.pre.sol
+            function slice_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
+            function compute_filter_folds(plan_ptr, builder_ptr, input_chi_eval) ->
                 plan_ptr_out,
                 c_fold,
                 d_fold,

--- a/solidity/src/proof_plans/ProjectionExec.pre.sol
+++ b/solidity/src/proof_plans/ProjectionExec.pre.sol
@@ -6,48 +6,58 @@ import "../base/Constants.sol";
 import "../base/Errors.sol";
 import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
 
-/// @title ProofPlan
-/// @dev Library for handling proof plans
-library ProofPlan {
-    enum PlanVariant {
-        Filter,
-        Empty,
-        Table,
-        Projection
-    }
-
-    /// @notice Evaluates a proof plan
+/// @title ProjectionExec
+/// @dev Library for handling projection execution plans
+library ProjectionExec {
+    /// @notice Evaluates a projection execution plan
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function
     /// ##### Signature
     /// ```yul
-    /// proof_plan_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr
+    /// projection_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval
     /// ```
     /// ##### Parameters
-    /// * `plan_ptr` - calldata pointer to the proof plan
+    /// * `plan_ptr` - calldata pointer to the projection execution plan
     /// * `builder_ptr` - memory pointer to the verification builder
     /// ##### Return Values
-    /// * `plan_ptr_out` - pointer to the remaining plan after consuming the proof plan
+    /// * `plan_ptr_out` - pointer to the remaining plan after consuming the projection execution plan
     /// * `evaluations_ptr` - pointer to the evaluations
-    /// * `output_chi_eval` - pointer to the evaluation of a column of 1s with same length output
-    /// @dev Evaluates a proof plan by dispatching to the appropriate sub-plan evaluator
-    /// @param __plan The proof plan data
+    /// * `output_chi_eval` - pointer to the evaluation of a column of 1s with same length as output
+    /// * Outputs: \\(D_1,\ldots,D_\ell=\texttt{d}\\) with length \\(m\\), and thus \\(\chi_{[0,m)}=\texttt{output_chi_eval}\\).
+    /// * Hints: No hints
+    /// * Challenges: No challenges
+    /// * Helpers: No helpers
+    /// * Constraints: No constraints
+    /// @notice ##### Proof of Correctness:
+    /// TODO
+    /// @notice **Completeness Proof:**
+    /// TODO
+    /// @notice **Soundness Proof:**
+    /// TODO
+    /// ##### Proof Plan Encoding
+    /// The projection plan is encoded as follows:
+    /// 1. the input proof plan
+    /// 2. The number of input/output columns (64 bit integer)
+    /// 3. The input column expressions, in order
+    /// @dev Evaluates a projection execution plan
+    /// @param __plan The projection execution plan data
     /// @param __builder The verification builder
     /// @return __planOut The remaining plan after processing
-    /// @return __builderOut The updated verification builder
-    /// @return __evaluations The evaluations pointer
+    /// @return __builderOut The verification builder result
+    /// @return __evaluationsPtr The evaluations pointer
     /// @return __outputChiEvaluation The output chi evaluation
-    function __proofPlanEvaluate( // solhint-disable-line gas-calldata-parameters
+    function __projectionExecEvaluate( // solhint-disable-line gas-calldata-parameters
     bytes calldata __plan, VerificationBuilder.Builder memory __builder)
         external
         pure
         returns (
             bytes calldata __planOut,
             VerificationBuilder.Builder memory __builderOut,
-            uint256[] memory __evaluations,
+            uint256[] memory __evaluationsPtr,
             uint256 __outputChiEvaluation
         )
     {
+        uint256[] memory __evaluations;
         assembly {
             // IMPORT-YUL ../base/Errors.sol
             function err(code) {
@@ -67,10 +77,6 @@ library ProofPlan {
             }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../base/Queue.pre.sol
-            function dequeue_uint512(queue_ptr) -> value {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
@@ -93,6 +99,10 @@ library ProofPlan {
             function builder_produce_identity_constraint(builder_ptr, evaluation, degree) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/SwitchUtil.pre.sol
             function case_const(lhs, rhs) {
                 revert(0, 0)
@@ -103,6 +113,27 @@ library ProofPlan {
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_get_column_evaluation(builder_ptr, column_num) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
+            function compute_folds(plan_ptr, builder_ptr, input_chi_eval) ->
+                plan_ptr_out,
+                c_fold,
+                d_fold,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL EmptyExec.pre.sol
+            function empty_exec_evaluate(builder_ptr) -> evaluations_ptr, output_chi_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
+            function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL TableExec.pre.sol
+            function table_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/ColumnExpr.pre.sol
@@ -118,15 +149,15 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/AddExpr.pre.sol
-            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/SubtractExpr.pre.sol
-            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/MultiplyExpr.pre.sol
-            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/AndExpr.pre.sol
@@ -143,6 +174,10 @@ library ProofPlan {
             }
             // IMPORT-YUL ../proof_exprs/CastExpr.pre.sol
             function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue_uint512(queue_ptr) -> value {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
@@ -163,46 +198,8 @@ library ProofPlan {
                 revert(0, 0)
             }
             // slither-disable-end cyclomatic-complexity
-            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
-            function builder_get_table_chi_evaluation(builder_ptr, table_num) -> value {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
-            function fold_expr_evals(plan_ptr, builder_ptr, input_chi_eval, beta, column_count) -> plan_ptr_out, fold {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
-            function fold_final_round_mles(builder_ptr, beta, column_count) -> fold, evaluations_ptr {
-                revert(0, 0)
-            }
-            // IMPORT-YUL FilterExec.pre.sol
-            function compute_filter_folds(plan_ptr, builder_ptr, input_chi_eval, beta) ->
-                plan_ptr_out,
-                c_fold,
-                d_fold,
-                evaluations_ptr
-            {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
-            function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
-                revert(0, 0)
-            }
-            // IMPORT-YUL EmptyExec.pre.sol
-            function empty_exec_evaluate(builder_ptr) -> evaluations_ptr, output_chi_eval {
-                revert(0, 0)
-            }
-            // IMPORT-YUL FilterExec.pre.sol
-            function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ProjectionExec.pre.sol
-            function get_proof_expr_evaluations(plan_ptr, builder_ptr, input_chi_eval) -> plan_ptr_out, evaluations_ptr
-            {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ProjectionExec.pre.sol
-            function projection_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+            // IMPORT-YUL ../proof_plans/ProofPlan.pre.sol
+            function proof_plan_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/DataType.pre.sol
@@ -217,42 +214,47 @@ library ProofPlan {
             function read_data_type(ptr) -> ptr_out, data_type {
                 revert(0, 0)
             }
-            // IMPORT-YUL TableExec.pre.sol
-            function table_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_table_chi_evaluation(builder_ptr, table_num) -> value {
                 revert(0, 0)
             }
 
-            function proof_plan_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
-                let proof_plan_variant := shr(UINT32_PADDING_BITS, calldataload(plan_ptr))
-                plan_ptr := add(plan_ptr, UINT32_SIZE)
+            function get_proof_expr_evaluations(plan_ptr, builder_ptr, input_chi_eval) -> plan_ptr_out, evaluations_ptr
+            {
+                let column_count := shr(UINT64_PADDING_BITS, calldataload(plan_ptr))
+                plan_ptr := add(plan_ptr, UINT64_SIZE)
 
-                switch proof_plan_variant
-                case 0 {
-                    case_const(0, FILTER_EXEC_VARIANT)
-                    plan_ptr_out, evaluations_ptr, output_chi_eval := filter_exec_evaluate(plan_ptr, builder_ptr)
+                evaluations_ptr := mload(FREE_PTR)
+                mstore(evaluations_ptr, column_count)
+                evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
+
+                for { let i := column_count } i { i := sub(i, 1) } {
+                    let evaluation
+                    plan_ptr, evaluation := proof_expr_evaluate(plan_ptr, builder_ptr, input_chi_eval)
+
+                    mstore(evaluations_ptr, evaluation)
+                    evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
                 }
-                case 1 {
-                    case_const(1, EMPTY_EXEC_VARIANT)
-                    evaluations_ptr, output_chi_eval := empty_exec_evaluate(builder_ptr)
-                    plan_ptr_out := plan_ptr
-                }
-                case 2 {
-                    case_const(2, TABLE_EXEC_VARIANT)
-                    plan_ptr_out, evaluations_ptr, output_chi_eval := table_exec_evaluate(plan_ptr, builder_ptr)
-                }
-                case 3 {
-                    case_const(3, PROJECTION_EXEC_VARIANT)
-                    plan_ptr_out, evaluations_ptr, output_chi_eval := projection_exec_evaluate(plan_ptr, builder_ptr)
-                }
-                default { err(ERR_UNSUPPORTED_PROOF_PLAN_VARIANT) }
+                evaluations_ptr := mload(FREE_PTR)
+                mstore(FREE_PTR, add(evaluations_ptr, add(WORD_SIZE, mul(column_count, WORD_SIZE))))
+                plan_ptr_out := plan_ptr
+            }
+
+            function projection_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+                let input_evaluations_ptr, input_chi_eval
+                plan_ptr, input_evaluations_ptr, input_chi_eval := proof_plan_evaluate(plan_ptr, builder_ptr)
+
+                plan_ptr_out, evaluations_ptr := get_proof_expr_evaluations(plan_ptr, builder_ptr, input_chi_eval)
+                output_chi_eval := input_chi_eval
             }
 
             let __planOutOffset
-            __planOutOffset, __evaluations, __outputChiEvaluation := proof_plan_evaluate(__plan.offset, __builder)
+            __planOutOffset, __evaluations, __outputChiEvaluation := projection_exec_evaluate(__plan.offset, __builder)
             __planOut.offset := __planOutOffset
             // slither-disable-next-line write-after-write
             __planOut.length := sub(__plan.length, sub(__planOutOffset, __plan.offset))
         }
+        __evaluationsPtr = __evaluations;
         __builderOut = __builder;
     }
 }

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -176,6 +176,10 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL FilterExec.pre.sol
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
             function compute_filter_folds(plan_ptr, builder_ptr, input_chi_eval, beta) ->
                 plan_ptr_out,
                 c_fold,

--- a/solidity/src/proof_plans/SliceExec.pre.sol
+++ b/solidity/src/proof_plans/SliceExec.pre.sol
@@ -6,49 +6,48 @@ import "../base/Constants.sol";
 import "../base/Errors.sol";
 import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
 
-/// @title ProofPlan
-/// @dev Library for handling proof plans
-library ProofPlan {
-    enum PlanVariant {
-        Filter,
-        Empty,
-        Table,
-        Projection,
-        Slice
-    }
-
-    /// @notice Evaluates a proof plan
+/// @title SliceExec
+/// @dev Library for handling slice execution plans
+library SliceExec {
+    /// @notice Evaluates a slice execution plan
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function
     /// ##### Signature
     /// ```yul
-    /// proof_plan_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr
+    /// slice_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval
     /// ```
     /// ##### Parameters
-    /// * `plan_ptr` - calldata pointer to the proof plan
+    /// * `plan_ptr` - calldata pointer to the slice execution plan
     /// * `builder_ptr` - memory pointer to the verification builder
     /// ##### Return Values
-    /// * `plan_ptr_out` - pointer to the remaining plan after consuming the proof plan
+    /// * `plan_ptr_out` - pointer to the remaining plan after consuming the slice execution plan
     /// * `evaluations_ptr` - pointer to the evaluations
-    /// * `output_chi_eval` - pointer to the evaluation of a column of 1s with same length output
-    /// @dev Evaluates a proof plan by dispatching to the appropriate sub-plan evaluator
-    /// @param __plan The proof plan data
+    /// * `output_chi_eval` - pointer to the evaluation of a column of 1s with same length as output
+    /// @notice Evaluates a slice execution plan
+    /// ##### Proof Plan Encoding
+    /// The slice plan is encoded as follows:
+    /// 1. The input plan
+    /// 2. The number of rows to skip
+    /// 3. The number of rows to fetch
+    /// @dev Evaluates a slice execution plan
+    /// @param __plan The slice execution plan data
     /// @param __builder The verification builder
     /// @return __planOut The remaining plan after processing
-    /// @return __builderOut The updated verification builder
-    /// @return __evaluations The evaluations pointer
+    /// @return __builderOut The verification builder result
+    /// @return __evaluationsPtr The evaluations pointer
     /// @return __outputChiEvaluation The output chi evaluation
-    function __proofPlanEvaluate( // solhint-disable-line gas-calldata-parameters
+    function __sliceExecEvaluate( // solhint-disable-line gas-calldata-parameters
     bytes calldata __plan, VerificationBuilder.Builder memory __builder)
         external
         pure
         returns (
             bytes calldata __planOut,
             VerificationBuilder.Builder memory __builderOut,
-            uint256[] memory __evaluations,
+            uint256[] memory __evaluationsPtr,
             uint256 __outputChiEvaluation
         )
     {
+        uint256[] memory __evaluations;
         assembly {
             // IMPORT-YUL ../base/Errors.sol
             function err(code) {
@@ -64,10 +63,6 @@ library ProofPlan {
             }
             // IMPORT-YUL ../base/MathUtil.pre.sol
             function mulmod_bn254(lhs, rhs) -> product {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../base/MathUtil.pre.sol
-            function compute_fold(beta, evals) -> fold {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/Queue.pre.sol
@@ -123,15 +118,15 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/AddExpr.pre.sol
-            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/SubtractExpr.pre.sol
-            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/MultiplyExpr.pre.sol
-            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_exprs/AndExpr.pre.sol
@@ -168,6 +163,18 @@ library ProofPlan {
                 revert(0, 0)
             }
             // slither-disable-end cyclomatic-complexity
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_data_type(ptr) -> ptr_out, data_type {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_get_table_chi_evaluation(builder_ptr, table_num) -> value {
                 revert(0, 0)
@@ -180,8 +187,13 @@ library ProofPlan {
             function fold_final_round_mles(builder_ptr, beta, column_count) -> fold, evaluations_ptr {
                 revert(0, 0)
             }
-            // IMPORT-YUL FilterExec.pre.sol
-            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+            // IMPORT-YUL ProjectionExec.pre.sol
+            function get_proof_expr_evaluations(plan_ptr, builder_ptr, input_chi_eval) -> plan_ptr_out, evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ProjectionExec.pre.sol
+            function projection_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL FilterExec.pre.sol
@@ -191,6 +203,14 @@ library ProofPlan {
                 d_fold,
                 evaluations_ptr
             {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FilterExec.pre.sol
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL TableExec.pre.sol
+            function table_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
@@ -205,75 +225,48 @@ library ProofPlan {
             function filter_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL ProjectionExec.pre.sol
-            function get_proof_expr_evaluations(plan_ptr, builder_ptr, input_chi_eval) -> plan_ptr_out, evaluations_ptr
-            {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ProjectionExec.pre.sol
-            function projection_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../base/DataType.pre.sol
-            function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../base/DataType.pre.sol
-            function read_binary(result_ptr) -> result_ptr_out, entry {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../base/DataType.pre.sol
-            function read_data_type(ptr) -> ptr_out, data_type {
-                revert(0, 0)
-            }
-            // IMPORT-YUL TableExec.pre.sol
-            function table_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
-                revert(0, 0)
-            }
-            // IMPORT-YUL SliceExec.pre.sol
-            function skip_unused_slice_fields(plan_ptr) -> plan_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL SliceExec.pre.sol
-            function slice_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
-                revert(0, 0)
-            }
-
+            // IMPORT-YUL ProofPlan.pre.sol
             function proof_plan_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
-                let proof_plan_variant := shr(UINT32_PADDING_BITS, calldataload(plan_ptr))
-                plan_ptr := add(plan_ptr, UINT32_SIZE)
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function compute_fold(beta, evals) -> fold {
+                revert(0, 0)
+            }
+            function skip_unused_slice_fields(plan_ptr) -> plan_ptr_out {
+                plan_ptr := add(plan_ptr, UINT64_SIZE)
+                let is_populated := shr(BOOLEAN_PADDING_BITS, calldataload(plan_ptr))
+                plan_ptr := add(plan_ptr, BOOLEAN_SIZE)
+                if is_populated { plan_ptr := add(plan_ptr, UINT64_SIZE) }
+                plan_ptr_out := plan_ptr
+            }
 
-                switch proof_plan_variant
-                case 0 {
-                    case_const(0, FILTER_EXEC_VARIANT)
-                    plan_ptr_out, evaluations_ptr, output_chi_eval := filter_exec_evaluate(plan_ptr, builder_ptr)
+            function slice_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+                let input_evaluations, input_chi_evaluation
+                plan_ptr, input_evaluations, input_chi_evaluation := proof_plan_evaluate(plan_ptr, builder_ptr)
+                output_chi_eval := builder_consume_chi_evaluation(builder_ptr)
+                let selection_eval := builder_consume_chi_evaluation(builder_ptr)
+                selection_eval := submod_bn254(builder_consume_chi_evaluation(builder_ptr), selection_eval)
+
+                let c_fold, d_fold
+                {
+                    let alpha := builder_consume_challenge(builder_ptr)
+                    let beta := builder_consume_challenge(builder_ptr)
+                    c_fold := mulmod_bn254(alpha, compute_fold(beta, input_evaluations))
+                    d_fold, evaluations_ptr := fold_final_round_mles(builder_ptr, beta, mload(input_evaluations))
+                    d_fold := mulmod_bn254(alpha, d_fold)
                 }
-                case 1 {
-                    case_const(1, EMPTY_EXEC_VARIANT)
-                    evaluations_ptr, output_chi_eval := empty_exec_evaluate(builder_ptr)
-                    plan_ptr_out := plan_ptr
-                }
-                case 2 {
-                    case_const(2, TABLE_EXEC_VARIANT)
-                    plan_ptr_out, evaluations_ptr, output_chi_eval := table_exec_evaluate(plan_ptr, builder_ptr)
-                }
-                case 3 {
-                    case_const(3, PROJECTION_EXEC_VARIANT)
-                    plan_ptr_out, evaluations_ptr, output_chi_eval := projection_exec_evaluate(plan_ptr, builder_ptr)
-                }
-                case 4 {
-                    case_const(4, SLICE_EXEC_VARIANT)
-                    plan_ptr_out, evaluations_ptr, output_chi_eval := slice_exec_evaluate(plan_ptr, builder_ptr)
-                }
-                default { err(ERR_UNSUPPORTED_PROOF_PLAN_VARIANT) }
+                verify_filter(builder_ptr, c_fold, d_fold, input_chi_evaluation, output_chi_eval, selection_eval)
+                plan_ptr_out := skip_unused_slice_fields(plan_ptr)
             }
 
             let __planOutOffset
-            __planOutOffset, __evaluations, __outputChiEvaluation := proof_plan_evaluate(__plan.offset, __builder)
+            __planOutOffset, __evaluations, __outputChiEvaluation := slice_exec_evaluate(__plan.offset, __builder)
             __planOut.offset := __planOutOffset
             // slither-disable-next-line write-after-write
             __planOut.length := sub(__plan.length, sub(__planOutOffset, __plan.offset))
         }
+        __evaluationsPtr = __evaluations;
         __builderOut = __builder;
     }
 }

--- a/solidity/src/proof_plans/TableExec.pre.sol
+++ b/solidity/src/proof_plans/TableExec.pre.sol
@@ -69,7 +69,7 @@ library TableExec {
             }
 
             function table_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
-                let table_number := shr(UINT64_PADDING_BITS, mload(plan_ptr))
+                let table_number := shr(UINT64_PADDING_BITS, calldataload(plan_ptr))
                 plan_ptr := add(plan_ptr, UINT64_SIZE)
                 output_chi_eval := builder_get_table_chi_evaluation(builder_ptr, table_number)
 

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -98,6 +98,10 @@ library Verifier {
             function log2_up(value) -> exponent {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function compute_fold(beta, evals) -> fold {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
                 revert(0, 0)
@@ -393,6 +397,14 @@ library Verifier {
                 expected_evaluation,
                 degree
             {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/SliceExec.pre.sol
+            function skip_unused_slice_fields(plan_ptr) -> plan_ptr_out {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/SliceExec.pre.sol
+            function slice_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_plans/ProofPlan.pre.sol

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -353,6 +353,10 @@ library Verifier {
             {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_plans/FilterExec.pre.sol
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_get_singleton_chi_evaluation(builder_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -369,6 +369,15 @@ library Verifier {
             function table_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_plans/ProjectionExec.pre.sol
+            function get_proof_expr_evaluations(plan_ptr, builder_ptr, input_chi_eval) -> plan_ptr_out, evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/ProjectionExec.pre.sol
+            function projection_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../sumcheck/Sumcheck.pre.sol
             function process_round(proof_ptr, degree, challenge) -> proof_ptr_out, round_evaluation, actual_sum {
                 revert(0, 0)

--- a/solidity/test/proof_plans/ProjectionExec.t.pre.sol
+++ b/solidity/test/proof_plans/ProjectionExec.t.pre.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {ProjectionExec} from "../../src/proof_plans/ProjectionExec.pre.sol";
+
+contract ProjectionExecTest is Test {
+    function testSimpleProjectionExec() public pure {
+        bytes memory inputPlan = abi.encodePacked(
+            FILTER_EXEC_VARIANT,
+            uint64(0), // table_number
+            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(101)), // where clause
+            abi.encodePacked( // select clause
+                uint64(3),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(102)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(103)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(104))
+            )
+        );
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.finalRoundMLEs = new uint256[](5);
+        builder.finalRoundMLEs[0] = 202;
+        builder.finalRoundMLEs[1] = 203;
+        builder.finalRoundMLEs[2] = 204;
+        builder.finalRoundMLEs[3] = 301;
+        builder.finalRoundMLEs[4] = 302;
+        builder.constraintMultipliers = new uint256[](4);
+        builder.constraintMultipliers[0] = 401;
+        builder.constraintMultipliers[1] = 402;
+        builder.constraintMultipliers[2] = 403;
+        builder.constraintMultipliers[3] = 404;
+        builder.challenges = new uint256[](2);
+        builder.challenges[0] = 501;
+        builder.challenges[1] = 502;
+        builder.aggregateEvaluation = 0;
+        builder.rowMultipliersEvaluation = 601;
+        builder.chiEvaluations = new uint256[](1);
+        builder.chiEvaluations[0] = 701;
+        builder.tableChiEvaluations = new uint256[](1);
+        builder.tableChiEvaluations[0] = 801;
+
+        bytes memory plan = abi.encodePacked(
+            inputPlan, // inputPlan
+            abi.encodePacked( // select clause
+                uint64(3), // It doesn't really make sense to select literals from a subquery, but this is just what's easiest for testing right now
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(102)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(103)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(104))
+            ),
+            hex"abcdef"
+        );
+
+        uint256[] memory evals;
+        uint256 outputChiEval;
+        (plan, builder, evals, outputChiEval) = ProjectionExec.__projectionExecEvaluate(plan, builder);
+
+        assert(evals.length == 3);
+        assert(evals[0] == 71502);
+        assert(evals[1] == 72203);
+        assert(evals[2] == 72904);
+        assert(outputChiEval == 701);
+
+        bytes memory expectedExprOut = hex"abcdef";
+        assert(plan.length == expectedExprOut.length);
+        uint256 exprOutLength = plan.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(plan[i] == expectedExprOut[i]);
+        }
+    }
+}

--- a/solidity/test/proof_plans/ProofPlan.t.pre.sol
+++ b/solidity/test/proof_plans/ProofPlan.t.pre.sol
@@ -200,10 +200,103 @@ contract ProofPlanTest is Test {
         }
     }
 
+    function testSliceExecVariant() public pure {
+        bytes memory plan = abi.encodePacked(
+            SLICE_EXEC_VARIANT,
+            TABLE_EXEC_VARIANT,
+            uint64(0), // table_number
+            uint64(2), // column_count
+            uint64(0), // column1_index
+            uint64(1), // column2_index
+            uint64(1), // skip 1
+            true, // fetch set
+            uint64(2), // fetch 2
+            hex"abcdef"
+        );
+
+        VerificationBuilder.Builder memory builder;
+
+        // column evaluations
+        builder.columnEvaluations = new uint256[](2);
+        uint256[2][4] memory column =
+            [[uint256(1), MODULUS_MINUS_ONE], [uint256(3), 7], [MODULUS_MINUS_ONE, 0], [uint256(400), 1]];
+
+        // chi evals
+        builder.tableChiEvaluations = new uint256[](1);
+        builder.tableChiEvaluations[0] = 1;
+        builder.chiEvaluations = new uint256[](12); // 3 chi evaluations times 4 rows
+        {
+            uint256[4] memory outputChiEval = [uint256(1), 1, 0, 0]; // This has length 2 because there are 2 rows selected
+            uint256[4] memory offsetChiEval = [uint256(1), 0, 0, 0]; // This has length 1 because 1 row is skipped
+            uint256[4] memory maxChiEval = [uint256(1), 1, 1, 0]; // This has length 3 because 1 row is skipped and 2 are fetched
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.chiEvaluations[i * 3] = outputChiEval[i];
+                builder.chiEvaluations[i * 3 + 1] = offsetChiEval[i];
+                builder.chiEvaluations[i * 3 + 2] = maxChiEval[i];
+            }
+        }
+
+        // challenges
+        builder.challenges = new uint256[](8);
+        builder.challenges[0] = 3; // alpha
+        builder.challenges[1] = 8; // beta
+        builder.challenges[2] = 3; // alpha
+        builder.challenges[3] = 8; // beta
+        builder.challenges[4] = 3; // alpha
+        builder.challenges[5] = 8; // beta
+        builder.challenges[6] = 3; // alpha
+        builder.challenges[7] = 8; // beta
+
+        // max degree and row multipliers
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+
+        // constraint multipliers
+        builder.constraintMultipliers = new uint256[](16); // 4 constraints times 4 rows
+        for (uint8 i = 0; i < 16; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+
+        // final round mles
+        builder.finalRoundMLEs = new uint256[](16); // 4 mles times 4 rows
+        {
+            uint256[4] memory filteredColumn1 = [column[1][0], column[2][0], 0, 0];
+            uint256[4] memory filteredColumn2 = [column[1][1], column[2][1], 0, 0];
+
+            uint256 inv22 = 14923801958072233106077094826311778469464793909374568870703321036301687610648;
+            uint256 inv94 = 12806950616501703587484599106267554573086808957690232860674481172996483694244;
+            uint256 invNegative23 = 13323278269815211004845638279721819619116395721992368730946732983133100823419;
+            uint256 inv9604 = 11712169941522494311445676710212113356939821392517492762626517213120895445541;
+            uint256[4] memory cStarColumn = [inv22, inv94, invNegative23, inv9604];
+            uint256[4] memory dStarColumn = [cStarColumn[1], cStarColumn[2], 0, 0];
+
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.finalRoundMLEs[i * 4] = filteredColumn1[i];
+                builder.finalRoundMLEs[i * 4 + 1] = filteredColumn2[i];
+                builder.finalRoundMLEs[i * 4 + 2] = cStarColumn[i];
+                builder.finalRoundMLEs[i * 4 + 3] = dStarColumn[i];
+            }
+        }
+        builder.aggregateEvaluation = 0;
+
+        for (uint8 i = 0; i < 4; ++i) {
+            bytes memory planOutput;
+            uint256[] memory evals;
+            uint256 outputChiEval;
+            builder.columnEvaluations[0] = column[i][0];
+            builder.columnEvaluations[1] = column[i][1];
+            (planOutput, builder, evals, outputChiEval) = ProofPlan.__proofPlanEvaluate(plan, builder);
+            assert(planOutput.length == 3);
+        }
+
+        assert(builder.aggregateEvaluation == 0);
+    }
+
     function testVariantsMatchEnum() public pure {
         assert(uint32(ProofPlan.PlanVariant.Filter) == FILTER_EXEC_VARIANT);
         assert(uint32(ProofPlan.PlanVariant.Empty) == EMPTY_EXEC_VARIANT);
         assert(uint32(ProofPlan.PlanVariant.Table) == TABLE_EXEC_VARIANT);
         assert(uint32(ProofPlan.PlanVariant.Projection) == PROJECTION_EXEC_VARIANT);
+        assert(uint32(ProofPlan.PlanVariant.Slice) == SLICE_EXEC_VARIANT);
     }
 }

--- a/solidity/test/proof_plans/ProofPlan.t.pre.sol
+++ b/solidity/test/proof_plans/ProofPlan.t.pre.sol
@@ -77,6 +77,71 @@ contract ProofPlanTest is Test {
         }
     }
 
+    function testProjectionExecVariant() public pure {
+        bytes memory inputPlan = abi.encodePacked(
+            FILTER_EXEC_VARIANT,
+            uint64(0), // table_number
+            abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(101)), // where clause
+            abi.encodePacked( // select clause
+                uint64(3),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(102)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(103)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(104))
+            )
+        );
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.finalRoundMLEs = new uint256[](5);
+        builder.finalRoundMLEs[0] = 202;
+        builder.finalRoundMLEs[1] = 203;
+        builder.finalRoundMLEs[2] = 204;
+        builder.finalRoundMLEs[3] = 301;
+        builder.finalRoundMLEs[4] = 302;
+        builder.constraintMultipliers = new uint256[](4);
+        builder.constraintMultipliers[0] = 401;
+        builder.constraintMultipliers[1] = 402;
+        builder.constraintMultipliers[2] = 403;
+        builder.constraintMultipliers[3] = 404;
+        builder.challenges = new uint256[](2);
+        builder.challenges[0] = 501;
+        builder.challenges[1] = 502;
+        builder.aggregateEvaluation = 0;
+        builder.rowMultipliersEvaluation = 601;
+        builder.chiEvaluations = new uint256[](1);
+        builder.chiEvaluations[0] = 701;
+        builder.tableChiEvaluations = new uint256[](1);
+        builder.tableChiEvaluations[0] = 801;
+
+        bytes memory plan = abi.encodePacked(
+            PROJECTION_EXEC_VARIANT,
+            inputPlan, // inputPlan
+            abi.encodePacked( // select clause
+                uint64(3), // It doesn't really make sense to select literals from a subquery, but this is just what's easiest for testing right now
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(102)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(103)),
+                abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BIGINT_VARIANT, int64(104))
+            ),
+            hex"abcdef"
+        );
+
+        uint256[] memory evals;
+        uint256 outputChiEval;
+        (plan, builder, evals, outputChiEval) = ProofPlan.__proofPlanEvaluate(plan, builder);
+
+        assert(evals.length == 3);
+        assert(evals[0] == 71502);
+        assert(evals[1] == 72203);
+        assert(evals[2] == 72904);
+        assert(outputChiEval == 701);
+
+        bytes memory expectedExprOut = hex"abcdef";
+        assert(plan.length == expectedExprOut.length);
+        uint256 exprOutLength = plan.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(plan[i] == expectedExprOut[i]);
+        }
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testUnsupportedVariant() public {
         VerificationBuilder.Builder memory builder;
@@ -139,5 +204,6 @@ contract ProofPlanTest is Test {
         assert(uint32(ProofPlan.PlanVariant.Filter) == FILTER_EXEC_VARIANT);
         assert(uint32(ProofPlan.PlanVariant.Empty) == EMPTY_EXEC_VARIANT);
         assert(uint32(ProofPlan.PlanVariant.Table) == TABLE_EXEC_VARIANT);
+        assert(uint32(ProofPlan.PlanVariant.Projection) == PROJECTION_EXEC_VARIANT);
     }
 }

--- a/solidity/test/proof_plans/SliceExec.t.pre.sol
+++ b/solidity/test/proof_plans/SliceExec.t.pre.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {SliceExec} from "../../src/proof_plans/SliceExec.pre.sol";
+
+contract SliceExecTest is Test {
+    function testSimpleSliceExec() public pure {
+        bytes memory plan = abi.encodePacked(
+            TABLE_EXEC_VARIANT,
+            uint64(0), // table_number
+            uint64(1), // column_count
+            uint64(0), // column1_index
+            uint64(2), // skip 2
+            false, // fetch not set
+            hex"abcdef"
+        );
+
+        VerificationBuilder.Builder memory builder;
+
+        // column evaluations
+        builder.columnEvaluations = new uint256[](1);
+        uint256[4] memory column = [uint256(1), 3, MODULUS_MINUS_ONE, 400];
+
+        // chi evals
+        builder.tableChiEvaluations = new uint256[](1);
+        builder.tableChiEvaluations[0] = 1;
+        builder.chiEvaluations = new uint256[](12); // 3 chi evaluations times 4 rows
+        {
+            uint256[4] memory outputChiEval = [uint256(1), 1, 0, 0];
+            // This has length 2 because there are 2 rows selected
+            uint256[4] memory offsetChiEval = [uint256(1), 1, 0, 0]; // This has length 2 because 2 are skipped
+            uint256[4] memory maxChiEval = [uint256(1), 1, 1, 1]; // This has the full length because fetch is not set
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.chiEvaluations[i * 3] = outputChiEval[i];
+                builder.chiEvaluations[i * 3 + 1] = offsetChiEval[i];
+                builder.chiEvaluations[i * 3 + 2] = maxChiEval[i];
+            }
+        }
+
+        // challenges
+        builder.challenges = new uint256[](8);
+        builder.challenges[0] = 3; // alpha
+        builder.challenges[1] = 8; // beta
+        builder.challenges[2] = 3; // alpha
+        builder.challenges[3] = 8; // beta
+        builder.challenges[4] = 3; // alpha
+        builder.challenges[5] = 8; // beta
+        builder.challenges[6] = 3; // alpha
+        builder.challenges[7] = 8; // beta
+
+        // max degree and row multipliers
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+
+        // constraint multipliers
+        builder.constraintMultipliers = new uint256[](16); // 4 constraints times 4 rows
+        for (uint8 i = 0; i < 16; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+
+        // final round mles
+        builder.finalRoundMLEs = new uint256[](12); // 3 mles times 4 rows
+        {
+            uint256[4] memory filteredColumn = [column[2], column[3], 0, 0];
+
+            uint256 inv4 = 16416182153879456416684804308942956316411273300312025757773653139931856371713;
+            uint256 inv10 = 15321770010287492655572484021680092561983855080291224040588742930603065946932;
+            uint256 invNegative2 = 10944121435919637611123202872628637544274182200208017171849102093287904247808;
+            uint256 inv1201 = 17860514583182755801666509267570465934036134148549303627663813574391583951461;
+            uint256[4] memory cStarColumn = [inv4, inv10, invNegative2, inv1201];
+            uint256[4] memory dStarColumn = [cStarColumn[2], cStarColumn[3], 0, 0];
+
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.finalRoundMLEs[i * 3] = filteredColumn[i];
+                builder.finalRoundMLEs[i * 3 + 1] = cStarColumn[i];
+                builder.finalRoundMLEs[i * 3 + 2] = dStarColumn[i];
+            }
+        }
+        builder.aggregateEvaluation = 0;
+
+        for (uint8 i = 0; i < 4; ++i) {
+            bytes memory planOutput;
+            uint256[] memory evals;
+            uint256 outputChiEval;
+            builder.columnEvaluations[0] = column[i];
+            (planOutput, builder, evals, outputChiEval) = SliceExec.__sliceExecEvaluate(plan, builder);
+            assert(planOutput.length == 3);
+        }
+
+        assert(builder.aggregateEvaluation == 0);
+    }
+
+    function testMultiColumnSliceExec() public pure {
+        bytes memory plan = abi.encodePacked(
+            TABLE_EXEC_VARIANT,
+            uint64(0), // table_number
+            uint64(2), // column_count
+            uint64(0), // column1_index
+            uint64(1), // column2_index
+            uint64(1), // skip 1
+            true, // fetch set
+            uint64(2), // fetch 2
+            hex"abcdef"
+        );
+
+        VerificationBuilder.Builder memory builder;
+
+        // column evaluations
+        builder.columnEvaluations = new uint256[](2);
+        uint256[2][4] memory column =
+            [[uint256(1), MODULUS_MINUS_ONE], [uint256(3), 7], [MODULUS_MINUS_ONE, 0], [uint256(400), 1]];
+
+        // chi evals
+        builder.tableChiEvaluations = new uint256[](1);
+        builder.tableChiEvaluations[0] = 1;
+        builder.chiEvaluations = new uint256[](12); // 3 chi evaluations times 4 rows
+        {
+            uint256[4] memory outputChiEval = [uint256(1), 1, 0, 0]; // This has length 2 because there are 2 rows selected
+            uint256[4] memory offsetChiEval = [uint256(1), 0, 0, 0]; // This has length 1 because 1 row is skipped
+            uint256[4] memory maxChiEval = [uint256(1), 1, 1, 0]; // This has length 3 because 1 row is skipped and 2 are fetched
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.chiEvaluations[i * 3] = outputChiEval[i];
+                builder.chiEvaluations[i * 3 + 1] = offsetChiEval[i];
+                builder.chiEvaluations[i * 3 + 2] = maxChiEval[i];
+            }
+        }
+
+        // challenges
+        builder.challenges = new uint256[](8);
+        builder.challenges[0] = 3; // alpha
+        builder.challenges[1] = 8; // beta
+        builder.challenges[2] = 3; // alpha
+        builder.challenges[3] = 8; // beta
+        builder.challenges[4] = 3; // alpha
+        builder.challenges[5] = 8; // beta
+        builder.challenges[6] = 3; // alpha
+        builder.challenges[7] = 8; // beta
+
+        // max degree and row multipliers
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+
+        // constraint multipliers
+        builder.constraintMultipliers = new uint256[](16); // 4 constraints times 4 rows
+        for (uint8 i = 0; i < 16; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+
+        // final round mles
+        builder.finalRoundMLEs = new uint256[](16); // 4 mles times 4 rows
+        {
+            uint256[4] memory filteredColumn1 = [column[1][0], column[2][0], 0, 0];
+            uint256[4] memory filteredColumn2 = [column[1][1], column[2][1], 0, 0];
+
+            uint256 inv22 = 14923801958072233106077094826311778469464793909374568870703321036301687610648;
+            uint256 inv94 = 12806950616501703587484599106267554573086808957690232860674481172996483694244;
+            uint256 invNegative23 = 13323278269815211004845638279721819619116395721992368730946732983133100823419;
+            uint256 inv9604 = 11712169941522494311445676710212113356939821392517492762626517213120895445541;
+            uint256[4] memory cStarColumn = [inv22, inv94, invNegative23, inv9604];
+            uint256[4] memory dStarColumn = [cStarColumn[1], cStarColumn[2], 0, 0];
+
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.finalRoundMLEs[i * 4] = filteredColumn1[i];
+                builder.finalRoundMLEs[i * 4 + 1] = filteredColumn2[i];
+                builder.finalRoundMLEs[i * 4 + 2] = cStarColumn[i];
+                builder.finalRoundMLEs[i * 4 + 3] = dStarColumn[i];
+            }
+        }
+        builder.aggregateEvaluation = 0;
+
+        for (uint8 i = 0; i < 4; ++i) {
+            bytes memory planOutput;
+            uint256[] memory evals;
+            uint256 outputChiEval;
+            builder.columnEvaluations[0] = column[i][0];
+            builder.columnEvaluations[1] = column[i][1];
+            (planOutput, builder, evals, outputChiEval) = SliceExec.__sliceExecEvaluate(plan, builder);
+            assert(planOutput.length == 3);
+        }
+
+        assert(builder.aggregateEvaluation == 0);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
