### PR TITLE
refactor: expose length with try consume chi evaluation

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -32,7 +32,7 @@ pub struct MockVerificationBuilder<S: Scalar> {
 }
 
 impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
-    fn try_consume_chi_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+    fn try_consume_chi_evaluation(&mut self) -> Result<(S, usize), ProofSizeMismatch> {
         let length = self
             .chi_evaluation_length_queue
             .get(self.consumed_chi_evaluations)
@@ -40,9 +40,9 @@ impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
             .ok_or(ProofSizeMismatch::TooFewChiLengths)?;
         self.consumed_chi_evaluations += 1;
         Ok(if self.evaluation_row_index < length {
-            S::ONE
+            (S::ONE, length)
         } else {
-            S::ZERO
+            (S::ZERO, length)
         })
     }
 
@@ -426,13 +426,13 @@ mod tests {
                 vec![2],
                 Vec::new(),
             );
-        let one = verification_builder.try_consume_chi_evaluation().unwrap();
+        let one = verification_builder.try_consume_chi_evaluation().unwrap().0;
         assert_eq!(one, TestScalar::ONE);
         verification_builder.increment_row_index();
-        let one = verification_builder.try_consume_chi_evaluation().unwrap();
+        let one = verification_builder.try_consume_chi_evaluation().unwrap().0;
         assert_eq!(one, TestScalar::ONE);
         verification_builder.increment_row_index();
-        let zero = verification_builder.try_consume_chi_evaluation().unwrap();
+        let zero = verification_builder.try_consume_chi_evaluation().unwrap().0;
         assert_eq!(zero, TestScalar::ZERO);
     }
 
@@ -448,7 +448,7 @@ mod tests {
                 vec![3],
                 Vec::new(),
             );
-        let one = verification_builder.try_consume_chi_evaluation().unwrap();
+        let one = verification_builder.try_consume_chi_evaluation().unwrap().0;
         assert_eq!(one, TestScalar::ONE);
         let err = verification_builder
             .try_consume_chi_evaluation()

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -102,7 +102,7 @@ impl ProofPlan for TrivialTestProofPlan {
         let _ = builder.try_consume_bit_distribution()?;
         Ok(TableEvaluation::new(
             vec![S::ZERO],
-            builder.try_consume_chi_evaluation()?,
+            builder.try_consume_chi_evaluation()?.0,
         ))
     }
     ///
@@ -324,7 +324,7 @@ impl ProofPlan for SquareTestProofPlan {
         )?;
         Ok(TableEvaluation::new(
             vec![res_eval],
-            builder.try_consume_chi_evaluation()?,
+            builder.try_consume_chi_evaluation()?.0,
         ))
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
@@ -526,7 +526,7 @@ impl ProofPlan for DoubleSquareTestProofPlan {
         )?;
         Ok(TableEvaluation::new(
             vec![res_eval],
-            builder.try_consume_chi_evaluation()?,
+            builder.try_consume_chi_evaluation()?.0,
         ))
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
@@ -721,7 +721,7 @@ impl ProofPlan for ChallengeTestProofPlan {
         )?;
         Ok(TableEvaluation::new(
             vec![res_eval],
-            builder.try_consume_chi_evaluation()?,
+            builder.try_consume_chi_evaluation()?.0,
         ))
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
@@ -863,7 +863,7 @@ impl ProofPlan for FirstRoundSquareTestProofPlan {
         )?;
         Ok(TableEvaluation::new(
             vec![final_round_res_eval],
-            builder.try_consume_chi_evaluation()?,
+            builder.try_consume_chi_evaluation()?.0,
         ))
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -76,7 +76,7 @@ impl ProofPlan for EmptyTestQueryExpr {
         );
         Ok(TableEvaluation::new(
             vec![S::ZERO; self.columns],
-            builder.try_consume_chi_evaluation()?,
+            builder.try_consume_chi_evaluation()?.0,
         ))
     }
 

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -5,7 +5,7 @@ use core::iter;
 
 pub trait VerificationBuilder<S: Scalar> {
     /// Consume the evaluation of a chi evaluation
-    fn try_consume_chi_evaluation(&mut self) -> Result<S, ProofSizeMismatch>;
+    fn try_consume_chi_evaluation(&mut self) -> Result<(S, usize), ProofSizeMismatch>;
 
     /// Consume the evaluation of a rho evaluation
     fn try_consume_rho_evaluation(&mut self) -> Result<S, ProofSizeMismatch>;
@@ -123,7 +123,7 @@ impl<'a, S: Scalar> VerificationBuilderImpl<'a, S> {
 }
 
 impl<S: Scalar> VerificationBuilder<S> for VerificationBuilderImpl<'_, S> {
-    fn try_consume_chi_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+    fn try_consume_chi_evaluation(&mut self) -> Result<(S, usize), ProofSizeMismatch> {
         let index = self.consumed_chi_evaluations;
         let length = self
             .chi_evaluation_length_queue
@@ -131,11 +131,14 @@ impl<S: Scalar> VerificationBuilder<S> for VerificationBuilderImpl<'_, S> {
             .copied()
             .ok_or(ProofSizeMismatch::TooFewChiLengths)?;
         self.consumed_chi_evaluations += 1;
-        Ok(*self
-            .mle_evaluations
-            .chi_evaluations
-            .get(&length)
-            .ok_or(ProofSizeMismatch::ChiLengthNotFound)?)
+        Ok((
+            *self
+                .mle_evaluations
+                .chi_evaluations
+                .get(&length)
+                .ok_or(ProofSizeMismatch::ChiLengthNotFound)?,
+            length,
+        ))
     }
 
     fn try_consume_rho_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -181,8 +181,8 @@ impl ProofPlan for MembershipCheckTestPlan {
         let candidate_subset_evals =
             builder.try_consume_final_round_mle_evaluations(num_columns)?;
         // Get the chi evaluations
-        let chi_n_eval = builder.try_consume_chi_evaluation()?;
-        let chi_m_eval = builder.try_consume_chi_evaluation()?;
+        let chi_n_eval = builder.try_consume_chi_evaluation()?.0;
+        let chi_m_eval = builder.try_consume_chi_evaluation()?.0;
         // Evaluate the verifier
         let multiplicities_eval = verify_membership_check(
             builder,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -86,7 +86,7 @@ pub(crate) fn verify_monotonic<S: Scalar, const STRICT: bool, const ASC: bool>(
 ) -> Result<(), ProofError> {
     // 1. Verify that `shifted_column` is a shift of `column`
     let shifted_column_eval = builder.try_consume_final_round_mle_evaluation()?;
-    let shifted_chi_eval = builder.try_consume_chi_evaluation()?;
+    let shifted_chi_eval = builder.try_consume_chi_evaluation()?.0;
     verify_shift(
         builder,
         alpha,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -108,7 +108,7 @@ impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT
         let beta = builder.try_consume_post_result_challenge()?;
         // Get evaluations
         let column_eval = builder.try_consume_final_round_mle_evaluation()?;
-        let chi_eval = builder.try_consume_chi_evaluation()?;
+        let chi_eval = builder.try_consume_chi_evaluation()?.0;
         // Evaluate the verifier
         verify_monotonic::<S, STRICT, ASC>(builder, alpha, beta, column_eval, chi_eval)?;
         Ok(TableEvaluation::new(vec![], S::zero()))

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -146,7 +146,7 @@ impl ProofPlan for PermutationCheckTestPlan {
         let candidate_permutation_evals =
             builder.try_consume_final_round_mle_evaluations(num_columns)?;
         // Get the chi evaluations
-        let chi_eval = builder.try_consume_chi_evaluation()?;
+        let chi_eval = builder.try_consume_chi_evaluation()?.0;
         // Evaluate the verifier
         verify_permutation_check(
             builder,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -239,7 +239,7 @@ pub(crate) fn verifier_evaluate_range_check<S: Scalar>(
 ) -> Result<(), ProofSizeMismatch> {
     // Retrieve the post-result challenge α
     let alpha = builder.try_consume_post_result_challenge()?;
-    let chi_256_eval = builder.try_consume_chi_evaluation()?;
+    let chi_256_eval = builder.try_consume_chi_evaluation()?.0;
 
     // We will accumulate ∑(wᵢ * 256ⁱ) in `sum`.
     // Additionally, we'll collect all (wᵢ + α)⁻¹ evaluations in `w_plus_alpha_inv_evals`

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -268,8 +268,8 @@ mod tests {
             // Get the columns
             let column_eval = builder.try_consume_final_round_mle_evaluation()?;
             let candidate_shift_eval = builder.try_consume_final_round_mle_evaluation()?;
-            let chi_n_eval = builder.try_consume_chi_evaluation()?;
-            let chi_n_plus_1_eval = builder.try_consume_chi_evaluation()?;
+            let chi_n_eval = builder.try_consume_chi_evaluation()?.0;
+            let chi_n_plus_1_eval = builder.try_consume_chi_evaluation()?.0;
             // Evaluate the verifier
             verify_shift(
                 builder,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -114,7 +114,7 @@ where
             builder.try_consume_final_round_mle_evaluations(self.aliased_results.len())?;
         assert!(filtered_columns_evals.len() == self.aliased_results.len());
 
-        let output_chi_eval = builder.try_consume_chi_evaluation()?;
+        let output_chi_eval = builder.try_consume_chi_evaluation()?.0;
 
         verify_filter(
             builder,

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -150,7 +150,7 @@ impl ProofPlan for GroupByExec {
 
         let alpha = builder.try_consume_post_result_challenge()?;
         let beta = builder.try_consume_post_result_challenge()?;
-        let output_chi_eval = builder.try_consume_chi_evaluation()?;
+        let output_chi_eval = builder.try_consume_chi_evaluation()?.0;
 
         let is_uniqueness_provable = self.is_uniqueness_provable();
         verify_group_by(

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -82,12 +82,12 @@ where
         let input_table_eval =
             self.input
                 .verifier_evaluate(builder, accessor, None, chi_eval_map, params)?;
-        let output_chi_eval = builder.try_consume_chi_evaluation()?;
+        let output_chi_eval = builder.try_consume_chi_evaluation()?.0;
         let columns_evals = input_table_eval.column_evals();
         // 2. selection
         // The selected range is (offset_index, max_index]
-        let offset_chi_eval = builder.try_consume_chi_evaluation()?;
-        let max_chi_eval = builder.try_consume_chi_evaluation()?;
+        let offset_chi_eval = builder.try_consume_chi_evaluation()?.0;
+        let max_chi_eval = builder.try_consume_chi_evaluation()?.0;
         let selection_eval = max_chi_eval - offset_chi_eval;
         // 3. filtered_columns
         let filtered_columns_evals =

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -144,8 +144,8 @@ where
         // 2. Chi evals and rho evals
         let left_chi_eval = left_eval.chi_eval();
         let right_chi_eval = right_eval.chi_eval();
-        let res_chi_eval = builder.try_consume_chi_evaluation()?;
-        let u_chi_eval = builder.try_consume_chi_evaluation()?;
+        let res_chi_eval = builder.try_consume_chi_evaluation()?.0;
+        let u_chi_eval = builder.try_consume_chi_evaluation()?.0;
         let left_rho_eval = builder.try_consume_rho_evaluation()?;
         let right_rho_eval = builder.try_consume_rho_evaluation()?;
         // 3. alpha, beta

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -81,7 +81,7 @@ where
 
         let d_bar_fold_eval = gamma * fold_vals(beta, &output_column_evals);
         let d_star_eval = builder.try_consume_final_round_mle_evaluation()?;
-        let chi_m_eval = builder.try_consume_chi_evaluation()?;
+        let chi_m_eval = builder.try_consume_chi_evaluation()?.0;
 
         // d_star + d_bar_fold * d_star - chi_m = 0
         builder.try_produce_sumcheck_subpolynomial_evaluation(

--- a/solidity/src/base/LagrangeBasisEvaluation.pre.sol
+++ b/solidity/src/base/LagrangeBasisEvaluation.pre.sol
@@ -132,6 +132,41 @@ library LagrangeBasisEvaluation {
         }
     }
 
+    /// @notice Computes evaluations of Lagrange basis polynomials for a given evaluation point and array.
+    /// @notice This is a wrapper around the `compute_evaluations_with_length` Yul function. Note that the function
+    /// does not return the evaluations, but rather modifies the input array in place.
+    /// @param __evaluationPoint The evaluation point at which to compute the evaluations.
+    /// @param __array The array of lengths to evaluate.
+    /// @dev This could likely be batched more efficiently. For now, we just naively compute the evaluations for each length.
+    function __computeEvaluationsWithLength(uint256[] memory __evaluationPoint, uint256[] memory __array)
+        internal
+        pure
+    {
+        assembly {
+            // IMPORT-YUL Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL LagrangeBasisEvaluation.pre.sol
+            function compute_truncated_lagrange_basis_sum(length, x_ptr, num_vars) -> result {
+                revert(0, 0)
+            }
+            function compute_evaluations_with_length(evaluation_point_ptr, array_ptr) {
+                let num_vars := mload(evaluation_point_ptr)
+                let x := add(evaluation_point_ptr, WORD_SIZE)
+                let array_len := mload(array_ptr)
+                array_ptr := add(array_ptr, WORD_SIZE)
+                for {} array_len { array_len := sub(array_len, 1) } {
+                    mstore(
+                        add(array_ptr, WORD_SIZE), compute_truncated_lagrange_basis_sum(mload(array_ptr), x, num_vars)
+                    )
+                    array_ptr := add(array_ptr, WORDX2_SIZE)
+                }
+            }
+            compute_evaluations_with_length(__evaluationPoint, __array)
+        }
+    }
+
     /// @notice Computes rho evaluations for a given evaluation point and array.
     /// @notice This is a wrapper around the `compute_rho_evaluations` Yul function. Note that the function
     /// does not return the evaluations, but rather modifies the input array in place.

--- a/solidity/src/builder/VerificationBuilder.pre.sol
+++ b/solidity/src/builder/VerificationBuilder.pre.sol
@@ -307,13 +307,51 @@ library VerificationBuilder {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/Queue.pre.sol
-            function dequeue(queue_ptr) -> value {
+            function dequeue_uint512(queue_ptr) -> upper, lower {
                 revert(0, 0)
             }
             function builder_consume_chi_evaluation(builder_ptr) -> value {
-                value := dequeue(add(builder_ptr, BUILDER_CHI_EVALUATIONS_OFFSET))
+                let length
+                length, value := dequeue_uint512(add(builder_ptr, BUILDER_CHI_EVALUATIONS_OFFSET))
             }
             __value := builder_consume_chi_evaluation(__builder)
+        }
+    }
+
+    /// @notice Consumes a chi column length and evaluation from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// function builder_consume_chi_evaluation_with_length(builder_ptr) -> length, chi_eval
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `length` - the length of the column of ones
+    /// * `chi_eval` - the consumed chi evaluation value
+    /// @dev Dequeues and returns a chi column length and evaluation value. Reverts with Errors.EmptyQueue if no values remain
+    /// @param __builder The builder struct
+    /// @return __length The length of the column of ones
+    /// @return __chiEval The consumed chi column evaluation value
+    function __consumeChiEvaluationWithLength(Builder memory __builder)
+        internal
+        pure
+        returns (uint256 __length, uint256 __chiEval)
+    {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue_uint512(queue_ptr) -> upper, lower {
+                revert(0, 0)
+            }
+            function builder_consume_chi_evaluation_with_length(builder_ptr) -> length, chi_eval {
+                length, chi_eval := dequeue_uint512(add(builder_ptr, BUILDER_CHI_EVALUATIONS_OFFSET))
+            }
+            __length, __chiEval := builder_consume_chi_evaluation_with_length(__builder)
         }
     }
 

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -31,6 +31,10 @@ library Verifier {
             function read_wordx2_array(proof_ptr_init) -> proof_ptr, array_ptr {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/Array.pre.sol
+            function read_uint64_array_as_uint512_array(source_ptr) -> source_ptr_out, array_ptr {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../base/ECPrecompiles.pre.sol
             function calldata_ec_add_assign(args_ptr, c_ptr) {
                 pop(staticcall(0, 0, 0, 0, 0, 0))
@@ -496,7 +500,7 @@ library Verifier {
 
                 let array_ptr
 
-                proof_ptr, array_ptr := read_uint64_array(proof_ptr)
+                proof_ptr, array_ptr := read_uint64_array_as_uint512_array(proof_ptr)
                 builder_set_chi_evaluations(builder_ptr, array_ptr)
 
                 proof_ptr, array_ptr := read_uint64_array(proof_ptr)
@@ -540,6 +544,10 @@ library Verifier {
             }
             // IMPORT-YUL ../base/LagrangeBasisEvaluation.pre.sol
             function compute_rho_evaluations(evaluation_point_ptr, array_ptr) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/LagrangeBasisEvaluation.pre.sol
+            function compute_evaluations_with_length(evaluation_point_ptr, array_ptr) {
                 revert(0, 0)
             }
             function read_pcs_evaluations(proof_ptr_init, transcript_ptr, builder_ptr) -> proof_ptr {
@@ -682,7 +690,7 @@ library Verifier {
                 verify_pcs_evaluations(proof_ptr, commitments_ptr, transcript_ptr, builder_ptr, evaluation_point_ptr)
 
                 compute_chi_evaluations(evaluation_point_ptr, builder_get_table_chi_evaluations(builder_ptr))
-                compute_chi_evaluations(evaluation_point_ptr, builder_get_chi_evaluations(builder_ptr))
+                compute_evaluations_with_length(evaluation_point_ptr, builder_get_chi_evaluations(builder_ptr))
                 builder_set_singleton_chi_evaluation(
                     builder_ptr, compute_truncated_lagrange_basis_sum(1, add(evaluation_point_ptr, WORD_SIZE), num_vars)
                 )

--- a/solidity/test/proof_gadgets/Monotonic.t.pre.sol
+++ b/solidity/test/proof_gadgets/Monotonic.t.pre.sol
@@ -49,10 +49,13 @@ contract MonotonicTest is Test {
         builder.rhoEvaluations[3] = 1;
         builder.rhoEvaluations[4] = 0;
         builder.rhoEvaluations[5] = 2;
-        builder.chiEvaluations = new uint256[](3);
-        builder.chiEvaluations[0] = 1; // shifted_chi_eval
-        builder.chiEvaluations[1] = 1;
-        builder.chiEvaluations[2] = 1;
+        builder.chiEvaluations = new uint256[](6);
+        builder.chiEvaluations[0] = 3;
+        builder.chiEvaluations[1] = 1; // shifted_chi_eval
+        builder.chiEvaluations[2] = 3;
+        builder.chiEvaluations[3] = 1;
+        builder.chiEvaluations[4] = 3;
+        builder.chiEvaluations[5] = 1;
 
         uint256[] memory bitDistribution = new uint256[](6);
         bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000000;
@@ -129,9 +132,13 @@ contract MonotonicTest is Test {
         builder.rhoEvaluations[4] = 0;
         builder.rhoEvaluations[5] = 2;
         builder.chiEvaluations = new uint256[](3);
-        builder.chiEvaluations[0] = 1; // shifted_chi_eval
-        builder.chiEvaluations[1] = 1;
-        builder.chiEvaluations[2] = 1;
+        builder.chiEvaluations = new uint256[](6);
+        builder.chiEvaluations[0] = 3;
+        builder.chiEvaluations[1] = 1; // shifted_chi_eval
+        builder.chiEvaluations[2] = 3;
+        builder.chiEvaluations[3] = 1;
+        builder.chiEvaluations[4] = 3;
+        builder.chiEvaluations[5] = 1;
 
         uint256[] memory bitDistribution = new uint256[](6);
         bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000001;
@@ -206,9 +213,13 @@ contract MonotonicTest is Test {
         builder.rhoEvaluations[4] = 0;
         builder.rhoEvaluations[5] = 2;
         builder.chiEvaluations = new uint256[](3);
-        builder.chiEvaluations[0] = 1; // shifted_chi_eval
-        builder.chiEvaluations[1] = 1;
-        builder.chiEvaluations[2] = 1;
+        builder.chiEvaluations = new uint256[](6);
+        builder.chiEvaluations[0] = 3;
+        builder.chiEvaluations[1] = 1; // shifted_chi_eval
+        builder.chiEvaluations[2] = 3;
+        builder.chiEvaluations[3] = 1;
+        builder.chiEvaluations[4] = 3;
+        builder.chiEvaluations[5] = 1;
 
         uint256[] memory bitDistribution = new uint256[](6);
         bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000000;
@@ -285,9 +296,13 @@ contract MonotonicTest is Test {
         builder.rhoEvaluations[4] = 0;
         builder.rhoEvaluations[5] = 2;
         builder.chiEvaluations = new uint256[](3);
-        builder.chiEvaluations[0] = 1; // shifted_chi_eval
-        builder.chiEvaluations[1] = 1;
-        builder.chiEvaluations[2] = 1;
+        builder.chiEvaluations = new uint256[](6);
+        builder.chiEvaluations[0] = 3;
+        builder.chiEvaluations[1] = 1; // shifted_chi_eval
+        builder.chiEvaluations[2] = 3;
+        builder.chiEvaluations[3] = 1;
+        builder.chiEvaluations[4] = 3;
+        builder.chiEvaluations[5] = 1;
 
         uint256[] memory bitDistribution = new uint256[](6);
         bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000001;
@@ -363,9 +378,13 @@ contract MonotonicTest is Test {
         builder.rhoEvaluations[4] = 0;
         builder.rhoEvaluations[5] = 2;
         builder.chiEvaluations = new uint256[](3);
-        builder.chiEvaluations[0] = 1; // shifted_chi_eval
-        builder.chiEvaluations[1] = 1;
-        builder.chiEvaluations[2] = 1;
+        builder.chiEvaluations = new uint256[](6);
+        builder.chiEvaluations[0] = 3;
+        builder.chiEvaluations[1] = 1; // shifted_chi_eval
+        builder.chiEvaluations[2] = 3;
+        builder.chiEvaluations[3] = 1;
+        builder.chiEvaluations[4] = 3;
+        builder.chiEvaluations[5] = 1;
 
         uint256[] memory bitDistribution = new uint256[](6);
         bitDistribution[0] = 0x8000000000000000000000000000000000000000000000000000000000000000;

--- a/solidity/test/proof_plans/FilterExec.t.pre.sol
+++ b/solidity/test/proof_plans/FilterExec.t.pre.sol
@@ -39,8 +39,9 @@ contract FilterExecTest is Test {
         builder.challenges[1] = 502;
         builder.aggregateEvaluation = 0;
         builder.rowMultipliersEvaluation = 601;
-        builder.chiEvaluations = new uint256[](1);
-        builder.chiEvaluations[0] = 701;
+        builder.chiEvaluations = new uint256[](2);
+        builder.chiEvaluations[0] = 1;
+        builder.chiEvaluations[1] = 701;
         builder.tableChiEvaluations = new uint256[](1);
         builder.tableChiEvaluations[0] = 801;
 
@@ -113,7 +114,7 @@ contract FilterExecTest is Test {
             dFold = dFold * beta + F.from(builder.finalRoundMLEs[i]);
         }
         FF dStar = F.from(builder.finalRoundMLEs[inputEvaluationsLength + 1]);
-        identityConstraint2 = (F.ONE + alpha * dFold) * dStar - F.from(builder.chiEvaluations[0]);
+        identityConstraint2 = (F.ONE + alpha * dFold) * dStar - F.from(builder.chiEvaluations[1]);
     }
 
     function _computeEqualsExprIdentityConstraint3(
@@ -127,7 +128,7 @@ contract FilterExecTest is Test {
         for (uint256 i = 0; i < inputEvaluationsLength; ++i) {
             dFold = dFold * beta + F.from(builder.finalRoundMLEs[i]);
         }
-        identityConstraint3 = alpha * dFold * (F.from(builder.chiEvaluations[0]) - F.ONE);
+        identityConstraint3 = alpha * dFold * (F.from(builder.chiEvaluations[1]) - F.ONE);
     }
 
     function _computeEqualsExprAggregateEvaluation(
@@ -176,7 +177,7 @@ contract FilterExecTest is Test {
         vm.assume(builder.finalRoundMLEs.length > inputsLength + 1);
         vm.assume(builder.constraintMultipliers.length > 3);
         vm.assume(builder.challenges.length > 1);
-        vm.assume(builder.chiEvaluations.length > 0);
+        vm.assume(builder.chiEvaluations.length > 1);
         vm.assume(builder.tableChiEvaluations.length > tableNumber);
 
         FF[] memory inputEvaluations = new FF[](inputsLength);

--- a/solidity/test/proof_plans/GroupByExec.t.pre.sol
+++ b/solidity/test/proof_plans/GroupByExec.t.pre.sol
@@ -65,15 +65,23 @@ contract GroupByExecTest is Test {
         builder.rhoEvaluations[5] = 2;
         builder.rhoEvaluations[6] = 0;
         builder.rhoEvaluations[7] = 0;
-        builder.chiEvaluations = new uint256[](8);
-        builder.chiEvaluations[0] = 1; // output_chi_eval
-        builder.chiEvaluations[1] = 1; // shifted_output_chi_eval
-        builder.chiEvaluations[2] = 1;
-        builder.chiEvaluations[3] = 1;
-        builder.chiEvaluations[4] = 0;
+        builder.chiEvaluations = new uint256[](16);
+        builder.chiEvaluations[0] = 4;
+        builder.chiEvaluations[1] = 1; // output_chi_eval
+        builder.chiEvaluations[2] = 4;
+        builder.chiEvaluations[3] = 1; // shifted_output_chi_eval
+        builder.chiEvaluations[4] = 4;
         builder.chiEvaluations[5] = 1;
-        builder.chiEvaluations[6] = 0;
-        builder.chiEvaluations[7] = 0;
+        builder.chiEvaluations[6] = 4;
+        builder.chiEvaluations[7] = 1;
+        builder.chiEvaluations[8] = 4;
+        builder.chiEvaluations[9] = 0;
+        builder.chiEvaluations[10] = 4;
+        builder.chiEvaluations[11] = 1;
+        builder.chiEvaluations[12] = 4;
+        builder.chiEvaluations[13] = 0;
+        builder.chiEvaluations[14] = 4;
+        builder.chiEvaluations[15] = 0;
 
         // bit distributions
         uint256[] memory bitDistribution = new uint256[](8);

--- a/solidity/test/proof_plans/ProofPlan.t.pre.sol
+++ b/solidity/test/proof_plans/ProofPlan.t.pre.sol
@@ -41,8 +41,9 @@ contract ProofPlanTest is Test {
         builder.challenges[1] = 502;
         builder.aggregateEvaluation = 0;
         builder.rowMultipliersEvaluation = 601;
-        builder.chiEvaluations = new uint256[](1);
-        builder.chiEvaluations[0] = 701;
+        builder.chiEvaluations = new uint256[](2);
+        builder.chiEvaluations[0] = 1;
+        builder.chiEvaluations[1] = 701;
         builder.tableChiEvaluations = new uint256[](1);
         builder.tableChiEvaluations[0] = 801;
 
@@ -96,15 +97,23 @@ contract ProofPlanTest is Test {
         builder.rhoEvaluations[5] = 2;
         builder.rhoEvaluations[6] = 0;
         builder.rhoEvaluations[7] = 0;
-        builder.chiEvaluations = new uint256[](8);
-        builder.chiEvaluations[0] = 1; // output_chi_eval
-        builder.chiEvaluations[1] = 1; // shifted_output_chi_eval
-        builder.chiEvaluations[2] = 1;
-        builder.chiEvaluations[3] = 1;
-        builder.chiEvaluations[4] = 0;
+        builder.chiEvaluations = new uint256[](16);
+        builder.chiEvaluations[0] = 4;
+        builder.chiEvaluations[1] = 1; // output_chi_eval
+        builder.chiEvaluations[2] = 4;
+        builder.chiEvaluations[3] = 1; // shifted_output_chi_eval
+        builder.chiEvaluations[4] = 4;
         builder.chiEvaluations[5] = 1;
-        builder.chiEvaluations[6] = 0;
-        builder.chiEvaluations[7] = 0;
+        builder.chiEvaluations[6] = 4;
+        builder.chiEvaluations[7] = 1;
+        builder.chiEvaluations[8] = 4;
+        builder.chiEvaluations[9] = 0;
+        builder.chiEvaluations[10] = 4;
+        builder.chiEvaluations[11] = 1;
+        builder.chiEvaluations[12] = 4;
+        builder.chiEvaluations[13] = 0;
+        builder.chiEvaluations[14] = 4;
+        builder.chiEvaluations[15] = 0;
 
         // bit distributions
         uint256[] memory bitDistribution = new uint256[](8);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We want to be able to access the length of the chi evals we use in our verifier code.

# What changes are included in this PR?

- Refactoring the rust function `try_consume_chi_evaluation` to return the length of the chi column.
- Refactoring the solidity to store the length and chi eval together on the builder.
- New solidity function that also returns the length with the chi eval.

# Are these changes tested?
Yes
