### PR TITLE
bench: add tracing to all code sections executed in the SumCount benchmark query

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -128,7 +128,11 @@ impl ProofExpr for EqualsExpr {
     }
 }
 
-#[tracing::instrument(level = "debug", skip_all)]
+#[tracing::instrument(
+    name = "EqualsExpr::first_round_evaluate_equals_zero",
+    level = "debug",
+    skip_all
+)]
 pub fn first_round_evaluate_equals_zero<'a, S: Scalar>(
     table_length: usize,
     alloc: &'a Bump,
@@ -138,7 +142,11 @@ pub fn first_round_evaluate_equals_zero<'a, S: Scalar>(
     alloc.alloc_slice_fill_with(table_length, |i| lhs[i] == S::zero())
 }
 
-#[tracing::instrument(level = "debug", skip_all)]
+#[tracing::instrument(
+    name = "EqualsExpr::final_round_evaluate_equals_zero",
+    level = "debug",
+    skip_all
+)]
 pub fn final_round_evaluate_equals_zero<'a, S: Scalar>(
     table_length: usize,
     builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -67,11 +67,7 @@ impl ProofExpr for MultiplyExpr {
         Ok(Column::Decimal75(self.precision(), self.scale(), res))
     }
 
-    #[tracing::instrument(
-        name = "proofs.sql.ast.multiply_expr.final_round_evaluate",
-        level = "info",
-        skip_all
-    )]
+    #[tracing::instrument(name = "MultiplyExpr::final_round_evaluate", level = "info", skip_all)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -39,6 +39,7 @@ pub(crate) fn add_subtract_columns<'a, S: Scalar>(
 /// Multiply two columns together.
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length.
+#[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn multiply_columns<'a, S: Scalar>(
     lhs: &Column<'a, S>,
     rhs: &Column<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
@@ -38,6 +38,11 @@ impl<S: Scalar> FoldLogExpr<S> {
         Ok((star_eval, fold_eval))
     }
 
+    #[tracing::instrument(
+        name = "FoldLogExpr::final_round_evaluate_with_chi",
+        level = "debug",
+        skip_all
+    )]
     pub fn final_round_evaluate_with_chi<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,


### PR DESCRIPTION
# Rationale for this change
This PR simply adds tracing around all the sections of code executed during the SumCount benchmark query. No code changes have occurred.

# What changes are included in this PR?
- Tracing is added in various functions

# Are these changes tested?
Yes