### PR TITLE
perf: optimize compute_varying_bit_matrix in bit_matrix module by making memory trade-off

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_matrix.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix.rs
@@ -39,7 +39,8 @@ pub fn compute_varying_bit_matrix<'a, S: Scalar>(
     // decompose
     let span = span!(Level::DEBUG, "decompose").entered();
     let masks: Vec<U256> = if_rayon!(vals.par_iter(), vals.iter())
-        .map(|val| make_bit_mask(*val))
+        .copied()
+        .map(make_bit_mask)
         .collect();
 
     let shifted_masks: Vec<U256> = dist


### PR DESCRIPTION
# Rationale for this change
The `Union All` query benchmark indicates that the `compute_varying_bit_matrix` has a performance improvement opportunity during the decomposition process. The overall `Union All` query sees a 1.23x speed up from 8.93s to 7.28s on the Multi-A100 GPU system.

The `UnionExec::final_round_evaluate` takes 2.55s on the Multi-A100 VM with a table size of 1,000,000.  The  `compute_varying_bit_matrix` function is called 4 times during this process. The decompose section takes around 478ms each execution, or ~75% of the overall time of the  `UnionExec::final_round_evaluate` .
![image](https://github.com/user-attachments/assets/2699d6c5-71d6-4147-8109-be022b367bc2)

This PR speeds up the decompose process 10x, which gives the `UnionExec::final_round_evaluate` a 2.5x performance improvement. Now, the decompose process takes 46.93ms. 
![image](https://github.com/user-attachments/assets/fb0df768-eca5-4a22-a874-0904973919ae)

The performance improvements come from 3 changes, but the changes introduce memory trade-offs. For a table of size 1,000,000, this change will use approximately 38MB (28MB in the memory logs) of additional, temporary data.
1. Shifting of the masks are also pre-computed to avoid calling `U256::ONE.shl` in the inner loop.
2. The `masks` are now precomputed to avoid a call in the loop.

# What changes are included in this PR?
- Bit and shifted-bit masks are now pre-computed and saved in vectors on the stack.
- A `results` vectors is created to store results in computed using parallelism.

# Are these changes tested?
Yes
