### PR TITLE
feat: remove the `blitzar` requirement from building `nova-snark` when using the HyperKZG commitment scheme

### DIFF
--- a/crates/proof-of-sql-benches/Cargo.toml
+++ b/crates/proof-of-sql-benches/Cargo.toml
@@ -22,7 +22,7 @@ indexmap = { version = "2.8", default-features = false }
 nova-snark = { version = "0.41.0", default-features = false }
 opentelemetry = { version = "0.23.0" }
 opentelemetry-jaeger = { version = "0.20.0" }
-proof-of-sql = { path = "../proof-of-sql", default-features = false, features = ["arrow", "hyperkzg_proof"] }
+proof-of-sql = { path = "../proof-of-sql", features = ["hyperkzg_proof"] }
 proof-of-sql-planner = { path = "../proof-of-sql-planner" }
 rand = { version = "0.8", default-features = false }
 sqlparser = { version = "0.45.0", default-features = false }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -43,7 +43,7 @@ indexmap = { workspace = true, features = ["serde"] }
 indicatif = { workspace = true, optional = true }
 itertools = { workspace = true }
 merlin = { workspace = true, optional = true }
-nova-snark = { workspace = true, optional = true, features = ["blitzar"] }
+nova-snark = { workspace = true, optional = true }
 num-traits = { workspace = true }
 num-bigint = { workspace = true, default-features = false }
 postcard = { workspace = true, features = ["alloc"] }
@@ -81,8 +81,8 @@ development = ["arrow-csv"]
 default = ["arrow", "perf"]
 utils = ["dep:indicatif", "dep:rand_chacha", "dep:sha2", "dep:clap", "dep:tempfile"]
 arrow = ["dep:arrow", "std"]
-blitzar = ["dep:blitzar", "dep:merlin", "std"]
-hyperkzg_proof = ["dep:nova-snark", "std", "dep:ff", "dep:halo2curves", "blitzar"]
+blitzar = ["dep:blitzar", "dep:merlin", "std", "nova-snark?/blitzar"]
+hyperkzg_proof = ["dep:nova-snark", "std", "dep:ff", "dep:halo2curves"]
 test = ["dep:rand", "std"]
 perf = ["blitzar", "cpu-perf"]
 cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm", "halo2curves/asm"]

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/arkworks_halo2_interop.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/arkworks_halo2_interop.rs
@@ -1,0 +1,92 @@
+// Copyright 2025-present Space and Time Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This code is adapted from the blitzar-rs project:
+// https://github.com/spaceandtimefdn/blitzar-rs/blob/main/src/compute/arkworks_halo2_interop.rs
+// Original copyright held by Space and Time Labs, Inc.
+
+use ark_bn254::{Fq as Bn254Fq, G1Affine as Bn254G1Affine};
+use ark_ff::BigInteger256;
+use core::mem;
+use halo2curves::{
+    bn256::{Fq as Halo2Bn256Fq, G1Affine as Halo2Bn256G1Affine},
+    serde::SerdeObject,
+};
+
+fn convert_halo2_to_limbs(point: &Halo2Bn256Fq) -> [u64; 4] {
+    let limbs: [u64; 4] = unsafe { mem::transmute(*point) };
+    limbs
+}
+
+/// Converts a Halo2 BN256 G1 Affine point to an Arkworks BN254 G1 Affine point.
+pub fn convert_to_ark_bn254_g1_affine(point: &Halo2Bn256G1Affine) -> Bn254G1Affine {
+    let x_limbs: [u64; 4] = convert_halo2_to_limbs(&point.x);
+    let y_limbs: [u64; 4] = convert_halo2_to_limbs(&point.y);
+
+    Bn254G1Affine {
+        x: Bn254Fq::new_unchecked(BigInteger256::new(x_limbs)),
+        y: Bn254Fq::new_unchecked(BigInteger256::new(y_limbs)),
+        infinity: *point == Halo2Bn256G1Affine::default(),
+    }
+}
+
+/// Converts an Arkworks BN254 G1 Affine point to a Halo2 BN256 G1 Affine point.
+pub fn convert_to_halo2_bn256_g1_affine(point: &Bn254G1Affine) -> Halo2Bn256G1Affine {
+    if point.infinity {
+        return Halo2Bn256G1Affine::default();
+    }
+
+    let x_bytes = bytemuck::cast::<[u64; 4], [u8; 32]>(point.x.0 .0);
+    let y_bytes = bytemuck::cast::<[u64; 4], [u8; 32]>(point.y.0 .0);
+
+    Halo2Bn256G1Affine {
+        x: Halo2Bn256Fq::from_raw_bytes_unchecked(&x_bytes),
+        y: Halo2Bn256Fq::from_raw_bytes_unchecked(&y_bytes),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use halo2curves::bn256::Fq as Halo2Bn256Fq;
+
+    #[test]
+    fn test_convert_halo2_modulus_to_limbs() {
+        let expected: [u64; 4] = [
+            4_332_616_871_279_656_263,
+            10_917_124_144_477_883_021,
+            13_281_191_951_274_694_749,
+            3_486_998_266_802_970_665,
+        ];
+        let modulus = Halo2Bn256Fq::from_raw(expected);
+        let point = convert_halo2_to_limbs(&modulus);
+        assert_eq!(point, [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_convert_halo2_one_to_one_in_montgomery_form_in_limbs() {
+        let one: [u64; 4] = [1, 0, 0, 0];
+        let one_in_mont = Halo2Bn256Fq::from_raw(one);
+        let point = convert_halo2_to_limbs(&one_in_mont);
+
+        let expected: [u64; 4] = [
+            15_230_403_791_020_821_917,
+            754_611_498_739_239_741,
+            7_381_016_538_464_732_716,
+            1_011_752_739_694_698_287,
+        ];
+
+        assert_eq!(point, expected);
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment_evaluation_proof.rs
@@ -1,10 +1,11 @@
 use super::{BNScalar, HyperKZGCommitment, HyperKZGEngine, HyperKZGPublicSetup};
 use crate::{
     base::{commitment::CommitmentEvaluationProof, slice_ops},
-    proof_primitive::hyperkzg::nova_commitment::NovaCommitment,
+    proof_primitive::hyperkzg::{
+        convert_to_halo2_bn256_g1_affine, nova_commitment::NovaCommitment,
+    },
 };
 use ark_bn254::{G1Affine, G1Projective};
-use blitzar;
 use core::ops::Add;
 use ff::Field;
 use halo2curves::bn256::G2Affine;
@@ -80,7 +81,7 @@ impl CommitmentEvaluationProof for HyperKZGCommitmentEvaluationProof {
 
         let span = span!(Level::DEBUG, "initialize nova_ck").entered();
         let nova_ck: CommitmentKey<HyperKZGEngine> = CommitmentKey::new(
-            slice_ops::slice_cast_with(setup, blitzar::compute::convert_to_halo2_bn256_g1_affine),
+            slice_ops::slice_cast_with(setup, convert_to_halo2_bn256_g1_affine),
             Affine::default(),   // I'm pretty sure this is unused in the proof
             G2Affine::default(), // I'm pretty sure this is unused in the proof
         );
@@ -126,7 +127,7 @@ impl CommitmentEvaluationProof for HyperKZGCommitmentEvaluationProof {
             .fold(G1Projective::default(), Add::add)
             .into();
         let nova_commit = nova_snark::provider::hyperkzg::Commitment::new(
-            blitzar::compute::convert_to_halo2_bn256_g1_affine(&commit).into(),
+            convert_to_halo2_bn256_g1_affine(&commit).into(),
         );
         let nova_eval = evaluations
             .iter()

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/mod.rs
@@ -23,6 +23,13 @@ mod commitment;
 pub use commitment::HyperKZGCommitment;
 
 #[cfg(feature = "hyperkzg_proof")]
+mod arkworks_halo2_interop;
+#[cfg(feature = "hyperkzg_proof")]
+pub(crate) use arkworks_halo2_interop::{
+    convert_to_ark_bn254_g1_affine, convert_to_halo2_bn256_g1_affine,
+};
+
+#[cfg(feature = "hyperkzg_proof")]
 mod nova_commitment;
 
 #[cfg(feature = "hyperkzg_proof")]

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
@@ -1,7 +1,10 @@
 use super::{BNScalar, HyperKZGPublicSetupOwned};
-use crate::base::{
-    proof::{Keccak256Transcript, Transcript},
-    slice_ops,
+use crate::{
+    base::{
+        proof::{Keccak256Transcript, Transcript},
+        slice_ops,
+    },
+    proof_primitive::hyperkzg::convert_to_ark_bn254_g1_affine,
 };
 use nova_snark::{
     errors::NovaError,
@@ -52,5 +55,5 @@ impl TranscriptEngineTrait<HyperKZGEngine> for Keccak256Transcript {
 pub fn nova_commitment_key_to_hyperkzg_public_setup(
     setup: &CommitmentKey<HyperKZGEngine>,
 ) -> HyperKZGPublicSetupOwned {
-    slice_ops::slice_cast_with(setup.ck(), blitzar::compute::convert_to_ark_bn254_g1_affine)
+    slice_ops::slice_cast_with(setup.ck(), convert_to_ark_bn254_g1_affine)
 }


### PR DESCRIPTION
# Rationale for this change
Currently when you run `cargo install` on the Proof of SQL CLI project you need to manually download the Blitzar `.so` file to make things work. This is required because they HyperKZG commitment scheme builds with `blitzar` enabled.

This PR removes that requirement by moving the code required by the HyperKZG setup that uses Blitzar, but not the GPU, locally to the project. That allows the HyperKZG commitment scheme to no longer require `blitzar` as a feature. The optional flag to build `nova-snark` with `blitzar` enabled is moved to the `blitzar` feature flag.

# What changes are included in this PR?
- `arkworks_halo2_interop` is copied from the `blitzar-rs` project
- Code using `arkworks_halo2_interop` functions no longer require `blitzar`
- `nova-snark` no longer has a `blitzar` requirement
- `nova-snark` will built with `blitzar` feature flag when `proof-of-sql` also is using the `blitzar` feature flag

# Are these changes tested?
Yes locally with CI checks and benchmarks