### PR TITLE
refactor: use fold in group by

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -28,7 +28,7 @@ use crate::{
 use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
 use core::iter;
-use num_traits::{One, Zero};
+use num_traits::One;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -161,14 +161,9 @@ impl ProofPlan for GroupByExec {
         // 3. filtered_columns
         let group_by_result_columns_evals =
             builder.try_consume_first_round_mle_evaluations(self.group_by_exprs.len())?;
-        let g_out_fold_eval = alpha * fold_vals(beta, &group_by_result_columns_evals);
-        let g_out_star_eval = builder.try_consume_final_round_mle_evaluation()?;
-
-        builder.try_produce_sumcheck_subpolynomial_evaluation(
-            SumcheckSubpolynomialType::Identity,
-            g_out_star_eval + g_out_star_eval * g_out_fold_eval - output_chi_eval.0,
-            2,
-        )?;
+        let g_out_star_eval = fold_gadget
+            .verify_evaluate(builder, &group_by_result_columns_evals, output_chi_eval.0)?
+            .0;
 
         let is_uniqueness_provable = self.is_uniqueness_provable();
         if is_uniqueness_provable {
@@ -366,7 +361,6 @@ impl ProverEvaluate for GroupByExec {
     }
 
     #[tracing::instrument(name = "GroupByExec::final_round_evaluate", level = "debug", skip_all)]
-    #[expect(clippy::too_many_lines)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
@@ -430,27 +424,10 @@ impl ProverEvaluate for GroupByExec {
             .expect("columns should be aggregatable");
 
         let m = count_column.len();
-        let chi_m = alloc.alloc_slice_fill_copy(m, true);
 
-        let g_out_fold = alloc.alloc_slice_fill_copy(m, Zero::zero());
-        fold_columns(g_out_fold, alpha, beta, &group_by_result_columns);
-        let g_out_star = alloc.alloc_slice_copy(g_out_fold);
-        slice_ops::add_const::<S, S>(g_out_star, One::one());
-        slice_ops::batch_inversion(g_out_star);
-
-        builder.produce_intermediate_mle(g_out_star as &[_]);
-
-        builder.produce_sumcheck_subpolynomial(
-            SumcheckSubpolynomialType::Identity,
-            vec![
-                (S::one(), vec![Box::new(g_out_star as &[_])]),
-                (
-                    S::one(),
-                    vec![Box::new(g_out_star as &[_]), Box::new(g_out_fold as &[_])],
-                ),
-                (-S::one(), vec![Box::new(chi_m as &[_])]),
-            ],
-        );
+        let g_out_star = fold_gadget
+            .final_round_evaluate(builder, alloc, &group_by_result_columns, m)
+            .0;
 
         let check_uniqueness = self.is_uniqueness_provable();
         if check_uniqueness {

--- a/solidity/src/proof_plans/GroupByExec.pre.sol
+++ b/solidity/src/proof_plans/GroupByExec.pre.sol
@@ -251,6 +251,21 @@ library GroupByExec {
             ) -> plan_ptr_out, star {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_star_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                fold,
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_gadgets/FoldUtil.pre.sol
             function fold_first_round_mles(builder_ptr, column_count, beta) -> fold, evaluations_ptr {
                 revert(0, 0)
@@ -326,20 +341,11 @@ library GroupByExec {
             function compute_g_out_star_eval(builder_ptr, alpha, beta, output_chi_eval, evaluations_ptr) ->
                 g_out_star_eval
             {
-                let mle := builder_consume_first_round_mle(builder_ptr)
+                let mles
+                g_out_star_eval, mles := fold_log_star_evaluate_from_mles(builder_ptr, alpha, beta, 1, output_chi_eval)
+                let mle := mload(add(mles, WORD_SIZE))
                 mstore(evaluations_ptr, mle)
                 evaluations_ptr := add(evaluations_ptr, WORD_SIZE)
-                let g_out_fold := mulmod_bn254(mle, alpha)
-                g_out_star_eval := builder_consume_final_round_mle(builder_ptr)
-                // Second constraint: g_out_star + g_out_star * g_out_fold - output_chi_eval = 0
-                builder_produce_identity_constraint(
-                    builder_ptr,
-                    submod_bn254(
-                        addmod_bn254(g_out_star_eval, mulmod_bn254(g_out_star_eval, g_out_fold)), output_chi_eval
-                    ),
-                    2
-                )
-                // Uniqueness constraint, currently only for single group by column using monotonicity
                 monotonic_verify(builder_ptr, alpha, beta, mle, output_chi_eval, 1, 1)
             }
             function compute_sum_out_fold_eval(

--- a/solidity/src/proof_plans/ProjectionExec.pre.sol
+++ b/solidity/src/proof_plans/ProjectionExec.pre.sol
@@ -235,6 +235,21 @@ library ProjectionExec {
             ) -> plan_ptr_out, star {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                fold,
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_star_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
             // IMPORT-YUL EmptyExec.pre.sol
             function empty_exec_evaluate(builder_ptr) -> evaluations_ptr, output_chi_eval {
                 revert(0, 0)

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -341,6 +341,21 @@ library ProofPlan {
             ) -> plan_ptr_out, star {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                fold,
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_star_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
             // IMPORT-YUL GroupByExec.pre.sol
             function group_by_exec_evaluate(plan_ptr, builder_ptr) ->
                 plan_ptr_out,

--- a/solidity/src/proof_plans/SliceExec.pre.sol
+++ b/solidity/src/proof_plans/SliceExec.pre.sol
@@ -356,6 +356,21 @@ library SliceExec {
             ) -> plan_ptr_out, star {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                fold,
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_star_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
             // IMPORT-YUL UnionExec.pre.sol
             function union_input_evaluate(plan_ptr, builder_ptr, gamma, beta) ->
                 plan_ptr_out,

--- a/solidity/src/proof_plans/UnionExec.pre.sol
+++ b/solidity/src/proof_plans/UnionExec.pre.sol
@@ -255,6 +255,21 @@ library UnionExec {
             ) -> plan_ptr_out, star {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                fold,
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_star_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
             // slither-disable-start cyclomatic-complexity
             // IMPORT-YUL ../base/DataType.pre.sol
             function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -490,6 +490,21 @@ library Verifier {
                 revert(0, 0)
             }
             // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                fold,
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
+            function fold_log_star_evaluate_from_mles(builder_ptr, alpha, beta, column_count, chi_eval) ->
+                star,
+                evaluations_ptr
+            {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/FoldLogExpr.pre.sol
             function fold_log_star_evaluate(builder_ptr, alpha, beta, column_evals, chi_eval) -> star {
                 revert(0, 0)
             }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
