### PR TITLE
chore: remove-small-clippy-expects

### DIFF
--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -63,12 +63,11 @@ mod time_unit_tests {
     use chrono::{TimeZone, Utc};
 
     #[test]
-    #[expect(clippy::unnecessary_fallible_conversions)]
     fn test_u64_conversion() {
-        assert_eq!(PoSQLTimeUnit::Second.try_into(), Ok(0));
-        assert_eq!(PoSQLTimeUnit::Millisecond.try_into(), Ok(3));
-        assert_eq!(PoSQLTimeUnit::Microsecond.try_into(), Ok(6));
-        assert_eq!(PoSQLTimeUnit::Nanosecond.try_into(), Ok(9));
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
     }
 
     #[test]

--- a/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
+++ b/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
@@ -4,7 +4,6 @@ use std::ops::ControlFlow;
 /// Returns an uppercased version of Ident
 /// Leaving this as public because the sdk also uses this function
 #[must_use]
-#[expect(clippy::needless_pass_by_value)]
 pub fn uppercase_identifier(ident: Ident) -> Ident {
     let value = ident.value.to_uppercase();
     Ident { value, ..ident }

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -141,9 +141,8 @@ impl<'a> QueryContextBuilder<'a> {
         Ok(self)
     }
 
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn build(self) -> ConversionResult<QueryContext> {
-        Ok(self.context)
+    pub fn build(self) -> QueryContext {
+        self.context
     }
 }
 

--- a/crates/proof-of-sql/src/sql/parse/query_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr.rs
@@ -64,7 +64,7 @@ impl QueryExpr {
                 .visit_where_expr(where_expr)?
                 .visit_order_by_exprs(ast.order_by.into_iter().map(Into::into).collect())?
                 .visit_slice_expr(ast.slice)
-                .build()?,
+                .build(),
         };
         let result_aliased_exprs = context.get_aliased_result_exprs()?.to_vec();
         let group_by = context.get_group_by_exprs();

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -421,7 +421,7 @@ impl ProverEvaluate for SortMergeJoinExec {
         level = "debug",
         skip_all
     )]
-    #[expect(clippy::too_many_lines, unused_variables)]
+    #[expect(clippy::too_many_lines)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
@@ -495,7 +495,6 @@ impl ProverEvaluate for SortMergeJoinExec {
         );
         let u_0 = u[0].to_scalar();
         let num_rows_u = u[0].len();
-        let alloc_u_0 = alloc.alloc_slice_copy(u_0.as_slice());
         let chi_u = alloc.alloc_slice_fill_copy(num_rows_u, true);
         let alloc_u_0 = alloc.alloc_slice_copy(u_0.as_slice());
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
