### PR TITLE
feat: fold log gadget

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
@@ -1,0 +1,69 @@
+use crate::{
+    base::{database::Column, proof::ProofError, scalar::Scalar, slice_ops},
+    sql::{
+        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        proof_plans::{fold_columns, fold_vals},
+    },
+};
+use alloc::{boxed::Box, vec};
+use ark_ff::{One, Zero};
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct FoldLogExpr<S: Scalar> {
+    alpha: S,
+    beta: S,
+}
+
+impl<S: Scalar> FoldLogExpr<S> {
+    pub fn new(alpha: S, beta: S) -> Self {
+        Self { alpha, beta }
+    }
+
+    pub fn verify_evaluate(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        column_evals: &[S],
+        chi_eval: S,
+    ) -> Result<(S, S), ProofError> {
+        let fold_eval = self.alpha * fold_vals(self.beta, column_evals);
+        let star_eval = builder.try_consume_final_round_mle_evaluation()?;
+        // star + fold * star - chi = 0
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            star_eval + fold_eval * star_eval - chi_eval,
+            2,
+        )?;
+        Ok((star_eval, fold_eval))
+    }
+
+    pub fn final_round_evaluate<'a>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        columns: &[Column<S>],
+        length: usize,
+    ) -> (&'a [S], &'a [S]) {
+        let chi = alloc.alloc_slice_fill_copy(length, true);
+        let fold = alloc.alloc_slice_fill_copy(length, Zero::zero());
+        fold_columns(fold, self.alpha, self.beta, columns);
+        let star = alloc.alloc_slice_copy(fold);
+        slice_ops::add_const::<S, S>(star, One::one());
+        slice_ops::batch_inversion(star);
+        builder.produce_intermediate_mle(star as &[_]);
+        // star + fold * star - chi = 0
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(star as &[_])]),
+                (
+                    S::one(),
+                    vec![Box::new(star as &[_]), Box::new(fold as &[_])],
+                ),
+                (-S::one(), vec![Box::new(chi as &[_])]),
+            ],
+        );
+        (star, fold)
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
 #[cfg(test)]
 mod divide_and_modulo_expr;
+pub(crate) mod fold_log_expr;
 mod membership_check;
 mod monotonic;
 #[cfg_attr(not(test), expect(dead_code))]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Many of our plans use the same folding logic to achieve zero sum constraints. Ideally this code/logic is not going to be duplicated everywhere. This is a start in that direction.

# What changes are included in this PR?

1. New `FoldLogExpr` gadget.
2. Replacing folding logic in `UnionExec` as a proof of concept.

# Are these changes tested?
Yes
