### PR TITLE
feat: add the `halo2curves asm` feature to the `cpu-perf` feature flag

### DIFF
--- a/crates/proof-of-sql-benches/Cargo.toml
+++ b/crates/proof-of-sql-benches/Cargo.toml
@@ -19,7 +19,7 @@ datafusion = { version = '38.0.0', default-features = false }
 ff = { version = "0.13.0"}
 halo2curves = { version = "0.8.0", default-features = false }
 indexmap = { version = "2.8", default-features = false }
-nova-snark = { version = "0.41.0",default-features = false }
+nova-snark = { version = "0.41.0", default-features = false }
 opentelemetry = { version = "0.23.0" }
 opentelemetry-jaeger = { version = "0.20.0" }
 proof-of-sql = { path = "../proof-of-sql", default-features = false, features = ["arrow", "hyperkzg_proof"] }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -85,7 +85,7 @@ blitzar = ["dep:blitzar", "dep:merlin", "std"]
 hyperkzg_proof = ["dep:nova-snark", "std", "dep:ff", "dep:halo2curves", "blitzar"]
 test = ["dep:rand", "std"]
 perf = ["blitzar", "cpu-perf"]
-cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]
+cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm", "halo2curves/asm"]
 rayon = ["dep:rayon", "std"]
 std = ["snafu/std", "ark-serialize/std", "dep:sysinfo" ]
 


### PR DESCRIPTION
# Rationale for this change
This is a follow up to a recent PR, https://github.com/spaceandtimefdn/sxt-proof-of-sql/pull/984. That PR needed to turn off the default features in the `nova-snark` crate in order to use WASM, but that introduced a performance regression in Nova specific code since that turned `halo2curves/asm` off. This PR adds the `halo2curves/asm`  feature flag back, but under the `cpu-perf` feature flag.

The following is an example of the `filter` benchmark query on the Multi-A100 system using a table size of `1,000,000`.

Currently in the `main` branch, without the `halo2curves/asm` feature flag, Nova specific code takes 531.23 ms to execute.
<img width="1866" height="511" alt="image" src="https://github.com/user-attachments/assets/d2d9957c-cc02-4040-b5c8-cacde6ba21c4" />

This PR, with the `halo2curves/asm` feature flag, Nova specific code takes 490.04 ms to execute.
<img width="1836" height="509" alt="image" src="https://github.com/user-attachments/assets/6318f7ee-0d85-475e-9aef-81bd1ad34cdb" />


# What changes are included in this PR?
- `halo2curves/asm` is added to the `cpu-pref` feature flag
- small formatting update

# Are these changes tested?
Yes, but not with WASM.