### PR TITLE
bench: add queries to cover currently supported syntax

### DIFF
--- a/crates/proof-of-sql-benches/src/main.rs
+++ b/crates/proof-of-sql-benches/src/main.rs
@@ -112,6 +112,12 @@ enum Query {
     Coin,
     /// Join query
     Join,
+    /// Union all query
+    UnionAll,
+    /// Limit Offset query
+    LimitOffset,
+    /// Not query
+    Not,
 }
 
 impl Query {
@@ -130,6 +136,9 @@ impl Query {
             Query::SumCount => "Sum Count",
             Query::Coin => "Coin",
             Query::Join => "Join",
+            Query::UnionAll => "Union All",
+            Query::LimitOffset => "Limit Offset",
+            Query::Not => "Not",
         }
     }
 }

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -446,9 +446,9 @@ impl BaseEntry for Join {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT bench_table.a, bench_table_2.a \
-         FROM bench_table \
-         JOIN bench_table_2 on bench_table.a=bench_table_2.a;"
+        r"SELECT bench_table.a, bench_table_2.a
+          FROM bench_table
+          JOIN bench_table_2 on bench_table.a=bench_table_2.a;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -485,9 +485,9 @@ impl BaseEntry for UnionAll {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT column1 FROM bench_table_1 WHERE column1 >= $1 AND column1 <= $2 \
-         UNION ALL \
-         SELECT column2 FROM bench_table_2 WHERE column2 >= $1 AND column2 <= $2;"
+        r"SELECT column1 FROM bench_table_1 WHERE column1 >= $1 AND column1 <= $2
+          UNION ALL
+          SELECT column2 FROM bench_table_2 WHERE column2 >= $1 AND column2 <= $2;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -547,9 +547,9 @@ impl BaseEntry for Not {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT a, b, (a != b) AS comparison_result, NOT(a != b) AS inverse_result \
-         FROM bench_table \
-         WHERE NOT(a != b) AND a > $1;"
+        r"SELECT a, b, (a != b) AS comparison_result, NOT(a != b) AS inverse_result
+          FROM bench_table
+          WHERE NOT(a != b) AND a > $1;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -400,17 +400,17 @@ impl BaseEntry for Coin {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT \
-         SUM( \
-         (CAST (to_address = $1 as bigint) - CAST (from_address = $1 as bigint)) \
-         * value * CAST(timestamp AS bigint) \
-         ) AS weighted_value, \
-         SUM( \
-         (CAST (to_address = $1 as bigint) - CAST (from_address = $1 as bigint)) \
-         * value \
-         ) AS total_balance, \
-         COUNT(1) AS num_transactions \
-         FROM bench_table;"
+        r#"SELECT
+         SUM(
+         (CAST (to_address = $1 as bigint) - CAST (from_address = $1 as bigint))
+         * value * CAST(timestamp AS bigint)
+         ) AS weighted_value,
+         SUM(
+         (CAST (to_address = $1 as bigint) - CAST (from_address = $1 as bigint))
+         * value
+         ) AS total_balance,
+         COUNT(1) AS num_transactions
+         FROM bench_table;"#
     }
 
     fn tables(&self) -> Vec<TableDefinition> {

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -52,7 +52,7 @@ impl BaseEntry for Filter {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT b FROM bench_table WHERE a = $1"
+        "SELECT b FROM bench_table WHERE a = $1;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -86,7 +86,7 @@ impl BaseEntry for ComplexFilter {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT * FROM bench_table WHERE (((a = $1) AND (b = $2)) OR ((c = $3) AND (d = $4)))"
+        "SELECT * FROM bench_table WHERE (((a = $1) AND (b = $2)) OR ((c = $3) AND (d = $4)));"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -127,7 +127,7 @@ impl BaseEntry for Arithmetic {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT a + b AS r0, a * b - $1 AS r1, c FROM bench_table WHERE a <= b AND a >= $2"
+        "SELECT a + b AS r0, a * b - $1 AS r1, c FROM bench_table WHERE a <= b AND a >= $2;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -162,7 +162,7 @@ impl BaseEntry for GroupBy {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT SUM(a), COUNT(*) FROM bench_table WHERE a = $1 GROUP BY b"
+        "SELECT SUM(a), COUNT(*) FROM bench_table WHERE a = $1 GROUP BY b;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -196,7 +196,7 @@ impl BaseEntry for Aggregate {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT SUM(a) AS foo, COUNT(1) AS values FROM bench_table WHERE a = b OR c = $1"
+        "SELECT SUM(a) AS foo, COUNT(1) AS values FROM bench_table WHERE a = b OR c = $1;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -231,7 +231,7 @@ impl BaseEntry for BooleanFilter {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT * FROM bench_table WHERE c = $1 and b = $2 or a = $3"
+        "SELECT * FROM bench_table WHERE c = $1 and b = $2 or a = $3;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -266,7 +266,7 @@ impl BaseEntry for LargeColumnSet {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT * FROM bench_table WHERE b = d"
+        "SELECT * FROM bench_table WHERE b = d;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -313,7 +313,7 @@ impl BaseEntry for ComplexCondition {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT * FROM bench_table WHERE (a > c * c AND b < c + $1) OR (d = $2)"
+        "SELECT * FROM bench_table WHERE (a > c * c AND b < c + $1) OR (d = $2);"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -356,7 +356,7 @@ impl BaseEntry for SumCount {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT SUM(a*b*c) AS foo, SUM(a*b) AS bar, COUNT(1) FROM bench_table WHERE a = $1 OR c-b = $2 AND d = $3"
+        "SELECT SUM(a*b*c) AS foo, SUM(a*b) AS bar, COUNT(1) FROM bench_table WHERE a = $1 OR c-b = $2 AND d = $3;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -400,24 +400,17 @@ impl BaseEntry for Coin {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT 
-        SUM( 
-        (
-            CAST (to_address = $1 as bigint)
-            - CAST (from_address = $1 as bigint)
-        )
-        * value
-        * CAST(timestamp AS bigint)
-        ) AS weighted_value,
-        SUM( 
-        (
-            CAST (to_address = $1 as bigint)
-            - CAST (from_address = $1 as bigint)
-        )
-        * value
-        ) AS total_balance,
-        COUNT(1) AS num_transactions
-        FROM bench_table;"
+        "SELECT \
+         SUM( \
+         (CAST (to_address = $1 as bigint) - CAST (from_address = $1 as bigint)) \
+         * value * CAST(timestamp AS bigint) \
+         ) AS weighted_value, \
+         SUM( \
+         (CAST (to_address = $1 as bigint) - CAST (from_address = $1 as bigint)) \
+         * value \
+         ) AS total_balance, \
+         COUNT(1) AS num_transactions \
+         FROM bench_table;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -453,9 +446,9 @@ impl BaseEntry for Join {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT bench_table.a, bench_table_2.a
-         FROM bench_table
-         JOIN bench_table_2 on bench_table.a=bench_table_2.a"
+        "SELECT bench_table.a, bench_table_2.a \
+         FROM bench_table \
+         JOIN bench_table_2 on bench_table.a=bench_table_2.a;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -492,9 +485,9 @@ impl BaseEntry for UnionAll {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT column1 FROM bench_table_1 WHERE column1 >= $1 AND column1 <= $2
-        UNION ALL
-        SELECT column2 FROM bench_table_2 WHERE column2 >= $1 AND column2 <= $2;"
+        "SELECT column1 FROM bench_table_1 WHERE column1 >= $1 AND column1 <= $2 \
+         UNION ALL \
+         SELECT column2 FROM bench_table_2 WHERE column2 >= $1 AND column2 <= $2;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {
@@ -554,9 +547,9 @@ impl BaseEntry for Not {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT a, b, (a != b) AS comparison_result, NOT(a != b) AS inverse_result
-        FROM bench_table
-        WHERE NOT(a != b) AND a > $1"
+        "SELECT a, b, (a != b) AS comparison_result, NOT(a != b) AS inverse_result \
+         FROM bench_table \
+         WHERE NOT(a != b) AND a > $1;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -231,7 +231,7 @@ impl BaseEntry for BooleanFilter {
     }
 
     fn sql(&self) -> &'static str {
-        "SELECT * FROM bench_table WHERE c = $1 and b = $2 or a = $3;"
+        "SELECT * FROM bench_table WHERE c = $1 AND b = $2 OR a = $3;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -484,6 +484,104 @@ impl BaseEntry for Join {
     }
 }
 
+/// Union All query.
+pub struct UnionAll;
+impl BaseEntry for UnionAll {
+    fn title(&self) -> &'static str {
+        "Union All"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT column1 FROM bench_table_1 WHERE column1 >= $1 AND column1 <= $2
+        UNION ALL
+        SELECT column2 FROM bench_table_2 WHERE column2 >= $1 AND column2 <= $2;"
+    }
+
+    fn tables(&self) -> Vec<TableDefinition> {
+        vec![
+            TableDefinition {
+                name: "bench_table_1",
+                columns: vec![(
+                    "column1",
+                    ColumnType::Int128,
+                    Some(|size| (size / 10 * size).max(10) as i64),
+                )],
+            },
+            TableDefinition {
+                name: "bench_table_2",
+                columns: vec![(
+                    "column2",
+                    ColumnType::Int128,
+                    Some(|size| (size / 10 * size).max(10) as i64),
+                )],
+            },
+        ]
+    }
+
+    fn params(&self) -> Vec<LiteralValue> {
+        vec![LiteralValue::Int128(0), LiteralValue::Int128(1_000_000)]
+    }
+}
+
+/// Limit Offset query.
+pub struct LimitOffset;
+impl BaseEntry for LimitOffset {
+    fn title(&self) -> &'static str {
+        "Limit Offset"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT column FROM bench_table LIMIT 10 OFFSET 5;"
+    }
+
+    fn tables(&self) -> Vec<TableDefinition> {
+        vec![TableDefinition {
+            name: "bench_table",
+            columns: vec![(
+                "column",
+                ColumnType::Uint8,
+                Some(|size| (size / 10).max(10) as i64),
+            )],
+        }]
+    }
+}
+
+/// Not query.
+pub struct Not;
+impl BaseEntry for Not {
+    fn title(&self) -> &'static str {
+        "Not"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT a, b, (a != b) AS comparison_result, NOT(a != b) AS inverse_result
+        FROM bench_table
+        WHERE NOT(a != b) AND a > $1"
+    }
+
+    fn tables(&self) -> Vec<TableDefinition> {
+        vec![TableDefinition {
+            name: "bench_table",
+            columns: vec![
+                (
+                    "a",
+                    ColumnType::Int,
+                    Some(|size| (size / 10).max(10) as i64),
+                ),
+                (
+                    "b",
+                    ColumnType::Int,
+                    Some(|size| (size / 10).max(10) as i64),
+                ),
+            ],
+        }]
+    }
+
+    fn params(&self) -> Vec<LiteralValue> {
+        vec![LiteralValue::Int(5)]
+    }
+}
+
 /// Retrieves all available queries.
 pub fn all_queries() -> Vec<QueryEntry> {
     vec![
@@ -498,6 +596,9 @@ pub fn all_queries() -> Vec<QueryEntry> {
         SumCount.entry(),
         Coin.entry(),
         Join.entry(),
+        UnionAll.entry(),
+        LimitOffset.entry(),
+        Not.entry(),
     ]
 }
 

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -400,7 +400,7 @@ impl BaseEntry for Coin {
     }
 
     fn sql(&self) -> &'static str {
-        r#"SELECT
+        r"SELECT
          SUM(
          (CAST (to_address = $1 as bigint) - CAST (from_address = $1 as bigint))
          * value * CAST(timestamp AS bigint)
@@ -410,7 +410,7 @@ impl BaseEntry for Coin {
          * value
          ) AS total_balance,
          COUNT(1) AS num_transactions
-         FROM bench_table;"#
+         FROM bench_table;"
     }
 
     fn tables(&self) -> Vec<TableDefinition> {

--- a/crates/proof-of-sql-benches/src/utils/random_util.rs
+++ b/crates/proof-of-sql-benches/src/utils/random_util.rs
@@ -35,9 +35,8 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::Uint8(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }
                     (ColumnType::Uint8, Some(b)) => {
+                        let clamped_b_value = b(num_rows).clamp(0, i64::from(u8::MAX)) as u8;
                         Column::Uint8(alloc.alloc_slice_fill_with(num_rows, |_| {
-                            let b_value = b(num_rows);
-                            let clamped_b_value = b_value.clamp(0, i64::from(u8::MAX)) as u8;
                             rng.gen_range(0..=clamped_b_value)
                         }))
                     }
@@ -45,10 +44,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::TinyInt(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }
                     (ColumnType::TinyInt, Some(b)) => {
+                        let clamped_b_value =
+                            b(num_rows).clamp(i64::from(i8::MIN), i64::from(i8::MAX)) as i8;
                         Column::TinyInt(alloc.alloc_slice_fill_with(num_rows, |_| {
-                            let b_value = b(num_rows);
-                            let clamped_b_value =
-                                b_value.clamp(i64::from(i8::MIN), i64::from(i8::MAX)) as i8;
                             rng.gen_range(-clamped_b_value..=clamped_b_value)
                         }))
                     }
@@ -56,10 +54,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::SmallInt(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }
                     (ColumnType::SmallInt, Some(b)) => {
+                        let clamped_b_value =
+                            b(num_rows).clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16;
                         Column::SmallInt(alloc.alloc_slice_fill_with(num_rows, |_| {
-                            let b_value = b(num_rows);
-                            let clamped_b_value =
-                                b_value.clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16;
                             rng.gen_range(-clamped_b_value..=clamped_b_value)
                         }))
                     }
@@ -67,10 +64,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::Int(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }
                     (ColumnType::Int, Some(b)) => {
+                        let clamped_b_value =
+                            b(num_rows).clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
                         Column::Int(alloc.alloc_slice_fill_with(num_rows, |_| {
-                            let b_value = b(num_rows);
-                            let clamped_b_value =
-                                b_value.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
                             rng.gen_range(-clamped_b_value..=clamped_b_value)
                         }))
                     }

--- a/crates/proof-of-sql-benches/src/utils/random_util.rs
+++ b/crates/proof-of-sql-benches/src/utils/random_util.rs
@@ -31,6 +31,16 @@ pub fn generate_random_columns<'a, S: Scalar>(
                     (ColumnType::Boolean, _) => {
                         Column::Boolean(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }
+                    (ColumnType::Uint8, None) => {
+                        Column::Uint8(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
+                    }
+                    (ColumnType::Uint8, Some(b)) => {
+                        Column::Uint8(alloc.alloc_slice_fill_with(num_rows, |_| {
+                            let b_value = b(num_rows);
+                            let clamped_b_value = b_value.clamp(0, i64::from(u8::MAX)) as u8;
+                            rng.gen_range(0..=clamped_b_value)
+                        }))
+                    }
                     (ColumnType::TinyInt, None) => {
                         Column::TinyInt(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }


### PR DESCRIPTION
# Rationale for this change
Benchmarks should cover all of the supported [SQL syntax](https://github.com/spaceandtimefdn/sxt-proof-of-sql/blob/6f0938f5ca72b7d2475eb39fa31c47c7eca618ce/docs/SQLSyntaxSpecification.md#posql-sql-syntax). This PR adds benchmarks that cover the remainder of the syntax. These benchmarks will be used to identify performance optimizations that can be made.

# What changes are included in this PR?
- Support for random Uint8 columns are added to the benchmark crate
-  Benchmark queries are added to cover all of the supported SQL syntax listed here https://github.com/spaceandtimefdn/sxt-proof-of-sql/blob/6f0938f5ca72b7d2475eb39fa31c47c7eca618ce/docs/SQLSyntaxSpecification.md#posql-sql-syntax
- The SQL syntax was cleaned up for the all of the benchmark queries

# Are these changes tested?
Yes