### PR TITLE
feat: make sure rho evals are actually computed

### DIFF
--- a/solidity/src/base/LagrangeBasisEvaluation.pre.sol
+++ b/solidity/src/base/LagrangeBasisEvaluation.pre.sol
@@ -132,8 +132,8 @@ library LagrangeBasisEvaluation {
         }
     }
 
-    /// @notice Computes evaluations of Lagrange basis polynomials for a given evaluation point and array.
-    /// @notice This is a wrapper around the `compute_evaluations` Yul function. Note that the function
+    /// @notice Computes rho evaluations for a given evaluation point and array.
+    /// @notice This is a wrapper around the `compute_rho_evaluations` Yul function. Note that the function
     /// does not return the evaluations, but rather modifies the input array in place.
     /// @param __evaluationPoint The evaluation point at which to compute the evaluations.
     /// @param __array The array of lengths to evaluate.

--- a/solidity/src/base/LagrangeBasisEvaluation.pre.sol
+++ b/solidity/src/base/LagrangeBasisEvaluation.pre.sol
@@ -106,19 +106,19 @@ library LagrangeBasisEvaluation {
         }
     }
 
-    /// @notice Computes evaluations of Lagrange basis polynomials for a given evaluation point and array.
-    /// @notice This is a wrapper around the `compute_evaluations` Yul function. Note that the function
+    /// @notice Computes chi evaluations for a given evaluation point and array.
+    /// @notice This is a wrapper around the `compute_chi_evaluations` Yul function. Note that the function
     /// does not return the evaluations, but rather modifies the input array in place.
     /// @param __evaluationPoint The evaluation point at which to compute the evaluations.
     /// @param __array The array of lengths to evaluate.
     /// @dev This could likely be batched more efficiently. For now, we just naively compute the evaluations for each length.
-    function __computeEvaluations(uint256[] memory __evaluationPoint, uint256[] memory __array) internal pure {
+    function __computeChiEvaluations(uint256[] memory __evaluationPoint, uint256[] memory __array) internal pure {
         assembly {
             // IMPORT-YUL LagrangeBasisEvaluation.pre.sol
             function compute_truncated_lagrange_basis_sum(length, x_ptr, num_vars) -> result {
                 revert(0, 0)
             }
-            function compute_evaluations(evaluation_point_ptr, array_ptr) {
+            function compute_chi_evaluations(evaluation_point_ptr, array_ptr) {
                 let num_vars := mload(evaluation_point_ptr)
                 let x := add(evaluation_point_ptr, WORD_SIZE)
                 let array_len := mload(array_ptr)
@@ -128,7 +128,7 @@ library LagrangeBasisEvaluation {
                     array_ptr := add(array_ptr, WORD_SIZE)
                 }
             }
-            compute_evaluations(__evaluationPoint, __array)
+            compute_chi_evaluations(__evaluationPoint, __array)
         }
     }
 

--- a/solidity/src/builder/VerificationBuilder.pre.sol
+++ b/solidity/src/builder/VerificationBuilder.pre.sol
@@ -868,6 +868,28 @@ library VerificationBuilder {
         }
     }
 
+    /// @notice Gets the rho column evaluations array from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_rho_evaluations(builder_ptr) -> values_ptr
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `values_ptr` - pointer to the array in memory
+    /// @param __builder The builder struct
+    /// @return __values The rho evaluations array
+    function __getRhoEvaluations(Builder memory __builder) internal pure returns (uint256[] memory __values) {
+        assembly {
+            function builder_get_rho_evaluations(builder_ptr) -> values_ptr {
+                values_ptr := mload(add(builder_ptr, BUILDER_RHO_EVALUATIONS_OFFSET))
+            }
+            __values := builder_get_rho_evaluations(__builder)
+        }
+    }
+
     /// @notice Checks if the aggregate evaluation is non-zero and triggers an error if so
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -531,7 +531,7 @@ library Verifier {
                 builder_set_max_degree(builder_ptr, sumcheck_degree)
             }
             // IMPORT-YUL ../base/LagrangeBasisEvaluation.pre.sol
-            function compute_evaluations(evaluation_point_ptr, array_ptr) {
+            function compute_chi_evaluations(evaluation_point_ptr, array_ptr) {
                 revert(0, 0)
             }
             function read_pcs_evaluations(proof_ptr_init, transcript_ptr, builder_ptr) -> proof_ptr {
@@ -673,8 +673,8 @@ library Verifier {
 
                 verify_pcs_evaluations(proof_ptr, commitments_ptr, transcript_ptr, builder_ptr, evaluation_point_ptr)
 
-                compute_evaluations(evaluation_point_ptr, builder_get_table_chi_evaluations(builder_ptr))
-                compute_evaluations(evaluation_point_ptr, builder_get_chi_evaluations(builder_ptr))
+                compute_chi_evaluations(evaluation_point_ptr, builder_get_table_chi_evaluations(builder_ptr))
+                compute_chi_evaluations(evaluation_point_ptr, builder_get_chi_evaluations(builder_ptr))
                 builder_set_singleton_chi_evaluation(
                     builder_ptr, compute_truncated_lagrange_basis_sum(1, add(evaluation_point_ptr, WORD_SIZE), num_vars)
                 )

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -152,6 +152,10 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_rho_evaluations(builder_ptr) -> values_ptr {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_rho_evaluation(builder_ptr) -> value {
                 revert(0, 0)
             }
@@ -534,6 +538,10 @@ library Verifier {
             function compute_chi_evaluations(evaluation_point_ptr, array_ptr) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/LagrangeBasisEvaluation.pre.sol
+            function compute_rho_evaluations(evaluation_point_ptr, array_ptr) {
+                revert(0, 0)
+            }
             function read_pcs_evaluations(proof_ptr_init, transcript_ptr, builder_ptr) -> proof_ptr {
                 proof_ptr := proof_ptr_init
 
@@ -678,6 +686,7 @@ library Verifier {
                 builder_set_singleton_chi_evaluation(
                     builder_ptr, compute_truncated_lagrange_basis_sum(1, add(evaluation_point_ptr, WORD_SIZE), num_vars)
                 )
+                compute_rho_evaluations(evaluation_point_ptr, builder_get_rho_evaluations(builder_ptr))
 
                 builder_set_row_multipliers_evaluation(
                     builder_ptr,

--- a/solidity/test/base/LagrangeBasisEvaluation.t.pre.sol
+++ b/solidity/test/base/LagrangeBasisEvaluation.t.pre.sol
@@ -215,7 +215,7 @@ contract LagrangeBasisEvaluationTest is Test {
         LagrangeBasisEvaluation.__computeEvaluationVec(maxLength + 1, point);
     }
 
-    function testSimpleComputeEvaluations() public pure {
+    function testSimpleComputeChiEvaluations() public pure {
         uint256[] memory point = new uint256[](3);
         point[0] = 2;
         point[1] = 3;
@@ -249,7 +249,7 @@ contract LagrangeBasisEvaluationTest is Test {
             evaluations[i] = i;
         }
 
-        LagrangeBasisEvaluation.__computeEvaluations(point, evaluations);
+        LagrangeBasisEvaluation.__computeChiEvaluations(point, evaluations);
 
         for (uint256 i = 0; i < 12; ++i) {
             assert(evaluations[i] == expectedSums[i].into());
@@ -257,7 +257,7 @@ contract LagrangeBasisEvaluationTest is Test {
     }
 
     // solhint-disable-next-line code-complexity
-    function testFuzzComputeEvaluations(uint256[] memory point) public pure {
+    function testFuzzComputeChiEvaluations(uint256[] memory point) public pure {
         uint256 numVars = point.length;
         // If the point is too long, we will run out of memory
         vm.assume(numVars < _MAX_FUZZ_POINT_LENGTH + 1);
@@ -292,7 +292,7 @@ contract LagrangeBasisEvaluationTest is Test {
             evaluations[i] = i;
         }
 
-        LagrangeBasisEvaluation.__computeEvaluations(point, evaluations);
+        LagrangeBasisEvaluation.__computeChiEvaluations(point, evaluations);
 
         for (uint256 i = 0; i < maxLength; ++i) {
             assert(evaluations[i] == expectedSums[i].into());

--- a/solidity/test/builder/VerificationBuilder.t.pre.sol
+++ b/solidity/test/builder/VerificationBuilder.t.pre.sol
@@ -1012,6 +1012,31 @@ contract VerificationBuilderTest is Test {
         }
     }
 
+    function testGetRhoEvaluations() public pure {
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        builder.rhoEvaluations = values;
+        uint256[] memory result = VerificationBuilder.__getRhoEvaluations(builder);
+        assert(result.length == 3);
+        assert(result[0] == 0x12345678);
+        assert(result[1] == 0x23456789);
+        assert(result[2] == 0x3456789A);
+    }
+
+    function testFuzzGetRhoEvaluations(uint256[] memory values) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.rhoEvaluations = values;
+        uint256[] memory result = VerificationBuilder.__getRhoEvaluations(builder);
+        assert(result.length == values.length);
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(result[i] == values[i]);
+        }
+    }
+
     function testSetSingletonChiEvaluation() public pure {
         VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
         VerificationBuilder.__setSingletonChiEvaluation(builder, 42);


### PR DESCRIPTION
## Summary of PR #919: feat: compute rho eval

### src/base/LagrangeBasisEvaluation.pre.sol
- **Refactor**:  
  - Renamed `__computeEvaluations` → `__computeChiEvaluations`  
  - Updated doc comments to refer to “chi evaluations” instead of generic evaluations  
- **Add**:  
  - Doc comments for a new Yul wrapper `compute_rho_evaluations` to compute rho evaluations in-place

### src/builder/VerificationBuilder.pre.sol
- **Add**:  
  - `__getRhoEvaluations(Builder memory)` function  
  - Yul wrapper `builder_get_rho_evaluations` to expose the builder’s `rhoEvaluations` array

### src/verifier/Verifier.pre.sol
- **Add**:  
  - Yul imports for `builder_get_rho_evaluations` and `builder_consume_rho_evaluation`  
  - Import of `compute_rho_evaluations` from the Lagrange basis lib  
- **Refactor**:  
  - Switched from `compute_evaluations` → `compute_chi_evaluations` in imports and calls  
- **Enhance**:  
  - In `verify_proof`, after chi evaluations, now calls `compute_rho_evaluations(...)` and sets the row multipliers evaluation

### test/base/LagrangeBasisEvaluation.t.pre.sol
- **Refactor**:  
  - Renamed `testSimpleComputeEvaluations` → `testSimpleComputeChiEvaluations`  
  - Renamed `testFuzzComputeEvaluations` → `testFuzzComputeChiEvaluations`  
- **Update**:  
  - Test bodies now invoke `__computeChiEvaluations` instead of `__computeEvaluations`

### test/builder/VerificationBuilder.t.pre.sol
- **Add**:  
  - `testGetRhoEvaluations` (static values)  
  - `testFuzzGetRhoEvaluations` (fuzzed input)  
  - Both validate that `__getRhoEvaluations` returns the correct array contents
