### PR TITLE
ci: ignore Solidity use-natspec warning in CI

### DIFF
--- a/solidity/.solhint.json
+++ b/solidity/.solhint.json
@@ -10,6 +10,7 @@
         "no-global-import": "off",
         "no-inline-assembly": "off",
         "one-contract-per-file": "off",
-        "ordering": "off"
+        "ordering": "off",
+        "use-natspec": "off"
     }
 }


### PR DESCRIPTION
# Rationale for this change
The Solhint project recently introduced a breaking change by promoting the `use-natscape` warning. See the [v6.0.0 release notes](https://github.com/protofire/solhint/releases/tag/v6.0.0). This warning "Promotes proper documentation with NatSpec for better audits and readability." This is currently blocking all check ins to the project, so this warning is turned off as a work around. An issue will be created in our backlog to revisit this warning and investigate turning it back on.

# What changes are included in this PR?
- The `use-natspec` warning is turned off in the `solhint.json` file

# Are these changes tested?
Testing CI now.