### PR TITLE
feat: add `min` function to `MathUtil`

### DIFF
--- a/solidity/src/base/MathUtil.pre.sol
+++ b/solidity/src/base/MathUtil.pre.sol
@@ -96,6 +96,21 @@ library MathUtil {
         }
     }
 
+    /// @notice Computes `min(a, b)`
+    /// @dev The minimum of two uint256 values.
+    /// @param __a The first value
+    /// @param __b The second value
+    /// @return __minimum The minimum of the two values
+    function __min(uint256 __a, uint256 __b) internal pure returns (uint256 __minimum) {
+        assembly {
+            function min(a, b) -> minimum {
+                minimum := a
+                if lt(b, a) { minimum := b }
+            }
+            __minimum := min(__a, __b)
+        }
+    }
+
     /// @notice Computes `compute_fold(beta, evals)`
     /// @dev The sum of a collection of vales with some mulitplier for each term.
     /// @param __beta The generator of the multipliers for each term in the fold

--- a/solidity/test/base/MathUtil.t.pre.sol
+++ b/solidity/test/base/MathUtil.t.pre.sol
@@ -59,6 +59,17 @@ library MathUtilTest {
         assert(MathUtil.__mulModBN254(MODULUS_MINUS_ONE, 2) == MODULUS_MINUS_ONE - 1);
     }
 
+    function testMin() public pure {
+        assert(MathUtil.__min(0, 0) == 0);
+        assert(MathUtil.__min(0, 1) == 0);
+        assert(MathUtil.__min(1, 0) == 0);
+        assert(MathUtil.__min(1, 2) == 1);
+        assert(MathUtil.__min(2, 1) == 1);
+        assert(MathUtil.__min(2, 2) == 2);
+        assert(MathUtil.__min(MODULUS_MINUS_ONE, MODULUS_MINUS_ONE - 1) == MODULUS_MINUS_ONE - 1);
+        assert(MathUtil.__min(2, MODULUS_MINUS_ONE) == 2);
+    }
+
     function testSimpleFold() public pure {
         uint256 beta = 4;
         uint256[] memory evals = new uint256[](3);


### PR DESCRIPTION
This is needed to simplify #959 since Yul doesn't have any opcode that can do min and that we need it in #959 and potentially other places. 