### PR TITLE
refactor(sol)!: move contracts code to po sql

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -51,6 +51,9 @@ uint256 constant INT8_PADDING_BITS = 0xF8;
 uint256 constant INT8_SIZE_MINUS_ONE = 0x00;
 /// @dev Size of uint8 in bytes
 uint256 constant UINT8_SIZE = 0x01;
+/// @dev Number of bits needed to pad uint8 to 256 bits
+/// @dev This is useful for shifting a uint256 to the right to extract a uint8
+uint256 constant UINT8_PADDING_BITS = 0xF8;
 /// @dev Size of int16 in bytes
 uint256 constant INT16_SIZE = 0x02;
 /// @dev Number of bits needed to pad int16 to 256 bits
@@ -58,6 +61,8 @@ uint256 constant INT16_SIZE = 0x02;
 uint256 constant INT16_PADDING_BITS = 0xF0;
 /// @dev Size of int16 minus one byte
 uint256 constant INT16_SIZE_MINUS_ONE = 0x01;
+/// @dev Size of uint16 in bytes
+uint256 constant UINT16_SIZE = 0x02;
 /// @dev Size of uint32 in bytes
 uint256 constant UINT32_SIZE = 0x04;
 /// @dev Number of bits needed to pad uint32 to 256 bits
@@ -82,6 +87,8 @@ uint256 constant INT64_SIZE = 0x08;
 uint256 constant INT64_PADDING_BITS = 0xC0;
 /// @dev Size of int64 minus one byte
 uint256 constant INT64_SIZE_MINUS_ONE = 0x07;
+/// @dev Size of uint128 in bytes
+uint256 constant UINT128_SIZE = 0x10;
 
 /// @dev Column variant constant for proof expressions
 uint32 constant COLUMN_EXPR_VARIANT = 0;

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -75,6 +75,8 @@ uint32 constant ERR_UNION_INVALID_COLUMN_COUNTS = 0x2b150620;
 uint32 constant ERR_INTERNAL = 0xfe835e35;
 /// @dev Error code for unprovable group by error.
 uint32 constant ERR_UNPROVABLE_GROUP_BY = 0x6bd33da2;
+/// @dev Error code for unsupported table commitments.
+uint32 constant ERR_TABLE_COMMITMENT_UNSUPPORTED = 0x4b35c9c3;
 
 library Errors {
     /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
@@ -150,6 +152,10 @@ library Errors {
     error InternalError();
     /// @notice Error thrown for unprovable group by error.
     error UnprovableGroupBy();
+    /// @notice Error thrown for commitments that are not found.
+    error CommitmentsNotFound();
+    /// @notice Error thrown for unsupported table commitments.
+    error TableCommitmentUnsupported();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -6,6 +6,315 @@ import "../base/Constants.sol";
 import "../base/Errors.sol";
 
 library Verifier {
+    function verify(
+        bytes calldata __result,
+        bytes calldata __plan,
+        uint256[] memory __placeholderParameters,
+        bytes calldata __proof,
+        bytes[] calldata __tableCommitments
+    ) public view {
+        (uint256[] memory tableLengths, uint256[] memory commitments) =
+            getCommitmentsAndLength(__plan, __tableCommitments);
+        __internalVerify({
+            __result: __result,
+            __plan: __plan,
+            __placeholderParameters: __placeholderParameters,
+            __proof: __proof,
+            __tableLengths: tableLengths,
+            __commitments: commitments
+        });
+    }
+
+    struct TableCommitment {
+        uint256 commitmentsPtr;
+        uint64 tableLength;
+        bytes32[] columnNameHashes;
+    }
+
+    // slither-disable-next-line cyclomatic-complexity
+    function deserializeTableCommitment(bytes calldata tableCommitment)
+        internal
+        pure
+        returns (TableCommitment memory result)
+    {
+        uint256 commitmentsPtr;
+        uint64 tableLength;
+        // columnNameHashes[columnId] = columnNameHash
+        bytes32[] memory columnNameHashes;
+        assembly {
+            function err(code) {
+                mstore(0, code)
+                revert(28, 4)
+            }
+
+            let ptr := tableCommitment.offset
+
+            // range.start (usize) must be 0
+            if shr(UINT64_PADDING_BITS, calldataload(ptr)) { err(ERR_TABLE_COMMITMENT_UNSUPPORTED) }
+            ptr := add(ptr, UINT64_SIZE)
+
+            // range.end *usize) is the table length
+            tableLength := shr(UINT64_PADDING_BITS, calldataload(ptr))
+            ptr := add(ptr, UINT64_SIZE)
+
+            // commitments.len() (usize) is the number of columns
+            let num_columns := shr(UINT64_PADDING_BITS, calldataload(ptr))
+            ptr := add(ptr, UINT64_SIZE)
+
+            // each commitment is a 2-word commitment
+            commitmentsPtr := ptr
+            ptr := add(ptr, mul(num_columns, WORDX2_SIZE))
+
+            // column_metadata.len() (usize) must match the number of columns
+            if sub(num_columns, shr(UINT64_PADDING_BITS, calldataload(ptr))) { err(ERR_TABLE_COMMITMENT_UNSUPPORTED) }
+            ptr := add(ptr, UINT64_SIZE)
+
+            // allocating space for column namess
+            let free_ptr := mload(FREE_PTR)
+            columnNameHashes := free_ptr
+
+            // initializing length of column names
+            mstore(free_ptr, num_columns)
+            free_ptr := add(free_ptr, WORD_SIZE)
+
+            // for each entry in column_metadata
+            for {} num_columns { num_columns := sub(num_columns, 1) } {
+                // column_metadata[i].Ident.value.len() (usize) is the number of characters in the column name
+                let name_len := shr(UINT64_PADDING_BITS, calldataload(ptr))
+                ptr := add(ptr, UINT64_SIZE)
+
+                // column_metadata[i].Ident.value (usize) is the column name. We hash it and store it in the columnNameHashes array
+                calldatacopy(free_ptr, ptr, name_len)
+                mstore(free_ptr, keccak256(free_ptr, name_len))
+                ptr := add(ptr, name_len)
+                free_ptr := add(free_ptr, WORD_SIZE)
+
+                // column_metadata[i].Ident.quote_style (Option<char>) must be None, i.e. 0
+                if shr(UINT8_PADDING_BITS, calldataload(ptr)) { err(ERR_TABLE_COMMITMENT_UNSUPPORTED) }
+                ptr := add(ptr, UINT8_SIZE)
+
+                // column_metadata[i].ColumnCommitmentMetadata.column_type (ColumnType)
+                switch shr(UINT32_PADDING_BITS, calldataload(ptr))
+                // ColumnType::Decimal75
+                case 8 { ptr := add(ptr, add(UINT32_SIZE, add(UINT8_SIZE, UINT8_SIZE))) }
+                // ColumnType::TimestampTZ
+                case 9 { ptr := add(ptr, add(UINT32_SIZE, add(UINT32_SIZE, UINT32_SIZE))) }
+                default { ptr := add(ptr, UINT32_SIZE) }
+
+                // column_metadata[i].ColumnCommitmentMetadata.bounds (ColumnBounds)
+                let variant := shr(UINT32_PADDING_BITS, calldataload(ptr))
+                ptr := add(ptr, UINT32_SIZE)
+                function skip_bounds(data_size, ptr_in) -> ptr_out {
+                    let bounds_variant := shr(UINT32_PADDING_BITS, calldataload(ptr_in))
+                    ptr_out := add(ptr_in, UINT32_SIZE)
+                    if bounds_variant { ptr_out := add(ptr_out, mul(data_size, 2)) }
+                }
+                switch variant
+                // ColumnBounds::NoOrder
+                case 0 {}
+                // ColumnBounds::Uint8
+                case 1 { ptr := skip_bounds(UINT8_SIZE, ptr) }
+                // ColumnBounds::TinyInt
+                case 2 { ptr := skip_bounds(UINT8_SIZE, ptr) }
+                // ColumnBounds::SmallInt
+                case 3 { ptr := skip_bounds(UINT16_SIZE, ptr) }
+                // ColumnBounds::Int
+                case 4 { ptr := skip_bounds(UINT32_SIZE, ptr) }
+                // ColumnBounds::BigInt
+                case 5 { ptr := skip_bounds(UINT64_SIZE, ptr) }
+                // ColumnBounds::Int128
+                case 6 { ptr := skip_bounds(UINT128_SIZE, ptr) }
+                // ColumnBounds::TimestampTZ
+                case 7 { ptr := skip_bounds(UINT64_SIZE, ptr) }
+                default { err(ERR_TABLE_COMMITMENT_UNSUPPORTED) }
+            }
+
+            // done allocating space for column names
+            mstore(FREE_PTR, free_ptr)
+        }
+        result = TableCommitment(commitmentsPtr, tableLength, columnNameHashes);
+    }
+
+    function deserializeTableCommitments(bytes[] calldata tableCommitments)
+        internal
+        pure
+        returns (
+            // tableCommitments[tableId] = TableCommitment
+            TableCommitment[] memory result
+        )
+    {
+        uint256 numTableCommitments = tableCommitments.length;
+        result = new TableCommitment[](numTableCommitments);
+        for (uint256 i = 0; i < numTableCommitments; ++i) {
+            result[i] = deserializeTableCommitment(tableCommitments[i]);
+        }
+    }
+
+    function deserializeProofPlanPrefix(bytes calldata plan)
+        internal
+        pure
+        returns (
+            // tableNameHashes[tableId] = tableNameHash
+            bytes32[] memory tableNameHashes,
+            // columnTableIndexes[columnId] = tableId
+            uint64[] memory columnTableIndexes,
+            // columnNameHashes[columnId] = columnNameHash
+            bytes32[] memory columnNameHashes
+        )
+    {
+        assembly {
+            let ptr := plan.offset
+
+            let free_ptr := mload(FREE_PTR)
+
+            // tables.len() (usize) is the number of tables
+            let num_tables := shr(UINT64_PADDING_BITS, calldataload(ptr))
+            ptr := add(ptr, UINT64_SIZE)
+
+            // allocating space for table names
+            tableNameHashes := free_ptr
+            mstore(free_ptr, num_tables)
+            free_ptr := add(free_ptr, WORD_SIZE)
+
+            // for each table
+            for {} num_tables { num_tables := sub(num_tables, 1) } {
+                // table[i].len() (usize) is the number of characters in the table name
+                let name_len := shr(UINT64_PADDING_BITS, calldataload(ptr))
+                ptr := add(ptr, UINT64_SIZE)
+
+                // table[i] is the table name. We hash it and store it in the tableNameHashes array
+                calldatacopy(free_ptr, ptr, name_len)
+                mstore(free_ptr, keccak256(free_ptr, name_len))
+                ptr := add(ptr, name_len)
+                free_ptr := add(free_ptr, WORD_SIZE)
+            }
+            // done allocating space for table names
+
+            // columns.len() (usize) is the number of columns
+            let num_columns := shr(UINT64_PADDING_BITS, calldataload(ptr))
+            ptr := add(ptr, UINT64_SIZE)
+
+            // allocating space for column table indexes
+            columnTableIndexes := free_ptr
+            let index_ptr := free_ptr
+
+            // initializing length of column table indexes
+            mstore(index_ptr, num_columns)
+            index_ptr := add(index_ptr, WORD_SIZE)
+
+            free_ptr := add(index_ptr, mul(num_columns, WORD_SIZE))
+            // done allocating space for column table indexes
+
+            // allocating space for column names
+            columnNameHashes := free_ptr
+
+            // initializing length of column names
+            mstore(free_ptr, num_columns)
+            free_ptr := add(free_ptr, WORD_SIZE)
+
+            // for each column
+            for {} num_columns { num_columns := sub(num_columns, 1) } {
+                // column[i].0 (usize) is the table id. We store it in the columnTableIndexes array
+                mstore(index_ptr, shr(UINT64_PADDING_BITS, calldataload(ptr)))
+                ptr := add(ptr, UINT64_SIZE)
+                index_ptr := add(index_ptr, WORD_SIZE)
+
+                // column[i].1.len() (usize) is number of characters in the column name
+                let name_len := shr(UINT64_PADDING_BITS, calldataload(ptr))
+                ptr := add(ptr, UINT64_SIZE)
+
+                // column[i].1 (usize) is the column name. We hash it and store it in the columnNameHashes array
+                calldatacopy(free_ptr, ptr, name_len)
+                mstore(free_ptr, keccak256(free_ptr, name_len))
+                ptr := add(ptr, name_len)
+                free_ptr := add(free_ptr, WORD_SIZE)
+
+                // column[i].2 (ColumnType)
+                switch shr(UINT32_PADDING_BITS, calldataload(ptr))
+                // ColumnType::Decimal75
+                case 8 { ptr := add(ptr, add(UINT32_SIZE, add(UINT8_SIZE, UINT8_SIZE))) }
+                // ColumnType::TimestampTZ
+                case 9 { ptr := add(ptr, add(UINT32_SIZE, add(UINT16_SIZE, UINT16_SIZE))) }
+                default { ptr := add(ptr, UINT32_SIZE) }
+            }
+
+            // done allocating space for column names
+            mstore(FREE_PTR, free_ptr)
+        }
+    }
+
+    /// @notice Internal function to get the relevant commitments
+    /// @dev validates that all commitments are found
+    /// @return commitments the commitments in the order of the columns
+    function getRelevantCommitments(
+        uint64[] memory columnTableIndexes,
+        bytes32[] memory columnNameHashes,
+        TableCommitment[] memory tableCommitments
+    ) internal pure returns (uint256[] memory commitments) {
+        uint256 numColumns = columnTableIndexes.length;
+        commitments = new uint256[](numColumns * 2);
+        uint256 commitmentsFreePtr;
+        assembly {
+            commitmentsFreePtr := add(commitments, 0x20)
+        }
+
+        for (uint256 i = 0; i < numColumns; ++i) {
+            uint64 columnTableIndex = columnTableIndexes[i];
+            bytes32 columnNameHash = columnNameHashes[i];
+
+            if (!(columnTableIndex < tableCommitments.length)) {
+                revert Errors.CommitmentsNotFound();
+            }
+            TableCommitment memory tableCommitment = tableCommitments[columnTableIndex];
+            uint256 commitmentsPtr = tableCommitment.commitmentsPtr;
+            bool found = false;
+            uint256 columnNameHashesLength = tableCommitment.columnNameHashes.length;
+            for (uint256 j = 0; j < columnNameHashesLength; ++j) {
+                if (tableCommitment.columnNameHashes[j] == columnNameHash) {
+                    assembly {
+                        calldatacopy(commitmentsFreePtr, add(commitmentsPtr, mul(j, WORDX2_SIZE)), WORDX2_SIZE)
+                        commitmentsFreePtr := add(commitmentsFreePtr, WORDX2_SIZE)
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                revert Errors.CommitmentsNotFound();
+            }
+        }
+    }
+
+    function getTableLengths(TableCommitment[] memory tableCommitments)
+        private
+        pure
+        returns (uint256[] memory tableLengths)
+    {
+        uint256 numTables = tableCommitments.length;
+        tableLengths = new uint256[](numTables);
+        for (uint256 i = 0; i < numTables; ++i) {
+            tableLengths[i] = tableCommitments[i].tableLength;
+        }
+    }
+
+    function getCommitmentsAndLength(bytes calldata queryPlan, bytes[] calldata tableCommitmentsAsBytes)
+        internal
+        pure
+        returns (uint256[] memory __tableLengths, uint256[] memory __commitments)
+    {
+        TableCommitment[] memory tableCommitments = deserializeTableCommitments(tableCommitmentsAsBytes);
+        (, uint64[] memory columnTableIndexes, bytes32[] memory columnNameHashes) =
+            deserializeProofPlanPrefix(queryPlan);
+
+        // construct `uint256[] memory commitments` and validate that all commitments are found
+        uint256[] memory commitments = getRelevantCommitments(columnTableIndexes, columnNameHashes, tableCommitments);
+
+        // construct `uint256[] memory tableLengths`
+        uint256[] memory tableLengths = getTableLengths(tableCommitments);
+        __tableLengths = tableLengths;
+        __commitments = commitments;
+    }
+
     function __internalVerify(
         bytes calldata __result,
         bytes calldata __plan,

--- a/solidity/test/verifier/Verifier.t.pre.sol
+++ b/solidity/test/verifier/Verifier.t.pre.sol
@@ -71,4 +71,138 @@ contract VerifierTest is Test {
             __commitments: commitments
         });
     }
+
+    function testVerify() public view {
+        bytes[] memory tableCommitments = new bytes[](1);
+        tableCommitments[0] =
+            hex"00000000000000000000000000000006000000000000000216D6B82D96CFEC48A1C026598F99BBF3C07CA111E6EB2A9C4E2E9187827D065B1a5ac01ef230e94760b6ad505b9a00be520384bc89cb0e72260135c637679e721a8482d208bad3eeadc836daec1e6bba51ccbc58387b4457d2175934a8fa5bd81e6c1ee8c9a4d39fe271abfb51d3662d199fe6856ded86f727174dbe21ab63dc00000000000000020000000000000001620000000005000000050000000180000000000000007fffffffffffffff0000000000000001610000000005000000050000000180000000000000007fffffffffffffff";
+        bytes memory queryPlan =
+            hex"0000000000000001000000000000000f6e616d6573706163652e7461626c650000000000000002000000000000000000000000000000016200000005000000000000000000000000000000016100000005000000000000000100000000000000016200000000000000000000000000000002000000000000000000000001000000010000000500000000000000050000000000000001000000000000000000000000";
+
+        Verifier.verify({
+            __result: hex"00000000000000010000000000000001620000000005000000000000000200000000000000000000000000000003",
+            __plan: queryPlan,
+            __placeholderParameters: new uint256[](0),
+            __proof: hex"000000000000000600000000000000020000000000000001000000000000000200000000000000000000000000000001236cd1dd5ae57dd08a8b09bd6bd3397fe4b58aa1638c554b8054dcb2d4d0297e12a7e3d2a6d11cf4e66979ea5458d24f66ba7866c43b933fd2135c2a761990140000000000000006000000000000000427a607595971e4f8531109d6bcf114838faac36652aa81d86d51f087cd08799c1095fa761ceaceb796068f4b8174492ede1e88c2f4aafee493331c267284be330078dfd5227feba93faa9a0c9c38432d6c169909d2546f8cef0b7a2108d44db71d518c19207b5ee92cca5cfe09ec5aca67af638b4205a7b650ccb9b9ecd6dd812bbc76361bfaf1e75d70512e9911c71b134404cecbce4053e29ec7c0067717941b11c59c7ba544571e02ba430f9256a63b51e7c8927ffd0d9763fc59bcdcad9521defadf9d440192285b6a0f4e7dc657225821e39bca44e618f7331859e431a62921dd8f70e56f4b52a667f4a851eef537584fb196d14cde47a607f2f6015f3c0000000000000000000000000000000c08a4646bbe5bcbd84f70d57e4199feea96727b0891cd7fc2b9c4548c79134fdc3056f9d01ed8ac370d2d91499df82105cc5842626884827bbd5da23bde9d9f2f27cd3ea9e52ec844140224a5237090c9ed9d1325f920dee410a1f45f884f10f700000000000000000000000000000000000000000000000000000000000000000cb3c1f4236d067d2121b1970bba959f6eb34a5dc55780360adf721cb7706d841e3a39b44aa419741fae45991ff853985acb44d6da117591f5c62bdcd34efa5e0cad3ebe8e7c85e28b999e7e98891b7f5de8dfeb641816693ff4c88ccd378bb10f76ac6934ab963d8cf2de36d5082457f1d4f37b399bab85a7a3e0748b98f4481f5fbcd1225d6fc2179d67784f8cc33f96af63fd2bc3bc0a0b24a2aef032f4e003ede74206e0c0224fbe9c670c28a6a8523bbb853df530b7e8d210d41fa1eeb20567b8ab1dd1ac6b76c90f55380a0e9f6ae397f9f2b29cdd9ed166243e6637591ac21cb2b3d1ed5ae89915fb2dfff88f8d86565b98cf106ed13c21abd2a0d86800000000000000012ab9aab80d43f7435784460a9a510611d5ea4cddb88ea32ccc3c7ca747b95c9d000000000000000216939642c7e9031cbb6e8dc903683c563fe29ffee7344b7c1705ecfb08c627b22f0a59c8d49c3b5d84f2e6e73cf44f2c05005ccf6f4b644e26399fa59e3eab2000000000000000041e837176dd46439a98b5e1aad2c2be57a9cec6c0a6e949e325681657fc59201824588a6ca09cd690acfac8a388cd7c2c2b2105cef96856365a2809a051aaaf231b7e9025b83e0435c1d7f5a8f42da0c4d0809a2b89df0792574778003419af3e2b59a06fd0744f42d07b57f7d8cda7a2032b86fc9eeaf80e4f858faa0e1da9ee00000000000000021cc3fcf38084a75d2d2e8f65edd2e7f1c98e27936ed4ec9c2f83d7d7f953d48d2276ff007d3bda222501c2f5b5ef10b7bf69d177de3ae102dc6e95507b7db4620d6089448b955000aec99031b580405143cd992004d92d0bb840748ad17cce2808947359cf839bc2792b71bb653862169475ccf7d354f0e05ff44b9600fb97500000000000000003120eef7fd4b3ee1684781b3828b14e5ce92a348993e090ef7aefed628428f04111c60d0bb82ab6223350ef46a99b6aaf72d9d10a090dc84c1b4dd1719f6d047829729324a31c3bcf393b4fa25704e2104cfd60e68e43f68892f8b69292efea7202e33bf988181994edcd6d7663b5590339d28e0509d8c0fc0d93334298e1295d12401b7ec5e8363c4ff0d04d7a20ff9584798bf571d5f5ea6a18ac08511742d229d4fa347951ed2d4812b378ac25dc7f278efea58239686edd309c65d1254b20238a63c8139c66b11f73e4490c47bd54517e9a3d84e7e1728bd2545c50070b8f2a5d10f0f8dc22249e979d95b4d5cbede923f576993884fc468d5a675bd7e4f02ae68ad8a170536483d1c64ad7763ee693cb2f963577bd6e530a275337a3480e2eefe01b65c73902b1bd918c0320fa626052596cdd8a43c1be1904df048ca02e16a1c960daf465f7578155147ee1ccf23aff18f620a299a539b3341a5bde26f80ef8f2d1a2febc7c56bf170a18a3215cdc2d2861002a582b7ff03c5c2ceceaf52f21e226bb2d43a1cfc1daee7dad66c1be678f2bb55ec1fc312916b58a240a980687fda634e438a343b885bc944199728f2161d6a244e06ac84a4cdbafdcb6d60e62f98d94384fa7bc869e213dce126be5d98e3b72241f7a615fa4f301d6af09",
+            __tableCommitments: tableCommitments
+        });
+    }
+
+    function testDeserializeTableCommitment() public pure {
+        bytes[] memory tableCommitments = new bytes[](1);
+        tableCommitments[0] =
+            hex"000000000000000000000000000000030000000000000009257aad035de6dc285d1be01072947fb3bbff4b71457613d266dbde54710e52dd0e5bab33d51316dd8f77fcd732e259fb1599aaefd7d55c59c63fe81bdf030ca21a21982f135adddb079a91b739a8d358e47f38478eeaf8844c2f670f6595895e276a4c8714fba9d532e03556294ffdb2c6fb376a11ec2dda177a056e9513a28b257aad035de6dc285d1be01072947fb3bbff4b71457613d266dbde54710e52dd0e5bab33d51316dd8f77fcd732e259fb1599aaefd7d55c59c63fe81bdf030ca2257aad035de6dc285d1be01072947fb3bbff4b71457613d266dbde54710e52dd0e5bab33d51316dd8f77fcd732e259fb1599aaefd7d55c59c63fe81bdf030ca2257aad035de6dc285d1be01072947fb3bbff4b71457613d266dbde54710e52dd0e5bab33d51316dd8f77fcd732e259fb1599aaefd7d55c59c63fe81bdf030ca2257aad035de6dc285d1be01072947fb3bbff4b71457613d266dbde54710e52dd0e5bab33d51316dd8f77fcd732e259fb1599aaefd7d55c59c63fe81bdf030ca2257aad035de6dc285d1be01072947fb3bbff4b71457613d266dbde54710e52dd0e5bab33d51316dd8f77fcd732e259fb1599aaefd7d55c59c63fe81bdf030ca2257aad035de6dc285d1be01072947fb3bbff4b71457613d266dbde54710e52dd0e5bab33d51316dd8f77fcd732e259fb1599aaefd7d55c59c63fe81bdf030ca2257aad035de6dc285d1be01072947fb3bbff4b71457613d266dbde54710e52dd0e5bab33d51316dd8f77fcd732e259fb1599aaefd7d55c59c63fe81bdf030ca20000000000000009000000000000000161000000000500000005000000020000000000000001000000000000000300000000000000016200000000070000000000000000000000016300000000010000000100000002010300000000000000016400000000020000000200000002010300000000000000016500000000030000000300000002000100030000000000000001660000000004000000040000000200000001000000030000000000000001670000000006000000060000000200000000000000000000000000000001000000000000000000000000000000030000000000000001680000000009000000010000000000000007000000020000000000000001000000000000000300000000000000016900000000080a0000000000";
+        Verifier.TableCommitment memory deserializedTableCommitment =
+            VerifierTestWrapper.deserializeTableCommitments(tableCommitments)[0];
+        assert(deserializedTableCommitment.tableLength == 3);
+        bytes32[] memory expectedColumnHashes = new bytes32[](9);
+        expectedColumnHashes[0] = keccak256(bytes("a"));
+        expectedColumnHashes[1] = keccak256(bytes("b"));
+        expectedColumnHashes[2] = keccak256(bytes("c"));
+        expectedColumnHashes[3] = keccak256(bytes("d"));
+        expectedColumnHashes[4] = keccak256(bytes("e"));
+        expectedColumnHashes[5] = keccak256(bytes("f"));
+        expectedColumnHashes[6] = keccak256(bytes("g"));
+        expectedColumnHashes[7] = keccak256(bytes("h"));
+        expectedColumnHashes[8] = keccak256(bytes("i"));
+        assert(deserializedTableCommitment.columnNameHashes[0] == expectedColumnHashes[0]);
+        assert(deserializedTableCommitment.columnNameHashes[1] == expectedColumnHashes[1]);
+        assert(deserializedTableCommitment.columnNameHashes[2] == expectedColumnHashes[2]);
+        assert(deserializedTableCommitment.columnNameHashes[3] == expectedColumnHashes[3]);
+        assert(deserializedTableCommitment.columnNameHashes[4] == expectedColumnHashes[4]);
+        assert(deserializedTableCommitment.columnNameHashes[5] == expectedColumnHashes[5]);
+        assert(deserializedTableCommitment.columnNameHashes[6] == expectedColumnHashes[6]);
+        assert(deserializedTableCommitment.columnNameHashes[7] == expectedColumnHashes[7]);
+        assert(deserializedTableCommitment.columnNameHashes[8] == expectedColumnHashes[8]);
+    }
+
+    function testDeserializeTableCommitmentWithUnsupportedType() public {
+        vm.expectRevert(Errors.TableCommitmentUnsupported.selector);
+        VerifierTestWrapper.deserializeTableCommitment(
+            hex"0000000000000000000000000000000300000000000000011a21982f135adddb079a91b739a8d358e47f38478eeaf8844c2f670f6595895e276a4c8714fba9d532e03556294ffdb2c6fb376a11ec2dda177a056e9513a28b0000000000000001000000000000000162000000000700000008"
+        );
+
+        vm.expectRevert(Errors.TableCommitmentUnsupported.selector);
+        VerifierTestWrapper.deserializeTableCommitment(hex"0000000000000001");
+
+        vm.expectRevert(Errors.TableCommitmentUnsupported.selector);
+        VerifierTestWrapper.deserializeTableCommitment(
+            hex"0000000000000000000000000000000000000000000000000000000000000001"
+        );
+
+        vm.expectRevert(Errors.TableCommitmentUnsupported.selector);
+        VerifierTestWrapper.deserializeTableCommitment(
+            hex"00000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000010001"
+        );
+    }
+
+    function testPlan() public pure {
+        bytes memory plan =
+            hex"0000000000000001000000000000000f6e616d6573706163652e7461626c6500000000000000030000000000000000000000000000000162000000080a000000000000000000000000000000000163000000090000000100000000000000000000000000000000000000016100000005000000000000000200000000000000016200000000000000016300000000000000000000000000000002000000000000000000000002000000010000000500000000000000050000000000000002000000000000000000000000000000000000000000000001";
+        VerifierTestWrapper.deserializeProofPlanPrefix(plan);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testNotEnoughTableCommitments() public {
+        uint64[] memory indices = new uint64[](1);
+        indices[0] = 0;
+        bytes32[] memory hashes = new bytes32[](1);
+        hashes[0] = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
+        vm.expectRevert(Errors.CommitmentsNotFound.selector);
+        Verifier.getRelevantCommitments(indices, hashes, new Verifier.TableCommitment[](0));
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testColumnHashesNotMatching() public {
+        uint64[] memory indices = new uint64[](1);
+        indices[0] = 0;
+        bytes32[] memory hashes = new bytes32[](1);
+        hashes[0] = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
+        Verifier.TableCommitment[] memory commitments = new Verifier.TableCommitment[](1);
+        Verifier.TableCommitment memory first;
+        bytes32[] memory firstHashes = new bytes32[](1);
+        firstHashes[0] = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdee;
+        first.columnNameHashes = firstHashes;
+        first.tableLength = 1;
+        first.commitmentsPtr = 1;
+        commitments[0] = first;
+        vm.expectRevert(Errors.CommitmentsNotFound.selector);
+        Verifier.getRelevantCommitments(indices, hashes, commitments);
+    }
+}
+
+library VerifierTestWrapper {
+    function deserializeProofPlanPrefix(bytes calldata plan)
+        external
+        pure
+        returns (
+            // tableNameHashes[tableId] = tableNameHash
+            bytes32[] memory tableNameHashes,
+            // columnTableIndexes[columnId] = tableId
+            uint64[] memory columnTableIndexes,
+            // columnNameHashes[columnId] = columnNameHash
+            bytes32[] memory columnNameHashes
+        )
+    {
+        (tableNameHashes, columnTableIndexes, columnNameHashes) = Verifier.deserializeProofPlanPrefix(plan);
+    }
+
+    function deserializeTableCommitment(bytes calldata tableCommitment)
+        external
+        pure
+        returns (Verifier.TableCommitment memory result)
+    {
+        result = Verifier.deserializeTableCommitment(tableCommitment);
+    }
+
+    function deserializeTableCommitments(bytes[] calldata tableCommitments)
+        external
+        pure
+        returns (
+            // tableCommitments[tableId] = TableCommitment
+            Verifier.TableCommitment[] memory result
+        )
+    {
+        result = Verifier.deserializeTableCommitments(tableCommitments);
+    }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
