### PR TITLE
fix!: use `LargeBinary` instead of `Binary`

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -7,8 +7,8 @@ use crate::base::{
 };
 use arrow::{
     array::{
-        Array, ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Decimal256Array, Int16Array,
-        Int32Array, Int64Array, Int8Array, StringArray, TimestampMicrosecondArray,
+        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
+        Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
         TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, TimeUnit as ArrowTimeUnit},
@@ -289,8 +289,8 @@ impl ArrayRefExt for ArrayRef {
                     })
                 }
             }
-            DataType::Binary => {
-                if let Some(array) = self.as_any().downcast_ref::<BinaryArray>() {
+            DataType::LargeBinary => {
+                if let Some(array) = self.as_any().downcast_ref::<LargeBinaryArray>() {
                     let vals = alloc
                         .alloc_slice_fill_with(range.end - range.start, |i| -> &'a [u8] {
                             array.value(range.start + i)
@@ -1026,7 +1026,7 @@ mod tests {
             .copied()
             .map(DoryScalar::from_byte_slice_via_hash)
             .collect();
-        let array: ArrayRef = Arc::new(arrow::array::BinaryArray::from(data.clone()));
+        let array: ArrayRef = Arc::new(arrow::array::LargeBinaryArray::from(data.clone()));
         assert_eq!(
             array
                 .to_column::<DoryScalar>(&alloc, &(0..2), None)
@@ -1163,7 +1163,7 @@ mod tests {
             .map(DoryScalar::from_byte_slice_via_hash)
             .collect();
 
-        let array: ArrayRef = Arc::new(arrow::array::BinaryArray::from(data.to_vec()));
+        let array: ArrayRef = Arc::new(arrow::array::LargeBinaryArray::from(data.to_vec()));
         assert_eq!(
             array
                 .to_column::<DoryScalar>(&alloc, &(1..3), None)
@@ -1195,7 +1195,7 @@ mod tests {
             .copied()
             .map(TestScalar::from_byte_slice_via_hash)
             .collect();
-        let array: ArrayRef = Arc::new(arrow::array::BinaryArray::from(data.clone()));
+        let array: ArrayRef = Arc::new(arrow::array::LargeBinaryArray::from(data.clone()));
         assert_eq!(
             array
                 .to_column::<TestScalar>(&alloc, &(0..2), Some(&scals))
@@ -1219,7 +1219,7 @@ mod tests {
     fn we_can_convert_valid_binary_array_refs_into_valid_columns_using_ranges_with_zero_size() {
         let alloc = Bump::new();
         let data = vec![b"ab".as_slice(), b"-f34".as_slice()];
-        let array: ArrayRef = Arc::new(arrow::array::BinaryArray::from(data.clone()));
+        let array: ArrayRef = Arc::new(arrow::array::LargeBinaryArray::from(data.clone()));
         let result = array
             .to_column::<DoryScalar>(&alloc, &(0..0), None)
             .unwrap();

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -21,7 +21,7 @@ impl From<&ColumnType> for DataType {
                 DataType::Decimal256(precision.value(), *scale)
             }
             ColumnType::VarChar => DataType::Utf8,
-            ColumnType::VarBinary => DataType::Binary,
+            ColumnType::VarBinary => DataType::LargeBinary,
             ColumnType::Scalar => unimplemented!("Cannot convert Scalar type to arrow type"),
             ColumnType::TimestampTZ(timeunit, timezone) => {
                 let arrow_timezone = Some(Arc::from(timezone.to_string()));
@@ -66,7 +66,7 @@ impl TryFrom<DataType> for ColumnType {
                 ))
             }
             DataType::Utf8 => Ok(ColumnType::VarChar),
-            DataType::Binary => Ok(ColumnType::VarBinary),
+            DataType::LargeBinary => Ok(ColumnType::VarBinary),
             _ => Err(format!("Unsupported arrow data type {data_type:?}")),
         }
     }

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -7,7 +7,8 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Float32Array, Int64Array, StringArray,
+        ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
+        StringArray,
     },
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
@@ -27,7 +28,7 @@ fn we_can_convert_between_owned_column_and_array_ref_impl(
 
 fn we_can_convert_between_varbinary_owned_column_and_array_ref_impl(data: &[Vec<u8>]) {
     let owned_col = OwnedColumn::<TestScalar>::VarBinary(data.to_owned());
-    let arrow_col = Arc::new(BinaryArray::from(
+    let arrow_col = Arc::new(LargeBinaryArray::from(
         data.iter()
             .map(std::vec::Vec::as_slice)
             .collect::<Vec<&[u8]>>(),

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 use arrow::{
-    array::{BinaryArray, Decimal128Array, Decimal256Array, Int64Array, StringArray},
+    array::{Decimal128Array, Decimal256Array, Int64Array, LargeBinaryArray, StringArray},
     datatypes::{i256, Field, Schema},
     record_batch::RecordBatch,
 };
@@ -352,12 +352,12 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_varbinary() {
 
     let schema = Arc::new(Schema::new(vec![Field::new(
         "vb_col",
-        arrow::datatypes::DataType::Binary,
+        arrow::datatypes::DataType::LargeBinary,
         false,
     )]));
     let expected = RecordBatch::try_new(
         schema,
-        vec![Arc::new(BinaryArray::from_vec(vec![
+        vec![Arc::new(LargeBinaryArray::from_vec(vec![
             b"foo".as_slice(),
             b"bar".as_slice(),
         ]))],


### PR DESCRIPTION
# Rationale for this change

Large tables with Binary data are not supported due to `RecordBatch` limitations.

# What changes are included in this PR?

Use `LargeBinary` instead of `Binary`

# Are these changes tested?
Yes