### PR TITLE
refactor: move shift logic from monotonic code to shift code

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -16,17 +16,36 @@ pub(crate) fn first_round_evaluate_shift<S: Scalar>(
     builder: &mut FirstRoundBuilder<'_, S>,
     num_rows: usize,
 ) {
-    // Note that we don't produce chi eval lengths here
-    // since it needs to be done in uniqueness check which uses shifts.
+    builder.produce_chi_evaluation_length(num_rows + 1);
     builder.produce_rho_evaluation_length(num_rows);
     builder.produce_rho_evaluation_length(num_rows + 1);
+}
+
+/// Perform final round evaluation of downward shift.
+pub(crate) fn final_round_evaluate_shift<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    column: &'a [S],
+) -> &'a [S] {
+    let shifted_column = alloc.alloc_slice_fill_with(column.len() + 1, |i| {
+        if i == 0 {
+            S::ZERO
+        } else {
+            column[i - 1]
+        }
+    });
+    builder.produce_intermediate_mle(shifted_column as &[_]);
+    final_round_evaluate_shift_base(builder, alloc, alpha, beta, column, shifted_column);
+    shifted_column
 }
 
 /// Perform final round evaluation of downward shift.
 ///
 /// # Panics
 /// Panics if `column.len() != shifted_column.len() - 1` which should always hold for shifts.
-pub(crate) fn final_round_evaluate_shift<'a, S: Scalar>(
+fn final_round_evaluate_shift_base<'a, S: Scalar>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     alpha: S,
@@ -103,10 +122,10 @@ pub(crate) fn verify_shift<S: Scalar>(
     alpha: S,
     beta: S,
     column_eval: S,
-    shifted_column_eval: S,
     chi_n_eval: S,
-    chi_n_plus_1_eval: S,
-) -> Result<(), ProofError> {
+) -> Result<(S, S), ProofError> {
+    let chi_n_plus_1_eval = builder.try_consume_chi_evaluation()?.0;
+    let shifted_column_eval = builder.try_consume_final_round_mle_evaluation()?;
     let rho_n_eval = builder.try_consume_rho_evaluation()?;
     let rho_n_plus_1_eval = builder.try_consume_rho_evaluation()?;
     let c_fold_eval = alpha * fold_vals(beta, &[rho_n_eval + chi_n_eval, column_eval]);
@@ -135,12 +154,12 @@ pub(crate) fn verify_shift<S: Scalar>(
         2,
     )?;
 
-    Ok(())
+    Ok((shifted_column_eval, chi_n_plus_1_eval))
 }
 
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
-    use super::{final_round_evaluate_shift, first_round_evaluate_shift, verify_shift};
+    use super::{final_round_evaluate_shift_base, first_round_evaluate_shift, verify_shift};
     use crate::{
         base::{
             database::{
@@ -222,7 +241,7 @@ mod tests {
             builder.produce_intermediate_mle(alloc_candidate_column as &[_]);
             let alpha = builder.consume_post_result_challenge();
             let beta = builder.consume_post_result_challenge();
-            final_round_evaluate_shift(
+            final_round_evaluate_shift_base(
                 builder,
                 alloc,
                 alpha,
@@ -267,19 +286,9 @@ mod tests {
             let beta = builder.try_consume_post_result_challenge()?;
             // Get the columns
             let column_eval = builder.try_consume_final_round_mle_evaluation()?;
-            let candidate_shift_eval = builder.try_consume_final_round_mle_evaluation()?;
             let chi_n_eval = builder.try_consume_chi_evaluation()?.0;
-            let chi_n_plus_1_eval = builder.try_consume_chi_evaluation()?.0;
             // Evaluate the verifier
-            verify_shift(
-                builder,
-                alpha,
-                beta,
-                column_eval,
-                candidate_shift_eval,
-                chi_n_eval,
-                chi_n_plus_1_eval,
-            )?;
+            verify_shift(builder, alpha, beta, column_eval, chi_n_eval)?;
             Ok(TableEvaluation::new(vec![], (S::zero(), 0)))
         }
     }

--- a/solidity/src/proof_gadgets/Monotonic.pre.sol
+++ b/solidity/src/proof_gadgets/Monotonic.pre.sol
@@ -107,7 +107,9 @@ library Monotonic {
                 revert(0, 0)
             }
             // IMPORT-YUL ./Shift.pre.sol
-            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, chi_eval) ->
+                shifted_expr_eval,
+                chi_plus_one_eval
             {
                 revert(0, 0)
             }
@@ -118,10 +120,8 @@ library Monotonic {
 
             function monotonic_verify(builder_ptr, alpha, beta, column_eval, chi_eval, strict, asc) {
                 // 1. Verify that `shifted_column` is a shift of `column`
-                let shifted_column_eval := builder_consume_final_round_mle(builder_ptr)
-                let shifted_chi_eval := builder_consume_chi_evaluation(builder_ptr)
-
-                shift_evaluate(builder_ptr, alpha, beta, column_eval, shifted_column_eval, chi_eval, shifted_chi_eval)
+                let shifted_column_eval, shifted_chi_eval :=
+                    shift_evaluate(builder_ptr, alpha, beta, column_eval, chi_eval)
 
                 // 2. Compute indicator evaluation based on strictness and direction
                 let ind_eval

--- a/solidity/src/proof_gadgets/Shift.pre.sol
+++ b/solidity/src/proof_gadgets/Shift.pre.sol
@@ -21,27 +21,30 @@ library Shift {
     /// * `alpha` - a challenge
     /// * `beta` - a challenge
     /// * `expr_eval` - the expression evaluation
-    /// * `shifted_expr_eval` - the evaluation of the shifted expression
     /// * `chi_eval` - the chi evaluation with length same as the column
+    /// ##### Return Values
+    /// * `shifted_expr_eval` - the evaluation of the shifted expression
     /// * `chi_plus_one_eval` - the chi evaluation with length one longer than the column
     /// @notice verifies that a shifted column is evaluated correctly
     /// @param __builder The verification builder
     /// @param __alpha a challenge
     /// @param __beta a challenge
     /// @param __exprEval the expression evaluation
-    /// @param __shiftedExprEval the evaluation of the shifted expression
     /// @param __chiEval The chi value for evaluation
-    /// @param __chiPlusOneEval The chi plus one value for evaluation
     /// @return __builderOut The verification builder result
+    /// @return __shiftedExprEval the evaluation of the shifted expression
+    /// @return __chiPlusOneEval The chi plus one value for evaluation
     function __shiftEvaluate( // solhint-disable-line gas-calldata-parameters
         VerificationBuilder.Builder memory __builder,
         uint256 __alpha,
         uint256 __beta,
         uint256 __exprEval,
-        uint256 __shiftedExprEval,
-        uint256 __chiEval,
-        uint256 __chiPlusOneEval
-    ) internal pure returns (VerificationBuilder.Builder memory __builderOut) {
+        uint256 __chiEval
+    )
+        internal
+        pure
+        returns (VerificationBuilder.Builder memory __builderOut, uint256 __shiftedExprEval, uint256 __chiPlusOneEval)
+    {
         assembly {
             // IMPORT-YUL ../base/Errors.sol
             function err(code) {
@@ -49,6 +52,10 @@ library Shift {
             }
             // IMPORT-YUL ../base/Queue.pre.sol
             function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue_uint512(queue_ptr) -> upper, lower {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/Array.pre.sol
@@ -69,6 +76,10 @@ library Shift {
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_rho_evaluation(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_chi_evaluation(builder_ptr) -> value {
                 revert(0, 0)
             }
             // IMPORT-YUL ../base/MathUtil.pre.sol
@@ -92,8 +103,12 @@ library Shift {
                 fold := mulmod_bn254(alpha, addmod_bn254(mulmod_bn254(beta, rho), eval))
             }
 
-            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, chi_eval) ->
+                shifted_expr_eval,
+                chi_plus_one_eval
             {
+                chi_plus_one_eval := builder_consume_chi_evaluation(builder_ptr)
+                shifted_expr_eval := builder_consume_final_round_mle(builder_ptr)
                 let rho_eval := builder_consume_rho_evaluation(builder_ptr)
                 let rho_plus_one_eval := builder_consume_rho_evaluation(builder_ptr)
                 let c_star_eval := builder_consume_final_round_mle(builder_ptr)
@@ -116,7 +131,7 @@ library Shift {
                 }
             }
 
-            shift_evaluate(__builder, __alpha, __beta, __exprEval, __shiftedExprEval, __chiEval, __chiPlusOneEval)
+            __shiftedExprEval, __chiPlusOneEval := shift_evaluate(__builder, __alpha, __beta, __exprEval, __chiEval)
         }
         __builderOut = __builder;
     }

--- a/solidity/src/proof_plans/GroupByExec.pre.sol
+++ b/solidity/src/proof_plans/GroupByExec.pre.sol
@@ -219,7 +219,9 @@ library GroupByExec {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
-            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, chi_eval) ->
+                shifted_expr_eval,
+                chi_plus_one_eval
             {
                 revert(0, 0)
             }

--- a/solidity/src/proof_plans/ProjectionExec.pre.sol
+++ b/solidity/src/proof_plans/ProjectionExec.pre.sol
@@ -322,7 +322,9 @@ library ProjectionExec {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
-            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, chi_eval) ->
+                shifted_expr_eval,
+                chi_plus_one_eval
             {
                 revert(0, 0)
             }

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -221,7 +221,9 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
-            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, chi_eval) ->
+                shifted_expr_eval,
+                chi_plus_one_eval
             {
                 revert(0, 0)
             }

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -332,7 +332,9 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_gadgets/Shift.pre.sol
-            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, shifted_expr_eval, chi_eval, chi_plus_one_eval)
+            function shift_evaluate(builder_ptr, alpha, beta, expr_eval, chi_eval) ->
+                shifted_expr_eval,
+                chi_plus_one_eval
             {
                 revert(0, 0)
             }

--- a/solidity/test/proof_gadgets/Shift.t.pre.sol
+++ b/solidity/test/proof_gadgets/Shift.t.pre.sol
@@ -29,13 +29,23 @@ contract ShiftTest is Test {
         builder.rhoEvaluations[3] = 1;
         builder.rhoEvaluations[4] = 0;
         builder.rhoEvaluations[5] = 2;
-        builder.finalRoundMLEs = new uint256[](6);
-        builder.finalRoundMLEs[0] = 17222184509042479139574583720503606563789583659997933845959245835272824378669;
-        builder.finalRoundMLEs[1] = 1;
-        builder.finalRoundMLEs[2] = 2824289402817970996418891063904164527554627664569810883057832798267846257499;
-        builder.finalRoundMLEs[3] = 17222184509042479139574583720503606563789583659997933845959245835272824378669;
-        builder.finalRoundMLEs[4] = 1;
-        builder.finalRoundMLEs[5] = 2824289402817970996418891063904164527554627664569810883057832798267846257499;
+        builder.chiEvaluations = new uint256[](6);
+        builder.chiEvaluations[0] = 3;
+        builder.chiEvaluations[1] = 1;
+        builder.chiEvaluations[2] = 3;
+        builder.chiEvaluations[3] = 1;
+        builder.chiEvaluations[4] = 3;
+        builder.chiEvaluations[5] = 1;
+        builder.finalRoundMLEs = new uint256[](9);
+        builder.finalRoundMLEs[0] = shiftedColumn[0];
+        builder.finalRoundMLEs[1] = 17222184509042479139574583720503606563789583659997933845959245835272824378669;
+        builder.finalRoundMLEs[2] = 1;
+        builder.finalRoundMLEs[3] = shiftedColumn[1];
+        builder.finalRoundMLEs[4] = 2824289402817970996418891063904164527554627664569810883057832798267846257499;
+        builder.finalRoundMLEs[5] = 17222184509042479139574583720503606563789583659997933845959245835272824378669;
+        builder.finalRoundMLEs[6] = shiftedColumn[2];
+        builder.finalRoundMLEs[7] = 1;
+        builder.finalRoundMLEs[8] = 2824289402817970996418891063904164527554627664569810883057832798267846257499;
 
         for (uint8 i = 0; i < 3; ++i) {
             uint256 chiEval = chi[i];
@@ -44,9 +54,7 @@ contract ShiftTest is Test {
                 __alpha: alpha,
                 __beta: beta,
                 __exprEval: F.from(column[i]).into(),
-                __shiftedExprEval: F.from(shiftedColumn[i]).into(),
-                __chiEval: chiEval,
-                __chiPlusOneEval: 1
+                __chiEval: chiEval
             });
         }
         assert(builder.aggregateEvaluation == 0);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

There is logic in the monotonic gadget that should be in the shift gadget.

# What changes are included in this PR?

Moving creation and retrieval of shifted columns and chis into the shift gadget.

# Are these changes tested?
Yes
