### PR TITLE
bench: add memory allocations logging to log module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ tempfile = { version = "3.13.0", default-features = false }
 tracing = { version = "0.1.36", default-features = false }
 tracing-opentelemetry = { version = "0.22.0" }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
+tracing-test = { version = "0.2" }
+
 uuid = { version = "=1.12.1", default-features = false }
 wasm-bindgen = { version = "0.2.92" }
 zerocopy = { version = "0.7.34" }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -73,6 +73,7 @@ tracing = { workspace = true }
 flexbuffers = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
+tracing-test = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 development = ["arrow-csv"]

--- a/crates/proof-of-sql/src/base/bit/bit_matrix.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix.rs
@@ -28,7 +28,7 @@ pub fn compute_varying_bit_matrix<'a, S: Scalar>(
     vals: &[S],
     dist: &BitDistribution,
 ) -> Vec<&'a [bool]> {
-    log::log_memory_usage("Start");
+    log::start();
 
     let span = span!(Level::DEBUG, "allocate").entered();
     let number_of_scalars = vals.len();
@@ -68,7 +68,7 @@ pub fn compute_varying_bit_matrix<'a, S: Scalar>(
         res.push(&data[first..last]);
     }
 
-    log::log_memory_usage("Stop");
+    log::stop();
 
     res
 }

--- a/crates/proof-of-sql/src/base/bit/bit_matrix.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix.rs
@@ -42,11 +42,13 @@ pub fn compute_varying_bit_matrix<'a, S: Scalar>(
         .copied()
         .map(make_bit_mask)
         .collect();
+    log::log_vector("masks", &masks);
 
     let shifted_masks: Vec<U256> = dist
         .vary_mask_iter()
         .map(|bit_index| U256::ONE.shl(bit_index))
         .collect();
+    log::log_vector("shifted_masks", &shifted_masks);
 
     let span_fill_data = span!(Level::DEBUG, "fill data").entered();
     for (scalar_index, mask) in masks.into_iter().enumerate() {

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -50,6 +50,22 @@ impl AllocationTracker {
     }
 }
 
+/// Starts memory and allocation tracking at the TRACE level.
+pub fn start() {
+    if tracing::level_enabled!(Level::TRACE) {
+        AllocationTracker::reset();
+        log_memory_usage("Start");
+    }
+}
+
+/// Stops memory and allocation tracking.
+pub fn stop() {
+    if tracing::level_enabled!(Level::TRACE) {
+        log_memory_usage("Stop");
+        AllocationTracker::report();
+    }
+}
+
 /// Logs the memory usage of the system at the TRACE level.
 ///
 /// This function logs the available memory, used memory, and the percentage of memory used.
@@ -62,8 +78,6 @@ impl AllocationTracker {
 pub fn log_memory_usage(name: &str) {
     #[cfg(feature = "std")]
     if tracing::level_enabled!(Level::TRACE) {
-        AllocationTracker::reset();
-
         let mut system = System::new_all();
         system.refresh_memory();
 

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -42,10 +42,12 @@ impl AllocationTracker {
     }
 
     /// Get the current allocation statistics
+    #[expect(clippy::cast_precision_loss)]
     pub fn report() -> (usize, usize) {
         let count = ALLOCATION_COUNT.load(Ordering::SeqCst);
         let bytes = ALLOCATION_BYTES.load(Ordering::SeqCst);
-        trace!("Total allocations: {} with {} bytes", count, bytes);
+        let megabytes = bytes as f64 / (1024.0 * 1024.0);
+        trace!("Total allocations: {} with {:.2} MB", count, megabytes);
         (count, bytes)
     }
 }

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(feature = "std")]
 use sysinfo::System;

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -218,7 +218,11 @@ mod tests {
         start();
 
         // Make an allocation that will trigger the log message
-        log_vector("test_start", &vec![1, 2, 3]);
+        let mut vec = Vec::with_capacity(10);
+        vec.push(1u32);
+        vec.push(2u32);
+        vec.push(3u32);
+        log_vector("test_start", &vec);
 
         // Verify the log message contains the expected parts
         assert!(logs_contain("Allocation #1"));

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -1,6 +1,53 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(feature = "std")]
 use sysinfo::System;
 use tracing::{trace, Level};
+
+// Static counters for allocation tracking
+static ALLOCATION_COUNT: AtomicUsize = AtomicUsize::new(0);
+static ALLOCATION_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Tracks memory allocations in the codebase
+pub struct AllocationTracker;
+
+impl AllocationTracker {
+    /// Reset the allocation counters
+    pub fn reset() {
+        ALLOCATION_COUNT.store(0, Ordering::SeqCst);
+        ALLOCATION_BYTES.store(0, Ordering::SeqCst);
+    }
+
+    /// Record a generic allocation with type information
+    pub fn record_allocation<T>(name: &str, count: usize, capacity: usize) {
+        let alloc_count = ALLOCATION_COUNT.fetch_add(1, Ordering::SeqCst);
+        let bytes = capacity * core::mem::size_of::<T>();
+        let total_bytes = ALLOCATION_BYTES.fetch_add(bytes, Ordering::SeqCst);
+
+        trace!(
+            "Allocation #{}: {} of {} elements with a capacity of {} of type {} ({} bytes), total: {} bytes", 
+            alloc_count + 1,
+            name,
+            count,
+            capacity,
+            core::any::type_name::<T>(),
+            bytes,
+            total_bytes + bytes
+        );
+    }
+
+    /// Record an allocation for a vector
+    pub fn record_vec<T>(name: &str, vec: &Vec<T>) {
+        Self::record_allocation::<T>(name, vec.len(), vec.capacity());
+    }
+
+    /// Get the current allocation statistics
+    pub fn report() -> (usize, usize) {
+        let count = ALLOCATION_COUNT.load(Ordering::SeqCst);
+        let bytes = ALLOCATION_BYTES.load(Ordering::SeqCst);
+        trace!("Total allocations: {} with {} bytes", count, bytes);
+        (count, bytes)
+    }
+}
 
 /// Logs the memory usage of the system at the TRACE level.
 ///
@@ -14,6 +61,8 @@ use tracing::{trace, Level};
 pub fn log_memory_usage(name: &str) {
     #[cfg(feature = "std")]
     if tracing::level_enabled!(Level::TRACE) {
+        AllocationTracker::reset();
+
         let mut system = System::new_all();
         system.refresh_memory();
 
@@ -28,5 +77,17 @@ pub fn log_memory_usage(name: &str) {
             used_memory,
             percentage_memory_used
         );
+    }
+}
+
+/// Logs detailed information about a vector allocation
+///
+/// # Arguments
+///
+/// * `name` - A descriptive name for the vector
+/// * `vec` - The vector to log information about
+pub fn log_vector<T>(name: &str, vec: &Vec<T>) {
+    if tracing::level_enabled!(Level::TRACE) {
+        AllocationTracker::record_vec(name, vec);
     }
 }

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -5,6 +5,16 @@ use sysinfo::System;
 use tracing::{trace, Level};
 
 // Static counters for allocation tracking
+//
+// Using static atomic counters allows us to:
+// 1. Track allocations across the entire program without passing tracker instances
+// 2. Provide zero-cost tracking when not enabled (no allocation overhead for tracker objects)
+// 3. Maintain thread safety through atomic operations
+// 4. Support global reset/reporting through a simple API
+//
+// Note: This approach creates global mutable state, which means tests must be
+// careful about resetting between test cases. For testing, we run tests
+// sequentially to avoid interference between concurrent tests.
 static ALLOCATION_COUNT: AtomicUsize = AtomicUsize::new(0);
 static ALLOCATION_BYTES: AtomicUsize = AtomicUsize::new(0);
 
@@ -106,5 +116,91 @@ pub fn log_memory_usage(name: &str) {
 pub fn log_vector<T>(name: &str, vec: &Vec<T>) {
     if tracing::level_enabled!(Level::TRACE) {
         AllocationTracker::record_vec(name, vec);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn we_can_reset_allocation_tracking() {
+        // Make some allocations first
+        let v: Vec<u32> = vec![1, 2, 3, 4];
+        AllocationTracker::record_vec("test_vec", &v);
+
+        // Reset and verify counters are zeroed
+        AllocationTracker::reset();
+        let (count, bytes) = AllocationTracker::report();
+        assert_eq!(count, 0, "Counter should be reset to zero");
+        assert_eq!(bytes, 0, "Bytes should be reset to zero");
+    }
+
+    fn we_can_count_allocations() {
+        AllocationTracker::reset();
+
+        // Record some allocations
+        AllocationTracker::record_allocation::<u32>("test1", 10, 16);
+        AllocationTracker::record_allocation::<u32>("test2", 5, 8);
+
+        // Check the count
+        let (count, _) = AllocationTracker::report();
+        assert_eq!(count, 2, "Should have recorded 2 allocations");
+    }
+
+    fn we_can_calcuate_allocation_bytes() {
+        AllocationTracker::reset();
+
+        // u32 = 4 bytes
+        // 16 × 4 = 64 bytes
+        AllocationTracker::record_allocation::<u32>("test", 10, 16);
+
+        // Check bytes
+        let (_, bytes) = AllocationTracker::report();
+        assert_eq!(bytes, 64, "Should have recorded 64 bytes for 16 u32s");
+    }
+
+    fn we_can_allocate_track_a_vec() {
+        AllocationTracker::reset();
+
+        // Create a vector with known capacity
+        let mut v = Vec::with_capacity(10);
+        v.push(1u32);
+        v.push(2u32);
+        v.push(3u32);
+
+        // Record it
+        AllocationTracker::record_vec("test_vec", &v);
+
+        // Check results
+        let (count, bytes) = AllocationTracker::report();
+        assert_eq!(count, 1, "Should have recorded 1 allocation");
+        assert_eq!(bytes, 40, "Should have recorded 40 bytes (10 u32s)");
+    }
+
+    fn we_can_track_allocations_of_different_types_of_vecs() {
+        AllocationTracker::reset();
+
+        // u8 = 1 byte
+        AllocationTracker::record_allocation::<u8>("u8_test", 10, 10);
+        let (_, bytes_u8) = AllocationTracker::report();
+        assert_eq!(bytes_u8, 10, "Should record 10 bytes for 10 u8s");
+
+        AllocationTracker::reset();
+
+        // u64 = 8 bytes
+        AllocationTracker::record_allocation::<u64>("u64_test", 10, 10);
+        let (_, bytes_u64) = AllocationTracker::report();
+        assert_eq!(bytes_u64, 80, "Should record 80 bytes for 10 u64s");
+    }
+
+    // Test sequentially to ensure we don't clear the static
+    // values during the parallel execution of tests.
+    #[test]
+    fn we_can_perform_allocation_tracking() {
+        we_can_reset_allocation_tracking();
+        we_can_count_allocations();
+        we_can_calcuate_allocation_bytes();
+        we_can_allocate_track_a_vec();
+        we_can_track_allocations_of_different_types_of_vecs();
     }
 }


### PR DESCRIPTION
# Rationale for this change
To help work on optimizations, an accurate picture of memory allocation help determine if the performance trade off should be made. This PR adds memory allocation logging for vectors created during the optimization process. The allocation tracking implementation can be expanded beyond vectors in future PRs, as needed.

Here is how they will appear in the benchmarks.
![image](https://github.com/user-attachments/assets/c486ba93-5800-4d62-ae19-a26b8ba9651e)

Note: the allocation tracking counters are static. Using static atomic counters allows us to:
1. Track allocations across the entire program without passing tracker instances
2. Provide zero-cost tracking when not enabled (no allocation overhead for tracker objects)
3. Maintain thread safety through atomic operations
4. Support global reset/reporting through a simple API

But an issue with static counters is that parallel execution paths that both call `start` will reset the counters and produce unexpected results. This is only for log tracing, so not too much of an issue, though tests have to be run sequentially.

# What changes are included in this PR?
- An Allocation Tracking implementation is added to the memory logging module.
- Tests are added.
- Vector allocation tracking is added to the bit_matrix module.

# Are these changes tested?
Yes, see image above.