### PR TITLE
refactor!: remove `ColumnType` from `ColumnRef`

### DIFF
--- a/crates/proof-of-sql-planner/src/aggregate.rs
+++ b/crates/proof-of-sql-planner/src/aggregate.rs
@@ -93,11 +93,10 @@ mod tests {
                 aggregate_function_to_proof_expr(&function, &schema).unwrap(),
                 (
                     *operator,
-                    DynProofExpr::new_column(ColumnRef::new(
-                        TableRef::from_names(None, "table"),
-                        "a".into(),
+                    DynProofExpr::new_column(
+                        ColumnRef::new(TableRef::from_names(None, "table"), "a".into(),),
                         ColumnType::BigInt
-                    ))
+                    )
                 )
             );
         }

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -129,7 +129,15 @@ pub fn expr_to_proof_expr(
 ) -> PlannerResult<DynProofExpr> {
     match expr {
         Expr::Alias(Alias { expr, .. }) => expr_to_proof_expr(expr, schema),
-        Expr::Column(col) => Ok(DynProofExpr::new_column(column_to_column_ref(col, schema)?)),
+        Expr::Column(col) => {
+            let column_ref = column_to_column_ref(col)?;
+            let column_type = schema
+                .iter()
+                .find(|(ident, _)| *ident == column_ref.column_id())
+                .ok_or(PlannerError::ColumnNotFound)?
+                .1;
+            Ok(DynProofExpr::new_column(column_ref, column_type))
+        }
         Expr::Placeholder(placeholder) => placeholder_to_placeholder_expr(placeholder),
         Expr::BinaryExpr(BinaryExpr { left, right, op }) => {
             binary_expr_to_proof_expr(left, right, *op, schema)
@@ -189,71 +197,85 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN_INT() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column".into(),
+            ),
             ColumnType::Int,
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN1_SMALLINT() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column1".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column1".into(),
+            ),
             ColumnType::SmallInt,
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN2_BIGINT() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column2".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column2".into(),
+            ),
             ColumnType::BigInt,
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN1_BOOLEAN() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column1".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column1".into(),
+            ),
             ColumnType::Boolean,
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN2_BOOLEAN() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column2".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column2".into(),
+            ),
             ColumnType::Boolean,
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN3_DECIMAL_75_5() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column3".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column3".into(),
+            ),
             ColumnType::Decimal75(
                 Precision::new(75).expect("Precision is definitely valid"),
                 5,
             ),
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN2_DECIMAL_25_5() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column2".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column2".into(),
+            ),
             ColumnType::Decimal75(
                 Precision::new(25).expect("Precision is definitely valid"),
                 5,
             ),
-        ))
+        )
     }
 
     // Alias
@@ -591,16 +613,20 @@ mod tests {
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_not(
                 DynProofExpr::try_new_equals(
-                    DynProofExpr::new_column(ColumnRef::new(
-                        TableRef::from_names(Some("namespace"), "table_name"),
-                        "column1".into(),
+                    DynProofExpr::new_column(
+                        ColumnRef::new(
+                            TableRef::from_names(Some("namespace"), "table_name"),
+                            "column1".into(),
+                        ),
                         ColumnType::BigInt,
-                    )),
-                    DynProofExpr::new_column(ColumnRef::new(
-                        TableRef::from_names(Some("namespace"), "table_name"),
-                        "column2".into(),
+                    ),
+                    DynProofExpr::new_column(
+                        ColumnRef::new(
+                            TableRef::from_names(Some("namespace"), "table_name"),
+                            "column2".into(),
+                        ),
                         ColumnType::BigInt,
-                    ))
+                    )
                 )
                 .unwrap()
             )
@@ -643,11 +669,10 @@ mod tests {
         let schema = vec![("column".into(), ColumnType::Boolean)];
         assert_eq!(
             expr_to_proof_expr(&expr, &schema).unwrap(),
-            DynProofExpr::try_new_not(DynProofExpr::new_column(ColumnRef::new(
-                TableRef::from_names(None, "table_name"),
-                "column".into(),
+            DynProofExpr::try_new_not(DynProofExpr::new_column(
+                ColumnRef::new(TableRef::from_names(None, "table_name"), "column".into(),),
                 ColumnType::Boolean
-            )))
+            ))
             .unwrap()
         );
     }

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -42,20 +42,20 @@ impl<C: Commitment> QueryCommitmentsExt<C> for QueryCommitments<C> {
                     table_columns
                         .entry(column.table_ref())
                         .or_default()
-                        .push(ColumnField::new(column.column_id(), *column.column_type()));
+                        .push(column.column_id());
                     table_columns
                 },
             )
             .into_iter()
-            .map(|(table_ref, column_fields)| {
+            .map(|(table_ref, column_ids)| {
                 let selected_column_fields = accessor
                     .lookup_schema(&table_ref)
                     .into_iter()
-                    .filter_map(|(ident, _)| {
-                        column_fields
+                    .filter_map(|(ident, column_type)| {
+                        column_ids
                             .iter()
-                            .find(|column_field| column_field.name() == ident)
-                            .cloned()
+                            .find(|column_id| **column_id == ident)
+                            .map(|_| ColumnField::new(ident, column_type))
                     })
                     .collect::<Vec<_>>();
                 let table_commitment = TableCommitment::from_accessor_with_max_bounds(
@@ -370,10 +370,10 @@ mod tests {
 
         let query_commitments = QueryCommitments::<DoryCommitment>::from_accessor_with_max_bounds(
             [
-                ColumnRef::new(table_a_id.clone(), column_a_id.clone(), ColumnType::BigInt),
-                ColumnRef::new(table_b_id.clone(), column_a_id, ColumnType::Scalar),
-                ColumnRef::new(table_a_id, column_b_id.clone(), ColumnType::VarChar),
-                ColumnRef::new(table_b_id, column_b_id, ColumnType::Int128),
+                ColumnRef::new(table_a_id.clone(), column_a_id.clone()),
+                ColumnRef::new(table_b_id.clone(), column_a_id),
+                ColumnRef::new(table_a_id, column_b_id.clone()),
+                ColumnRef::new(table_b_id, column_b_id),
             ],
             &accessor,
         );

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -634,17 +634,15 @@ impl Display for ColumnType {
 pub struct ColumnRef {
     column_id: Ident,
     table_ref: TableRef,
-    column_type: ColumnType,
 }
 
 impl ColumnRef {
-    /// Create a new `ColumnRef` from a table, column identifier and column type
+    /// Create a new `ColumnRef` from a table and column identifier
     #[must_use]
-    pub fn new(table_ref: TableRef, column_id: Ident, column_type: ColumnType) -> Self {
+    pub fn new(table_ref: TableRef, column_id: Ident) -> Self {
         Self {
             column_id,
             table_ref,
-            column_type,
         }
     }
 
@@ -658,12 +656,6 @@ impl ColumnRef {
     #[must_use]
     pub fn column_id(&self) -> Ident {
         self.column_id.clone()
-    }
-
-    /// Returns the column type of this column
-    #[must_use]
-    pub fn column_type(&self) -> &ColumnType {
-        &self.column_type
     }
 }
 

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -2,12 +2,11 @@ use super::{EVMProofPlanError, EVMProofPlanResult};
 use crate::{
     base::{
         database::{ColumnRef, ColumnType, LiteralValue, TableRef},
-        map::IndexSet,
+        map::{IndexMap, IndexSet},
     },
     sql::proof_exprs::{
         AddExpr, AndExpr, CastExpr, ColumnExpr, DynProofExpr, EqualsExpr, InequalityExpr,
-        LiteralExpr, MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ProofExpr, ScalingCastExpr,
-        SubtractExpr,
+        LiteralExpr, MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ScalingCastExpr, SubtractExpr,
     },
 };
 use alloc::boxed::Box;
@@ -84,43 +83,44 @@ impl EVMDynProofExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<DynProofExpr> {
         match self {
             EVMDynProofExpr::Column(column_expr) => Ok(DynProofExpr::Column(
-                column_expr.try_into_proof_expr(column_refs)?,
+                column_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
             EVMDynProofExpr::Equals(equals_expr) => Ok(DynProofExpr::Equals(
-                equals_expr.try_into_proof_expr(column_refs)?,
+                equals_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
             EVMDynProofExpr::Inequality(inequality_expr) => Ok(DynProofExpr::Inequality(
-                inequality_expr.try_into_proof_expr(column_refs)?,
+                inequality_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
             EVMDynProofExpr::Literal(literal_expr) => {
                 Ok(DynProofExpr::Literal(literal_expr.to_proof_expr()))
             }
             EVMDynProofExpr::Add(add_expr) => Ok(DynProofExpr::Add(
-                add_expr.try_into_proof_expr(column_refs)?,
+                add_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
             EVMDynProofExpr::Subtract(subtract_expr) => Ok(DynProofExpr::Subtract(
-                subtract_expr.try_into_proof_expr(column_refs)?,
+                subtract_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
             EVMDynProofExpr::Multiply(multiply_expr) => Ok(DynProofExpr::Multiply(
-                multiply_expr.try_into_proof_expr(column_refs)?,
+                multiply_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
             EVMDynProofExpr::And(and_expr) => Ok(DynProofExpr::And(
-                and_expr.try_into_proof_expr(column_refs)?,
+                and_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
-            EVMDynProofExpr::Or(or_expr) => {
-                Ok(DynProofExpr::Or(or_expr.try_into_proof_expr(column_refs)?))
-            }
+            EVMDynProofExpr::Or(or_expr) => Ok(DynProofExpr::Or(
+                or_expr.try_into_proof_expr(column_refs, column_type_map)?,
+            )),
             EVMDynProofExpr::Not(not_expr) => Ok(DynProofExpr::Not(
-                not_expr.try_into_proof_expr(column_refs)?,
+                not_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
             EVMDynProofExpr::Cast(cast_expr) => Ok(DynProofExpr::Cast(
-                cast_expr.try_into_proof_expr(column_refs)?,
+                cast_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
             EVMDynProofExpr::ScalingCast(scaling_cast_expr) => Ok(DynProofExpr::ScalingCast(
-                scaling_cast_expr.try_into_proof_expr(column_refs)?,
+                scaling_cast_expr.try_into_proof_expr(column_refs, column_type_map)?,
             )),
             EVMDynProofExpr::Placeholder(placeholder_expr) => {
                 Ok(DynProofExpr::Placeholder(placeholder_expr.to_proof_expr()))
@@ -153,7 +153,6 @@ impl EVMColumnExpr {
                     column_refs.get_index_of(&ColumnRef::new(
                         TableRef::from_names(None, ""),
                         expr.column_id(),
-                        expr.data_type(),
                     ))
                 })
                 .ok_or(EVMProofPlanError::ColumnNotFound)?,
@@ -163,13 +162,17 @@ impl EVMColumnExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<ColumnExpr> {
-        Ok(ColumnExpr::new(
-            column_refs
-                .get_index(self.column_number)
-                .ok_or(EVMProofPlanError::ColumnNotFound)?
-                .clone(),
-        ))
+        let column_ref = column_refs
+            .get_index(self.column_number)
+            .ok_or(EVMProofPlanError::ColumnNotFound)?
+            .clone();
+        let column_type = column_type_map
+            .get(&column_ref)
+            .copied()
+            .ok_or(EVMProofPlanError::ColumnNotFound)?;
+        Ok(ColumnExpr::new(column_ref, column_type))
     }
 }
 
@@ -227,10 +230,11 @@ impl EVMEqualsExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<EqualsExpr> {
         Ok(EqualsExpr::try_new(
-            Box::new(self.lhs.try_into_proof_expr(column_refs)?),
-            Box::new(self.rhs.try_into_proof_expr(column_refs)?),
+            Box::new(self.lhs.try_into_proof_expr(column_refs, column_type_map)?),
+            Box::new(self.rhs.try_into_proof_expr(column_refs, column_type_map)?),
         )?)
     }
 }
@@ -274,10 +278,11 @@ impl EVMInequalityExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<InequalityExpr> {
         Ok(InequalityExpr::try_new(
-            Box::new(self.lhs.try_into_proof_expr(column_refs)?),
-            Box::new(self.rhs.try_into_proof_expr(column_refs)?),
+            Box::new(self.lhs.try_into_proof_expr(column_refs, column_type_map)?),
+            Box::new(self.rhs.try_into_proof_expr(column_refs, column_type_map)?),
             self.is_lt,
         )?)
     }
@@ -319,10 +324,11 @@ impl EVMAddExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<AddExpr> {
         Ok(AddExpr::try_new(
-            Box::new(self.lhs.try_into_proof_expr(column_refs)?),
-            Box::new(self.rhs.try_into_proof_expr(column_refs)?),
+            Box::new(self.lhs.try_into_proof_expr(column_refs, column_type_map)?),
+            Box::new(self.rhs.try_into_proof_expr(column_refs, column_type_map)?),
         )?)
     }
 }
@@ -363,10 +369,11 @@ impl EVMSubtractExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<SubtractExpr> {
         Ok(SubtractExpr::try_new(
-            Box::new(self.lhs.try_into_proof_expr(column_refs)?),
-            Box::new(self.rhs.try_into_proof_expr(column_refs)?),
+            Box::new(self.lhs.try_into_proof_expr(column_refs, column_type_map)?),
+            Box::new(self.rhs.try_into_proof_expr(column_refs, column_type_map)?),
         )?)
     }
 }
@@ -407,10 +414,11 @@ impl EVMMultiplyExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<MultiplyExpr> {
         Ok(MultiplyExpr::try_new(
-            Box::new(self.lhs.try_into_proof_expr(column_refs)?),
-            Box::new(self.rhs.try_into_proof_expr(column_refs)?),
+            Box::new(self.lhs.try_into_proof_expr(column_refs, column_type_map)?),
+            Box::new(self.rhs.try_into_proof_expr(column_refs, column_type_map)?),
         )?)
     }
 }
@@ -451,10 +459,11 @@ impl EVMAndExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<AndExpr> {
         Ok(AndExpr::try_new(
-            Box::new(self.lhs.try_into_proof_expr(column_refs)?),
-            Box::new(self.rhs.try_into_proof_expr(column_refs)?),
+            Box::new(self.lhs.try_into_proof_expr(column_refs, column_type_map)?),
+            Box::new(self.rhs.try_into_proof_expr(column_refs, column_type_map)?),
         )?)
     }
 }
@@ -495,10 +504,11 @@ impl EVMOrExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<OrExpr> {
         Ok(OrExpr::try_new(
-            Box::new(self.lhs.try_into_proof_expr(column_refs)?),
-            Box::new(self.rhs.try_into_proof_expr(column_refs)?),
+            Box::new(self.lhs.try_into_proof_expr(column_refs, column_type_map)?),
+            Box::new(self.rhs.try_into_proof_expr(column_refs, column_type_map)?),
         )?)
     }
 }
@@ -533,9 +543,11 @@ impl EVMNotExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<NotExpr> {
         Ok(NotExpr::try_new(Box::new(
-            self.expr.try_into_proof_expr(column_refs)?,
+            self.expr
+                .try_into_proof_expr(column_refs, column_type_map)?,
         ))?)
     }
 }
@@ -573,9 +585,13 @@ impl EVMCastExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<CastExpr> {
         Ok(CastExpr::try_new(
-            Box::new(self.from_expr.try_into_proof_expr(column_refs)?),
+            Box::new(
+                self.from_expr
+                    .try_into_proof_expr(column_refs, column_type_map)?,
+            ),
             self.to_type,
         )?)
     }
@@ -627,9 +643,13 @@ impl EVMScalingCastExpr {
     pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
+        column_type_map: &IndexMap<ColumnRef, ColumnType>,
     ) -> EVMProofPlanResult<ScalingCastExpr> {
         let expr = ScalingCastExpr::try_new(
-            Box::new(self.from_expr.try_into_proof_expr(column_refs)?),
+            Box::new(
+                self.from_expr
+                    .try_into_proof_expr(column_refs, column_type_map)?,
+            ),
             self.to_type,
         )?;
         let reversed_scaling_factor = [
@@ -671,7 +691,7 @@ mod tests {
     use crate::{
         base::{
             database::{ColumnType, TableRef},
-            map::indexset,
+            map::{indexmap, indexset},
             math::{decimal::Precision, i256::I256},
             posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
             try_standard_binary_serialization,
@@ -685,10 +705,10 @@ mod tests {
     fn we_can_put_a_column_expr_in_evm() {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident = "a".into();
-        let column_ref = ColumnRef::new(table_ref.clone(), ident, ColumnType::BigInt);
+        let column_ref = ColumnRef::new(table_ref.clone(), ident);
 
         let evm_column_expr = EVMColumnExpr::try_from_proof_expr(
-            &ColumnExpr::new(column_ref.clone()),
+            &ColumnExpr::new(column_ref.clone(), ColumnType::BigInt),
             &indexset! {column_ref.clone()},
         )
         .unwrap();
@@ -696,7 +716,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped_column_expr = evm_column_expr
-            .try_into_proof_expr(&indexset! {column_ref.clone()})
+            .try_into_proof_expr(
+                &indexset! {column_ref.clone()},
+                &indexmap! {column_ref.clone() => ColumnType::BigInt},
+            )
             .unwrap();
         assert_eq!(*roundtripped_column_expr.column_ref(), column_ref);
     }
@@ -705,10 +728,13 @@ mod tests {
     fn we_cannot_put_a_column_expr_in_evm_if_column_not_found() {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident = "a".into();
-        let column_ref = ColumnRef::new(table_ref.clone(), ident, ColumnType::BigInt);
+        let column_ref = ColumnRef::new(table_ref.clone(), ident);
 
         assert_eq!(
-            EVMColumnExpr::try_from_proof_expr(&ColumnExpr::new(column_ref.clone()), &indexset! {}),
+            EVMColumnExpr::try_from_proof_expr(
+                &ColumnExpr::new(column_ref.clone(), ColumnType::BigInt),
+                &indexset! {}
+            ),
             Err(EVMProofPlanError::ColumnNotFound)
         );
     }
@@ -717,9 +743,10 @@ mod tests {
     fn we_cannot_get_a_column_expr_from_evm_if_column_number_out_of_bounds() {
         let evm_column_expr = EVMColumnExpr { column_number: 0 };
         let column_refs = IndexSet::<ColumnRef>::default();
+        let column_type_map = IndexMap::<ColumnRef, ColumnType>::default();
         assert_eq!(
             evm_column_expr
-                .try_into_proof_expr(&column_refs)
+                .try_into_proof_expr(&column_refs, &column_type_map)
                 .unwrap_err(),
             EVMProofPlanError::ColumnNotFound
         );
@@ -929,11 +956,14 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b);
 
         let equals_expr = EqualsExpr::try_new(
-            Box::new(DynProofExpr::new_column(column_ref_b.clone())),
+            Box::new(DynProofExpr::new_column(
+                column_ref_b.clone(),
+                ColumnType::BigInt,
+            )),
             Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(5))),
         )
         .unwrap();
@@ -955,7 +985,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped_equals_expr = evm_equals_expr
-            .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+            .try_into_proof_expr(
+                &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+                &indexmap! {column_ref_a.clone() => ColumnType::BigInt, column_ref_b.clone() => ColumnType::BigInt},
+            )
             .unwrap();
         assert_eq!(roundtripped_equals_expr, equals_expr);
     }
@@ -966,11 +999,14 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b);
 
         let add_expr = AddExpr::try_new(
-            Box::new(DynProofExpr::new_column(column_ref_b.clone())),
+            Box::new(DynProofExpr::new_column(
+                column_ref_b.clone(),
+                ColumnType::BigInt,
+            )),
             Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(5))),
         )
         .unwrap();
@@ -990,7 +1026,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped_add_expr = evm_add_expr
-            .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+            .try_into_proof_expr(
+                &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+                &indexmap! {column_ref_a.clone() => ColumnType::BigInt, column_ref_b.clone() => ColumnType::BigInt},
+            )
             .unwrap();
         assert_eq!(roundtripped_add_expr, add_expr);
     }
@@ -1001,11 +1040,14 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b);
 
         let subtract_expr = SubtractExpr::try_new(
-            Box::new(DynProofExpr::new_column(column_ref_b.clone())),
+            Box::new(DynProofExpr::new_column(
+                column_ref_b.clone(),
+                ColumnType::BigInt,
+            )),
             Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(5))),
         )
         .unwrap();
@@ -1025,7 +1067,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped_subtract_expr = evm_subtract_expr
-            .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+            .try_into_proof_expr(
+                &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+                &indexmap! {column_ref_a.clone() => ColumnType::BigInt, column_ref_b.clone() => ColumnType::BigInt},
+            )
             .unwrap();
         assert_eq!(roundtripped_subtract_expr, subtract_expr);
     }
@@ -1036,12 +1081,15 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b);
 
         // b * 10 so we see column_number = 1
         let multiply_expr = MultiplyExpr::try_new(
-            Box::new(DynProofExpr::new_column(column_ref_b.clone())),
+            Box::new(DynProofExpr::new_column(
+                column_ref_b.clone(),
+                ColumnType::BigInt,
+            )),
             Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(10))),
         )
         .unwrap();
@@ -1061,7 +1109,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped = evm_multiply_expr
-            .try_into_proof_expr(&indexset! { column_ref_a, column_ref_b })
+            .try_into_proof_expr(
+                &indexset! { column_ref_a.clone(), column_ref_b.clone() },
+                &indexmap! {column_ref_a => ColumnType::BigInt, column_ref_b => ColumnType::BigInt},
+            )
             .unwrap();
         assert_eq!(roundtripped, multiply_expr);
     }
@@ -1073,9 +1124,10 @@ mod tests {
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 }),
         );
         let column_refs = IndexSet::<ColumnRef>::default();
+        let column_type_map = IndexMap::<ColumnRef, ColumnType>::default();
         assert_eq!(
             evm_column_expr
-                .try_into_proof_expr(&column_refs)
+                .try_into_proof_expr(&column_refs, &column_type_map)
                 .unwrap_err(),
             EVMProofPlanError::ColumnNotFound
         );
@@ -1087,12 +1139,18 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_x = "x".into();
         let ident_y = "y".into();
-        let column_ref_x = ColumnRef::new(table_ref.clone(), ident_x, ColumnType::Boolean);
-        let column_ref_y = ColumnRef::new(table_ref.clone(), ident_y, ColumnType::Boolean);
+        let column_ref_x = ColumnRef::new(table_ref.clone(), ident_x);
+        let column_ref_y = ColumnRef::new(table_ref.clone(), ident_y);
 
         let and_expr = AndExpr::try_new(
-            Box::new(DynProofExpr::new_column(column_ref_x.clone())),
-            Box::new(DynProofExpr::new_column(column_ref_y.clone())),
+            Box::new(DynProofExpr::new_column(
+                column_ref_x.clone(),
+                ColumnType::Boolean,
+            )),
+            Box::new(DynProofExpr::new_column(
+                column_ref_y.clone(),
+                ColumnType::Boolean,
+            )),
         )
         .unwrap();
 
@@ -1111,7 +1169,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped = evm_and_expr
-            .try_into_proof_expr(&indexset! { column_ref_x, column_ref_y })
+            .try_into_proof_expr(
+                &indexset! { column_ref_x.clone(), column_ref_y.clone() },
+                &indexmap! {column_ref_x => ColumnType::Boolean, column_ref_y => ColumnType::Boolean},
+            )
             .unwrap();
         assert_eq!(roundtripped, and_expr);
     }
@@ -1123,8 +1184,11 @@ mod tests {
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 }),
         );
         let column_refs = IndexSet::<ColumnRef>::default();
+        let column_type_map = IndexMap::<ColumnRef, ColumnType>::default();
         assert_eq!(
-            evm_and_expr.try_into_proof_expr(&column_refs).unwrap_err(),
+            evm_and_expr
+                .try_into_proof_expr(&column_refs, &column_type_map)
+                .unwrap_err(),
             EVMProofPlanError::ColumnNotFound
         );
     }
@@ -1135,12 +1199,18 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_x = "x".into();
         let ident_y = "y".into();
-        let column_ref_x = ColumnRef::new(table_ref.clone(), ident_x, ColumnType::Boolean);
-        let column_ref_y = ColumnRef::new(table_ref.clone(), ident_y, ColumnType::Boolean);
+        let column_ref_x = ColumnRef::new(table_ref.clone(), ident_x);
+        let column_ref_y = ColumnRef::new(table_ref.clone(), ident_y);
 
         let or_expr = OrExpr::try_new(
-            Box::new(DynProofExpr::new_column(column_ref_x.clone())),
-            Box::new(DynProofExpr::new_column(column_ref_y.clone())),
+            Box::new(DynProofExpr::new_column(
+                column_ref_x.clone(),
+                ColumnType::Boolean,
+            )),
+            Box::new(DynProofExpr::new_column(
+                column_ref_y.clone(),
+                ColumnType::Boolean,
+            )),
         )
         .unwrap();
 
@@ -1159,7 +1229,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped = evm_or_expr
-            .try_into_proof_expr(&indexset! { column_ref_x, column_ref_y })
+            .try_into_proof_expr(
+                &indexset! { column_ref_x.clone(), column_ref_y.clone() },
+                &indexmap! {column_ref_x => ColumnType::Boolean, column_ref_y => ColumnType::Boolean},
+            )
             .unwrap();
         assert_eq!(roundtripped, or_expr);
     }
@@ -1171,8 +1244,11 @@ mod tests {
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 }),
         );
         let column_refs = IndexSet::<ColumnRef>::default();
+        let column_type_map = IndexMap::<ColumnRef, ColumnType>::default();
         assert_eq!(
-            evm_or_expr.try_into_proof_expr(&column_refs).unwrap_err(),
+            evm_or_expr
+                .try_into_proof_expr(&column_refs, &column_type_map)
+                .unwrap_err(),
             EVMProofPlanError::ColumnNotFound
         );
     }
@@ -1182,10 +1258,13 @@ mod tests {
     fn we_can_put_a_not_expr_in_evm() {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_flag = "flag".into();
-        let column_ref_flag = ColumnRef::new(table_ref.clone(), ident_flag, ColumnType::Boolean);
+        let column_ref_flag = ColumnRef::new(table_ref.clone(), ident_flag);
 
-        let not_expr =
-            NotExpr::try_new(Box::new(DynProofExpr::new_column(column_ref_flag.clone()))).unwrap();
+        let not_expr = NotExpr::try_new(Box::new(DynProofExpr::new_column(
+            column_ref_flag.clone(),
+            ColumnType::Boolean,
+        )))
+        .unwrap();
 
         let evm_not_expr =
             EVMNotExpr::try_from_proof_expr(&not_expr, &indexset! { column_ref_flag.clone() })
@@ -1197,7 +1276,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped = evm_not_expr
-            .try_into_proof_expr(&indexset! { column_ref_flag })
+            .try_into_proof_expr(
+                &indexset! { column_ref_flag.clone() },
+                &indexmap! {column_ref_flag => ColumnType::Boolean},
+            )
             .unwrap();
         assert_eq!(roundtripped, not_expr);
     }
@@ -1207,8 +1289,11 @@ mod tests {
         let evm_not_expr =
             EVMNotExpr::new(EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }));
         let column_refs = IndexSet::<ColumnRef>::default();
+        let column_type_map = IndexMap::<ColumnRef, ColumnType>::default();
         assert_eq!(
-            evm_not_expr.try_into_proof_expr(&column_refs).unwrap_err(),
+            evm_not_expr
+                .try_into_proof_expr(&column_refs, &column_type_map)
+                .unwrap_err(),
             EVMProofPlanError::ColumnNotFound
         );
     }
@@ -1219,11 +1304,14 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b);
 
         let cast_expr = CastExpr::try_new(
-            Box::new(DynProofExpr::new_column(column_ref_b.clone())),
+            Box::new(DynProofExpr::new_column(
+                column_ref_b.clone(),
+                ColumnType::Int,
+            )),
             ColumnType::BigInt,
         )
         .unwrap();
@@ -1243,7 +1331,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped_cast_expr = evm_cast_expr
-            .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+            .try_into_proof_expr(
+                &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+                &indexmap! {column_ref_a.clone() => ColumnType::Int, column_ref_b.clone() => ColumnType::Int},
+            )
             .unwrap();
         assert_eq!(roundtripped_cast_expr, cast_expr);
     }
@@ -1255,8 +1346,11 @@ mod tests {
             ColumnType::BigInt,
         );
         let column_refs = IndexSet::<ColumnRef>::default();
+        let column_type_map = IndexMap::<ColumnRef, ColumnType>::default();
         assert_eq!(
-            evm_cast_expr.try_into_proof_expr(&column_refs).unwrap_err(),
+            evm_cast_expr
+                .try_into_proof_expr(&column_refs, &column_type_map)
+                .unwrap_err(),
             EVMProofPlanError::ColumnNotFound
         );
     }
@@ -1303,7 +1397,11 @@ mod tests {
             column_type: ColumnType::Int,
         });
         assert_eq!(evm, expected);
-        assert_eq!(evm.try_into_proof_expr(&indexset! {}).unwrap(), expr);
+        assert_eq!(
+            evm.try_into_proof_expr(&indexset! {}, &indexmap! {})
+                .unwrap(),
+            expr
+        );
     }
 
     // EVMInequalityExpr
@@ -1312,11 +1410,14 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b);
 
         let inequality_expr = InequalityExpr::try_new(
-            Box::new(DynProofExpr::new_column(column_ref_b.clone())),
+            Box::new(DynProofExpr::new_column(
+                column_ref_b.clone(),
+                ColumnType::BigInt,
+            )),
             Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(5))),
             true,
         )
@@ -1338,7 +1439,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped_add_expr = evm_inquality_expr
-            .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+            .try_into_proof_expr(
+                &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+                &indexmap! {column_ref_a.clone() => ColumnType::BigInt, column_ref_b.clone() => ColumnType::BigInt},
+            )
             .unwrap();
         assert_eq!(roundtripped_add_expr, inequality_expr);
     }
@@ -1349,11 +1453,14 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b);
 
         let scaling_cast_expr = ScalingCastExpr::try_new(
-            Box::new(DynProofExpr::new_column(column_ref_b.clone())),
+            Box::new(DynProofExpr::new_column(
+                column_ref_b.clone(),
+                ColumnType::Int,
+            )),
             ColumnType::Decimal75(Precision::new(15).unwrap(), 2),
         )
         .unwrap();
@@ -1374,7 +1481,10 @@ mod tests {
 
         // Roundtrip
         let roundtripped_scaling_cast_expr = evm_scaling_cast_expr
-            .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+            .try_into_proof_expr(
+                &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+                &indexmap! {column_ref_a.clone() => ColumnType::Int, column_ref_b.clone() => ColumnType::Int},
+            )
             .unwrap();
         assert_eq!(roundtripped_scaling_cast_expr, scaling_cast_expr);
     }
@@ -1387,9 +1497,10 @@ mod tests {
             [0, 0, 0, 100],
         );
         let column_refs = IndexSet::<ColumnRef>::default();
+        let column_type_map = IndexMap::<ColumnRef, ColumnType>::default();
         assert_eq!(
             evm_scaling_cast_expr
-                .try_into_proof_expr(&column_refs)
+                .try_into_proof_expr(&column_refs, &column_type_map)
                 .unwrap_err(),
             EVMProofPlanError::ColumnNotFound
         );
@@ -1400,8 +1511,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b);
 
         let evm_scaling_cast_expr = EVMScalingCastExpr::new(
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
@@ -1410,7 +1521,10 @@ mod tests {
         );
         assert_eq!(
             evm_scaling_cast_expr
-                .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+                .try_into_proof_expr(
+                    &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+                    &indexmap! {column_ref_a.clone() => ColumnType::Int, column_ref_b.clone() => ColumnType::Int},
+                )
                 .unwrap_err(),
             EVMProofPlanError::IncorrectScalingFactor
         );
@@ -1420,11 +1534,11 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_equals_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = ColumnRef::new(table_ref.clone(), "b".into());
 
         let expr = equal(
             DynProofExpr::new_literal(LiteralValue::BigInt(5)),
-            DynProofExpr::new_column(column_b.clone()),
+            DynProofExpr::new_column(column_b.clone(), ColumnType::BigInt),
         );
         let evm =
             EVMDynProofExpr::try_from_proof_expr(&expr, &indexset! { column_b.clone() }).unwrap();
@@ -1436,7 +1550,11 @@ mod tests {
         });
         assert_eq!(evm, expected);
         assert_eq!(
-            evm.try_into_proof_expr(&indexset! { column_b }).unwrap(),
+            evm.try_into_proof_expr(
+                &indexset! { column_b.clone() },
+                &indexmap! {column_b => ColumnType::BigInt}
+            )
+            .unwrap(),
             expr
         );
     }
@@ -1444,10 +1562,10 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_add_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = ColumnRef::new(table_ref.clone(), "b".into());
 
         let expr = add(
-            DynProofExpr::new_column(column_b.clone()),
+            DynProofExpr::new_column(column_b.clone(), ColumnType::BigInt),
             DynProofExpr::new_literal(LiteralValue::BigInt(3)),
         );
         let evm =
@@ -1458,7 +1576,11 @@ mod tests {
         ));
         assert_eq!(evm, expected);
         assert_eq!(
-            evm.try_into_proof_expr(&indexset! { column_b }).unwrap(),
+            evm.try_into_proof_expr(
+                &indexset! { column_b.clone() },
+                &indexmap! {column_b => ColumnType::BigInt}
+            )
+            .unwrap(),
             expr
         );
     }
@@ -1466,10 +1588,10 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_subtract_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = ColumnRef::new(table_ref.clone(), "b".into());
 
         let expr = subtract(
-            DynProofExpr::new_column(column_b.clone()),
+            DynProofExpr::new_column(column_b.clone(), ColumnType::BigInt),
             DynProofExpr::new_literal(LiteralValue::BigInt(2)),
         );
         let evm =
@@ -1480,7 +1602,11 @@ mod tests {
         ));
         assert_eq!(evm, expected);
         assert_eq!(
-            evm.try_into_proof_expr(&indexset! { column_b }).unwrap(),
+            evm.try_into_proof_expr(
+                &indexset! { column_b.clone() },
+                &indexmap! {column_b => ColumnType::BigInt}
+            )
+            .unwrap(),
             expr
         );
     }
@@ -1488,10 +1614,10 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_multiply_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = ColumnRef::new(table_ref.clone(), "b".into());
 
         let expr = multiply(
-            DynProofExpr::new_column(column_b.clone()),
+            DynProofExpr::new_column(column_b.clone(), ColumnType::BigInt),
             DynProofExpr::new_literal(LiteralValue::BigInt(4)),
         );
         let evm =
@@ -1502,7 +1628,11 @@ mod tests {
         ));
         assert_eq!(evm, expected);
         assert_eq!(
-            evm.try_into_proof_expr(&indexset! { column_b }).unwrap(),
+            evm.try_into_proof_expr(
+                &indexset! { column_b.clone() },
+                &indexmap! {column_b => ColumnType::BigInt}
+            )
+            .unwrap(),
             expr
         );
     }
@@ -1510,12 +1640,12 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_and_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Boolean);
-        let d = ColumnRef::new(table_ref.clone(), "d".into(), ColumnType::Boolean);
+        let c = ColumnRef::new(table_ref.clone(), "c".into());
+        let d = ColumnRef::new(table_ref.clone(), "d".into());
 
         let expr = and(
-            DynProofExpr::new_column(c.clone()),
-            DynProofExpr::new_column(d.clone()),
+            DynProofExpr::new_column(c.clone(), ColumnType::Boolean),
+            DynProofExpr::new_column(d.clone(), ColumnType::Boolean),
         );
         let evm = EVMDynProofExpr::try_from_proof_expr(&expr, &indexset! { c.clone(), d.clone() })
             .unwrap();
@@ -1524,18 +1654,25 @@ mod tests {
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 }),
         ));
         assert_eq!(evm, expected);
-        assert_eq!(evm.try_into_proof_expr(&indexset! { c, d }).unwrap(), expr);
+        assert_eq!(
+            evm.try_into_proof_expr(
+                &indexset! { c.clone(), d.clone() },
+                &indexmap! {c => ColumnType::Boolean, d => ColumnType::Boolean}
+            )
+            .unwrap(),
+            expr
+        );
     }
 
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_or_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Boolean);
-        let d = ColumnRef::new(table_ref.clone(), "d".into(), ColumnType::Boolean);
+        let c = ColumnRef::new(table_ref.clone(), "c".into());
+        let d = ColumnRef::new(table_ref.clone(), "d".into());
 
         let expr = or(
-            DynProofExpr::new_column(c.clone()),
-            DynProofExpr::new_column(d.clone()),
+            DynProofExpr::new_column(c.clone(), ColumnType::Boolean),
+            DynProofExpr::new_column(d.clone(), ColumnType::Boolean),
         );
         let evm = EVMDynProofExpr::try_from_proof_expr(&expr, &indexset! { c.clone(), d.clone() })
             .unwrap();
@@ -1544,46 +1681,67 @@ mod tests {
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 }),
         ));
         assert_eq!(evm, expected);
-        assert_eq!(evm.try_into_proof_expr(&indexset! { c, d }).unwrap(), expr);
+        assert_eq!(
+            evm.try_into_proof_expr(
+                &indexset! { c.clone(), d.clone() },
+                &indexmap! {c => ColumnType::Boolean, d => ColumnType::Boolean}
+            )
+            .unwrap(),
+            expr
+        );
     }
 
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_not_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Boolean);
+        let c = ColumnRef::new(table_ref.clone(), "c".into());
 
-        let expr = not(DynProofExpr::new_column(c.clone()));
+        let expr = not(DynProofExpr::new_column(c.clone(), ColumnType::Boolean));
         let evm = EVMDynProofExpr::try_from_proof_expr(&expr, &indexset! { c.clone() }).unwrap();
         let expected =
             EVMDynProofExpr::Not(EVMNotExpr::new(EVMDynProofExpr::Column(EVMColumnExpr {
                 column_number: 0,
             })));
         assert_eq!(evm, expected);
-        assert_eq!(evm.try_into_proof_expr(&indexset! { c }).unwrap(), expr);
+        assert_eq!(
+            evm.try_into_proof_expr(
+                &indexset! { c.clone() },
+                &indexmap! {c => ColumnType::Boolean}
+            )
+            .unwrap(),
+            expr
+        );
     }
 
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_cast_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Int);
+        let c = ColumnRef::new(table_ref.clone(), "c".into());
 
-        let expr = cast(DynProofExpr::new_column(c.clone()), ColumnType::BigInt);
+        let expr = cast(
+            DynProofExpr::new_column(c.clone(), ColumnType::Int),
+            ColumnType::BigInt,
+        );
         let evm = EVMDynProofExpr::try_from_proof_expr(&expr, &indexset! { c.clone() }).unwrap();
         let expected = EVMDynProofExpr::Cast(EVMCastExpr {
             from_expr: Box::new(EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 })),
             to_type: ColumnType::BigInt,
         });
         assert_eq!(evm, expected);
-        assert_eq!(evm.try_into_proof_expr(&indexset! { c }).unwrap(), expr);
+        assert_eq!(
+            evm.try_into_proof_expr(&indexset! { c.clone() }, &indexmap! {c => ColumnType::Int})
+                .unwrap(),
+            expr
+        );
     }
 
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_inequality_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = ColumnRef::new(table_ref.clone(), "b".into());
 
         let expr = lt(
-            DynProofExpr::new_column(column_b.clone()),
+            DynProofExpr::new_column(column_b.clone(), ColumnType::BigInt),
             DynProofExpr::new_literal(LiteralValue::BigInt(4)),
         );
         let evm =
@@ -1595,7 +1753,11 @@ mod tests {
         ));
         assert_eq!(evm, expected);
         assert_eq!(
-            evm.try_into_proof_expr(&indexset! { column_b }).unwrap(),
+            evm.try_into_proof_expr(
+                &indexset! { column_b.clone() },
+                &indexmap! {column_b => ColumnType::BigInt}
+            )
+            .unwrap(),
             expr
         );
     }
@@ -1603,10 +1765,10 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_scaling_cast_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Int);
+        let c = ColumnRef::new(table_ref.clone(), "c".into());
 
         let expr = DynProofExpr::try_new_scaling_cast(
-            DynProofExpr::new_column(c.clone()),
+            DynProofExpr::new_column(c.clone(), ColumnType::Int),
             ColumnType::Decimal75(Precision::new(30).unwrap(), 2),
         )
         .unwrap();
@@ -1617,7 +1779,11 @@ mod tests {
             scaling_factor: [0, 0, 0, 100],
         });
         assert_eq!(evm, expected);
-        assert_eq!(evm.try_into_proof_expr(&indexset! { c }).unwrap(), expr);
+        assert_eq!(
+            evm.try_into_proof_expr(&indexset! { c.clone() }, &indexmap! {c => ColumnType::Int})
+                .unwrap(),
+            expr
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -67,6 +67,9 @@ impl TryFrom<&EVMProofPlan> for CompactPlan {
         let table_refs = value.get_table_references();
         let column_refs = value.get_column_references();
         let result_fields = value.get_column_result_fields();
+        dbg!(&table_refs);
+        dbg!(&column_refs);
+        dbg!(&result_fields);
         let output_column_names = result_fields
             .iter()
             .map(|field| field.name().to_string())
@@ -82,21 +85,28 @@ impl TryFrom<&EVMProofPlan> for CompactPlan {
                     .map(|field| (col_ref.clone(), field.data_type()))
             })
             .collect();
+        dbg!(&column_type_map);
 
         let plan = EVMDynProofPlan::try_from_proof_plan(value.inner(), &table_refs, &column_refs)?;
+        dbg!(&plan);
         let columns = column_refs
             .into_iter()
             .map(|column_ref| -> EVMProofPlanResult<_> {
                 let table_index = table_refs
                     .get_index_of(&column_ref.table_ref())
                     .ok_or(EVMProofPlanError::TableNotFound)?;
+                dbg!(&column_ref);
+                dbg!(&table_index);
+                dbg!(&column_type_map);
                 let column_type = column_type_map
                     .get(&column_ref)
                     .copied()
                     .ok_or(EVMProofPlanError::ColumnNotFound)?;
+                dbg!(&column_type);
                 Ok((table_index, column_ref.column_id().to_string(), column_type))
             })
             .try_collect()?;
+        dbg!(&columns);
         let tables = table_refs.iter().map(ToString::to_string).collect();
 
         Ok(Self {

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -42,7 +42,6 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
             .unwrap(),
         ),
     ));
-
     let bytes = try_standard_binary_serialization(EVMProofPlan::new(plan)).unwrap();
 
     let expected_bytes: Vec<_> = iter::empty()

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -20,18 +20,21 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
     let identifier_b = "b".into();
     let identifier_alias = "alias".into();
 
-    let column_ref_a = ColumnRef::new(table_ref.clone(), identifier_a, ColumnType::BigInt);
-    let column_ref_b = ColumnRef::new(table_ref.clone(), identifier_b, ColumnType::BigInt);
+    let column_ref_a = ColumnRef::new(table_ref.clone(), identifier_a);
+    let column_ref_b = ColumnRef::new(table_ref.clone(), identifier_b);
 
     let plan = DynProofPlan::LegacyFilter(LegacyFilterExec::new(
         vec![AliasedDynProofExpr {
-            expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b)),
+            expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b, ColumnType::BigInt)),
             alias: identifier_alias,
         }],
         TableExpr { table_ref },
         DynProofExpr::Equals(
             EqualsExpr::try_new(
-                Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a))),
+                Box::new(DynProofExpr::Column(ColumnExpr::new(
+                    column_ref_a,
+                    ColumnType::BigInt,
+                ))),
                 Box::new(DynProofExpr::Literal(LiteralExpr::new(
                     LiteralValue::BigInt(5),
                 ))),
@@ -82,18 +85,21 @@ fn we_can_deserialize_proof_plan_for_simple_filter() {
     let identifier_b = "b".into();
     let identifier_alias = "alias".into();
 
-    let column_ref_a = ColumnRef::new(table_ref.clone(), identifier_a, ColumnType::BigInt);
-    let column_ref_b = ColumnRef::new(table_ref.clone(), identifier_b, ColumnType::BigInt);
+    let column_ref_a = ColumnRef::new(table_ref.clone(), identifier_a);
+    let column_ref_b = ColumnRef::new(table_ref.clone(), identifier_b);
 
     let expected_plan = DynProofPlan::LegacyFilter(LegacyFilterExec::new(
         vec![AliasedDynProofExpr {
-            expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b)),
+            expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b, ColumnType::BigInt)),
             alias: identifier_alias,
         }],
         TableExpr { table_ref },
         DynProofExpr::Equals(
             EqualsExpr::try_new(
-                Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a))),
+                Box::new(DynProofExpr::Column(ColumnExpr::new(
+                    column_ref_a,
+                    ColumnType::BigInt,
+                ))),
                 Box::new(DynProofExpr::Literal(LiteralExpr::new(
                     LiteralValue::BigInt(5),
                 ))),

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -332,7 +332,6 @@ impl ProofPlan for SquareTestProofPlan {
         indexset! {ColumnRef::new(
         TableRef::new("sxt", "test"),
               "x".into(),
-              ColumnType::BigInt,
           )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
@@ -533,7 +532,6 @@ impl ProofPlan for DoubleSquareTestProofPlan {
         indexset! {ColumnRef::new(
         TableRef::new("sxt", "test"),
               "x".into(),
-              ColumnType::BigInt,
           )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
@@ -727,7 +725,6 @@ impl ProofPlan for ChallengeTestProofPlan {
         indexset! {ColumnRef::new(
             TableRef::new("sxt", "test"),
             "x".into(),
-            ColumnType::BigInt,
         )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
@@ -868,7 +865,6 @@ impl ProofPlan for FirstRoundSquareTestProofPlan {
         indexset! {ColumnRef::new(
             TableRef::new("sxt", "test"),
             "x".into(),
-            ColumnType::BigInt,
         )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -230,11 +230,17 @@ fn we_can_verify_a_simple_proof() {
         "b".into() => Column::Boolean::<TestScalar>(rhs),
     })
     .unwrap();
-    let a = ColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
-    let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+    let a = ColumnRef::new(t.clone(), Ident::from("a"));
+    let b = ColumnRef::new(t, Ident::from("b"));
     let and_expr = AndExpr::try_new(
-        Box::new(DynProofExpr::Column(ColumnExpr::new(a.clone()))),
-        Box::new(DynProofExpr::Column(ColumnExpr::new(b.clone()))),
+        Box::new(DynProofExpr::Column(ColumnExpr::new(
+            a.clone(),
+            ColumnType::Boolean,
+        ))),
+        Box::new(DynProofExpr::Column(ColumnExpr::new(
+            b.clone(),
+            ColumnType::Boolean,
+        ))),
     )
     .unwrap();
 
@@ -274,11 +280,17 @@ fn we_can_reject_a_simple_tampered_proof() {
     let t: TableRef = "sxt.t".parse().unwrap();
     let lhs = &[true, true, false, false];
     let rhs = &[true, false, true, false];
-    let a = ColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
-    let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+    let a = ColumnRef::new(t.clone(), Ident::from("a"));
+    let b = ColumnRef::new(t, Ident::from("b"));
     let and_expr = AndExpr::try_new(
-        Box::new(DynProofExpr::Column(ColumnExpr::new(a.clone()))),
-        Box::new(DynProofExpr::Column(ColumnExpr::new(b.clone()))),
+        Box::new(DynProofExpr::Column(ColumnExpr::new(
+            a.clone(),
+            ColumnType::Boolean,
+        ))),
+        Box::new(DynProofExpr::Column(ColumnExpr::new(
+            b.clone(),
+            ColumnType::Boolean,
+        ))),
     )
     .unwrap();
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -17,13 +17,17 @@ use sqlparser::ast::Ident;
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct ColumnExpr {
     column_ref: ColumnRef,
+    column_type: ColumnType,
 }
 
 impl ColumnExpr {
     /// Create a new column expression
     #[must_use]
-    pub fn new(column_ref: ColumnRef) -> Self {
-        Self { column_ref }
+    pub fn new(column_ref: ColumnRef, column_type: ColumnType) -> Self {
+        Self {
+            column_ref,
+            column_type,
+        }
     }
 
     /// Return the column referenced by this [`ColumnExpr`]
@@ -41,7 +45,7 @@ impl ColumnExpr {
     /// Wrap the column output name and its type within the [`ColumnField`]
     #[must_use]
     pub fn get_column_field(&self) -> ColumnField {
-        ColumnField::new(self.column_ref.column_id(), *self.column_ref.column_type())
+        ColumnField::new(self.column_ref.column_id(), self.column_type)
     }
 
     /// Get the column identifier
@@ -67,7 +71,7 @@ impl ColumnExpr {
 impl ProofExpr for ColumnExpr {
     /// Get the data type of the expression
     fn data_type(&self) -> ColumnType {
-        *self.get_column_reference().column_type()
+        self.column_type
     }
 
     /// Evaluate the column expression and

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -54,8 +54,8 @@ pub enum DynProofExpr {
 impl DynProofExpr {
     /// Create column expression
     #[must_use]
-    pub fn new_column(column_ref: ColumnRef) -> Self {
-        Self::Column(ColumnExpr::new(column_ref))
+    pub fn new_column(column_ref: ColumnRef, column_type: ColumnType) -> Self {
+        Self::Column(ColumnExpr::new(column_ref, column_type))
     }
     /// Create logical AND expression
     pub fn try_new_and(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -8,8 +8,8 @@ use sqlparser::ast::Ident;
 
 pub fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> ColumnRef {
     let name: Ident = name.into();
-    let type_col = accessor.lookup_column(tab, &name).unwrap();
-    ColumnRef::new(tab.clone(), name, type_col)
+    let _type_col = accessor.lookup_column(tab, &name).unwrap();
+    ColumnRef::new(tab.clone(), name)
 }
 
 /// # Panics
@@ -18,7 +18,7 @@ pub fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> Co
 pub fn column(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> DynProofExpr {
     let name: Ident = name.into();
     let type_col = accessor.lookup_column(tab, &name).unwrap();
-    DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(tab.clone(), name, type_col)))
+    DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(tab.clone(), name), type_col))
 }
 
 /// # Panics
@@ -184,9 +184,11 @@ pub fn col_expr_plan(
     name: &str,
     accessor: &impl SchemaAccessor,
 ) -> AliasedDynProofExpr {
+    let name_ident: Ident = name.into();
+    let type_col = accessor.lookup_column(tab, &name_ident).unwrap();
     AliasedDynProofExpr {
-        expr: DynProofExpr::Column(ColumnExpr::new(col_ref(tab, name, accessor))),
-        alias: name.into(),
+        expr: DynProofExpr::Column(ColumnExpr::new(col_ref(tab, name, accessor), type_col)),
+        alias: name_ident,
     }
 }
 
@@ -202,7 +204,9 @@ pub fn cols_expr_plan(
 }
 
 pub fn col_expr(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> ColumnExpr {
-    ColumnExpr::new(col_ref(tab, name, accessor))
+    let name_ident: Ident = name.into();
+    let type_col = accessor.lookup_column(tab, &name_ident).unwrap();
+    ColumnExpr::new(col_ref(tab, name, accessor), type_col)
 }
 
 pub fn cols_expr(

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -166,11 +166,17 @@ mod tests {
         let table_ref: TableRef = "sxt.t".parse().unwrap();
         let lhs_ident = Ident::from("lhs");
         let rhs_ident = Ident::from("rhs");
-        let lhs_ref = ColumnRef::new(table_ref.clone(), lhs_ident.clone(), ColumnType::Int128);
-        let rhs_ref = ColumnRef::new(table_ref, rhs_ident.clone(), ColumnType::Int128);
+        let lhs_ref = ColumnRef::new(table_ref.clone(), lhs_ident.clone());
+        let rhs_ref = ColumnRef::new(table_ref, rhs_ident.clone());
         let divide_and_modulo_expr = DivideAndModuloExpr::new(
-            Box::new(DynProofExpr::Column(ColumnExpr::new(lhs_ref.clone()))),
-            Box::new(DynProofExpr::Column(ColumnExpr::new(rhs_ref.clone()))),
+            Box::new(DynProofExpr::Column(ColumnExpr::new(
+                lhs_ref.clone(),
+                ColumnType::Int128,
+            ))),
+            Box::new(DynProofExpr::Column(ColumnExpr::new(
+                rhs_ref.clone(),
+                ColumnType::Int128,
+            ))),
         );
         let lhs = &[i128::MAX, i128::MIN, 2];
         let rhs = &[3i128, 3, -4];

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -200,7 +200,7 @@ impl ProofPlan for MembershipCheckTestPlan {
 mod tests {
     use super::*;
     use crate::{
-        base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
+        base::database::{table_utility::*, TableTestAccessor, TestAccessor},
         proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
         sql::proof::VerifiableQueryResult,
     };
@@ -223,16 +223,8 @@ mod tests {
         let plan = MembershipCheckTestPlan {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
-            source_columns: vec![ColumnRef::new(
-                source_table_ref,
-                "a".into(),
-                ColumnType::BigInt,
-            )],
-            candidate_columns: vec![ColumnRef::new(
-                candidate_table_ref,
-                "c".into(),
-                ColumnType::BigInt,
-            )],
+            source_columns: vec![ColumnRef::new(source_table_ref, "a".into())],
+            candidate_columns: vec![ColumnRef::new(candidate_table_ref, "c".into())],
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
@@ -272,14 +264,14 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+                ColumnRef::new(source_table_ref.clone(), "a".into()),
+                ColumnRef::new(source_table_ref.clone(), "b".into()),
+                ColumnRef::new(source_table_ref, "c".into()),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+                ColumnRef::new(candidate_table_ref.clone(), "c".into()),
+                ColumnRef::new(candidate_table_ref.clone(), "d".into()),
+                ColumnRef::new(candidate_table_ref, "e".into()),
             ],
         };
         let verifiable_res =
@@ -320,14 +312,14 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+                ColumnRef::new(source_table_ref.clone(), "a".into()),
+                ColumnRef::new(source_table_ref.clone(), "b".into()),
+                ColumnRef::new(source_table_ref, "c".into()),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+                ColumnRef::new(candidate_table_ref.clone(), "c".into()),
+                ColumnRef::new(candidate_table_ref.clone(), "d".into()),
+                ColumnRef::new(candidate_table_ref, "e".into()),
             ],
         };
         let verifiable_res =
@@ -362,14 +354,10 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref, "b".into(), ColumnType::BigInt),
+                ColumnRef::new(source_table_ref.clone(), "a".into()),
+                ColumnRef::new(source_table_ref, "b".into()),
             ],
-            candidate_columns: vec![ColumnRef::new(
-                candidate_table_ref,
-                "a".into(),
-                ColumnType::BigInt,
-            )],
+            candidate_columns: vec![ColumnRef::new(candidate_table_ref, "a".into())],
         };
         VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -136,11 +136,11 @@ mod tests {
         table_ref: TableRef,
         accessor: &TableTestAccessor<InnerProductProof>,
         column_name: &str,
-        column_type: ColumnType,
+        _column_type: ColumnType,
         shall_error: bool,
     ) {
         let plan = MonotonicTestPlan::<STRICT, ASC> {
-            column: ColumnRef::new(table_ref, column_name.into(), column_type),
+            column: ColumnRef::new(table_ref, column_name.into()),
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, accessor, &(), &[]).unwrap();

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -163,7 +163,7 @@ impl ProofPlan for PermutationCheckTestPlan {
 mod tests {
     use super::*;
     use crate::{
-        base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
+        base::database::{table_utility::*, TableTestAccessor, TestAccessor},
         proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
         sql::proof::VerifiableQueryResult,
     };
@@ -186,16 +186,8 @@ mod tests {
         let plan = PermutationCheckTestPlan {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
-            source_columns: vec![ColumnRef::new(
-                source_table_ref,
-                "a".into(),
-                ColumnType::BigInt,
-            )],
-            candidate_columns: vec![ColumnRef::new(
-                candidate_table_ref,
-                "c".into(),
-                ColumnType::BigInt,
-            )],
+            source_columns: vec![ColumnRef::new(source_table_ref, "a".into())],
+            candidate_columns: vec![ColumnRef::new(candidate_table_ref, "c".into())],
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
@@ -230,14 +222,14 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+                ColumnRef::new(source_table_ref.clone(), "a".into()),
+                ColumnRef::new(source_table_ref.clone(), "b".into()),
+                ColumnRef::new(source_table_ref, "c".into()),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+                ColumnRef::new(candidate_table_ref.clone(), "c".into()),
+                ColumnRef::new(candidate_table_ref.clone(), "d".into()),
+                ColumnRef::new(candidate_table_ref, "e".into()),
             ],
         };
         let verifiable_res =
@@ -273,14 +265,14 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+                ColumnRef::new(source_table_ref.clone(), "a".into()),
+                ColumnRef::new(source_table_ref.clone(), "b".into()),
+                ColumnRef::new(source_table_ref, "c".into()),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+                ColumnRef::new(candidate_table_ref.clone(), "c".into()),
+                ColumnRef::new(candidate_table_ref.clone(), "d".into()),
+                ColumnRef::new(candidate_table_ref, "e".into()),
             ],
         };
         let verifiable_res =
@@ -310,14 +302,10 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref, "b".into(), ColumnType::BigInt),
+                ColumnRef::new(source_table_ref.clone(), "a".into()),
+                ColumnRef::new(source_table_ref, "b".into()),
             ],
-            candidate_columns: vec![ColumnRef::new(
-                candidate_table_ref,
-                "a".into(),
-                ColumnType::BigInt,
-            )],
+            candidate_columns: vec![ColumnRef::new(candidate_table_ref, "a".into())],
         };
         VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
@@ -25,6 +25,8 @@ use sqlparser::ast::Ident;
 struct RangeCheckTestPlan {
     // The column reference for the range check test.
     column: ColumnRef,
+    // The column type for the range check test.
+    column_type: ColumnType,
 }
 
 macro_rules! handle_column_with_match {
@@ -143,10 +145,7 @@ impl ProverEvaluate for RangeCheckTestPlan {
 
 impl ProofPlan for RangeCheckTestPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new(
-            self.column.column_id(),
-            *self.column.column_type(),
-        )]
+        vec![ColumnField::new(self.column.column_id(), self.column_type)]
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
@@ -196,11 +195,12 @@ mod tests {
     fn check_range(
         table_name: TableRef,
         col_name: &str,
-        col_type: ColumnType,
+        _col_type: ColumnType,
         accessor: &OwnedTableTestAccessor<InnerProductProof>,
     ) {
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(table_name, col_name.into(), col_type),
+            column: ColumnRef::new(table_name, col_name.into()),
+            column_type: _col_type,
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, accessor, &(), &[]).unwrap();
@@ -273,7 +273,8 @@ mod tests {
         let accessor =
             OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
+            column: ColumnRef::new(t.clone(), "a".into()),
+            column_type: ColumnType::Scalar,
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
@@ -303,7 +304,8 @@ mod tests {
         let accessor =
             OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
+            column: ColumnRef::new(t.clone(), "a".into()),
+            column_type: ColumnType::Scalar,
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
@@ -342,7 +344,8 @@ mod tests {
         let accessor =
             OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
+            column: ColumnRef::new(t.clone(), "a".into()),
+            column_type: ColumnType::Scalar,
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
@@ -383,7 +386,8 @@ mod tests {
         let accessor =
             OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t, "a".into(), ColumnType::Scalar),
+            column: ColumnRef::new(t, "a".into()),
+            column_type: ColumnType::Scalar,
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -207,8 +207,8 @@ mod tests {
     use crate::{
         base::{
             database::{
-                table_utility::*, ColumnField, ColumnRef, ColumnType, LiteralValue, Table,
-                TableEvaluation, TableOptions, TableRef, TableTestAccessor, TestAccessor,
+                table_utility::*, ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation,
+                TableOptions, TableRef, TableTestAccessor, TestAccessor,
             },
             map::{indexset, IndexMap, IndexSet},
             proof::{PlaceholderResult, ProofError},
@@ -372,12 +372,8 @@ mod tests {
 
         // BigInt column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-            candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref.clone(),
-                "c".into(),
-                ColumnType::BigInt,
-            ),
+            column: ColumnRef::new(source_table_ref.clone(), "a".into()),
+            candidate_shifted_column: ColumnRef::new(candidate_table_ref.clone(), "c".into()),
             column_length: 3,
         };
         let verifiable_res =
@@ -387,12 +383,8 @@ mod tests {
 
         // Varchar column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-            candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref.clone(),
-                "d".into(),
-                ColumnType::VarChar,
-            ),
+            column: ColumnRef::new(source_table_ref.clone(), "b".into()),
+            candidate_shifted_column: ColumnRef::new(candidate_table_ref.clone(), "d".into()),
             column_length: 3,
         };
         let verifiable_res =
@@ -402,12 +394,8 @@ mod tests {
 
         // Boolean column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
-            candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref,
-                "e".into(),
-                ColumnType::Boolean,
-            ),
+            column: ColumnRef::new(source_table_ref, "c".into()),
+            candidate_shifted_column: ColumnRef::new(candidate_table_ref, "e".into()),
             column_length: 3,
         };
         let verifiable_res =
@@ -443,12 +431,8 @@ mod tests {
 
         // BigInt column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-            candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref.clone(),
-                "c".into(),
-                ColumnType::BigInt,
-            ),
+            column: ColumnRef::new(source_table_ref.clone(), "a".into()),
+            candidate_shifted_column: ColumnRef::new(candidate_table_ref.clone(), "c".into()),
             column_length: 3,
         };
         let verifiable_res =
@@ -457,12 +441,8 @@ mod tests {
 
         // Varchar column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-            candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref.clone(),
-                "d".into(),
-                ColumnType::VarChar,
-            ),
+            column: ColumnRef::new(source_table_ref.clone(), "b".into()),
+            candidate_shifted_column: ColumnRef::new(candidate_table_ref.clone(), "d".into()),
             column_length: 3,
         };
         let verifiable_res =
@@ -471,12 +451,8 @@ mod tests {
 
         // Boolean column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "c".into(), ColumnType::Boolean),
-            candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref.clone(),
-                "e".into(),
-                ColumnType::Boolean,
-            ),
+            column: ColumnRef::new(source_table_ref.clone(), "c".into()),
+            candidate_shifted_column: ColumnRef::new(candidate_table_ref.clone(), "e".into()),
             column_length: 3,
         };
         let verifiable_res =
@@ -485,12 +461,8 @@ mod tests {
 
         // Success case: The last pair of columns is correct even though the others are not
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "d".into(), ColumnType::BigInt),
-            candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref,
-                "f".into(),
-                ColumnType::BigInt,
-            ),
+            column: ColumnRef::new(source_table_ref, "d".into()),
+            candidate_shifted_column: ColumnRef::new(candidate_table_ref, "f".into()),
             column_length: 3,
         };
         let verifiable_res =
@@ -520,12 +492,8 @@ mod tests {
 
         // BigInt column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
-            candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref,
-                "a".into(),
-                ColumnType::BigInt,
-            ),
+            column: ColumnRef::new(source_table_ref, "a".into()),
+            candidate_shifted_column: ColumnRef::new(candidate_table_ref, "a".into()),
             column_length: 7,
         };
         let verifiable_res =

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+        database::{
+            ColumnField, ColumnRef, ColumnType, LiteralValue, Table, TableEvaluation, TableRef,
+        },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -17,6 +19,7 @@ use sqlparser::ast::Ident;
 #[derive(Debug, Serialize)]
 pub(crate) struct DemoMockPlan {
     pub column: ColumnRef,
+    pub column_type: ColumnType,
 }
 
 impl ProofPlan for DemoMockPlan {
@@ -36,10 +39,7 @@ impl ProofPlan for DemoMockPlan {
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new(
-            self.column.column_id(),
-            *self.column.column_type(),
-        )]
+        vec![ColumnField::new(self.column.column_id(), self.column_type)]
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
@@ -94,9 +94,11 @@ mod tests {
     fn we_can_create_and_prove_a_demo_mock_plan() {
         let table_ref = "namespace.table_name".parse::<TableRef>().unwrap();
         let table = owned_table([bigint("column_name", [0, 1, 2, 3])]);
-        let column_ref =
-            ColumnRef::new(table_ref.clone(), "column_name".into(), ColumnType::BigInt);
-        let plan = DemoMockPlan { column: column_ref };
+        let column_ref = ColumnRef::new(table_ref.clone(), "column_name".into());
+        let plan = DemoMockPlan {
+            column: column_ref,
+            column_type: ColumnType::BigInt,
+        };
         let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
             table_ref,
             table.clone(),

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -180,7 +180,7 @@ impl DynProofPlan {
     pub(crate) fn get_column_result_fields_as_references(&self) -> IndexSet<ColumnRef> {
         self.get_column_result_fields()
             .into_iter()
-            .map(|f| ColumnRef::new(TableRef::from_names(None, ""), f.name(), f.data_type()))
+            .map(|f| ColumnRef::new(TableRef::from_names(None, ""), f.name()))
             .collect()
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -273,27 +273,24 @@ fn we_can_have_projection_as_input_plan_for_filter() {
     let projection = projection(
         vec![
             AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
-                    t.clone(),
-                    "a".into(),
+                expr: DynProofExpr::new_column(
+                    ColumnRef::new(t.clone(), "a".into()),
                     ColumnType::BigInt,
-                )),
+                ),
                 alias: "x".into(),
             },
             AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
-                    t.clone(),
-                    "b".into(),
+                expr: DynProofExpr::new_column(
+                    ColumnRef::new(t.clone(), "b".into()),
                     ColumnType::BigInt,
-                )),
+                ),
                 alias: "y".into(),
             },
             AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
-                    t.clone(),
-                    "c".into(),
+                expr: DynProofExpr::new_column(
+                    ColumnRef::new(t.clone(), "c".into()),
                     ColumnType::Int128,
-                )),
+                ),
                 alias: "z".into(),
             },
         ],
@@ -305,27 +302,24 @@ fn we_can_have_projection_as_input_plan_for_filter() {
         AliasedDynProofExpr {
             expr: DynProofExpr::Add(
                 AddExpr::try_new(
-                    Box::new(DynProofExpr::new_column(ColumnRef::new(
-                        dummy_table.clone(),
-                        "x".into(),
+                    Box::new(DynProofExpr::new_column(
+                        ColumnRef::new(dummy_table.clone(), "x".into()),
                         ColumnType::BigInt,
-                    ))),
-                    Box::new(DynProofExpr::new_column(ColumnRef::new(
-                        dummy_table.clone(),
-                        "y".into(),
+                    )),
+                    Box::new(DynProofExpr::new_column(
+                        ColumnRef::new(dummy_table.clone(), "y".into()),
                         ColumnType::BigInt,
-                    ))),
+                    )),
                 )
                 .unwrap(),
             ),
             alias: "xplusy".into(),
         },
         AliasedDynProofExpr {
-            expr: DynProofExpr::new_column(ColumnRef::new(
-                dummy_table.clone(),
-                "z".into(),
+            expr: DynProofExpr::new_column(
+                ColumnRef::new(dummy_table.clone(), "z".into()),
                 ColumnType::Int128,
-            )),
+            ),
             alias: "z".into(),
         },
     ];
@@ -334,11 +328,10 @@ fn we_can_have_projection_as_input_plan_for_filter() {
         filter_results,
         projection,
         gt(
-            DynProofExpr::new_column(ColumnRef::new(
-                dummy_table.clone(),
-                "z".into(),
+            DynProofExpr::new_column(
+                ColumnRef::new(dummy_table.clone(), "z".into()),
                 ColumnType::Int128,
-            )),
+            ),
             const_int128(13_i128),
         ),
     );

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
@@ -32,19 +32,17 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     let provable_ast = LegacyFilterExec::new(
         vec![
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                    table_ref.clone(),
-                    a,
+                DynProofExpr::Column(ColumnExpr::new(
+                    ColumnRef::new(table_ref.clone(), a),
                     ColumnType::BigInt,
-                ))),
+                )),
                 "a",
             ),
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                    table_ref.clone(),
-                    b,
+                DynProofExpr::Column(ColumnExpr::new(
+                    ColumnRef::new(table_ref.clone(), b),
                     ColumnType::BigInt,
-                ))),
+                )),
                 "b",
             ),
         ],
@@ -52,11 +50,10 @@ fn we_can_correctly_fetch_the_query_result_schema() {
             table_ref: table_ref.clone(),
         },
         DynProofExpr::try_new_equals(
-            DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                table_ref.clone(),
-                Ident::new("c"),
+            DynProofExpr::Column(ColumnExpr::new(
+                ColumnRef::new(table_ref.clone(), Ident::new("c")),
                 ColumnType::BigInt,
-            ))),
+            )),
             DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(123))),
         )
         .unwrap(),
@@ -83,19 +80,17 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     let provable_ast = LegacyFilterExec::new(
         vec![
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                    table_ref.clone(),
-                    a,
+                DynProofExpr::Column(ColumnExpr::new(
+                    ColumnRef::new(table_ref.clone(), a),
                     ColumnType::BigInt,
-                ))),
+                )),
                 "a",
             ),
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                    table_ref.clone(),
-                    f,
+                DynProofExpr::Column(ColumnExpr::new(
+                    ColumnRef::new(table_ref.clone(), f),
                     ColumnType::BigInt,
-                ))),
+                )),
                 "f",
             ),
         ],
@@ -105,30 +100,27 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
         not(and(
             or(
                 DynProofExpr::try_new_equals(
-                    DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                        table_ref.clone(),
-                        Ident::new("f"),
+                    DynProofExpr::Column(ColumnExpr::new(
+                        ColumnRef::new(table_ref.clone(), Ident::new("f")),
                         ColumnType::BigInt,
-                    ))),
+                    )),
                     DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(45))),
                 )
                 .unwrap(),
                 DynProofExpr::try_new_equals(
-                    DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                        table_ref.clone(),
-                        Ident::new("c"),
+                    DynProofExpr::Column(ColumnExpr::new(
+                        ColumnRef::new(table_ref.clone(), Ident::new("c")),
                         ColumnType::BigInt,
-                    ))),
+                    )),
                     DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(-2))),
                 )
                 .unwrap(),
             ),
             DynProofExpr::try_new_equals(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                    table_ref.clone(),
-                    Ident::new("b"),
+                DynProofExpr::Column(ColumnExpr::new(
+                    ColumnRef::new(table_ref.clone(), Ident::new("b")),
                     ColumnType::BigInt,
-                ))),
+                )),
                 DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(3))),
             )
             .unwrap(),
@@ -140,10 +132,10 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     assert_eq!(
         ref_columns,
         IndexSet::from_iter([
-            ColumnRef::new(table_ref.clone(), Ident::new("a"), ColumnType::BigInt),
-            ColumnRef::new(table_ref.clone(), Ident::new("f"), ColumnType::BigInt),
-            ColumnRef::new(table_ref.clone(), Ident::new("c"), ColumnType::BigInt),
-            ColumnRef::new(table_ref.clone(), Ident::new("b"), ColumnType::BigInt)
+            ColumnRef::new(table_ref.clone(), Ident::new("a")),
+            ColumnRef::new(table_ref.clone(), Ident::new("f")),
+            ColumnRef::new(table_ref.clone(), Ident::new("c")),
+            ColumnRef::new(table_ref.clone(), Ident::new("b"))
         ])
     );
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -30,19 +30,17 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     let provable_ast = ProjectionExec::new(
         vec![
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                    table_ref.clone(),
-                    a,
+                DynProofExpr::Column(ColumnExpr::new(
+                    ColumnRef::new(table_ref.clone(), a),
                     ColumnType::BigInt,
-                ))),
+                )),
                 "a",
             ),
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                    table_ref.clone(),
-                    b,
+                DynProofExpr::Column(ColumnExpr::new(
+                    ColumnRef::new(table_ref.clone(), b),
                     ColumnType::BigInt,
-                ))),
+                )),
                 "b",
             ),
         ],
@@ -72,19 +70,17 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     let provable_ast = projection(
         vec![
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                    table_ref.clone(),
-                    a,
+                DynProofExpr::Column(ColumnExpr::new(
+                    ColumnRef::new(table_ref.clone(), a),
                     ColumnType::BigInt,
-                ))),
+                )),
                 "a",
             ),
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
-                    table_ref.clone(),
-                    f,
+                DynProofExpr::Column(ColumnExpr::new(
+                    ColumnRef::new(table_ref.clone(), f),
                     ColumnType::BigInt,
-                ))),
+                )),
                 "f",
             ),
         ],
@@ -102,8 +98,8 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     assert_eq!(
         ref_columns,
         IndexSet::from_iter([
-            ColumnRef::new(table_ref.clone(), Ident::new("a"), ColumnType::BigInt),
-            ColumnRef::new(table_ref.clone(), Ident::new("f"), ColumnType::BigInt),
+            ColumnRef::new(table_ref.clone(), Ident::new("a")),
+            ColumnRef::new(table_ref.clone(), Ident::new("f")),
         ])
     );
 

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -79,7 +79,7 @@ impl ProofPlan for TableExec {
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         self.schema
             .iter()
-            .map(|field| ColumnRef::new(self.table_ref.clone(), field.name(), field.data_type()))
+            .map(|field| ColumnRef::new(self.table_ref.clone(), field.name()))
             .collect()
     }
 

--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -77,68 +77,82 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN1_BOOLEAN() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column1".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column1".into(),
+            ),
             ColumnType::Boolean,
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN1_SMALLINT() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column1".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column1".into(),
+            ),
             ColumnType::SmallInt,
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN1_DECIMAL_3_MINUS2() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column1".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column1".into(),
+            ),
             ColumnType::Decimal75(
                 Precision::new(3).expect("Precision is definitely valid"),
                 -2,
             ),
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN1_DECIMAL_10_5() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column1".into(),
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column1".into(),
+            ),
             ColumnType::Decimal75(
                 Precision::new(10).expect("Precision is definitely valid"),
                 5,
             ),
-        ))
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN3_DECIMAL_75_10() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column3".into(),
-            ColumnType::Decimal75(
-                Precision::new(75).expect("Precision is definitely valid"),
-                10,
+        let column_type = ColumnType::Decimal75(
+            Precision::new(75).expect("Precision is definitely valid"),
+            10,
+        );
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column3".into(),
             ),
-        ))
+            column_type,
+        )
     }
 
     #[expect(non_snake_case)]
     fn COLUMN2_DECIMAL_25_5() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
-            TableRef::from_names(Some("namespace"), "table_name"),
-            "column2".into(),
-            ColumnType::Decimal75(
-                Precision::new(25).expect("Precision is definitely valid"),
-                5,
+        let column_type = ColumnType::Decimal75(
+            Precision::new(25).expect("Precision is definitely valid"),
+            5,
+        );
+        DynProofExpr::new_column(
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table_name"),
+                "column2".into(),
             ),
-        ))
+            column_type,
+        )
     }
 
     // decimal_scale_cast_expr


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
