### PR TITLE
refactor(sol): reduce group by local variables

### DIFF
--- a/solidity/src/proof_plans/GroupByExec.pre.sol
+++ b/solidity/src/proof_plans/GroupByExec.pre.sol
@@ -411,18 +411,26 @@ library GroupByExec {
                 // Get chi evaluation
                 output_chi_eval := builder_consume_chi_evaluation(builder_ptr)
                 // Read the number of result columns
-                let total_column_count := shr(UINT64_PADDING_BITS, calldataload(plan_ptr))
-                plan_ptr := add(plan_ptr, UINT64_SIZE)
-                evaluations_ptr := mload(FREE_PTR)
-                mstore(evaluations_ptr, total_column_count)
-                evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
-                plan_ptr, evaluations_ptr :=
-                    build_groupby_constraints(
-                        plan_ptr, builder_ptr, alpha, beta, input_chi_eval, output_chi_eval, evaluations_ptr
-                    )
-                // slither-disable-next-line write-after-write
-                evaluations_ptr := mload(FREE_PTR)
-                mstore(FREE_PTR, add(evaluations_ptr, add(WORD_SIZE, mul(total_column_count, WORD_SIZE))))
+                {
+                    let total_column_count := shr(UINT64_PADDING_BITS, calldataload(plan_ptr))
+                    plan_ptr := add(plan_ptr, UINT64_SIZE)
+                    evaluations_ptr := mload(FREE_PTR)
+                    mstore(evaluations_ptr, total_column_count)
+                    mstore(FREE_PTR, add(evaluations_ptr, add(WORD_SIZE, mul(total_column_count, WORD_SIZE))))
+                }
+                {
+                    let evaluations_ptr_out
+                    plan_ptr, evaluations_ptr_out :=
+                        build_groupby_constraints(
+                            plan_ptr,
+                            builder_ptr,
+                            alpha,
+                            beta,
+                            input_chi_eval,
+                            output_chi_eval,
+                            add(evaluations_ptr, WORD_SIZE)
+                        )
+                }
                 plan_ptr_out := plan_ptr
             }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We need to be able to add another local variable to group by, so we need to make space for it.

# What changes are included in this PR?

Rearranging group by code so that local variables are dropped as quickly as possible. In the process, the FREE_PTR is only loaded once now.

# Are these changes tested?
Yes
