### PR TITLE
perf: add parallel branch to `add_subtract_columns` function in the `numerical_utils` module

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -32,13 +32,15 @@ pub(crate) fn add_subtract_columns<'a, S: Scalar>(
     if_rayon!(
         {
             let result = alloc.alloc_slice_fill_with(lhs_len, |_| S::ZERO);
-            result.par_iter_mut().enumerate().for_each(|(i, val)| {
-                *val = if is_subtract {
-                    lhs.scalar_at(i).unwrap() - rhs.scalar_at(i).unwrap()
-                } else {
-                    lhs.scalar_at(i).unwrap() + rhs.scalar_at(i).unwrap()
-                };
-            });
+            if is_subtract {
+                result.par_iter_mut().enumerate().for_each(|(i, val)| {
+                    *val = lhs.scalar_at(i).unwrap() - rhs.scalar_at(i).unwrap();
+                });
+            } else {
+                result.par_iter_mut().enumerate().for_each(|(i, val)| {
+                    *val = lhs.scalar_at(i).unwrap() + rhs.scalar_at(i).unwrap();
+                });
+            }
             result
         },
         {


### PR DESCRIPTION
# Rationale for this change
The performance of the `add_subtract_columns` function in the `numerical_utils` module can be improved with a parallel branch of execution when the project is built with Rayon. The parallel branch also eliminates the cost of temporarily adding the `Scalar` vectors to the heap. See note below on why the non-Rayon build needs to keep the temporary vectors on the heap.

On the Multi-A100 VM with a table size of `1,000,000`, the current implementation took `11.83`ms in the Sum Count benchmark query.
<img width="1440" height="179" alt="image" src="https://github.com/user-attachments/assets/06fefdcd-6311-4124-8186-f36fc43eff61" />

With this PR, the same call is now `7.78`ms - a `1.52`x improvement
<img width="1440" height="179" alt="image" src="https://github.com/user-attachments/assets/3eb1ad40-6752-497e-93d0-fec921fe2717" />

NOTE, if we eliminate the `Scalar` memory allocation from the original code and use `scalar_at(i).unwrap()`, the performance regresses.

For example, in the Filter benchmark query, making a temporary copy of the `Scalars` on the heap took `11.63`ms 
<img width="1258" height="120" alt="image" src="https://github.com/user-attachments/assets/d7b8023b-823c-4ce0-becf-c778d16f43d2" />

Updating the code to eliminate the temporary copies of the vectors, and using `scalars_at(i).unwrap()` took `120.61`ms
<img width="1691" height="125" alt="image" src="https://github.com/user-attachments/assets/ed3cab66-df43-4ae7-b2f8-01beb71d2255" />

Adding an `unsafe_scalar_at` function that doesn't return an `Option` did not help either, the same section of code using `unsafe_scalar_at(i)` took `106.31`ms
<img width="1662" height="125" alt="image" src="https://github.com/user-attachments/assets/99a14ce2-974d-4d28-a65d-3661b5cc199d" />


# What changes are included in this PR?
- A parallel branch for Rayon builds is added to the `add_subtract_columns` function in the `numerical_utils` module

# Are these changes tested?
Yes
