### PR TITLE
refactor: use fold gadget on group by inputs

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -19,7 +19,8 @@ use crate::{
         },
         proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, ProofExpr, TableExpr},
         proof_gadgets::{
-            final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic,
+            final_round_evaluate_monotonic, first_round_evaluate_monotonic,
+            fold_log_expr::FoldLogExpr, verify_monotonic,
         },
     },
     utils::log,
@@ -107,7 +108,6 @@ impl GroupByExec {
 }
 
 impl ProofPlan for GroupByExec {
-    #[expect(clippy::too_many_lines)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -128,18 +128,15 @@ impl ProofPlan for GroupByExec {
             .unwrap_or_else(|| [].into_iter().collect());
 
         // Compute g_in_star
+        let fold_gadget = FoldLogExpr::new(alpha, beta);
         let group_by_evals = self
             .group_by_exprs
             .iter()
             .map(|expr| expr.verifier_evaluate(builder, &accessor, input_chi_eval, params))
             .collect::<Result<Vec<_>, _>>()?;
-        let g_in_fold_eval = alpha * fold_vals(beta, &group_by_evals);
-        let g_in_star_eval = builder.try_consume_final_round_mle_evaluation()?;
-        builder.try_produce_sumcheck_subpolynomial_evaluation(
-            SumcheckSubpolynomialType::Identity,
-            g_in_star_eval + g_in_star_eval * g_in_fold_eval - input_chi_eval,
-            2,
-        )?;
+        let g_in_star_eval = fold_gadget
+            .verify_evaluate(builder, &group_by_evals, input_chi_eval)?
+            .0;
         // End compute g_in_star
 
         let where_eval =
@@ -387,7 +384,6 @@ impl ProverEvaluate for GroupByExec {
             .expect("Table not found");
 
         let n = table.num_rows();
-        let chi_n = alloc.alloc_slice_fill_copy(n, true);
 
         // Compute g_in_star
         let group_by_columns = self
@@ -397,23 +393,10 @@ impl ProverEvaluate for GroupByExec {
                 expr.final_round_evaluate(builder, alloc, table, params)
             })
             .collect::<PlaceholderResult<Vec<_>>>()?;
-        let g_in_fold = alloc.alloc_slice_fill_copy(n, Zero::zero());
-        fold_columns(g_in_fold, alpha, beta, &group_by_columns);
-        let g_in_star = alloc.alloc_slice_copy(g_in_fold);
-        slice_ops::add_const::<S, S>(g_in_star, One::one());
-        slice_ops::batch_inversion(g_in_star);
-        builder.produce_intermediate_mle(g_in_star as &[_]);
-        builder.produce_sumcheck_subpolynomial(
-            SumcheckSubpolynomialType::Identity,
-            vec![
-                (S::one(), vec![Box::new(g_in_star as &[_])]),
-                (
-                    S::one(),
-                    vec![Box::new(g_in_star as &[_]), Box::new(g_in_fold as &[_])],
-                ),
-                (-S::one(), vec![Box::new(chi_n as &[_])]),
-            ],
-        );
+        let fold_gadget = FoldLogExpr::new(alpha, beta);
+        let g_in_star = fold_gadget
+            .final_round_evaluate(builder, alloc, &group_by_columns, n)
+            .0;
         // End compute g_in_star
 
         let selection_column: Column<'a, S> = self


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
