### PR TITLE
perf: improve bit distribution

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_matrix.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix.rs
@@ -38,10 +38,12 @@ pub fn compute_varying_bit_matrix<'a, S: Scalar>(
 
     // decompose
     let span = span!(Level::DEBUG, "decompose").entered();
+    let span_masks = span!(Level::DEBUG, "create masks vec").entered();
     let masks: Vec<U256> = if_rayon!(vals.par_iter(), vals.iter())
         .copied()
         .map(make_bit_mask)
         .collect();
+    span_masks.exit();
 
     let shifted_masks: Vec<U256> = dist
         .vary_mask_iter()

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -16,7 +16,6 @@ use bumpalo::Bump;
 use core::ops::Shl;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use tracing::{span, Level};
 
 /// Compute the sign bit for a column of scalars.
 ///
@@ -56,11 +55,9 @@ pub fn final_round_evaluate_sign<'a, S: Scalar>(
     alloc: &'a Bump,
     expr: &'a [S],
 ) -> &'a [bool] {
-    let span = span!(Level::DEBUG, "produce_bit_distribution").entered();
     // bit_distribution
     let dist = BitDistribution::new::<S, _>(expr);
     builder.produce_bit_distribution(dist.clone());
-    span.exit();
 
     if dist.num_varying_bits() > 0 {
         // prove that the bits are binary


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
