### PR TITLE
feat(sol): fold-log-gadget

### DIFF
--- a/solidity/src/proof_gadgets/FoldLogExpr.pre.sol
+++ b/solidity/src/proof_gadgets/FoldLogExpr.pre.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../base/Constants.sol";
+import "../base/Errors.sol";
+import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
+
+/// @title FoldLogExpr
+/// @dev Library for handling the frequently used fold constraint
+library FoldLogExpr {
+    /// @notice Folds expression evaluations with beta challenge
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// fold_log_star_evaluate(builder_ptr, alpha, beta, column_evals, chi_eval) -> star
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the verification builder
+    /// * `alpha` - challenge value
+    /// * `beta` - challenge value
+    /// * `column_evals` - columns to fold
+    /// * `chi_eval` - column of ones with same length is the column evaluations
+    /// ##### Return Values
+    /// * `star` - consumed star value
+    /// @param __builder The verification builder
+    /// @param __alpha The alpha challenge value
+    /// @param __beta The beta challenge value
+    /// @param __columnEvals The columns to fold
+    /// @param __chiEval The column of ones with same length is the column evaluations
+    /// @return __builderOut The updated verification builder
+    /// @return __star The consumed star value
+    function __foldLogStarEvaluate( // solhint-disable-line gas-calldata-parameters
+        VerificationBuilder.Builder memory __builder,
+        uint256 __alpha,
+        uint256 __beta,
+        uint256[] memory __columnEvals,
+        uint256 __chiEval
+    ) external pure returns (VerificationBuilder.Builder memory __builderOut, uint256 __star) {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function compute_fold(beta, evals) -> fold {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_final_round_mle(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_identity_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            // slither-disable-end cyclomatic-complexity
+            function fold_log_star_evaluate(builder_ptr, alpha, beta, column_evals, chi_eval) -> star {
+                let fold := mulmod_bn254(alpha, compute_fold(beta, column_evals))
+                star := builder_consume_final_round_mle(builder_ptr)
+                // star + fold * star - chi = 0
+                builder_produce_identity_constraint(
+                    builder_ptr, submod_bn254(addmod_bn254(star, mulmod_bn254(fold, star)), chi_eval), 2
+                )
+            }
+
+            __star := fold_log_star_evaluate(__builder, __alpha, __beta, __columnEvals, __chiEval)
+        }
+        __builderOut = __builder;
+    }
+}

--- a/solidity/test/proof_gadgets/FoldLog.t.pre.sol
+++ b/solidity/test/proof_gadgets/FoldLog.t.pre.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {FoldLogExpr} from "../../src/proof_gadgets/FoldLogExpr.pre.sol";
+
+contract FoldLogExprTest is Test {
+    function testSimpleFoldLogExprEvalsWithMultipleColumn() public pure {
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+        uint256 alpha = 3;
+        uint256 beta = 8;
+        uint256[2][8] memory column = [
+            [uint256(300), 2],
+            [uint256(1), 1],
+            [uint256(MODULUS_MINUS_ONE), 3],
+            [uint256(1), 1],
+            [uint256(MODULUS_MINUS_ONE), 3],
+            [uint256(1), 1],
+            [uint256(5), 0],
+            [uint256(2), 1]
+        ];
+        builder.finalRoundMLEs = new uint256[](8);
+        {
+            uint256 inv7207 = 5767416846624501685451078744310193616366497016288337618798791418108430738612;
+            uint256 inv28 = 11725844395628183154774860220673540226008052357365732684124037957094183122652;
+            uint256 invNegative14 = 20324796952422184134943091049167469725080624086100603319148332458963250745930;
+            uint256 inv121 = 18632140626441697090011403237698341604301500274734310226453843233200894835112;
+            uint256 inv52 = 21467315124303904544895513327079250567614742008100341375550161798372427563009;
+            uint256[8] memory star = [inv7207, inv28, invNegative14, inv28, invNegative14, inv28, inv121, inv52];
+            for (uint8 i = 0; i < 8; ++i) {
+                builder.finalRoundMLEs[i] = star[i];
+            }
+        }
+
+        builder.constraintMultipliers = new uint256[](24);
+        for (uint8 i = 0; i < 8; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+
+        for (uint8 i = 0; i < 1; ++i) {
+            uint256[] memory columnEval = new uint256[](2);
+            columnEval[0] = column[i][0];
+            columnEval[1] = column[i][1];
+            uint256 actualStar;
+            (builder, actualStar) = FoldLogExpr.__foldLogStarEvaluate({
+                __builder: builder,
+                __alpha: alpha,
+                __beta: beta,
+                __columnEvals: columnEval,
+                __chiEval: 1
+            });
+        }
+        assert(builder.aggregateEvaluation == 0);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
