### PR TITLE
perf: optimize the `bit_distribution` and `bit_mask_util`

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
@@ -1,18 +1,21 @@
 use crate::base::scalar::ScalarExt;
 use bnum::types::U256;
-use core::ops::Shl;
+
+/// Mask with only the most significant bit (255) set
+/// Equivalent to `U256::ONE.shl(255)`
+const MSB_MASK: U256 = U256::from_digits([0, 0, 0, 1 << 63]);
 
 #[inline]
 pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
     let x_as_u256 = x.into_u256_wrapping();
     if x > S::MAX_SIGNED {
-        x_as_u256 - S::MAX_SIGNED_U256 + (U256::ONE.shl(255)) - S::MAX_SIGNED_U256 - U256::ONE
+        x_as_u256 - S::MAX_SIGNED_U256 + MSB_MASK - S::MAX_SIGNED_U256 - U256::ONE
     } else {
-        x_as_u256 + (U256::ONE.shl(255))
+        x_as_u256 + MSB_MASK
     }
 }
 
 #[inline]
 pub fn is_bit_mask_negative_representation(bit_mask: U256) -> bool {
-    bit_mask & (U256::ONE.shl(255)) == U256::ZERO
+    bit_mask & MSB_MASK == U256::ZERO
 }

--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
@@ -17,5 +17,5 @@ pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
 
 #[inline]
 pub fn is_bit_mask_negative_representation(bit_mask: U256) -> bool {
-    bit_mask & MSB_MASK == U256::ZERO
+    bit_mask < MSB_MASK
 }

--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
@@ -6,9 +6,7 @@ use core::ops::Shl;
 pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
     let x_as_u256 = x.into_u256_wrapping();
     if x > S::MAX_SIGNED {
-        x_as_u256 - S::into_u256_wrapping(S::MAX_SIGNED) + (U256::ONE.shl(255))
-            - S::into_u256_wrapping(S::MAX_SIGNED)
-            - U256::ONE
+        x_as_u256 - S::MAX_SIGNED_U256 + (U256::ONE.shl(255)) - S::MAX_SIGNED_U256 - U256::ONE
     } else {
         x_as_u256 + (U256::ONE.shl(255))
     }

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -402,6 +402,7 @@ where
         );
         255 - T::MODULUS.0[3].leading_zeros() as u8
     };
+    const MAX_SIGNED_U256: U256 = U256::from_digits(T::MODULUS.divide_by_2_round_down().0);
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -83,4 +83,6 @@ pub trait Scalar:
     const CHALLENGE_MASK: U256;
     /// The largest n such that 2^n <=p
     const MAX_BITS: u8;
+    /// A U256 representation of the largest signed value in the field.
+    const MAX_SIGNED_U256: U256;
 }


### PR DESCRIPTION
# Rationale for this change
The modules in `base/bit`, in particular `bit_distribution` and `bit_mask_util` are used extensively with the `SignExpr`. There are a number of opportunities to improve the code by avoiding recalculating constant values and updating a `fold` operation to be a `reduce` operation. Additionally, the `reduce` operations offers a clear path to use the Rayon crate to introduce parallelism.

Results from benchmarks on this PR show the `SignExpr::final_round_evaluate` improves by 2.14x. Below are screen shots of benchmarks from 1,000,000 rows on a Multi-A100 system.

`SignExpr:final_round_evaluate` in `main` - 63.86 ms
<img width="1551" height="197" alt="image" src="https://github.com/user-attachments/assets/0feaae56-936f-47e0-b68d-30897f51a375" />

`SignExpr:final_round_evaluate` with improvements to the `bit_mask_util` module - 56.75 ms
<img width="1652" height="139" alt="image" src="https://github.com/user-attachments/assets/1201395c-baad-4934-9019-8907ed5bb512" />

`SignExpr:final_round_evaluate` with improvements to the `bit_mask_util` and `bit_distribution` modules - 29.78 ms
<img width="1336" height="195" alt="image" src="https://github.com/user-attachments/assets/9d7ffaf6-ad70-418d-b3ef-801a9a53ac0c" />

# What changes are included in this PR?
- A constant, `MAX_SIGNED_U256`, is added to the `Scalar` trait
- Frequently recalculated const values in the `bit_mask_util` module are replaced with constants
  - `S::into_u256_wrapping(S::MAX_SIGNED)` becomes `S::MAX_SIGNED_U256`
  - `U256::ONE.shl(255)` becomes `MSB_MASK`
- The `BitDistribution` `new` method updates the `fold` operation to a `reduce` and adds Rayon support

# Are these changes tested?
Yes