### PR TITLE
perf: improve performance of the sign expr module's methods

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
@@ -2,6 +2,7 @@ use crate::base::scalar::ScalarExt;
 use bnum::types::U256;
 use core::ops::Shl;
 
+#[inline]
 pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
     let x_as_u256 = x.into_u256_wrapping();
     if x > S::MAX_SIGNED {
@@ -13,6 +14,7 @@ pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
     }
 }
 
+#[inline]
 pub fn is_bit_mask_negative_representation(bit_mask: U256) -> bool {
     bit_mask & (U256::ONE.shl(255)) == U256::ZERO
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -35,10 +35,9 @@ pub fn first_round_evaluate_sign<'a, S: Scalar>(
     expr: &'a [S],
 ) -> &'a [bool] {
     assert_eq!(table_length, expr.len());
-    let signs = expr
-        .iter()
-        .map(|s| make_bit_mask(*s))
-        .map(is_bit_mask_negative_representation)
+    let signs = if_rayon!(expr.par_iter(), expr.iter())
+        .copied()
+        .map(|val| is_bit_mask_negative_representation(make_bit_mask(val)))
         .collect::<Vec<_>>();
     assert_eq!(table_length, signs.len());
     alloc.alloc_slice_copy(&signs)


### PR DESCRIPTION
# Rationale for this change
The `Union All` query benchmark uncovered a performance improvement opportunity in the `sign_expr` module. On a Multi-A100 VM with a table size of 1,000,000, the `sign_expr` methods in this PR show a 15x speed up, both in the first and final round evaluates. The first round evaluate has gone from 336.7ms to 88.64ms (3.8x boost). The final round evaluate has gone from  823.46ms to 615.53ms (1.34x boost). The `Union All` query improves from 7.11s to 6.88s (1.03x boost).

In the `UnionExec::final_round_evaluate`, `sign_expr` takes 65.91ms.
![image](https://github.com/user-attachments/assets/30273b4e-8045-4657-952a-e355d187bf70)

In this PR, `sign_expr` takes 4.16ms, a 15.8x speed up.
![image](https://github.com/user-attachments/assets/1ed9bd37-6b18-4990-82e3-4c3e45b195be)

`#[inline]` was added to the methods in the `bit_mask_util` to eliminate function call overhead with the newly parallelized method. Without `#[inline]`, performance degradations are seen. The benchmarks indicated a 4.7x regression in the `compute_varying_bit_matix` method. 
![image](https://github.com/user-attachments/assets/95e644d7-ea8d-4dc2-9471-4dfc622a9667)

Adding `#[inline]` increased the `rlib` size by `~2.78KB`.

# What changes are included in this PR?
- Rayon is added to the `sign_expr` module to allow for parallel execution
- `#[inline]` is added to the methods in the `bit_mask_util` module
- Loops are reworked to avoid creating intermediate iterators

# Are these changes tested?
Yes