### PR TITLE
refactor: filter base gadget

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -10,7 +10,7 @@ use ark_ff::{One, Zero};
 use bumpalo::Bump;
 
 #[expect(clippy::similar_names)]
-pub(crate) fn verify_filter<S: Scalar>(
+pub(crate) fn verify_evaluate_filter<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
     c_fold_eval: S,
     d_fold_eval: S,
@@ -59,7 +59,7 @@ pub(crate) fn verify_filter<S: Scalar>(
 /// `m = output_length`
 #[expect(clippy::too_many_arguments)]
 #[tracing::instrument(level = "debug", skip_all)]
-pub(crate) fn prove_filter<'a, S: Scalar + 'a>(
+pub(crate) fn final_round_evaluate_filter<'a, S: Scalar + 'a>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     alpha: S,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -29,7 +29,7 @@ pub(crate) fn verify_evaluate_filter<S: Scalar>(
     let filtered_columns_evals =
         builder.try_consume_final_round_mle_evaluations(column_evals.len())?;
     assert_eq!(column_evals.len(), filtered_columns_evals.len());
-    let chi_m_eval = builder.try_consume_chi_evaluation()?.0;
+    let output_chi_eval = builder.try_consume_chi_evaluation()?.0;
     let c_fold_eval = alpha * fold_vals(beta, column_evals);
     let d_fold_eval = alpha * fold_vals(beta, &filtered_columns_evals);
     let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;
@@ -52,20 +52,20 @@ pub(crate) fn verify_evaluate_filter<S: Scalar>(
     // d_star + d_fold * d_star - chi_m = 0
     builder.try_produce_sumcheck_subpolynomial_evaluation(
         SumcheckSubpolynomialType::Identity,
-        d_star_eval + d_fold_eval * d_star_eval - chi_m_eval,
+        d_star_eval + d_fold_eval * d_star_eval - output_chi_eval,
         2,
     )?;
 
     // d_fold * chi_m - d_fold = 0
     builder.try_produce_sumcheck_subpolynomial_evaluation(
         SumcheckSubpolynomialType::Identity,
-        d_fold_eval * (chi_m_eval - S::ONE),
+        d_fold_eval * (output_chi_eval - S::ONE),
         2,
     )?;
 
     Ok(TableEvaluation::new(
-        filtered_columns_evals.to_vec(),
-        chi_m_eval,
+        filtered_columns_evals,
+        output_chi_eval,
     ))
 }
 

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -2,7 +2,7 @@ use crate::{
     base::{database::Column, proof::ProofError, scalar::Scalar, slice_ops},
     sql::{
         proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
-        proof_plans::fold_columns,
+        proof_plans::{fold_columns, fold_vals},
     },
 };
 use alloc::{boxed::Box, vec};
@@ -12,12 +12,16 @@ use bumpalo::Bump;
 #[expect(clippy::similar_names)]
 pub(crate) fn verify_evaluate_filter<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
-    c_fold_eval: S,
-    d_fold_eval: S,
+    alpha: S,
+    beta: S,
+    column_evals: &[S],
+    filtered_columns_evals: &[S],
     chi_n_eval: S,
     chi_m_eval: S,
     s_eval: S,
 ) -> Result<(), ProofError> {
+    let c_fold_eval = alpha * fold_vals(beta, column_evals);
+    let d_fold_eval = alpha * fold_vals(beta, filtered_columns_evals);
     let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;
     let d_star_eval = builder.try_consume_final_round_mle_evaluation()?;
 

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -89,12 +89,35 @@ pub(crate) fn final_round_evaluate_filter<'a, S: Scalar + 'a>(
     builder.produce_intermediate_mle(c_star as &[_]);
     builder.produce_intermediate_mle(d_star as &[_]);
 
+    final_round_filter_constraints(
+        builder,
+        c_star as &[_],
+        d_star as &[_],
+        s,
+        c_fold as &[_],
+        d_fold as &[_],
+        chi_n,
+        chi_m,
+    );
+}
+
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn final_round_filter_constraints<'a, S: Scalar + 'a>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    c_star: &'a [S],
+    d_star: &'a [S],
+    selection: &'a [bool],
+    c_fold: &'a [S],
+    d_fold: &'a [S],
+    input_chi: &'a [bool],
+    output_chi: &'a [bool],
+) {
     // sum c_star * s - d_star = 0
     builder.produce_sumcheck_subpolynomial(
         SumcheckSubpolynomialType::ZeroSum,
         vec![
-            (S::one(), vec![Box::new(c_star as &[_]), Box::new(s)]),
-            (-S::one(), vec![Box::new(d_star as &[_])]),
+            (S::one(), vec![Box::new(c_star), Box::new(selection)]),
+            (-S::one(), vec![Box::new(d_star)]),
         ],
     );
 
@@ -102,12 +125,9 @@ pub(crate) fn final_round_evaluate_filter<'a, S: Scalar + 'a>(
     builder.produce_sumcheck_subpolynomial(
         SumcheckSubpolynomialType::Identity,
         vec![
-            (S::one(), vec![Box::new(c_star as &[_])]),
-            (
-                S::one(),
-                vec![Box::new(c_star as &[_]), Box::new(c_fold as &[_])],
-            ),
-            (-S::one(), vec![Box::new(chi_n as &[_])]),
+            (S::one(), vec![Box::new(c_star)]),
+            (S::one(), vec![Box::new(c_star), Box::new(c_fold)]),
+            (-S::one(), vec![Box::new(input_chi)]),
         ],
     );
 
@@ -115,12 +135,9 @@ pub(crate) fn final_round_evaluate_filter<'a, S: Scalar + 'a>(
     builder.produce_sumcheck_subpolynomial(
         SumcheckSubpolynomialType::Identity,
         vec![
-            (S::one(), vec![Box::new(d_star as &[_])]),
-            (
-                S::one(),
-                vec![Box::new(d_star as &[_]), Box::new(d_fold as &[_])],
-            ),
-            (-S::one(), vec![Box::new(chi_m as &[_])]),
+            (S::one(), vec![Box::new(d_star)]),
+            (S::one(), vec![Box::new(d_star), Box::new(d_fold)]),
+            (-S::one(), vec![Box::new(output_chi)]),
         ],
     );
 
@@ -128,11 +145,8 @@ pub(crate) fn final_round_evaluate_filter<'a, S: Scalar + 'a>(
     builder.produce_sumcheck_subpolynomial(
         SumcheckSubpolynomialType::Identity,
         vec![
-            (
-                S::one(),
-                vec![Box::new(d_fold as &[_]), Box::new(chi_m as &[_])],
-            ),
-            (-S::one(), vec![Box::new(d_fold as &[_])]),
+            (S::one(), vec![Box::new(d_fold), Box::new(output_chi)]),
+            (-S::one(), vec![Box::new(d_fold)]),
         ],
     );
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -15,6 +15,7 @@ use crate::{
 use alloc::{boxed::Box, vec};
 use ark_ff::{One, Zero};
 use bumpalo::Bump;
+use sqlparser::ast::Ident;
 
 #[expect(clippy::similar_names)]
 pub(crate) fn verify_evaluate_filter<S: Scalar>(
@@ -70,6 +71,8 @@ pub(crate) fn verify_evaluate_filter<S: Scalar>(
 pub(crate) fn first_round_evaluate_filter<S: Scalar>(
     builder: &mut FirstRoundBuilder<S>,
     output_length: usize,
+    _output_idents: Vec<Ident>,
+    _filtered_columns: &[Column<S>],
 ) {
     builder.produce_chi_evaluation_length(output_length);
 }
@@ -87,6 +90,7 @@ pub(crate) fn final_round_evaluate_filter<'a, S: Scalar + 'a>(
     alpha: S,
     beta: S,
     columns: &[Column<S>],
+    _output_idents: Vec<Ident>,
     s: &'a [bool],
     filtered_columns: &[Column<S>],
     input_length: usize,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -1,7 +1,13 @@
 use crate::{
-    base::{proof::ProofError, scalar::Scalar},
-    sql::proof::{SumcheckSubpolynomialType, VerificationBuilder},
+    base::{database::Column, proof::ProofError, scalar::Scalar, slice_ops},
+    sql::{
+        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        proof_plans::fold_columns,
+    },
 };
+use alloc::{boxed::Box, vec};
+use ark_ff::{One, Zero};
+use bumpalo::Bump;
 
 #[expect(clippy::similar_names)]
 pub(crate) fn verify_filter<S: Scalar>(
@@ -44,4 +50,89 @@ pub(crate) fn verify_filter<S: Scalar>(
     )?;
 
     Ok(())
+}
+
+/// Below are the mappings between the names of the parameters in the math and the code
+/// `c = columns`
+/// `d = filtered_columns`
+/// `n = input_length`
+/// `m = output_length`
+#[expect(clippy::too_many_arguments)]
+#[tracing::instrument(level = "debug", skip_all)]
+pub(crate) fn prove_filter<'a, S: Scalar + 'a>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    columns: &[Column<S>],
+    s: &'a [bool],
+    filtered_columns: &[Column<S>],
+    input_length: usize,
+    output_length: usize,
+) {
+    let chi_n = alloc.alloc_slice_fill_copy(input_length, true);
+    let chi_m = alloc.alloc_slice_fill_copy(output_length, true);
+
+    let c_fold = alloc.alloc_slice_fill_copy(input_length, Zero::zero());
+    fold_columns(c_fold, alpha, beta, columns);
+    let d_fold = alloc.alloc_slice_fill_copy(output_length, Zero::zero());
+    fold_columns(d_fold, alpha, beta, filtered_columns);
+
+    let c_star = alloc.alloc_slice_copy(c_fold);
+    slice_ops::add_const::<S, S>(c_star, One::one());
+    slice_ops::batch_inversion(c_star);
+
+    let d_star = alloc.alloc_slice_copy(d_fold);
+    slice_ops::add_const::<S, S>(d_star, One::one());
+    slice_ops::batch_inversion(d_star);
+
+    builder.produce_intermediate_mle(c_star as &[_]);
+    builder.produce_intermediate_mle(d_star as &[_]);
+
+    // sum c_star * s - d_star = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::ZeroSum,
+        vec![
+            (S::one(), vec![Box::new(c_star as &[_]), Box::new(s)]),
+            (-S::one(), vec![Box::new(d_star as &[_])]),
+        ],
+    );
+
+    // c_star + c_fold * c_star - chi_n = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (S::one(), vec![Box::new(c_star as &[_])]),
+            (
+                S::one(),
+                vec![Box::new(c_star as &[_]), Box::new(c_fold as &[_])],
+            ),
+            (-S::one(), vec![Box::new(chi_n as &[_])]),
+        ],
+    );
+
+    // d_star + d_fold * d_star - chi_m = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (S::one(), vec![Box::new(d_star as &[_])]),
+            (
+                S::one(),
+                vec![Box::new(d_star as &[_]), Box::new(d_fold as &[_])],
+            ),
+            (-S::one(), vec![Box::new(chi_m as &[_])]),
+        ],
+    );
+
+    // d_fold * chi_m - d_fold = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (
+                S::one(),
+                vec![Box::new(d_fold as &[_]), Box::new(chi_m as &[_])],
+            ),
+            (-S::one(), vec![Box::new(d_fold as &[_])]),
+        ],
+    );
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -1,0 +1,47 @@
+use crate::{
+    base::{proof::ProofError, scalar::Scalar},
+    sql::proof::{SumcheckSubpolynomialType, VerificationBuilder},
+};
+
+#[expect(clippy::similar_names)]
+pub(crate) fn verify_filter<S: Scalar>(
+    builder: &mut impl VerificationBuilder<S>,
+    c_fold_eval: S,
+    d_fold_eval: S,
+    chi_n_eval: S,
+    chi_m_eval: S,
+    s_eval: S,
+) -> Result<(), ProofError> {
+    let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;
+    let d_star_eval = builder.try_consume_final_round_mle_evaluation()?;
+
+    // sum c_star * s - d_star = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::ZeroSum,
+        c_star_eval * s_eval - d_star_eval,
+        2,
+    )?;
+
+    // c_star + c_fold * c_star - chi_n = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        c_star_eval + c_fold_eval * c_star_eval - chi_n_eval,
+        2,
+    )?;
+
+    // d_star + d_fold * d_star - chi_m = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        d_star_eval + d_fold_eval * d_star_eval - chi_m_eval,
+        2,
+    )?;
+
+    // d_fold * chi_m - d_fold = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        d_fold_eval * (chi_m_eval - S::ONE),
+        2,
+    )?;
+
+    Ok(())
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,7 +1,8 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
 #[cfg(test)]
 mod divide_and_modulo_expr;
-pub(crate) mod filter_base;
+mod filter_base;
+pub(crate) use filter_base::{final_round_evaluate_filter, verify_evaluate_filter};
 mod membership_check;
 mod monotonic;
 #[cfg_attr(not(test), expect(dead_code))]

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
 #[cfg(test)]
 mod divide_and_modulo_expr;
+pub(crate) mod filter_base;
 mod membership_check;
 mod monotonic;
 #[cfg_attr(not(test), expect(dead_code))]

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -4,7 +4,9 @@ mod divide_and_modulo_expr;
 mod filter_base;
 #[cfg(test)]
 pub(crate) use filter_base::final_round_filter_constraints;
-pub(crate) use filter_base::{final_round_evaluate_filter, verify_evaluate_filter};
+pub(crate) use filter_base::{
+    final_round_evaluate_filter, first_round_evaluate_filter, verify_evaluate_filter,
+};
 mod membership_check;
 mod monotonic;
 #[cfg_attr(not(test), expect(dead_code))]

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -2,6 +2,8 @@
 #[cfg(test)]
 mod divide_and_modulo_expr;
 mod filter_base;
+#[cfg(test)]
+pub(crate) use filter_base::final_round_filter_constraints;
 pub(crate) use filter_base::{final_round_evaluate_filter, verify_evaluate_filter};
 mod membership_check;
 mod monotonic;

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -1,4 +1,3 @@
-use super::fold_vals;
 use crate::{
     base::{
         database::{
@@ -118,13 +117,12 @@ where
 
         let output_chi_eval = builder.try_consume_chi_evaluation()?.0;
 
-        let c_fold_eval = alpha * fold_vals(beta, &columns_evals);
-        let d_fold_eval = alpha * fold_vals(beta, &filtered_columns_evals);
-
         verify_evaluate_filter(
             builder,
-            c_fold_eval,
-            d_fold_eval,
+            alpha,
+            beta,
+            &columns_evals,
+            &filtered_columns_evals,
             input_chi_eval.0,
             output_chi_eval,
             selection_eval,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -183,7 +183,6 @@ impl ProverEvaluate for FilterExec {
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
-        let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
         let columns: Vec<_> = self
@@ -196,14 +195,14 @@ impl ProverEvaluate for FilterExec {
 
         builder.request_post_result_challenges(2);
         // Compute filtered_columns and indexes
-        let (filtered_columns, _) = filter_columns(alloc, &columns, selection);
-        builder.produce_chi_evaluation_length(output_length);
+        let (filtered_columns, result_len) = filter_columns(alloc, &columns, selection);
+        builder.produce_chi_evaluation_length(result_len);
         let res = Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results
                 .iter()
                 .map(|expr| expr.alias.clone())
                 .zip(filtered_columns),
-            TableOptions::new(Some(output_length)),
+            TableOptions::new(Some(result_len)),
         )
         .expect("Failed to create table from iterator");
 
@@ -250,7 +249,6 @@ impl ProverEvaluate for FilterExec {
         filtered_columns.iter().copied().for_each(|column| {
             builder.produce_intermediate_mle(column);
         });
-        let output_length = selection.iter().filter(|b| **b).count();
 
         final_round_evaluate_filter::<S>(
             builder,
@@ -268,7 +266,7 @@ impl ProverEvaluate for FilterExec {
                 .iter()
                 .map(|expr| expr.alias.clone())
                 .zip(filtered_columns),
-            TableOptions::new(Some(output_length)),
+            TableOptions::new(Some(result_len)),
         )
         .expect("Failed to create table from iterator");
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -15,7 +15,7 @@ use crate::{
             ProverHonestyMarker, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
-        proof_gadgets::filter_base::{final_round_evaluate_filter, verify_evaluate_filter},
+        proof_gadgets::{final_round_evaluate_filter, verify_evaluate_filter},
     },
     utils::log,
 };

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -1,4 +1,4 @@
-use super::{fold_columns, fold_vals};
+use super::fold_vals;
 use crate::{
     base::{
         database::{
@@ -8,22 +8,20 @@ use crate::{
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
-        slice_ops,
     },
     sql::{
         proof::{
             FinalRoundBuilder, FirstRoundBuilder, HonestProver, ProofPlan, ProverEvaluate,
-            ProverHonestyMarker, SumcheckSubpolynomialType, VerificationBuilder,
+            ProverHonestyMarker, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
-        proof_gadgets::filter_base::verify_filter,
+        proof_gadgets::filter_base::{prove_filter, verify_filter},
     },
     utils::log,
 };
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::vec::Vec;
 use bumpalo::Bump;
 use core::marker::PhantomData;
-use num_traits::{One, Zero};
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -281,89 +279,4 @@ impl ProverEvaluate for FilterExec {
 
         Ok(res)
     }
-}
-
-/// Below are the mappings between the names of the parameters in the math and the code
-/// `c = columns`
-/// `d = filtered_columns`
-/// `n = input_length`
-/// `m = output_length`
-#[expect(clippy::too_many_arguments)]
-#[tracing::instrument(level = "debug", skip_all)]
-pub(super) fn prove_filter<'a, S: Scalar + 'a>(
-    builder: &mut FinalRoundBuilder<'a, S>,
-    alloc: &'a Bump,
-    alpha: S,
-    beta: S,
-    columns: &[Column<S>],
-    s: &'a [bool],
-    filtered_columns: &[Column<S>],
-    input_length: usize,
-    output_length: usize,
-) {
-    let chi_n = alloc.alloc_slice_fill_copy(input_length, true);
-    let chi_m = alloc.alloc_slice_fill_copy(output_length, true);
-
-    let c_fold = alloc.alloc_slice_fill_copy(input_length, Zero::zero());
-    fold_columns(c_fold, alpha, beta, columns);
-    let d_fold = alloc.alloc_slice_fill_copy(output_length, Zero::zero());
-    fold_columns(d_fold, alpha, beta, filtered_columns);
-
-    let c_star = alloc.alloc_slice_copy(c_fold);
-    slice_ops::add_const::<S, S>(c_star, One::one());
-    slice_ops::batch_inversion(c_star);
-
-    let d_star = alloc.alloc_slice_copy(d_fold);
-    slice_ops::add_const::<S, S>(d_star, One::one());
-    slice_ops::batch_inversion(d_star);
-
-    builder.produce_intermediate_mle(c_star as &[_]);
-    builder.produce_intermediate_mle(d_star as &[_]);
-
-    // sum c_star * s - d_star = 0
-    builder.produce_sumcheck_subpolynomial(
-        SumcheckSubpolynomialType::ZeroSum,
-        vec![
-            (S::one(), vec![Box::new(c_star as &[_]), Box::new(s)]),
-            (-S::one(), vec![Box::new(d_star as &[_])]),
-        ],
-    );
-
-    // c_star + c_fold * c_star - chi_n = 0
-    builder.produce_sumcheck_subpolynomial(
-        SumcheckSubpolynomialType::Identity,
-        vec![
-            (S::one(), vec![Box::new(c_star as &[_])]),
-            (
-                S::one(),
-                vec![Box::new(c_star as &[_]), Box::new(c_fold as &[_])],
-            ),
-            (-S::one(), vec![Box::new(chi_n as &[_])]),
-        ],
-    );
-
-    // d_star + d_fold * d_star - chi_m = 0
-    builder.produce_sumcheck_subpolynomial(
-        SumcheckSubpolynomialType::Identity,
-        vec![
-            (S::one(), vec![Box::new(d_star as &[_])]),
-            (
-                S::one(),
-                vec![Box::new(d_star as &[_]), Box::new(d_fold as &[_])],
-            ),
-            (-S::one(), vec![Box::new(chi_m as &[_])]),
-        ],
-    );
-
-    // d_fold * chi_m - d_fold = 0
-    builder.produce_sumcheck_subpolynomial(
-        SumcheckSubpolynomialType::Identity,
-        vec![
-            (
-                S::one(),
-                vec![Box::new(d_fold as &[_]), Box::new(chi_m as &[_])],
-            ),
-            (-S::one(), vec![Box::new(d_fold as &[_])]),
-        ],
-    );
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -15,7 +15,7 @@ use crate::{
             ProverHonestyMarker, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
-        proof_gadgets::filter_base::{prove_filter, verify_filter},
+        proof_gadgets::filter_base::{final_round_evaluate_filter, verify_evaluate_filter},
     },
     utils::log,
 };
@@ -121,7 +121,7 @@ where
         let c_fold_eval = alpha * fold_vals(beta, &columns_evals);
         let d_fold_eval = alpha * fold_vals(beta, &filtered_columns_evals);
 
-        verify_filter(
+        verify_evaluate_filter(
             builder,
             c_fold_eval,
             d_fold_eval,
@@ -255,7 +255,7 @@ impl ProverEvaluate for FilterExec {
             builder.produce_intermediate_mle(column);
         });
 
-        prove_filter::<S>(
+        final_round_evaluate_filter::<S>(
             builder,
             alloc,
             alpha,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -16,6 +16,7 @@ use crate::{
             ProverHonestyMarker, SumcheckSubpolynomialType, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
+        proof_gadgets::filter_base::verify_filter,
     },
     utils::log,
 };
@@ -280,49 +281,6 @@ impl ProverEvaluate for FilterExec {
 
         Ok(res)
     }
-}
-
-#[expect(clippy::similar_names)]
-pub(super) fn verify_filter<S: Scalar>(
-    builder: &mut impl VerificationBuilder<S>,
-    c_fold_eval: S,
-    d_fold_eval: S,
-    chi_n_eval: S,
-    chi_m_eval: S,
-    s_eval: S,
-) -> Result<(), ProofError> {
-    let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;
-    let d_star_eval = builder.try_consume_final_round_mle_evaluation()?;
-
-    // sum c_star * s - d_star = 0
-    builder.try_produce_sumcheck_subpolynomial_evaluation(
-        SumcheckSubpolynomialType::ZeroSum,
-        c_star_eval * s_eval - d_star_eval,
-        2,
-    )?;
-
-    // c_star + c_fold * c_star - chi_n = 0
-    builder.try_produce_sumcheck_subpolynomial_evaluation(
-        SumcheckSubpolynomialType::Identity,
-        c_star_eval + c_fold_eval * c_star_eval - chi_n_eval,
-        2,
-    )?;
-
-    // d_star + d_fold * d_star - chi_m = 0
-    builder.try_produce_sumcheck_subpolynomial_evaluation(
-        SumcheckSubpolynomialType::Identity,
-        d_star_eval + d_fold_eval * d_star_eval - chi_m_eval,
-        2,
-    )?;
-
-    // d_fold * chi_m - d_fold = 0
-    builder.try_produce_sumcheck_subpolynomial_evaluation(
-        SumcheckSubpolynomialType::Identity,
-        d_fold_eval * (chi_m_eval - S::ONE),
-        2,
-    )?;
-
-    Ok(())
 }
 
 /// Below are the mappings between the names of the parameters in the math and the code

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -199,6 +199,7 @@ impl ProverEvaluate for FilterExec {
         builder.request_post_result_challenges(2);
         // Compute filtered_columns and indexes
         let (filtered_columns, _) = filter_columns(alloc, &columns, selection);
+        builder.produce_chi_evaluation_length(output_length);
         let res = Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results
                 .iter()
@@ -207,7 +208,6 @@ impl ProverEvaluate for FilterExec {
             TableOptions::new(Some(output_length)),
         )
         .expect("Failed to create table from iterator");
-        builder.produce_chi_evaluation_length(output_length);
 
         log::log_memory_usage("End");
 
@@ -233,7 +233,6 @@ impl ProverEvaluate for FilterExec {
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
-        let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
         let columns: Vec<_> = self
@@ -253,6 +252,7 @@ impl ProverEvaluate for FilterExec {
         filtered_columns.iter().copied().for_each(|column| {
             builder.produce_intermediate_mle(column);
         });
+        let output_length = selection.iter().filter(|b| **b).count();
 
         final_round_evaluate_filter::<S>(
             builder,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -18,7 +18,7 @@ use crate::{
             test_utility::{cols_expr_plan, column, const_int128, equal, tab},
             ProofExpr,
         },
-        proof_gadgets::filter_base::prove_filter,
+        proof_gadgets::filter_base::final_round_evaluate_filter,
     },
     utils::log,
 };
@@ -129,7 +129,7 @@ impl ProverEvaluate for DishonestFilterExec {
         let alpha = builder.consume_post_result_challenge();
         let beta = builder.consume_post_result_challenge();
 
-        prove_filter(
+        final_round_evaluate_filter(
             builder,
             alloc,
             alpha,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -1,4 +1,4 @@
-use super::{filter_exec::prove_filter, OstensibleFilterExec};
+use super::OstensibleFilterExec;
 use crate::{
     base::{
         database::{
@@ -18,6 +18,7 @@ use crate::{
             test_utility::{cols_expr_plan, column, const_int128, equal, tab},
             ProofExpr,
         },
+        proof_gadgets::filter_base::prove_filter,
     },
     utils::log,
 };

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -18,7 +18,7 @@ use crate::{
             test_utility::{cols_expr_plan, column, const_int128, equal, tab},
             ProofExpr,
         },
-        proof_gadgets::filter_base::final_round_evaluate_filter,
+        proof_gadgets::final_round_evaluate_filter,
     },
     utils::log,
 };

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -1,7 +1,4 @@
-use super::{
-    filter_exec::{prove_filter, verify_filter},
-    DynProofPlan,
-};
+use super::{filter_exec::prove_filter, DynProofPlan};
 use crate::{
     base::{
         database::{
@@ -16,6 +13,7 @@ use crate::{
         proof::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
+        proof_gadgets::filter_base::verify_filter,
         proof_plans::fold_vals,
     },
     utils::log,

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -1,4 +1,4 @@
-use super::{filter_exec::prove_filter, DynProofPlan};
+use super::DynProofPlan;
 use crate::{
     base::{
         database::{
@@ -13,7 +13,7 @@ use crate::{
         proof::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
-        proof_gadgets::filter_base::verify_filter,
+        proof_gadgets::filter_base::{prove_filter, verify_filter},
         proof_plans::fold_vals,
     },
     utils::log,

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -14,7 +14,6 @@ use crate::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
         proof_gadgets::{final_round_evaluate_filter, verify_evaluate_filter},
-        proof_plans::fold_vals,
     },
     utils::log,
 };
@@ -96,13 +95,12 @@ where
             builder.try_consume_final_round_mle_evaluations(columns_evals.len())?;
         let output_chi_eval = builder.try_consume_chi_evaluation()?.0;
 
-        let c_fold_eval = alpha * fold_vals(beta, columns_evals);
-        let d_fold_eval = alpha * fold_vals(beta, &filtered_columns_evals);
-
         verify_evaluate_filter(
             builder,
-            c_fold_eval,
-            d_fold_eval,
+            alpha,
+            beta,
+            &columns_evals,
+            &filtered_columns_evals,
             input_table_eval.chi_eval(),
             output_chi_eval,
             selection_eval,

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -13,7 +13,9 @@ use crate::{
         proof::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
-        proof_gadgets::{final_round_evaluate_filter, verify_evaluate_filter},
+        proof_gadgets::{
+            final_round_evaluate_filter, first_round_evaluate_filter, verify_evaluate_filter,
+        },
     },
     utils::log,
 };
@@ -93,7 +95,6 @@ where
         // 3. filtered_columns
         let filtered_columns_evals =
             builder.try_consume_final_round_mle_evaluations(columns_evals.len())?;
-        let output_chi_eval = builder.try_consume_chi_evaluation()?.0;
 
         verify_evaluate_filter(
             builder,
@@ -102,13 +103,8 @@ where
             &columns_evals,
             &filtered_columns_evals,
             input_table_eval.chi_eval(),
-            output_chi_eval,
             selection_eval,
-        )?;
-        Ok(TableEvaluation::new(
-            filtered_columns_evals,
-            output_chi_eval,
-        ))
+        )
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
@@ -155,7 +151,7 @@ impl ProverEvaluate for SliceExec {
         builder.request_post_result_challenges(2);
         // Compute filtered_columns
         let (filtered_columns, result_len) = filter_columns(alloc, &columns, &select);
-        builder.produce_chi_evaluation_length(result_len);
+        first_round_evaluate_filter(builder, result_len);
         let res = Table::<'a, S>::try_from_iter_with_options(
             self.get_column_result_fields()
                 .into_iter()

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -13,7 +13,7 @@ use crate::{
         proof::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
-        proof_gadgets::filter_base::{final_round_evaluate_filter, verify_evaluate_filter},
+        proof_gadgets::{final_round_evaluate_filter, verify_evaluate_filter},
         proof_plans::fold_vals,
     },
     utils::log,

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -13,7 +13,7 @@ use crate::{
         proof::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
-        proof_gadgets::filter_base::{prove_filter, verify_filter},
+        proof_gadgets::filter_base::{final_round_evaluate_filter, verify_evaluate_filter},
         proof_plans::fold_vals,
     },
     utils::log,
@@ -99,7 +99,7 @@ where
         let c_fold_eval = alpha * fold_vals(beta, columns_evals);
         let d_fold_eval = alpha * fold_vals(beta, &filtered_columns_evals);
 
-        verify_filter(
+        verify_evaluate_filter(
             builder,
             c_fold_eval,
             d_fold_eval,
@@ -201,7 +201,7 @@ impl ProverEvaluate for SliceExec {
         let alpha = builder.consume_post_result_challenge();
         let beta = builder.consume_post_result_challenge();
 
-        prove_filter::<S>(
+        final_round_evaluate_filter::<S>(
             builder,
             alloc,
             alpha,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
