### PR TITLE
fix(sol): retrieve multiplicity from first round for membership

### DIFF
--- a/solidity/src/proof_gadgets/MembershipCheck.pre.sol
+++ b/solidity/src/proof_gadgets/MembershipCheck.pre.sol
@@ -63,6 +63,10 @@ library MembershipCheck {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_first_round_mle(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_produce_identity_constraint(builder_ptr, evaluation, degree) {
                 revert(0, 0)
             }
@@ -99,7 +103,7 @@ library MembershipCheck {
                 if sub(num_columns, num_candidate_columns) { err(ERR_INTERNAL) }
                 let c_fold := mulmod_bn254(compute_fold(beta, column_evals), alpha)
                 let d_fold := mulmod_bn254(compute_fold(beta, candidate_evals), alpha)
-                multiplicity_eval := builder_consume_final_round_mle(builder_ptr)
+                multiplicity_eval := builder_consume_first_round_mle(builder_ptr)
                 let c_star_eval := builder_consume_final_round_mle(builder_ptr)
                 let d_star_eval := builder_consume_final_round_mle(builder_ptr)
 

--- a/solidity/test/proof_gadgets/MembershipCheck.t.pre.sol
+++ b/solidity/test/proof_gadgets/MembershipCheck.t.pre.sol
@@ -19,7 +19,8 @@ contract MembershipCheckTest is Test {
         uint256[8] memory chiN = [uint256(1), 1, 1, 1, 1, 1, 1, 1];
         uint256[8] memory candidate = [uint256(300), 300, 0, 1, 1, 0, 0, 0];
         uint256[8] memory chiM = [uint256(1), 1, 1, 1, 1, 0, 0, 0];
-        builder.finalRoundMLEs = new uint256[](24);
+        builder.firstRoundMLEs = new uint256[](8);
+        builder.finalRoundMLEs = new uint256[](16);
         {
             uint256 inv901 = 6340545382408491490573043173709377134418560608777563777697260036288885701838;
             uint256 inv4 = 16416182153879456416684804308942956316411273300312025757773653139931856371713;
@@ -28,9 +29,9 @@ contract MembershipCheckTest is Test {
             uint256[8] memory cStar = [inv901, inv4, inv4, inv4, inv4, inv4, 1, inv7];
             uint256[8] memory dStar = [inv901, inv901, 1, inv4, inv4, 0, 0, 0];
             for (uint8 i = 0; i < 8; ++i) {
-                builder.finalRoundMLEs[i * 3] = multiplicity[i];
-                builder.finalRoundMLEs[i * 3 + 1] = cStar[i];
-                builder.finalRoundMLEs[i * 3 + 2] = dStar[i];
+                builder.firstRoundMLEs[i] = multiplicity[i];
+                builder.finalRoundMLEs[i * 2] = cStar[i];
+                builder.finalRoundMLEs[i * 2 + 1] = dStar[i];
             }
         }
 
@@ -84,7 +85,8 @@ contract MembershipCheckTest is Test {
             [uint256(0), 0]
         ];
         uint256[8] memory chiM = [uint256(1), 1, 1, 1, 1, 0, 0, 0];
-        builder.finalRoundMLEs = new uint256[](24);
+        builder.firstRoundMLEs = new uint256[](8);
+        builder.finalRoundMLEs = new uint256[](16);
         {
             uint256 inv7207 = 5767416846624501685451078744310193616366497016288337618798791418108430738612;
             uint256 inv28 = 11725844395628183154774860220673540226008052357365732684124037957094183122652;
@@ -95,9 +97,9 @@ contract MembershipCheckTest is Test {
             uint256[8] memory cStar = [inv7207, inv28, invNegative14, inv28, invNegative14, inv28, inv121, inv52];
             uint256[8] memory dStar = [inv7207, invNegative14, inv121, inv28, inv28, 0, 0, 0];
             for (uint8 i = 0; i < 8; ++i) {
-                builder.finalRoundMLEs[i * 3] = multiplicity[i];
-                builder.finalRoundMLEs[i * 3 + 1] = cStar[i];
-                builder.finalRoundMLEs[i * 3 + 2] = dStar[i];
+                builder.firstRoundMLEs[i] = multiplicity[i];
+                builder.finalRoundMLEs[i * 2] = cStar[i];
+                builder.finalRoundMLEs[i * 2 + 1] = dStar[i];
             }
         }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
