### PR TITLE
refactor: remove unnecessary usage of `apply_slice_to_indexes` in join

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -160,28 +160,20 @@ where
                 error: "Join on multiple columns not supported yet",
             });
         }
-        let num_columns_res_hat = num_columns_left + num_columns_right - num_columns_u + 2;
         // `\hat{J}` in the protocol
-        let res_hat_column_evals =
-            builder.try_consume_first_round_mle_evaluations(num_columns_res_hat)?;
+        let res_u_column_evals = builder.try_consume_first_round_mle_evaluations(num_columns_u)?;
+        let res_left_column_evals =
+            builder.try_consume_first_round_mle_evaluations(num_columns_left - num_columns_u)?;
+        let rho_bar_left_eval = builder.try_consume_first_round_mle_evaluation()?;
+        let res_right_column_evals =
+            builder.try_consume_first_round_mle_evaluations(num_columns_right - num_columns_u)?;
+        let rho_bar_right_eval = builder.try_consume_first_round_mle_evaluation()?;
         // 5. First round MLE evaluations: `i` and `U`
         //TODO: Make it possible for `U` to have multiple columns
-        let rho_bar_left_eval = res_hat_column_evals[num_columns_left];
-        let rho_bar_right_eval = res_hat_column_evals[num_columns_res_hat - 1];
         let i_eval: S = itertools::repeat_n(S::TWO, 64_usize).product::<S>() * rho_bar_left_eval
             + rho_bar_right_eval;
         let u_column_eval = builder.try_consume_first_round_mle_evaluation()?;
         // 6. Membership checks
-        let res_left_column_indexes = (0..=num_columns_left).collect::<Vec<_>>();
-        let res_right_column_indexes = (0..num_columns_u)
-            .chain(num_columns_left + 1..num_columns_res_hat)
-            .collect::<Vec<_>>();
-        let res_left_column_evals =
-            apply_slice_to_indexes(&res_hat_column_evals, &res_left_column_indexes)
-                .expect("Indexes can not be out of bounds");
-        let res_right_column_evals =
-            apply_slice_to_indexes(&res_hat_column_evals, &res_right_column_indexes)
-                .expect("Indexes can not be out of bounds");
         verify_membership_check(
             builder,
             alpha,
@@ -189,7 +181,12 @@ where
             left_chi_eval,
             res_chi.0,
             &hat_left_column_evals,
-            &res_left_column_evals,
+            &res_u_column_evals
+                .iter()
+                .copied()
+                .chain(res_left_column_evals.iter().copied())
+                .chain(core::iter::once(rho_bar_left_eval))
+                .collect::<Vec<_>>(),
         )?;
         verify_membership_check(
             builder,
@@ -198,7 +195,12 @@ where
             right_chi_eval,
             res_chi.0,
             &hat_right_column_evals,
-            &res_right_column_evals,
+            &res_u_column_evals
+                .iter()
+                .copied()
+                .chain(res_right_column_evals.iter().copied())
+                .chain(core::iter::once(rho_bar_right_eval))
+                .collect::<Vec<_>>(),
         )?;
         //TODO: Relax to allow multiple columns
         if left_join_column_evals.len() != 1 || right_join_column_evals.len() != 1 {
@@ -236,11 +238,11 @@ where
         )?;
         // 9. Return the result
         // Drop the two rho columns of `\hat{J}` to get `J`
-        let res_column_indexes = (0..num_columns_left)
-            .chain(num_columns_left + 1..num_columns_left + 1 + num_columns_right - num_columns_u)
-            .collect::<Vec<_>>();
-        let res_column_evals = apply_slice_to_indexes(&res_hat_column_evals, &res_column_indexes)
-            .expect("Indexes can not be out of bounds");
+        let res_column_evals = res_u_column_evals
+            .into_iter()
+            .chain(res_left_column_evals)
+            .chain(res_right_column_evals)
+            .collect();
         Ok(TableEvaluation::new(res_column_evals, res_chi))
     }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
