### PR TITLE
refactor: try into proof plan returns dyn proof plan

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -111,13 +111,8 @@ impl EVMDynProofPlan {
             EVMDynProofPlan::Union(union_exec) => {
                 Ok(union_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)?)
             }
-            EVMDynProofPlan::SortMergeJoin(sort_merge_join_exec) => Ok(
-                DynProofPlan::SortMergeJoin(sort_merge_join_exec.try_into_proof_plan(
-                    table_refs,
-                    column_refs,
-                    output_column_names,
-                )?),
-            ),
+            EVMDynProofPlan::SortMergeJoin(sort_merge_join_exec) => Ok(sort_merge_join_exec
+                .try_into_proof_plan(table_refs, column_refs, output_column_names)?),
             EVMDynProofPlan::Filter(filter_exec) => Ok(filter_exec.try_into_proof_plan(
                 table_refs,
                 column_refs,
@@ -611,7 +606,7 @@ impl EVMSortMergeJoinExec {
         table_refs: &IndexSet<TableRef>,
         column_refs: &IndexSet<ColumnRef>,
         output_column_names: &IndexSet<String>,
-    ) -> EVMProofPlanResult<SortMergeJoinExec> {
+    ) -> EVMProofPlanResult<DynProofPlan> {
         let left = Box::new(self.left.try_into_proof_plan(
             table_refs,
             column_refs,
@@ -626,13 +621,13 @@ impl EVMSortMergeJoinExec {
         let right_join_column_indexes = self.right_join_column_indexes.clone();
         let result_idents = self.result_aliases.iter().map(Ident::new).collect();
 
-        Ok(SortMergeJoinExec::new(
+        Ok(DynProofPlan::SortMergeJoin(SortMergeJoinExec::new(
             left,
             right,
             left_join_column_indexes,
             right_join_column_indexes,
             result_idents,
-        ))
+        )))
     }
 }
 

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -89,9 +89,7 @@ impl EVMDynProofPlan {
         output_column_names: &IndexSet<String>,
     ) -> EVMProofPlanResult<DynProofPlan> {
         match self {
-            EVMDynProofPlan::Empty(_empty_exec) => {
-                Ok(DynProofPlan::Empty(EVMEmptyExec::try_into_proof_plan()))
-            }
+            EVMDynProofPlan::Empty(_empty_exec) => Ok(EVMEmptyExec::try_into_proof_plan()),
             EVMDynProofPlan::Table(table_exec) => Ok(DynProofPlan::Table(
                 table_exec.try_into_proof_plan(table_refs, column_refs)?,
             )),
@@ -139,8 +137,8 @@ impl EVMEmptyExec {
     }
 
     /// Convert into a proof plan
-    pub(crate) fn try_into_proof_plan() -> EmptyExec {
-        EmptyExec::new()
+    pub(crate) fn try_into_proof_plan() -> DynProofPlan {
+        DynProofPlan::Empty(EmptyExec::new())
     }
 }
 
@@ -787,7 +785,7 @@ mod tests {
 
     #[test]
     fn we_can_put_empty_exec_in_evm() {
-        let empty_exec = EmptyExec::new();
+        let empty_exec = DynProofPlan::new_empty();
 
         // Roundtrip
         let roundtripped_empty_exec = EVMEmptyExec::try_into_proof_plan();

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -91,33 +91,28 @@ impl EVMDynProofPlan {
         match self {
             EVMDynProofPlan::Empty(_empty_exec) => Ok(EVMEmptyExec::try_into_proof_plan()),
             EVMDynProofPlan::Table(table_exec) => {
-                Ok(table_exec.try_into_proof_plan(table_refs, column_refs)?)
+                table_exec.try_into_proof_plan(table_refs, column_refs)
             }
-            EVMDynProofPlan::LegacyFilter(filter_exec) => Ok(filter_exec.try_into_proof_plan(
-                table_refs,
-                column_refs,
-                output_column_names,
-            )?),
-            EVMDynProofPlan::Projection(projection_exec) => Ok(projection_exec
-                .try_into_proof_plan(table_refs, column_refs, output_column_names)?),
+            EVMDynProofPlan::LegacyFilter(filter_exec) => {
+                filter_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)
+            }
+            EVMDynProofPlan::Projection(projection_exec) => {
+                projection_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)
+            }
             EVMDynProofPlan::Slice(slice_exec) => {
-                Ok(slice_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)?)
+                slice_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)
             }
-            EVMDynProofPlan::GroupBy(group_by_exec) => Ok(group_by_exec.try_into_proof_plan(
-                table_refs,
-                column_refs,
-                output_column_names,
-            )?),
+            EVMDynProofPlan::GroupBy(group_by_exec) => {
+                group_by_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)
+            }
             EVMDynProofPlan::Union(union_exec) => {
-                Ok(union_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)?)
+                union_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)
             }
-            EVMDynProofPlan::SortMergeJoin(sort_merge_join_exec) => Ok(sort_merge_join_exec
-                .try_into_proof_plan(table_refs, column_refs, output_column_names)?),
-            EVMDynProofPlan::Filter(filter_exec) => Ok(filter_exec.try_into_proof_plan(
-                table_refs,
-                column_refs,
-                output_column_names,
-            )?),
+            EVMDynProofPlan::SortMergeJoin(sort_merge_join_exec) => sort_merge_join_exec
+                .try_into_proof_plan(table_refs, column_refs, output_column_names),
+            EVMDynProofPlan::Filter(filter_exec) => {
+                filter_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)
+            }
         }
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is meant to help make the diffs for a future fix easier.

# What changes are included in this PR?

Refactoring all the `try_into_proof_plan` functions to return a `DynProofPlan`

# Are these changes tested?
Yes
