### PR TITLE
fix!: move mles to first round for sort merge join

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -27,10 +27,7 @@ use crate::{
     },
 };
 use alloc::{boxed::Box, vec, vec::Vec};
-use bumpalo::{
-    collections::{CollectIn, Vec as BumpVec},
-    Bump,
-};
+use bumpalo::Bump;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
@@ -165,7 +162,7 @@ where
         let num_columns_res_hat = num_columns_left + num_columns_right - num_columns_u + 2;
         // `\hat{J}` in the protocol
         let res_hat_column_evals =
-            builder.try_consume_final_round_mle_evaluations(num_columns_res_hat)?;
+            builder.try_consume_first_round_mle_evaluations(num_columns_res_hat)?;
         // 5. First round MLE evaluations: `i` and `U`
         //TODO: Make it possible for `U` to have multiple columns
         let rho_bar_left_eval = res_hat_column_evals[num_columns_left];
@@ -334,7 +331,7 @@ impl ProverEvaluate for SortMergeJoinExec {
                 .copied()
                 .unzip();
         // `\hat{J}` in the protocol
-        let res_hat = apply_sort_merge_join_indexes(
+        let raw_res_hat = apply_sort_merge_join_indexes(
             &left_hat,
             &right_hat,
             &self.left_join_column_indexes,
@@ -344,6 +341,10 @@ impl ProverEvaluate for SortMergeJoinExec {
             alloc,
         )
         .expect("Can not do sort merge join");
+        let res_hat = alloc.alloc_slice_copy(raw_res_hat.as_slice());
+        for column in res_hat {
+            builder.produce_intermediate_mle(*column);
+        }
         let num_rows_res = left_row_indexes.len();
         // 2. Get and commit the strictly increasing columns, `U`
         // ordered set union `U`
@@ -380,11 +381,11 @@ impl ProverEvaluate for SortMergeJoinExec {
         let hat_right_columns = get_columns_of_table(&right_hat, &hat_right_column_indexes)
             .expect("Indexes can not be out of bounds");
         // `J_l` in the protocol
-        let res_left_columns = res_hat[0..=num_columns_left].to_vec();
+        let res_left_columns = raw_res_hat[0..=num_columns_left].to_vec();
         // `J_r` in the protocol
-        let res_right_columns: Vec<_> = res_hat[0..num_columns_u]
+        let res_right_columns: Vec<_> = raw_res_hat[0..num_columns_u]
             .iter()
-            .chain(&res_hat[num_columns_left + 1..])
+            .chain(&raw_res_hat[num_columns_left + 1..])
             .copied()
             .collect();
         first_round_evaluate_membership_check(builder, alloc, &hat_left_columns, &res_left_columns);
@@ -406,7 +407,7 @@ impl ProverEvaluate for SortMergeJoinExec {
         let res_column_indexes = (0..num_columns_left)
             .chain(num_columns_left + 1..num_columns_left + 1 + num_columns_right - num_columns_u)
             .collect::<Vec<_>>();
-        let res_columns = apply_slice_to_indexes(&res_hat, &res_column_indexes)
+        let res_columns = apply_slice_to_indexes(&raw_res_hat, &res_column_indexes)
             .expect("Indexes can not be out of bounds");
         let tab = Table::try_from_iter_with_options(
             self.result_idents.iter().cloned().zip_eq(res_columns),
@@ -503,14 +504,7 @@ impl ProverEvaluate for SortMergeJoinExec {
         let alpha = builder.consume_post_result_challenge();
         let beta = builder.consume_post_result_challenge();
 
-        // 4. Produce MLEs for `res_hat`
-        // We can reference `res_hat` safely because it's bump-allocated.
-        let alloc_res_hat = res_hat.iter().collect_in::<BumpVec<_>>(alloc);
-        for column in &alloc_res_hat {
-            builder.produce_intermediate_mle(*column);
-        }
-
-        // 5. Membership checks
+        // 4. Membership checks
         let hat_left_column_indexes = self
             .left_join_column_indexes
             .iter()


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
