### PR TITLE
feat(sol): `get_uint512_array_element`

### DIFF
--- a/solidity/src/base/Array.pre.sol
+++ b/solidity/src/base/Array.pre.sol
@@ -42,6 +42,48 @@ library Array {
         }
     }
 
+    /// @notice Gets two uint256 values from an array
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// function get_uint512_array_element(arr_ptr, index) -> upper, lower
+    /// ```
+    /// ##### Parameters
+    /// * `arr_ptr` - pointer to the array in memory. In Solidity memory layout,
+    ///   this points to where the array length is stored, followed by the array elements
+    /// * `index` - the index of the element to retrieve
+    /// ##### Return Values
+    /// * `upper` - the first word from the two word element
+    /// * `lower` - the second word from the two word element
+    /// @dev Removes and returns the first element from the queue.
+    /// Reverts with Errors.EmptyQueue if the queue is empty.
+    /// @param __array Single-element array containing the array to get the two word element from
+    /// @param __index The index of the two word element to retrieve
+    /// @return __upper The first word from the two word element
+    /// @return __lower The second word from the two word element
+    function __getUint512ArrayElement(uint256[][1] memory __array, uint256 __index)
+        internal
+        pure
+        returns (uint256 __upper, uint256 __lower)
+    {
+        assembly {
+            // IMPORT-YUL Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            function get_uint512_array_element(arr_ptr, index) -> upper, lower {
+                let arr := mload(arr_ptr)
+                let length := mload(arr)
+                if iszero(lt(index, length)) { err(ERR_INVALID_INDEX) }
+                let element_ptr := add(add(arr, WORD_SIZE), mul(index, WORDX2_SIZE))
+                upper := mload(element_ptr)
+                lower := mload(add(element_ptr, WORD_SIZE))
+            }
+            __upper, __lower := get_uint512_array_element(__array, __index)
+        }
+    }
+
     /// @notice Reads a uint64 array from calldata
     /// @custom:yul-function
     /// #### Yul Function

--- a/solidity/test/base/Array.t.pre.sol
+++ b/solidity/test/base/Array.t.pre.sol
@@ -48,6 +48,27 @@ contract ArrayTest is Test {
         }
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testGetUint512ArrayElement() public pure {
+        uint256[] memory array = new uint256[](4);
+        array[0] = 1;
+        array[1] = 2;
+        array[2] = 3;
+        array[3] = 4;
+        assembly {
+            mstore(array, 2)
+        }
+        uint256[][1] memory wrappedArray = [array];
+        uint256 upper;
+        uint256 lower;
+        (upper, lower) = Array.__getUint512ArrayElement(wrappedArray, 0);
+        assert(upper == 1);
+        assert(lower == 2);
+        (upper, lower) = Array.__getUint512ArrayElement(wrappedArray, 1);
+        assert(upper == 3);
+        assert(lower == 4);
+    }
+
     function testEmptyReadUint64Array() public pure {
         bytes memory source = abi.encodePacked(uint64(0), hex"abcdef");
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
