### PR TITLE
feat(sol): compute rho evaluations

### DIFF
--- a/solidity/test/base/LagrangeBasisEvaluation.t.pre.sol
+++ b/solidity/test/base/LagrangeBasisEvaluation.t.pre.sol
@@ -298,4 +298,35 @@ contract LagrangeBasisEvaluationTest is Test {
             assert(evaluations[i] == expectedSums[i].into());
         }
     }
+
+    function testSimpleComputeRhoEvaluations() public pure {
+        uint256[] memory point = new uint256[](3);
+        point[0] = 2;
+        point[1] = 5;
+        point[2] = 7;
+
+        uint256[] memory evaluations = new uint256[](9);
+        for (uint256 i = 0; i < 9; ++i) {
+            evaluations[i] = i;
+        }
+
+        // These values were retrieved using the rust test
+        // `compute_rho_eval_gives_correct_values_with_3_variables`
+        uint256[] memory expectedEvaluations = new uint256[](9);
+        expectedEvaluations[0] = 0;
+        expectedEvaluations[1] = 0;
+        expectedEvaluations[2] = 48;
+        expectedEvaluations[3] = 108;
+        expectedEvaluations[4] = MODULUS - 72;
+        expectedEvaluations[5] = 40;
+        expectedEvaluations[6] = MODULUS - 240;
+        expectedEvaluations[7] = MODULUS - 450;
+        expectedEvaluations[8] = 40;
+
+        LagrangeBasisEvaluation.__computeRhoEvaluations(point, evaluations);
+
+        for (uint256 i = 0; i < 2; ++i) {
+            assert(evaluations[i] == expectedEvaluations[i]);
+        }
+    }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
