### PR TITLE
feat(sol): `fold_log_star_evaluate_from_expr_evals`

### DIFF
--- a/solidity/src/proof_gadgets/FoldLogExpr.pre.sol
+++ b/solidity/src/proof_gadgets/FoldLogExpr.pre.sol
@@ -288,4 +288,192 @@ library FoldLogExpr {
         }
         __builderOut = __builder;
     }
+
+    /// @notice Folds expression evaluations with beta challenge
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// fold_expr_evals(plan_ptr, builder_ptr, input_chi_eval, beta, column_count) -> plan_ptr_out, fold
+    /// ```
+    /// ##### Parameters
+    /// * `plan_ptr` - calldata pointer to the plan
+    /// * `builder_ptr` - memory pointer to the verification builder
+    /// * `input_chi_eval` - input chi evaluation
+    /// * `beta` - challenge value
+    /// * `column_count` - number of columns to process
+    /// ##### Return Values
+    /// * `plan_ptr_out` - pointer to the remaining plan after consuming
+    /// * `fold` - computed fold value
+    /// @param __plan The plan data
+    /// @param __builder The verification builder
+    /// @param __inputChiEval The input chi evaluation
+    /// @param __alpha The beta challenge value
+    /// @param __beta The beta challenge value
+    /// @param __columnCount The number of columns
+    /// @return __builderOut The updated verification builder
+    /// @return __star The consumed star value
+    function __foldLogStarEvaluateFromExprEvals( // solhint-disable-line gas-calldata-parameters
+        bytes calldata __plan,
+        VerificationBuilder.Builder memory __builder,
+        uint256 __inputChiEval,
+        uint256 __alpha,
+        uint256 __beta,
+        uint256 __columnCount
+    ) external pure returns (VerificationBuilder.Builder memory __builderOut, uint256 __star) {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function addmod_bn254(lhs, rhs) -> sum {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function submod_bn254(lhs, rhs) -> difference {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/MathUtil.pre.sol
+            function mulmod_bn254(lhs, rhs) -> product {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue_uint512(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/SwitchUtil.pre.sol
+            function case_const(lhs, rhs) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_column_evaluation(builder_ptr, column_num) -> eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Array.pre.sol
+            function get_array_element(arr_ptr, index) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/ColumnExpr.pre.sol
+            function column_expr_evaluate(expr_ptr, builder_ptr) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/LiteralExpr.pre.sol
+            function literal_expr_evaluate(expr_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_final_round_mle(builder_ptr) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_produce_identity_constraint(builder_ptr, evaluation, degree) {
+                revert(0, 0)
+            }
+            // slither-disable-start cyclomatic-complexity
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // slither-disable-end cyclomatic-complexity
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_data_type(ptr) -> ptr_out, data_type {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/EqualsExpr.pre.sol
+            function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/AddExpr.pre.sol
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/SubtractExpr.pre.sol
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/MultiplyExpr.pre.sol
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/AndExpr.pre.sol
+            function and_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/OrExpr.pre.sol
+            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/NotExpr.pre.sol
+            function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/CastExpr.pre.sol
+            function cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_consume_bit_distribution(builder_ptr) -> vary_mask, leading_bit_mask {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
+            function builder_get_placeholder_parameter(builder_ptr, index) -> value {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_gadgets/SignExpr.pre.sol
+            function sign_expr_evaluate(expr_eval, builder_ptr, chi_eval) -> result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/InequalityExpr.pre.sol
+            function inequality_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/PlaceholderExpr.pre.sol
+            function placeholder_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/ScalingCastExpr.pre.sol
+            function scaling_cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // slither-disable-start cyclomatic-complexity
+            // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
+            function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // slither-disable-end cyclomatic-complexity
+            // IMPORT-YUL FoldLogExpr.pre.sol
+            function fold_log_star_evaluate_from_fold(builder_ptr, fold, chi_eval) -> star {
+                revert(0, 0)
+            }
+            // IMPORT-YUL FoldUtil.pre.sol
+            function fold_expr_evals(plan_ptr, builder_ptr, input_chi_eval, beta, column_count) -> plan_ptr_out, fold {
+                revert(0, 0)
+            }
+            function fold_log_star_evaluate_from_expr_evals(
+                plan_ptr, builder_ptr, input_chi_eval, alpha, beta, column_count
+            ) -> plan_ptr_out, star {
+                let fold
+                plan_ptr, fold := fold_expr_evals(plan_ptr, builder_ptr, input_chi_eval, beta, column_count)
+                fold := mulmod_bn254(fold, alpha)
+                star := fold_log_star_evaluate_from_fold(builder_ptr, fold, input_chi_eval)
+            }
+
+            // We don't keep the plan out, because it isn't needed for testing.
+            let __planOutOffset
+            __planOutOffset, __star :=
+                fold_log_star_evaluate_from_expr_evals(
+                    __plan.offset, __builder, __inputChiEval, __alpha, __beta, __columnCount
+                )
+        }
+        __builderOut = __builder;
+    }
 }

--- a/solidity/test/proof_gadgets/FoldLog.t.pre.sol
+++ b/solidity/test/proof_gadgets/FoldLog.t.pre.sol
@@ -162,4 +162,55 @@ contract FoldLogExprTest is Test {
         }
         assert(builder.aggregateEvaluation == 0);
     }
+
+    function testFoldExprEvalsWithMultipleColumnsProofExprs() public pure {
+        bytes memory plan = abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(0), COLUMN_EXPR_VARIANT, uint64(1));
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.rowMultipliersEvaluation = 1;
+
+        builder.finalRoundMLEs = new uint256[](8);
+        {
+            uint256 inv7207 = 5767416846624501685451078744310193616366497016288337618798791418108430738612;
+            uint256 inv28 = 11725844395628183154774860220673540226008052357365732684124037957094183122652;
+            uint256 invNegative14 = 20324796952422184134943091049167469725080624086100603319148332458963250745930;
+            uint256 inv121 = 18632140626441697090011403237698341604301500274734310226453843233200894835112;
+            uint256 inv52 = 21467315124303904544895513327079250567614742008100341375550161798372427563009;
+            uint256[8] memory star = [inv7207, inv28, invNegative14, inv28, invNegative14, inv28, inv121, inv52];
+            for (uint8 i = 0; i < 8; ++i) {
+                builder.finalRoundMLEs[i] = star[i];
+            }
+        }
+
+        builder.constraintMultipliers = new uint256[](8);
+        for (uint8 i = 0; i < 8; ++i) {
+            builder.constraintMultipliers[i] = 1;
+        }
+
+        uint256[2][8] memory columnEvals = [
+            [uint256(300), 2],
+            [uint256(1), 1],
+            [uint256(MODULUS_MINUS_ONE), 3],
+            [uint256(1), 1],
+            [uint256(MODULUS_MINUS_ONE), 3],
+            [uint256(1), 1],
+            [uint256(5), 0],
+            [uint256(2), 1]
+        ];
+        builder.columnEvaluations = new uint256[](2);
+        for (uint8 i = 0; i < 8; ++i) {
+            builder.columnEvaluations[0] = columnEvals[i][0];
+            builder.columnEvaluations[1] = columnEvals[i][1];
+            uint256 actualStar;
+            (builder, actualStar) = FoldLogExpr.__foldLogStarEvaluateFromExprEvals({
+                __plan: plan,
+                __builder: builder,
+                __inputChiEval: 1,
+                __alpha: 3,
+                __beta: 8,
+                __columnCount: 2
+            });
+        }
+        assert(builder.aggregateEvaluation == 0);
+    }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
