### PR TITLE
feat(sol): filter base

### DIFF
--- a/solidity/src/proof_gadgets/FilterBase.pre.sol
+++ b/solidity/src/proof_gadgets/FilterBase.pre.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../base/Constants.sol";
+import "../base/Errors.sol";
+import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
+
+/// @title FilterBase
+/// @dev Library for handling common filter functionality
+library FilterBase {
+    /// @notice Verifies the filtered columns
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the verification builder
+    /// * `c_fold` - the folded value of the input columns
+    /// * `d_fold` - the folded value of the filtered columns
+    /// * `input_chi_eval` - the column of ones with same length as the input columns
+    /// * `output_chi_eval` - column of ones with same length as the filtered columns
+    /// * `selection_eval` - column of ones and zeroes which indicate which rows to include in the result
+    /// @param __builder The verification builder
+    /// @param __cFold The folded value of the input columns
+    /// @param __dFold The folded value of the filtered columns
+    /// @param __inputChiEval The column of ones with same length as the input columns
+    /// @param __outputChiEval The column of ones with same length as the filtered columns
+    /// @param __selectionEval The column of ones and zeroes which indicate which rows to include in the result
+    /// @return __builderOut The updated verification builder
+    function __filterBaseEvaluate( // solhint-disable-line gas-calldata-parameters
+        VerificationBuilder.Builder memory __builder,
+        uint256 __cFold,
+        uint256 __dFold,
+        uint256 __inputChiEval,
+        uint256 __outputChiEval,
+        uint256 __selectionEval
+    ) external pure returns (VerificationBuilder.Builder memory __builderOut) {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_final_round_mle(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_identity_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_zerosum_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                let c_star := builder_consume_final_round_mle(builder_ptr)
+                let d_star := builder_consume_final_round_mle(builder_ptr)
+
+                builder_produce_identity_constraint(
+                    builder_ptr, submod_bn254(mulmod_bn254(addmod_bn254(1, c_fold), c_star), input_chi_eval), 2
+                )
+                builder_produce_identity_constraint(
+                    builder_ptr, submod_bn254(mulmod_bn254(addmod_bn254(1, d_fold), d_star), output_chi_eval), 2
+                )
+                builder_produce_zerosum_constraint(
+                    builder_ptr, submod_bn254(mulmod_bn254(c_star, selection_eval), d_star), 2
+                )
+                builder_produce_identity_constraint(
+                    builder_ptr, mulmod_bn254(d_fold, submod_bn254(output_chi_eval, 1)), 2
+                )
+            }
+
+            verify_filter(__builder, __cFold, __dFold, __inputChiEval, __outputChiEval, __selectionEval)
+        }
+        __builderOut = __builder;
+    }
+}

--- a/solidity/src/proof_plans/FilterExec.pre.sol
+++ b/solidity/src/proof_plans/FilterExec.pre.sol
@@ -255,6 +255,10 @@ library FilterExec {
             function fold_first_round_mles(builder_ptr, beta, column_count) -> fold, evaluations_ptr {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_gadgets/FilterBase.pre.sol
+            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
+                revert(0, 0)
+            }
             function compute_filter_folds(plan_ptr, builder_ptr, input_chi_eval, beta) ->
                 plan_ptr_out,
                 c_fold,
@@ -267,24 +271,6 @@ library FilterExec {
                 plan_ptr, c_fold := fold_expr_evals(plan_ptr, builder_ptr, input_chi_eval, beta, column_count)
                 d_fold, evaluations_ptr := fold_first_round_mles(builder_ptr, beta, column_count)
                 plan_ptr_out := plan_ptr
-            }
-
-            function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
-                let c_star := builder_consume_final_round_mle(builder_ptr)
-                let d_star := builder_consume_final_round_mle(builder_ptr)
-
-                builder_produce_identity_constraint(
-                    builder_ptr, submod_bn254(mulmod_bn254(addmod_bn254(1, c_fold), c_star), input_chi_eval), 2
-                )
-                builder_produce_identity_constraint(
-                    builder_ptr, submod_bn254(mulmod_bn254(addmod_bn254(1, d_fold), d_star), output_chi_eval), 2
-                )
-                builder_produce_zerosum_constraint(
-                    builder_ptr, submod_bn254(mulmod_bn254(c_star, selection_eval), d_star), 2
-                )
-                builder_produce_identity_constraint(
-                    builder_ptr, mulmod_bn254(d_fold, submod_bn254(output_chi_eval, 1)), 2
-                )
             }
 
             // IMPORT-YUL TableExec.pre.sol

--- a/solidity/src/proof_plans/GroupByExec.pre.sol
+++ b/solidity/src/proof_plans/GroupByExec.pre.sol
@@ -264,7 +264,7 @@ library GroupByExec {
             {
                 revert(0, 0)
             }
-            // IMPORT-YUL ../proof_plans/FilterExec.pre.sol
+            // IMPORT-YUL ../proof_gadgets/FilterBase.pre.sol
             function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
                 revert(0, 0)
             }

--- a/solidity/src/proof_plans/ProjectionExec.pre.sol
+++ b/solidity/src/proof_plans/ProjectionExec.pre.sol
@@ -191,7 +191,7 @@ library ProjectionExec {
             function fold_first_round_mles(builder_ptr, beta, column_count) -> fold, evaluations_ptr {
                 revert(0, 0)
             }
-            // IMPORT-YUL FilterExec.pre.sol
+            // IMPORT-YUL ../proof_gadgets/FilterBase.pre.sol
             function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
                 revert(0, 0)
             }

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -244,7 +244,7 @@ library ProofPlan {
             {
                 revert(0, 0)
             }
-            // IMPORT-YUL FilterExec.pre.sol
+            // IMPORT-YUL ../proof_gadgets/FilterBase.pre.sol
             function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
                 revert(0, 0)
             }

--- a/solidity/src/proof_plans/SliceExec.pre.sol
+++ b/solidity/src/proof_plans/SliceExec.pre.sol
@@ -264,7 +264,7 @@ library SliceExec {
             {
                 revert(0, 0)
             }
-            // IMPORT-YUL FilterExec.pre.sol
+            // IMPORT-YUL ../proof_gadgets/FilterBase.pre.sol
             function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
                 revert(0, 0)
             }

--- a/solidity/src/proof_plans/UnionExec.pre.sol
+++ b/solidity/src/proof_plans/UnionExec.pre.sol
@@ -277,7 +277,7 @@ library UnionExec {
             function table_exec_evaluate(plan_ptr, builder_ptr) -> plan_ptr_out, evaluations_ptr, output_chi_eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL FilterExec.pre.sol
+            // IMPORT-YUL ../proof_gadgets/FilterBase.pre.sol
             function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
                 revert(0, 0)
             }

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -499,7 +499,7 @@ library Verifier {
             ) -> plan_ptr_out, star {
                 revert(0, 0)
             }
-            // IMPORT-YUL ../proof_plans/FilterExec.pre.sol
+            // IMPORT-YUL ../proof_gadgets/FilterBase.pre.sol
             function verify_filter(builder_ptr, c_fold, d_fold, input_chi_eval, output_chi_eval, selection_eval) {
                 revert(0, 0)
             }

--- a/solidity/test/proof_gadgets/FilterBase.t.pre.sol
+++ b/solidity/test/proof_gadgets/FilterBase.t.pre.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {FilterBase} from "../../src/proof_gadgets/FilterBase.pre.sol";
+
+contract FilterBaseTest is Test {
+    function testSimpleSliceExec() public pure {
+        VerificationBuilder.Builder memory builder;
+
+        // max degree and row multipliers
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+
+        // constraint multipliers
+        builder.constraintMultipliers = new uint256[](16); // 4 constraints times 4 rows
+        for (uint8 i = 0; i < 16; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+
+        // final round mles
+        builder.finalRoundMLEs = new uint256[](8); // 2 mles times 4 rows
+        {
+            uint256 inv4 = 16416182153879456416684804308942956316411273300312025757773653139931856371713;
+            uint256 inv10 = 15321770010287492655572484021680092561983855080291224040588742930603065946932;
+            uint256 invNegative2 = 10944121435919637611123202872628637544274182200208017171849102093287904247808;
+            uint256 inv1201 = 17860514583182755801666509267570465934036134148549303627663813574391583951461;
+            uint256[4] memory cStarColumn = [inv4, inv10, invNegative2, inv1201];
+            uint256[4] memory dStarColumn = [cStarColumn[0], cStarColumn[2], 0, 0];
+
+            for (uint8 i = 0; i < 4; ++i) {
+                builder.finalRoundMLEs[i * 2] = cStarColumn[i];
+                builder.finalRoundMLEs[i * 2 + 1] = dStarColumn[i];
+            }
+        }
+        builder.aggregateEvaluation = 0;
+
+        uint256[4] memory inputChiEval = [uint256(1), 1, 1, 1];
+        uint256[4] memory outputChiEval = [uint256(1), 1, 0, 0];
+        uint256[4] memory selectionEval = [uint256(1), 0, 1, 0];
+        uint256[4] memory cFoldEval = [uint256(3), 9, MODULUS - 3, 1200];
+        uint256[4] memory dFoldEval = [uint256(3), MODULUS - 3, 0, 0];
+        for (uint8 i = 0; i < 4; ++i) {
+            builder = FilterBase.__filterBaseEvaluate({
+                __builder: builder,
+                __cFold: cFoldEval[i],
+                __dFold: dFoldEval[i],
+                __inputChiEval: inputChiEval[i],
+                __outputChiEval: outputChiEval[i],
+                __selectionEval: selectionEval[i]
+            });
+        }
+
+        assert(builder.aggregateEvaluation == 0);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
