### PR TITLE
refactor: add UnionAll query to table_size benchmark half size check

### DIFF
--- a/crates/proof-of-sql-benches/src/main.rs
+++ b/crates/proof-of-sql-benches/src/main.rs
@@ -210,7 +210,7 @@ fn rng(cli: &Cli) -> StdRng {
 
 /// Returns the size of the table based on the query type.
 fn table_size(cli: &Cli, query: &str) -> usize {
-    if query == Query::Join.to_string() {
+    if query == Query::Join.to_string() || query == Query::UnionAll.to_string() {
         cli.table_size.div_ceil(2)
     } else {
         cli.table_size


### PR DESCRIPTION
# Rationale for this change
Like the `Join` benchmark query, `UnionAll` also uses two input tables. To help get a more accurate picture of the performance in regards to things like MSM, the `UnionAll` query is added to the `table_size` check in the benchmarks crate.

# What changes are included in this PR?
- `UnionAll` will also run benchmarks at half size, like the `Join` query.

# Are these changes tested?
Yes