### PR TITLE
test: add group by EVM integration test

### DIFF
--- a/crates/proof-of-sql-planner/tests/evm_tests.rs
+++ b/crates/proof-of-sql-planner/tests/evm_tests.rs
@@ -609,3 +609,41 @@ fn we_can_verify_a_empty_exec_using_the_evm() {
 
     assert!(evm_verifier_all(plan, "[]", &verifiable_result, &accessor));
 }
+
+#[ignore = "This test requires the forge binary to be present"]
+#[test]
+#[expect(clippy::missing_panics_doc)]
+fn we_can_verify_a_groupby_query_using_the_evm() {
+    let (ps, vk) = load_small_setup_for_testing();
+
+    let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
+        TableRef::new("namespace", "table"),
+        owned_table([
+            bigint("a", [5, 3, 2, 5, 3]),
+            bigint("b", [0, 1, 2, 3, 4]),
+            bigint("c", [0, 2, 2, 1, 2]),
+        ]),
+        0,
+        &ps[..],
+    );
+    let statements = Parser::parse_sql(
+        &GenericDialect {},
+        "SELECT a, sum(b) as sum_b, count(1) as count_0 FROM namespace.table WHERE c = 2 GROUP BY a",
+    )
+    .unwrap();
+    let plan = &sql_to_proof_plans(&statements, &accessor, &ConfigOptions::default()).unwrap()[0];
+    let verifiable_result = VerifiableQueryResult::<HyperKZGCommitmentEvaluationProof>::new(
+        &EVMProofPlan::new(plan.clone()),
+        &accessor,
+        &&ps[..],
+        &[],
+    )
+    .unwrap();
+
+    assert!(evm_verifier_all(plan, "[]", &verifiable_result, &accessor));
+
+    verifiable_result
+        .clone()
+        .verify(&EVMProofPlan::new(plan.clone()), &accessor, &&vk, &[])
+        .unwrap();
+}

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -314,7 +314,6 @@ impl EVMSliceExec {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct EVMGroupByExec {
     table_number: usize,
-    total_column_count: usize,
     group_by_exprs: Vec<usize>,
     where_clause: EVMDynProofExpr,
     sum_expr: Vec<EVMDynProofExpr>,
@@ -344,7 +343,6 @@ impl EVMGroupByExec {
                 .get_index_of(&plan.table().table_ref)
                 .ok_or(EVMProofPlanError::TableNotFound)?,
             group_by_exprs: group_by_exprs.clone(),
-            total_column_count: group_by_exprs.len() + plan.sum_expr().len() + 1, // +1 for the count alias
             sum_expr: plan
                 .sum_expr()
                 .iter()
@@ -404,10 +402,6 @@ impl EVMGroupByExec {
             }
         } else {
             return Err(EVMProofPlanError::InvalidOutputColumnName);
-        }
-
-        if self.total_column_count != group_by_exprs.len() + sum_expr.len() + 1 {
-            return Err(EVMProofPlanError::InconsistentGroupByColumnCounts);
         }
 
         Ok(GroupByExec::new(
@@ -776,7 +770,6 @@ mod tests {
             EVMDynProofExpr::Column(_)
         ));
         assert_eq!(evm_group_by_exec.count_alias_name, count_alias);
-        assert_eq!(evm_group_by_exec.total_column_count, 3); // 1 group by + 1 sum + 1 count
         assert!(matches!(
             evm_group_by_exec.where_clause,
             EVMDynProofExpr::Equals(_)
@@ -1077,45 +1070,6 @@ mod tests {
         assert!(matches!(
             result,
             Err(EVMProofPlanError::InvalidOutputColumnName)
-        ));
-    }
-
-    #[test]
-    fn group_by_exec_fails_with_inconsistent_column_counts_into_proof_plan() {
-        let table_ref: TableRef = "namespace.table".parse().unwrap();
-        let ident_a: Ident = "a".into();
-        let ident_b: Ident = "b".into();
-        let sum_alias = "sum_b".to_string();
-        let count_alias = "count".to_string();
-
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
-
-        let evm_group_by_exec = EVMGroupByExec {
-            table_number: 0,
-            group_by_exprs: vec![0],
-            total_column_count: 4, // Wrong count
-            sum_expr: vec![EVMDynProofExpr::Column(EVMColumnExpr::new(1))],
-            count_alias_name: count_alias.clone(),
-            where_clause: EVMDynProofExpr::Equals(EVMEqualsExpr::new(
-                EVMDynProofExpr::Column(EVMColumnExpr::new(0)),
-                EVMDynProofExpr::Literal(EVMLiteralExpr::BigInt(5)),
-            )),
-        };
-        // Try to convert back with inconsistent column counts
-        let result = EVMGroupByExec::try_into_proof_plan(
-            &evm_group_by_exec,
-            &indexset![table_ref.clone()],
-            &indexset![column_ref_a.clone(), column_ref_b.clone()],
-            &indexset![
-                ident_a.value.clone(),
-                sum_alias.clone(),
-                count_alias.clone()
-            ],
-        );
-        assert!(matches!(
-            result,
-            Err(EVMProofPlanError::InconsistentGroupByColumnCounts)
         ));
     }
 }

--- a/solidity/src/proof_plans/GroupByExec.pre.sol
+++ b/solidity/src/proof_plans/GroupByExec.pre.sol
@@ -384,12 +384,13 @@ library GroupByExec {
             ) -> evaluations_ptr, output_chi_eval {
                 // Allocate memory for evaluations
                 {
-                    evaluations_ptr := mload(FREE_PTR)
-                    mstore(evaluations_ptr, add(num_group_by_columns, add(num_sum_columns, 1)))
-                    mstore(
-                        FREE_PTR,
-                        add(evaluations_ptr, mul(add(num_group_by_columns, add(num_sum_columns, 2)), WORD_SIZE))
-                    )
+                    let free_ptr := mload(FREE_PTR)
+                    evaluations_ptr := free_ptr
+                    let num_evals := add(num_group_by_columns, add(num_sum_columns, 1))
+                    mstore(free_ptr, num_evals)
+                    free_ptr := add(free_ptr, WORD_SIZE)
+                    free_ptr := add(free_ptr, mul(num_evals, WORD_SIZE))
+                    mstore(FREE_PTR, free_ptr)
                 }
 
                 output_chi_eval := builder_consume_chi_evaluation(builder_ptr)

--- a/solidity/src/proof_plans/GroupByExec.pre.sol
+++ b/solidity/src/proof_plans/GroupByExec.pre.sol
@@ -269,7 +269,7 @@ library GroupByExec {
             {
                 num_group_by_columns := shr(UINT64_PADDING_BITS, calldataload(plan_ptr))
                 // We can not prove uniqueness for multiple columns yet
-                if iszero(eq(num_group_by_columns, 1)) { err(ERR_UNPROVABLE_GROUP_BY) }
+                if sub(num_group_by_columns, 1) { err(ERR_UNPROVABLE_GROUP_BY) }
                 plan_ptr := add(plan_ptr, UINT64_SIZE)
 
                 // Process group by columns
@@ -436,9 +436,6 @@ library GroupByExec {
                         num_group_by_columns,
                         num_sum_columns
                     )
-                if iszero(eq(add(num_group_by_columns, add(num_sum_columns, 1)), mload(evaluations_ptr))) {
-                    err(ERR_HYPER_KZG_EMPTY_POINT)
-                }
             }
 
             let __planOutOffset

--- a/solidity/src/proof_plans/ProjectionExec.pre.sol
+++ b/solidity/src/proof_plans/ProjectionExec.pre.sol
@@ -119,6 +119,51 @@ library ProjectionExec {
             function builder_get_column_evaluation(builder_ptr, column_num) -> value {
                 revert(0, 0)
             }
+
+            // IMPORT-YUL GroupByExec.pre.sol
+            function compute_g_in_star_eval(plan_ptr, builder_ptr, alpha, beta, input_chi_eval) ->
+                plan_ptr_out,
+                g_in_fold,
+                g_in_star_eval_times_selection_eval,
+                num_group_by_columns
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function compute_sum_in_fold_eval(plan_ptr, builder_ptr, alpha, beta, input_chi_eval) ->
+                plan_ptr_out,
+                sum_in_fold_eval,
+                num_sum_columns
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function compute_g_out_star_eval(
+                builder_ptr, alpha, beta, output_chi_eval, num_group_by_columns, evaluations_ptr
+            ) -> g_out_star_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function compute_sum_out_fold_eval(
+                builder_ptr, alpha, beta, output_chi_eval, num_sum_columns, evaluations_ptr
+            ) -> sum_out_fold_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function read_input_evals(plan_ptr, builder_ptr, alpha, beta) ->
+                plan_ptr_out,
+                partial_dlog_zero_sum_constraint_eval,
+                num_group_by_columns,
+                num_sum_columns
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function read_output_evals(
+                builder_ptr, alpha, beta, partial_dlog_zero_sum_constraint_eval, num_group_by_columns, num_sum_columns
+            ) -> evaluations_ptr, output_chi_eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
             function fold_expr_evals(plan_ptr, builder_ptr, input_chi_eval, beta, column_count) -> plan_ptr_out, fold {
                 revert(0, 0)
@@ -267,54 +312,6 @@ library ProjectionExec {
             }
             // IMPORT-YUL ../proof_gadgets/Monotonic.pre.sol
             function monotonic_verify(builder_ptr, alpha, beta, column_eval, chi_eval, strict, asc) {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function get_and_check_group_by_input_columns(
-                plan_ptr, builder_ptr, alpha, beta, column_count, input_chi_eval
-            ) -> plan_ptr_out, g_star_selected_eval {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function get_and_check_group_by_output_columns(
-                builder_ptr, alpha, beta, column_count, output_chi_eval, evaluations_ptr
-            ) -> g_out_star_eval, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function get_and_check_sum_input_columns(
-                plan_ptr, builder_ptr, input_chi_eval, beta, column_count, g_star_selected_eval
-            ) -> plan_ptr_out, constraint_lhs {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function get_and_check_sum_output_columns(
-                builder_ptr, output_chi_eval, beta, column_count, g_out_star_eval, evaluations_ptr
-            ) -> constraint_rhs, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function build_groupby_zerosum_constraint(
-                plan_ptr,
-                builder_ptr,
-                alpha,
-                beta,
-                input_chi_eval,
-                output_chi_eval,
-                g_star_selected_eval,
-                g_out_star_eval,
-                evaluations_ptr
-            ) -> plan_ptr_out, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function build_groupby_constraints(
-                plan_ptr, builder_ptr, alpha, beta, input_chi_eval, output_chi_eval, evaluations_ptr
-            ) -> plan_ptr_out, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) -> plan_ptr_out, evaluations_ptr {
                 revert(0, 0)
             }
             // IMPORT-YUL GroupByExec.pre.sol

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -244,55 +244,47 @@ library ProofPlan {
                 revert(0, 0)
             }
             // IMPORT-YUL GroupByExec.pre.sol
-            function get_and_check_group_by_input_columns(
-                plan_ptr, builder_ptr, alpha, beta, column_count, input_chi_eval
-            ) -> plan_ptr_out, g_star_selected_eval {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function get_and_check_group_by_output_columns(
-                builder_ptr, alpha, beta, column_count, output_chi_eval, evaluations_ptr
-            ) -> g_out_star_eval, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function get_and_check_sum_input_columns(
-                plan_ptr, builder_ptr, input_chi_eval, beta, column_count, g_star_selected_eval
-            ) -> plan_ptr_out, constraint_lhs {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function get_and_check_sum_output_columns(
-                builder_ptr, output_chi_eval, beta, column_count, g_out_star_eval, evaluations_ptr
-            ) -> constraint_rhs, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function build_groupby_zerosum_constraint(
-                plan_ptr,
-                builder_ptr,
-                alpha,
-                beta,
-                input_chi_eval,
-                output_chi_eval,
-                g_star_selected_eval,
-                g_out_star_eval,
-                evaluations_ptr
-            ) -> plan_ptr_out, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function build_groupby_constraints(
-                plan_ptr, builder_ptr, alpha, beta, input_chi_eval, output_chi_eval, evaluations_ptr
-            ) -> plan_ptr_out, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL GroupByExec.pre.sol
-            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) ->
+            function compute_g_in_star_eval(plan_ptr, builder_ptr, alpha, beta, input_chi_eval) ->
                 plan_ptr_out,
-                evaluations_ptr,
-                output_chi_eval
+                g_in_fold,
+                g_in_star_eval_times_selection_eval,
+                num_group_by_columns
             {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function compute_sum_in_fold_eval(plan_ptr, builder_ptr, alpha, beta, input_chi_eval) ->
+                plan_ptr_out,
+                sum_in_fold_eval,
+                num_sum_columns
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function compute_g_out_star_eval(
+                builder_ptr, alpha, beta, g_in_fold, output_chi_eval, num_group_by_columns, evaluations_ptr
+            ) -> g_out_star_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function compute_sum_out_fold_eval(
+                builder_ptr, alpha, beta, output_chi_eval, num_sum_columns, evaluations_ptr
+            ) -> sum_out_fold_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function read_input_evals(plan_ptr, builder_ptr, alpha, beta) ->
+                plan_ptr_out,
+                partial_dlog_zero_sum_constraint_eval,
+                num_group_by_columns,
+                num_sum_columns
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL GroupByExec.pre.sol
+            function read_output_evals(
+                builder_ptr, alpha, beta, partial_dlog_zero_sum_constraint_eval, num_group_by_columns, num_sum_columns
+            ) -> evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
             // IMPORT-YUL GroupByExec.pre.sol

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -376,6 +376,50 @@ library Verifier {
             function inequality_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function compute_g_in_star_eval(plan_ptr, builder_ptr, alpha, beta, input_chi_eval) ->
+                plan_ptr_out,
+                g_in_fold,
+                g_in_star_eval_times_selection_eval,
+                num_group_by_columns
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function compute_sum_in_fold_eval(plan_ptr, builder_ptr, alpha, beta, input_chi_eval) ->
+                plan_ptr_out,
+                sum_in_fold_eval,
+                num_sum_columns
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function compute_g_out_star_eval(
+                builder_ptr, alpha, beta, output_chi_eval, num_group_by_columns, evaluations_ptr
+            ) -> g_out_star_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function compute_sum_out_fold_eval(
+                builder_ptr, alpha, beta, output_chi_eval, num_sum_columns, evaluations_ptr
+            ) -> sum_out_fold_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function read_input_evals(plan_ptr, builder_ptr, alpha, beta) ->
+                plan_ptr_out,
+                partial_dlog_zero_sum_constraint_eval,
+                num_group_by_columns,
+                num_sum_columns
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
+            function read_output_evals(
+                builder_ptr, alpha, beta, partial_dlog_zero_sum_constraint_eval, num_group_by_columns, num_sum_columns
+            ) -> evaluations_ptr, output_chi_eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/PlaceholderExpr.pre.sol
             function placeholder_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
@@ -425,58 +469,6 @@ library Verifier {
             }
             // IMPORT-YUL ../proof_plans/ProjectionExec.pre.sol
             function projection_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
-            function get_and_check_group_by_input_columns(
-                plan_ptr, builder_ptr, alpha, beta, column_count, input_chi_eval
-            ) -> plan_ptr_out, g_star_selected_eval {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
-            function get_and_check_group_by_output_columns(
-                builder_ptr, alpha, beta, column_count, output_chi_eval, evaluations_ptr
-            ) -> g_out_star_eval, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
-            function get_and_check_sum_input_columns(
-                plan_ptr, builder_ptr, input_chi_eval, beta, column_count, g_star_selected_eval
-            ) -> plan_ptr_out, constraint_lhs {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
-            function get_and_check_sum_output_columns(
-                builder_ptr, output_chi_eval, beta, column_count, g_out_star_eval, evaluations_ptr
-            ) -> constraint_rhs, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
-            function build_groupby_zerosum_constraint(
-                plan_ptr,
-                builder_ptr,
-                alpha,
-                beta,
-                input_chi_eval,
-                output_chi_eval,
-                g_star_selected_eval,
-                g_out_star_eval,
-                evaluations_ptr
-            ) -> plan_ptr_out, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
-            function build_groupby_constraints(
-                plan_ptr, builder_ptr, alpha, beta, input_chi_eval, output_chi_eval, evaluations_ptr
-            ) -> plan_ptr_out, evaluations_ptr_out {
-                revert(0, 0)
-            }
-            // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol
-            function check_groupby_constraints(plan_ptr, builder_ptr, alpha, beta) ->
-                plan_ptr_out,
-                evaluations_ptr,
-                output_chi_eval
-            {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_plans/GroupByExec.pre.sol

--- a/solidity/test/proof_plans/GroupByExec.t.pre.sol
+++ b/solidity/test/proof_plans/GroupByExec.t.pre.sol
@@ -12,7 +12,6 @@ contract GroupByExecTest is Test {
     function testUnprovableGroupByExec() public {
         bytes memory plan = abi.encodePacked(
             uint64(0), // table_number
-            uint64(3), // total_column_count
             uint64(2), // group_by_count
             abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause
             abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(0)), // group_by_expr[0] - column 0
@@ -288,7 +287,6 @@ contract GroupByExecTest is Test {
     function testMinimalGroupByExec() public pure {
         bytes memory plan = abi.encodePacked(
             uint64(0), // table_number
-            uint64(2), // total_column_count
             uint64(1), // group_by_count
             uint64(0), // group_by_expr[0] - column 0
             abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause
@@ -319,7 +317,6 @@ contract GroupByExecTest is Test {
     function testSimpleGroupByExec() public pure {
         bytes memory plan = abi.encodePacked(
             uint64(0), // table_number
-            uint64(3), // total_column_count
             uint64(1), // group_by_count
             uint64(0), // group_by_expr[0] - column 0
             abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause
@@ -353,7 +350,6 @@ contract GroupByExecTest is Test {
     function testComplexGroupByExec() public pure {
         bytes memory plan = abi.encodePacked(
             uint64(0), // table_number
-            uint64(4), // total_column_count
             uint64(1), // group_by_count
             uint64(0), // group_by_expr[0] - column 0
             abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause

--- a/solidity/test/proof_plans/ProofPlan.t.pre.sol
+++ b/solidity/test/proof_plans/ProofPlan.t.pre.sol
@@ -277,7 +277,6 @@ contract ProofPlanTest is Test {
         bytes memory plan = abi.encodePacked(
             GROUP_BY_EXEC_VARIANT,
             uint64(0), // table_number
-            uint64(2), // total_column_count
             uint64(1), // group_by_count
             uint64(0), // group_by_expr[0] - column 0
             abi.encodePacked(LITERAL_EXPR_VARIANT, DATA_TYPE_BOOLEAN_VARIANT, uint8(1)), // where clause


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
