### PR TITLE
feat(sol): read_word_array_as_uint512_array

### DIFF
--- a/solidity/test/base/Array.t.pre.sol
+++ b/solidity/test/base/Array.t.pre.sol
@@ -48,6 +48,22 @@ contract ArrayTest is Test {
         }
     }
 
+    function testReadWordArrayAsUint512Array() public pure {
+        uint256[] memory inputArray = new uint256[](3);
+        inputArray[0] = 0x12345678;
+        inputArray[1] = 0x23456789;
+        inputArray[2] = 0x3456789A;
+
+        uint256[2][] memory outputArray = Array.__readWordArrayAsUint512Array(inputArray);
+
+        assert(outputArray[0][0] == 0x12345678);
+        assert(outputArray[0][1] == 0);
+        assert(outputArray[1][0] == 0x23456789);
+        assert(outputArray[1][1] == 0);
+        assert(outputArray[2][0] == 0x3456789A);
+        assert(outputArray[2][1] == 0);
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testGetUint512ArrayElement() public pure {
         uint256[] memory array = new uint256[](4);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We want to be able to retrieve the length of chi evaluations for a particular table. The easiest way to do that is to store the lengths and evals together, so we will need space in the array.

# What changes are included in this PR?

A new function for reading a word array as an array of two word elements.

# Are these changes tested?
Yes
