### PR TITLE
feat(sol): params builder

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -90,6 +90,9 @@ uint256 constant INT64_SIZE_MINUS_ONE = 0x07;
 /// @dev Size of uint128 in bytes
 uint256 constant UINT128_SIZE = 0x10;
 
+/// @dev Max value for a uint64
+uint256 constant MAX_UINT64 = 0xFFFFFFFFFFFFFFFF;
+
 /// @dev Column variant constant for proof expressions
 uint32 constant COLUMN_EXPR_VARIANT = 0;
 /// @dev Literal variant constant for proof expressions
@@ -152,6 +155,11 @@ uint32 constant DATA_TYPE_TIMESTAMP_VARIANT = 9;
 uint32 constant DATA_TYPE_SCALAR_VARIANT = 10;
 /// @dev Varbinary variant constant for column types
 uint32 constant DATA_TYPE_VARBINARY_VARIANT = 11;
+
+/// @dev Timestamp variant constant for column types
+uint32 constant TIMEUNIT_MILLISECOND_VARIANT = 1;
+/// @dev Timestamp variant constant for column types
+int32 constant TIMEZONE_UTC = 0;
 
 /// @dev Position of the free memory pointer in the context of the EVM memory.
 uint256 constant FREE_PTR = 0x40;

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -156,6 +156,8 @@ library Errors {
     error CommitmentsNotFound();
     /// @notice Error thrown for unsupported table commitments.
     error TableCommitmentUnsupported();
+    /// @notice Error thrown for having too many parameters.
+    error TooManyParameters();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/src/client/ParamsBuilder.pre.sol
+++ b/solidity/src/client/ParamsBuilder.pre.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../base/Constants.sol";
+import "../base/Errors.sol";
+
+/// @title ParamsBuilder
+/// @dev Library for constructing an array of sql params
+library ParamsBuilder {
+    /// @dev Returns a serialized array of parameters
+    /// @param arrayOfSerializedParamElements An array of serialized parameters
+    /// @return serializedParams The serialized array of parameters
+    function serializeParamArray(bytes[] memory arrayOfSerializedParamElements)
+        internal
+        pure
+        returns (bytes memory serializedParams)
+    {
+        uint256 uncastLength = arrayOfSerializedParamElements.length;
+        if (uncastLength > MAX_UINT64) {
+            revert Errors.TooManyParameters();
+        } else {
+            uint64 length = uint64(uncastLength);
+            serializedParams = abi.encodePacked(length);
+            for (uint64 i = 0; i < length; ++i) {
+                serializedParams = abi.encodePacked(serializedParams, arrayOfSerializedParamElements[i]);
+            }
+        }
+    }
+
+    /// @dev Returns an array of parameters
+    /// @param serializedParams The serialized parameters
+    /// @return params The parameters as scalars
+    function deserializeParamArray(bytes calldata serializedParams) internal pure returns (uint256[] memory params) {
+        uint64 length;
+        assembly {
+            length := shr(UINT64_PADDING_BITS, calldataload(serializedParams.offset))
+        }
+        params = new uint256[](length);
+
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/SwitchUtil.pre.sol
+            function case_const(lhs, rhs) {
+                revert(0, 0)
+            }
+            // slither-disable-start cyclomatic-complexity
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_entry(result_ptr, data_type_variant) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // slither-disable-end cyclomatic-complexity
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_binary(result_ptr) -> result_ptr_out, entry {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/DataType.pre.sol
+            function read_data_type(ptr) -> ptr_out, data_type {
+                revert(0, 0)
+            }
+            // skip length of byte array
+            let paramsOffset := add(serializedParams.offset, UINT64_SIZE)
+            let paramsArray := add(params, WORD_SIZE)
+            for {} length { length := sub(length, 1) } {
+                let data_type
+                paramsOffset, data_type := read_data_type(paramsOffset)
+                let entry
+                paramsOffset, entry := read_entry(paramsOffset, data_type)
+                mstore(paramsArray, entry)
+                paramsArray := add(paramsArray, WORD_SIZE)
+            }
+        }
+    }
+
+    /// @dev Serializes a bool parameter
+    /// @param param The parameter
+    /// @return serializedParam The serialized parameter
+    function boolParam(bool param) internal pure returns (bytes memory serializedParam) {
+        serializedParam = abi.encodePacked(DATA_TYPE_BOOLEAN_VARIANT, param);
+    }
+
+    /// @dev Serializes a tinyint parameter
+    /// @param param The parameter
+    /// @return serializedParam The serialized parameter
+    function tinyIntParam(int8 param) internal pure returns (bytes memory serializedParam) {
+        serializedParam = abi.encodePacked(DATA_TYPE_TINYINT_VARIANT, param);
+    }
+
+    /// @dev Serializes a smallint parameter
+    /// @param param The parameter
+    /// @return serializedParam The serialized parameter
+    function smallIntParam(int16 param) internal pure returns (bytes memory serializedParam) {
+        serializedParam = abi.encodePacked(DATA_TYPE_SMALLINT_VARIANT, param);
+    }
+
+    /// @dev Serializes an int32 parameter
+    /// @param param The parameter
+    /// @return serializedParam The serialized parameter
+    function intParam(int32 param) internal pure returns (bytes memory serializedParam) {
+        serializedParam = abi.encodePacked(DATA_TYPE_INT_VARIANT, param);
+    }
+
+    /// @dev Serializes a bigint parameter
+    /// @param param The parameter
+    /// @return serializedParam The serialized parameter
+    function bigIntParam(int64 param) internal pure returns (bytes memory serializedParam) {
+        serializedParam = abi.encodePacked(DATA_TYPE_BIGINT_VARIANT, param);
+    }
+
+    /// @dev Serializes a string parameter
+    /// @param param The parameter
+    /// @return serializedParam The serialized parameter
+    function varCharParam(string memory param) internal pure returns (bytes memory serializedParam) {
+        uint64 length = uint64(bytes(param).length);
+        serializedParam = abi.encodePacked(DATA_TYPE_VARCHAR_VARIANT, length, param);
+    }
+
+    /// @dev Serializes a decimal parameter
+    /// @param param The parameter
+    /// @param precision The precision of the decimal
+    /// @param scale The scale of the decimal
+    /// @return serializedParam The serialized parameter
+    function decimal75Param(uint256 param, uint8 precision, int8 scale)
+        internal
+        pure
+        returns (bytes memory serializedParam)
+    {
+        serializedParam = abi.encodePacked(DATA_TYPE_DECIMAL75_VARIANT, precision, scale, param);
+    }
+
+    /// @dev Serializes a timestamp parameter
+    /// @param param The parameter
+    /// @return serializedParam The serialized parameter
+    function unixTimestampMillisParam(int64 param) internal pure returns (bytes memory serializedParam) {
+        serializedParam =
+            abi.encodePacked(DATA_TYPE_TIMESTAMP_VARIANT, TIMEUNIT_MILLISECOND_VARIANT, TIMEZONE_UTC, param);
+    }
+
+    /// @dev Serializes a scalar parameter
+    /// @param param The parameter
+    /// @return serializedParam The serialized parameter
+    function scalarParam(uint256 param) internal pure returns (bytes memory serializedParam) {
+        serializedParam = abi.encodePacked(DATA_TYPE_SCALAR_VARIANT, param);
+    }
+
+    /// @dev Serializes a varbinary parameter
+    /// @param param The parameter
+    /// @return serializedParam The serialized parameter
+    function varBinaryParam(bytes memory param) internal pure returns (bytes memory serializedParam) {
+        uint64 length = uint64(param.length);
+        serializedParam = abi.encodePacked(DATA_TYPE_VARBINARY_VARIANT, length, param);
+    }
+}

--- a/solidity/test/client/ParamsBuilder.t.pre.sol
+++ b/solidity/test/client/ParamsBuilder.t.pre.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import "../../src/base/Errors.sol";
+import {ParamsBuilder} from "../../src/client/ParamsBuilder.pre.sol";
+
+function _areByteArraysEqual(bytes memory left, bytes memory right) pure returns (bool areEqual) {
+    uint256 leftLength = left.length;
+    areEqual = leftLength == right.length;
+    for (uint8 i = 0; i < leftLength; ++i) {
+        areEqual = areEqual && (left[i] == right[i]);
+    }
+}
+
+// This library enables testing internal functions that use calldata
+library ParamsBuilderTestWrapper {
+    function deserializeParamArray(bytes calldata serializedParams) external pure returns (uint256[] memory params) {
+        params = ParamsBuilder.deserializeParamArray(serializedParams);
+    }
+}
+
+contract ParamsBuilderTest is Test {
+    function testSerializationOfAllSupportedTypes() public pure {
+        bytes memory expectedBytes =
+            hex"000000000000000a000000000100000002020000000300030000000400000004000000050000000000000005000000070000000000000001360000000a0000000000000000000000000000000000000000000000000000000000000007000000080a0000000000000000000000000000000000000000000000000000000000000000080000000b000000000000000109000000090000000100000000000000000000000a";
+        bytes[] memory arrayOfSerializedParamElements = new bytes[](10);
+        arrayOfSerializedParamElements[0] = ParamsBuilder.boolParam(true);
+        arrayOfSerializedParamElements[1] = ParamsBuilder.tinyIntParam(2);
+        arrayOfSerializedParamElements[2] = ParamsBuilder.smallIntParam(3);
+        arrayOfSerializedParamElements[3] = ParamsBuilder.intParam(4);
+        arrayOfSerializedParamElements[4] = ParamsBuilder.bigIntParam(5);
+        arrayOfSerializedParamElements[5] = ParamsBuilder.varCharParam("6");
+        arrayOfSerializedParamElements[6] = ParamsBuilder.scalarParam(7);
+        arrayOfSerializedParamElements[7] = ParamsBuilder.decimal75Param(8, 10, 0);
+        arrayOfSerializedParamElements[8] = ParamsBuilder.varBinaryParam(bytes("\x09"));
+        arrayOfSerializedParamElements[9] = ParamsBuilder.unixTimestampMillisParam(10);
+        bytes memory actualBytes = ParamsBuilder.serializeParamArray(arrayOfSerializedParamElements);
+        uint256[] memory actualParams = ParamsBuilderTestWrapper.deserializeParamArray(actualBytes);
+        assert(_areByteArraysEqual(actualBytes, expectedBytes));
+        assert(actualParams.length == 10);
+        assert(actualParams[0] == 1);
+        assert(actualParams[1] == 2);
+        assert(actualParams[2] == 3);
+        assert(actualParams[3] == 4);
+        assert(actualParams[4] == 5);
+        assert(actualParams[5] == 6018613808072455048935921990747708200856747868835246493831327293258478867940);
+        assert(actualParams[6] == 7);
+        assert(actualParams[7] == 8);
+        assert(actualParams[8] == 14368806583393397743267686700701231208279041777806019220663728442259589818290);
+        assert(actualParams[9] == 10);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testSerializationOfTooManyParamsFails() public {
+        bytes[] memory arrayOfSerializedParamElements = new bytes[](1);
+        assembly {
+            mstore(arrayOfSerializedParamElements, add(MAX_UINT64, 1))
+        }
+        vm.expectRevert(Errors.TooManyParameters.selector);
+        ParamsBuilder.serializeParamArray(arrayOfSerializedParamElements);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This will enable easier use of sql params in contracts.

# What changes are included in this PR?

New library for initialization, serialization, and deserialization of sql params.

# Are these changes tested?
Yes.
