### PR TITLE
refactor: sort merge join

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -334,6 +334,9 @@ impl ProverEvaluate for SortMergeJoinExec {
             .first_round_evaluate(builder, alloc, table_map, params)?;
         let num_rows_left = left.num_rows();
         let num_rows_right = right.num_rows();
+
+        builder.produce_rho_evaluation_length(num_rows_left);
+        builder.produce_rho_evaluation_length(num_rows_right);
         let (left_hat, hat_left_columns, c_l, num_columns_left) =
             compute_hat_columns(alloc, left, &self.left_join_column_indexes);
         let (right_hat, hat_right_columns, c_r, num_columns_right) =
@@ -372,9 +375,6 @@ impl ProverEvaluate for SortMergeJoinExec {
         let num_rows_u = u[0].len();
         let alloc_u_0 = alloc.alloc_slice_copy(u_0.as_slice());
         builder.produce_intermediate_mle(alloc_u_0 as &[_]);
-        // 3. Chi eval and rho eval
-        builder.produce_rho_evaluation_length(num_rows_left);
-        builder.produce_rho_evaluation_length(num_rows_right);
         // 4. Membership checks
         // `J_l` in the protocol
         let res_left_columns = raw_res_hat[0..=num_columns_left].to_vec();

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -323,6 +323,14 @@ impl ProverEvaluate for SortMergeJoinExec {
         let num_columns_right = right.num_columns();
         let left_hat = left.add_rho_column(alloc);
         let right_hat = right.add_rho_column(alloc);
+        let hat_left_column_indexes =
+            get_hat_column_indices(&self.left_join_column_indexes, num_columns_left);
+        let hat_right_column_indexes =
+            get_hat_column_indices(&self.right_join_column_indexes, num_columns_right);
+        let hat_left_columns = get_columns_of_table(&left_hat, &hat_left_column_indexes)
+            .expect("Indexes can not be out of bounds");
+        let hat_right_columns = get_columns_of_table(&right_hat, &hat_right_column_indexes)
+            .expect("Indexes can not be out of bounds");
         let c_l = get_columns_of_table(&left_hat, &self.left_join_column_indexes)
             .expect("Indexes can not be out of bounds");
         let c_r = get_columns_of_table(&right_hat, &self.right_join_column_indexes)
@@ -365,14 +373,6 @@ impl ProverEvaluate for SortMergeJoinExec {
         builder.produce_rho_evaluation_length(num_rows_left);
         builder.produce_rho_evaluation_length(num_rows_right);
         // 4. Membership checks
-        let hat_left_column_indexes =
-            get_hat_column_indices(&self.left_join_column_indexes, num_columns_left);
-        let hat_right_column_indexes =
-            get_hat_column_indices(&self.right_join_column_indexes, num_columns_right);
-        let hat_left_columns = get_columns_of_table(&left_hat, &hat_left_column_indexes)
-            .expect("Indexes can not be out of bounds");
-        let hat_right_columns = get_columns_of_table(&right_hat, &hat_right_column_indexes)
-            .expect("Indexes can not be out of bounds");
         // `J_l` in the protocol
         let res_left_columns = raw_res_hat[0..=num_columns_left].to_vec();
         // `J_r` in the protocol
@@ -416,7 +416,7 @@ impl ProverEvaluate for SortMergeJoinExec {
         level = "debug",
         skip_all
     )]
-    #[expect(clippy::too_many_lines, unused_variables)]
+    #[expect(clippy::too_many_lines)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
@@ -440,6 +440,16 @@ impl ProverEvaluate for SortMergeJoinExec {
 
         let left_hat = left.add_rho_column(alloc);
         let right_hat = right.add_rho_column(alloc);
+
+        let hat_left_column_indexes =
+            get_hat_column_indices(&self.left_join_column_indexes, num_columns_left);
+        let hat_right_column_indexes =
+            get_hat_column_indices(&self.right_join_column_indexes, num_columns_right);
+
+        let hat_left_columns = get_columns_of_table(&left_hat, &hat_left_column_indexes)
+            .expect("Indexes can not be out of bounds");
+        let hat_right_columns = get_columns_of_table(&right_hat, &hat_right_column_indexes)
+            .expect("Indexes can not be out of bounds");
 
         let c_l = get_columns_of_table(&left_hat, &self.left_join_column_indexes)
             .expect("Indexes can not be out of bounds");
@@ -489,16 +499,6 @@ impl ProverEvaluate for SortMergeJoinExec {
         let alloc_u_0 = alloc.alloc_slice_copy(u_0.as_slice());
 
         // 3. Membership checks
-        let hat_left_column_indexes =
-            get_hat_column_indices(&self.left_join_column_indexes, num_columns_left);
-        let hat_right_column_indexes =
-            get_hat_column_indices(&self.right_join_column_indexes, num_columns_right);
-
-        let hat_left_columns = get_columns_of_table(&left_hat, &hat_left_column_indexes)
-            .expect("Indexes can not be out of bounds");
-        let hat_right_columns = get_columns_of_table(&right_hat, &hat_right_column_indexes)
-            .expect("Indexes can not be out of bounds");
-
         let res_left_columns = res_hat[0..=num_columns_left].to_vec();
         let res_right_columns: Vec<_> = res_hat[0..num_columns_u] // rho col is right after left columns
             .iter()

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -129,11 +129,11 @@ fn compute_hat_columns<'a, S: Scalar>(
 ) -> (Table<'a, S>, Vec<Column<'a, S>>, Vec<Column<'a, S>>, usize) {
     let num_columns = columns.num_columns();
     let hat = columns.add_rho_column(alloc);
-    let hat_column_indices = get_hat_column_indices(&join_column_indexes, num_columns);
+    let hat_column_indices = get_hat_column_indices(join_column_indexes, num_columns);
     let hat_columns =
         get_columns_of_table(&hat, &hat_column_indices).expect("Indexes can not be out of bounds");
     let join_columns =
-        get_columns_of_table(&hat, &join_column_indexes).expect("Indexes can not be out of bounds");
+        get_columns_of_table(&hat, join_column_indexes).expect("Indexes can not be out of bounds");
     (hat, hat_columns, join_columns, num_columns)
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -487,7 +487,6 @@ impl ProverEvaluate for SortMergeJoinExec {
         );
         let u_0 = u[0].to_scalar();
         let alloc_u_0 = alloc.alloc_slice_copy(u_0.as_slice());
-        let alloc_u_0 = alloc.alloc_slice_copy(u_0.as_slice());
 
         // 3. Membership checks
         let hat_left_column_indexes =


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
