### PR TITLE
fix: downgrade datafusion to 37.1.0 and sqlparser to 0.44.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ criterion = { version = "0.5.1" }
 chrono = { version = "=0.4.39", default-features = false }
 csv = { version = "1.3.1" }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
-datafusion = { version = "38.0.0", default-features = false }
+datafusion = { version = "37.1.0", default-features = false }
 derive_more = { version = "0.99" }
 enum_dispatch = { version = "0.3.13" }
 getrandom = { version = "0.2.15", default-features = false }
@@ -66,7 +66,7 @@ serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10.8", default-features = false }
 snafu = { version = "0.8.4", default-features = false }
-sqlparser = { version = "0.45.0", default-features = false }
+sqlparser = { version = "0.44.0", default-features = false }
 sysinfo = { version = "0.33" }
 tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
 tempfile = { version = "3.13.0", default-features = false }
@@ -88,5 +88,5 @@ allow_attributes = "warn"
 
 [patch.crates-io]
 # patch for sqlparser no_std compatibility with the serde feature enabled.
-# required until sqlparser releases a similar update and proof-of-sql upgrades to it.
-sqlparser = { git = "https://github.com/tlovell-sxt/datafusion-sqlparser-rs.git", rev = "a828cbea22cf19bb6b4596f902bdd6f4d14a00b8" }
+# required until proof-of-sql upgrades to at least sqlparser 0.56.0.
+sqlparser = { git = "https://github.com/iajoiner/datafusion-sqlparser-rs.git", rev = "fc4b33e72395462f62898808c7562319cf1bb58f" }

--- a/crates/proof-of-sql-benches/Cargo.toml
+++ b/crates/proof-of-sql-benches/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5.4", features = ["derive", "env"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 csv = { version = "1.3.1" }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
-datafusion = { version = '38.0.0', default-features = false }
+datafusion = { version = '37.1.0', default-features = false }
 ff = { version = "0.13.0"}
 halo2curves = { version = "0.8.0", default-features = false }
 indexmap = { version = "2.8", default-features = false }
@@ -25,7 +25,7 @@ opentelemetry-jaeger = { version = "0.20.0" }
 proof-of-sql = { path = "../proof-of-sql", features = ["hyperkzg_proof"] }
 proof-of-sql-planner = { path = "../proof-of-sql-planner" }
 rand = { version = "0.8", default-features = false }
-sqlparser = { version = "0.45.0", default-features = false }
+sqlparser = { version = "0.44.0", default-features = false }
 tracing = { version = "0.1.36", default-features = false }
 tracing-opentelemetry = { version = "0.22.0" }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }

--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -3,7 +3,7 @@ use alloc::{sync::Arc, vec::Vec};
 use datafusion::{
     config::ConfigOptions,
     logical_expr::LogicalPlan,
-    optimizer::{Analyzer, Optimizer, OptimizerContext, OptimizerRule},
+    optimizer::{analyzer::Analyzer, optimizer::Optimizer, OptimizerContext, OptimizerRule},
     sql::planner::{ParserOptions, SqlToRel},
 };
 use indexmap::IndexSet;
@@ -68,12 +68,12 @@ where
             // 3. Analyze the `LogicalPlan` using `Analyzer`
             let analyzer = Analyzer::new();
             let analyzed_logical_plan =
-                analyzer.execute_and_check(raw_logical_plan, config, |_, _| {})?;
+                analyzer.execute_and_check(&raw_logical_plan, config, |_, _| {})?;
             // 4. Optimize the `LogicalPlan` using `Optimizer`
             let optimizer = optimizer();
             let optimizer_context = OptimizerContext::default();
             let optimized_logical_plan =
-                optimizer.optimize(analyzed_logical_plan, &optimizer_context, |_, _| {})?;
+                optimizer.optimize(&analyzed_logical_plan, &optimizer_context, |_, _| {})?;
             // 5. Convert the optimized `LogicalPlan` into a Proof of SQL plan
             planner_converter(&optimized_logical_plan, schemas)
         })

--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -7,10 +7,8 @@ use datafusion::{
 
 /// Create a `Expr::Column` from full table name and column
 pub(crate) fn df_column(table_name: &str, column: &str) -> Expr {
-    Expr::Column(Column::new(
-        Some(TableReference::from(table_name)),
-        column.to_string(),
-    ))
+    let reference = TableReference::parse_str(table_name).to_owned_reference();
+    Expr::Column(Column::new(Some(reference), column.to_string()))
 }
 
 /// Create a `DFSchema` from table name, column name and data type pairs

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -151,11 +151,9 @@ mod tests {
     use arrow::datatypes::DataType;
     use core::ops::{Add, Mul, Sub};
     use datafusion::{
-        common::ScalarValue,
-        logical_expr::{
-            expr::{Placeholder, Unnest},
-            Cast,
-        },
+        catalog::TableReference,
+        common::{Column, ScalarValue},
+        logical_expr::{expr::Placeholder, Cast},
     };
     use proof_of_sql::base::{
         database::{ColumnRef, ColumnType, LiteralValue, TableRef},
@@ -722,7 +720,10 @@ mod tests {
     // Unsupported logical expression
     #[test]
     fn we_cannot_convert_unsupported_expr_to_proof_expr() {
-        let expr = Expr::Unnest(Unnest::new(Expr::Literal(ScalarValue::Int32(Some(100)))));
+        let expr = Expr::OuterReferenceColumn(
+            DataType::Int32,
+            Column::new(None::<TableReference>, "column"),
+        );
         assert!(matches!(
             expr_to_proof_expr(&expr, &Vec::new()),
             Err(PlannerError::UnsupportedLogicalExpression { .. })

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -114,9 +114,8 @@ fn try_get_schema_as_vec_from_df_schema(
     df_schema: &DFSchema,
 ) -> PlannerResult<Vec<(Ident, ColumnType)>> {
     df_schema
-        .inner()
         .fields()
-        .into_iter()
+        .iter()
         .map(|f| {
             ColumnType::try_from(f.data_type().clone())
                 .map_err(|_| PlannerError::UnsupportedDataType {
@@ -138,7 +137,7 @@ fn projection_to_proof_plan(
     let input_schema = try_get_schema_as_vec_from_df_schema(input.schema())?;
     let aliased_exprs = expr
         .iter()
-        .zip(output_schema.fields().into_iter())
+        .zip(output_schema.fields().iter())
         .map(|(e, field)| -> PlannerResult<AliasedDynProofExpr> {
             let proof_expr = expr_to_proof_expr(e, &input_schema)?;
             let alias = field.name().as_str().into();


### PR DESCRIPTION
# Rationale for this change
`datafusion` 38 is not really compatible with any `deltalake` version which we need in a downstream repo. Hence we need to slightly downgrade `datafusion` to 37.1.0 and `sqlparser` to 0.44.0 for consistency
