### PR TITLE
fix(sol): group by should return output chi

### DIFF
--- a/solidity/src/proof_plans/GroupByExec.pre.sol
+++ b/solidity/src/proof_plans/GroupByExec.pre.sol
@@ -393,13 +393,17 @@ library GroupByExec {
                     )
             }
 
-            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) -> plan_ptr_out, evaluations_ptr {
+            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) ->
+                plan_ptr_out,
+                evaluations_ptr,
+                output_chi_eval
+            {
                 // Table input
                 let input_chi_eval :=
                     builder_get_table_chi_evaluation(builder_ptr, shr(UINT64_PADDING_BITS, calldataload(plan_ptr)))
                 plan_ptr := add(plan_ptr, UINT64_SIZE)
                 // Get chi evaluation
-                let output_chi_eval := builder_consume_chi_evaluation(builder_ptr)
+                output_chi_eval := builder_consume_chi_evaluation(builder_ptr)
                 // Read the number of result columns
                 let total_column_count := shr(UINT64_PADDING_BITS, calldataload(plan_ptr))
                 plan_ptr := add(plan_ptr, UINT64_SIZE)
@@ -419,7 +423,8 @@ library GroupByExec {
             function group_by_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 let alpha := builder_consume_challenge(builder_ptr)
                 let beta := builder_consume_challenge(builder_ptr)
-                plan_ptr, evaluations_ptr := check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta)
+                plan_ptr, evaluations_ptr, output_chi_eval :=
+                    check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta)
                 {
                     // Skip the count alias (we don't need to parse it for verification)
                     let count_alias

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -280,7 +280,11 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL GroupByExec.pre.sol
-            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) -> plan_ptr_out, evaluations_ptr {
+            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) ->
+                plan_ptr_out,
+                evaluations_ptr,
+                output_chi_eval
+            {
                 revert(0, 0)
             }
             // IMPORT-YUL GroupByExec.pre.sol

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -464,7 +464,11 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
-            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) -> plan_ptr_out, evaluations_ptr {
+            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) ->
+                plan_ptr_out,
+                evaluations_ptr,
+                output_chi_eval
+            {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
