### PR TITLE
refactor!: rename `ColumnRef` to `TypedColumnRef` and add a new `ColumnRef` without column types

### DIFF
--- a/crates/proof-of-sql-planner/src/aggregate.rs
+++ b/crates/proof-of-sql-planner/src/aggregate.rs
@@ -64,7 +64,7 @@ pub(crate) fn aggregate_function_to_proof_expr(
 mod tests {
     use super::*;
     use crate::df_util::*;
-    use proof_of_sql::base::database::{ColumnRef, ColumnType, TableRef};
+    use proof_of_sql::base::database::{ColumnType, TableRef, TypedColumnRef};
 
     // AggregateFunction to DynProofExpr
     #[test]
@@ -93,7 +93,7 @@ mod tests {
                 aggregate_function_to_proof_expr(&function, &schema).unwrap(),
                 (
                     *operator,
-                    DynProofExpr::new_column(ColumnRef::new(
+                    DynProofExpr::new_column(TypedColumnRef::new(
                         TableRef::from_names(None, "table"),
                         "a".into(),
                         ColumnType::BigInt

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -183,13 +183,13 @@ mod tests {
         logical_expr::{expr::Placeholder, Cast},
     };
     use proof_of_sql::base::{
-        database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+        database::{ColumnType, LiteralValue, TableRef, TypedColumnRef},
         math::decimal::Precision,
     };
 
     #[expect(non_snake_case)]
     fn COLUMN_INT() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column".into(),
             ColumnType::Int,
@@ -198,7 +198,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN1_SMALLINT() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column1".into(),
             ColumnType::SmallInt,
@@ -207,7 +207,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN2_BIGINT() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column2".into(),
             ColumnType::BigInt,
@@ -216,7 +216,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN1_BOOLEAN() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column1".into(),
             ColumnType::Boolean,
@@ -225,7 +225,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN2_BOOLEAN() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column2".into(),
             ColumnType::Boolean,
@@ -234,7 +234,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN3_DECIMAL_75_5() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column3".into(),
             ColumnType::Decimal75(
@@ -246,7 +246,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN2_DECIMAL_25_5() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column2".into(),
             ColumnType::Decimal75(
@@ -591,12 +591,12 @@ mod tests {
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_not(
                 DynProofExpr::try_new_equals(
-                    DynProofExpr::new_column(ColumnRef::new(
+                    DynProofExpr::new_column(TypedColumnRef::new(
                         TableRef::from_names(Some("namespace"), "table_name"),
                         "column1".into(),
                         ColumnType::BigInt,
                     )),
-                    DynProofExpr::new_column(ColumnRef::new(
+                    DynProofExpr::new_column(TypedColumnRef::new(
                         TableRef::from_names(Some("namespace"), "table_name"),
                         "column2".into(),
                         ColumnType::BigInt,
@@ -643,7 +643,7 @@ mod tests {
         let schema = vec![("column".into(), ColumnType::Boolean)];
         assert_eq!(
             expr_to_proof_expr(&expr, &schema).unwrap(),
-            DynProofExpr::try_new_not(DynProofExpr::new_column(ColumnRef::new(
+            DynProofExpr::try_new_not(DynProofExpr::new_column(TypedColumnRef::new(
                 TableRef::from_names(None, "table_name"),
                 "column".into(),
                 ColumnType::Boolean

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -14,7 +14,9 @@ use datafusion::{
 };
 use indexmap::{IndexMap, IndexSet};
 use proof_of_sql::{
-    base::database::{ColumnField, ColumnRef, ColumnType, LiteralValue, SchemaAccessor, TableRef},
+    base::database::{
+        ColumnField, ColumnType, LiteralValue, SchemaAccessor, TableRef, TypedColumnRef,
+    },
     sql::{
         proof::ProofPlan,
         proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
@@ -45,7 +47,7 @@ fn get_aliased_dyn_proof_exprs(
                 let (input_column_name, data_type) = input_schema
                     .get(*input_index)
                     .ok_or(PlannerError::ColumnNotFound)?;
-                let expr = DynProofExpr::new_column(ColumnRef::new(
+                let expr = DynProofExpr::new_column(TypedColumnRef::new(
                     table_ref.clone(),
                     input_column_name.clone(),
                     *data_type,
@@ -469,7 +471,7 @@ pub fn logical_plan_to_proof_plan(
                 .map(|field| -> PlannerResult<AliasedDynProofExpr> {
                     let alias = field.name();
                     Ok(AliasedDynProofExpr {
-                        expr: DynProofExpr::new_column(ColumnRef::new(
+                        expr: DynProofExpr::new_column(TypedColumnRef::new(
                             TableRef::from_names(None, "__filter_input__"), // Dummy table ref
                             alias.clone(),
                             field.data_type(),
@@ -592,7 +594,7 @@ mod tests {
     #[expect(non_snake_case)]
     fn ALIASED_A() -> AliasedDynProofExpr {
         AliasedDynProofExpr {
-            expr: DynProofExpr::new_column(ColumnRef::new(
+            expr: DynProofExpr::new_column(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "a".into(),
                 ColumnType::BigInt,
@@ -604,7 +606,7 @@ mod tests {
     #[expect(non_snake_case)]
     fn ALIASED_B() -> AliasedDynProofExpr {
         AliasedDynProofExpr {
-            expr: DynProofExpr::new_column(ColumnRef::new(
+            expr: DynProofExpr::new_column(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "b".into(),
                 ColumnType::Int,
@@ -616,7 +618,7 @@ mod tests {
     #[expect(non_snake_case)]
     fn ALIASED_C() -> AliasedDynProofExpr {
         AliasedDynProofExpr {
-            expr: DynProofExpr::new_column(ColumnRef::new(
+            expr: DynProofExpr::new_column(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "c".into(),
                 ColumnType::VarChar,
@@ -628,7 +630,7 @@ mod tests {
     #[expect(non_snake_case)]
     fn ALIASED_D() -> AliasedDynProofExpr {
         AliasedDynProofExpr {
-            expr: DynProofExpr::new_column(ColumnRef::new(
+            expr: DynProofExpr::new_column(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "d".into(),
                 ColumnType::Boolean,
@@ -756,13 +758,13 @@ mod tests {
 
         // Expected result
         let expected = DynProofPlan::try_new_group_by(
-            vec![ColumnExpr::new(ColumnRef::new(
+            vec![ColumnExpr::new(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "a".into(),
                 ColumnType::BigInt,
             ))],
             vec![AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     TABLE_REF_TABLE(),
                     "b".into(),
                     ColumnType::Int,
@@ -820,13 +822,13 @@ mod tests {
 
         // Expected result
         let expected = DynProofPlan::try_new_group_by(
-            vec![ColumnExpr::new(ColumnRef::new(
+            vec![ColumnExpr::new(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "a".into(),
                 ColumnType::BigInt,
             ))],
             vec![AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     TABLE_REF_TABLE(),
                     "b".into(),
                     ColumnType::Int,
@@ -837,7 +839,7 @@ mod tests {
             TableExpr {
                 table_ref: TABLE_REF_TABLE(),
             },
-            DynProofExpr::new_column(ColumnRef::new(
+            DynProofExpr::new_column(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "d".into(),
                 ColumnType::Boolean,
@@ -889,19 +891,19 @@ mod tests {
         // Expected result
         let expected = DynProofPlan::try_new_group_by(
             vec![
-                ColumnExpr::new(ColumnRef::new(
+                ColumnExpr::new(TypedColumnRef::new(
                     TABLE_REF_TABLE(),
                     "a".into(),
                     ColumnType::BigInt,
                 )),
-                ColumnExpr::new(ColumnRef::new(
+                ColumnExpr::new(TypedColumnRef::new(
                     TABLE_REF_TABLE(),
                     "c".into(),
                     ColumnType::VarChar,
                 )),
             ],
             vec![AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     TABLE_REF_TABLE(),
                     "b".into(),
                     ColumnType::Int,
@@ -955,14 +957,14 @@ mod tests {
 
         // Expected result
         let expected = DynProofPlan::try_new_group_by(
-            vec![ColumnExpr::new(ColumnRef::new(
+            vec![ColumnExpr::new(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "a".into(),
                 ColumnType::BigInt,
             ))],
             vec![
                 AliasedDynProofExpr {
-                    expr: DynProofExpr::new_column(ColumnRef::new(
+                    expr: DynProofExpr::new_column(TypedColumnRef::new(
                         TABLE_REF_TABLE(),
                         "b".into(),
                         ColumnType::Int,
@@ -970,7 +972,7 @@ mod tests {
                     alias: "sum_b".into(),
                 },
                 AliasedDynProofExpr {
-                    expr: DynProofExpr::new_column(ColumnRef::new(
+                    expr: DynProofExpr::new_column(TypedColumnRef::new(
                         TABLE_REF_TABLE(),
                         "d".into(),
                         ColumnType::Boolean,
@@ -1022,7 +1024,7 @@ mod tests {
 
         // Expected result
         let expected = DynProofPlan::try_new_group_by(
-            vec![ColumnExpr::new(ColumnRef::new(
+            vec![ColumnExpr::new(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "a".into(),
                 ColumnType::BigInt,
@@ -1398,19 +1400,19 @@ mod tests {
             ),
             DynProofExpr::try_new_and(
                 DynProofExpr::try_new_equals(
-                    DynProofExpr::new_column(ColumnRef::new(
+                    DynProofExpr::new_column(TypedColumnRef::new(
                         TABLE_REF_TABLE(),
                         "a".into(),
                         ColumnType::BigInt,
                     )),
-                    DynProofExpr::new_column(ColumnRef::new(
+                    DynProofExpr::new_column(TypedColumnRef::new(
                         TABLE_REF_TABLE(),
                         "b".into(),
                         ColumnType::Int,
                     )),
                 )
                 .unwrap(),
-                DynProofExpr::new_column(ColumnRef::new(
+                DynProofExpr::new_column(TypedColumnRef::new(
                     TABLE_REF_TABLE(),
                     "d".into(),
                     ColumnType::Boolean,
@@ -1504,12 +1506,12 @@ mod tests {
                 ),
                 DynProofExpr::try_new_and(
                     DynProofExpr::try_new_inequality(
-                        DynProofExpr::new_column(ColumnRef::new(
+                        DynProofExpr::new_column(TypedColumnRef::new(
                             TABLE_REF_TABLE(),
                             "a".into(),
                             ColumnType::BigInt,
                         )),
-                        DynProofExpr::new_column(ColumnRef::new(
+                        DynProofExpr::new_column(TypedColumnRef::new(
                             TABLE_REF_TABLE(),
                             "b".into(),
                             ColumnType::Int,
@@ -1517,7 +1519,7 @@ mod tests {
                         false,
                     )
                     .unwrap(),
-                    DynProofExpr::new_column(ColumnRef::new(
+                    DynProofExpr::new_column(TypedColumnRef::new(
                         TABLE_REF_TABLE(),
                         "d".into(),
                         ColumnType::Boolean,
@@ -1553,43 +1555,42 @@ mod tests {
         );
         let schemas = SCHEMAS();
         let result = logical_plan_to_proof_plan(&plan, &schemas).unwrap();
-        let expected = DynProofPlan::new_projection(
-            vec![
-                AliasedDynProofExpr {
-                    expr: DynProofExpr::try_new_add(
-                        DynProofExpr::new_column(ColumnRef::new(
-                            TABLE_REF_TABLE(),
-                            "a".into(),
-                            ColumnType::BigInt,
-                        )),
-                        DynProofExpr::new_column(ColumnRef::new(
-                            TABLE_REF_TABLE(),
-                            "b".into(),
-                            ColumnType::Int,
-                        )),
-                    )
-                    .unwrap(),
-                    alias: "table.a + table.b".into(),
-                },
-                AliasedDynProofExpr {
-                    expr: DynProofExpr::try_new_not(DynProofExpr::new_column(ColumnRef::new(
-                        TABLE_REF_TABLE(),
-                        "d".into(),
-                        ColumnType::Boolean,
-                    )))
-                    .unwrap(),
-                    alias: "NOT table.d".into(),
-                },
-            ],
-            DynProofPlan::new_table(
-                TABLE_REF_TABLE(),
+        let expected =
+            DynProofPlan::new_projection(
                 vec![
-                    ColumnField::new("a".into(), ColumnType::BigInt),
-                    ColumnField::new("b".into(), ColumnType::Int),
-                    ColumnField::new("d".into(), ColumnType::Boolean),
+                    AliasedDynProofExpr {
+                        expr: DynProofExpr::try_new_add(
+                            DynProofExpr::new_column(TypedColumnRef::new(
+                                TABLE_REF_TABLE(),
+                                "a".into(),
+                                ColumnType::BigInt,
+                            )),
+                            DynProofExpr::new_column(TypedColumnRef::new(
+                                TABLE_REF_TABLE(),
+                                "b".into(),
+                                ColumnType::Int,
+                            )),
+                        )
+                        .unwrap(),
+                        alias: "table.a + table.b".into(),
+                    },
+                    AliasedDynProofExpr {
+                        expr: DynProofExpr::try_new_not(DynProofExpr::new_column(
+                            TypedColumnRef::new(TABLE_REF_TABLE(), "d".into(), ColumnType::Boolean),
+                        ))
+                        .unwrap(),
+                        alias: "NOT table.d".into(),
+                    },
                 ],
-            ),
-        );
+                DynProofPlan::new_table(
+                    TABLE_REF_TABLE(),
+                    vec![
+                        ColumnField::new("a".into(), ColumnType::BigInt),
+                        ColumnField::new("b".into(), ColumnType::Int),
+                        ColumnField::new("d".into(), ColumnType::Boolean),
+                    ],
+                ),
+            );
         assert_eq!(result, expected);
     }
 
@@ -1790,13 +1791,13 @@ mod tests {
 
         // Expected result
         let expected = DynProofPlan::try_new_group_by(
-            vec![ColumnExpr::new(ColumnRef::new(
+            vec![ColumnExpr::new(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "a".into(),
                 ColumnType::BigInt,
             ))],
             vec![AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     TABLE_REF_TABLE(),
                     "b".into(),
                     ColumnType::Int,
@@ -1807,7 +1808,7 @@ mod tests {
             TableExpr {
                 table_ref: TABLE_REF_TABLE(),
             },
-            DynProofExpr::new_column(ColumnRef::new(
+            DynProofExpr::new_column(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "d".into(),
                 ColumnType::Boolean,
@@ -1877,13 +1878,13 @@ mod tests {
 
         // Expected result
         let expected = DynProofPlan::try_new_group_by(
-            vec![ColumnExpr::new(ColumnRef::new(
+            vec![ColumnExpr::new(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "a".into(),
                 ColumnType::BigInt,
             ))],
             vec![AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     TABLE_REF_TABLE(),
                     "b".into(),
                     ColumnType::Int,
@@ -1894,7 +1895,7 @@ mod tests {
             TableExpr {
                 table_ref: TABLE_REF_TABLE(),
             },
-            DynProofExpr::new_column(ColumnRef::new(
+            DynProofExpr::new_column(TypedColumnRef::new(
                 TABLE_REF_TABLE(),
                 "d".into(),
                 ColumnType::Boolean,

--- a/crates/proof-of-sql-planner/tests/evm_tests.rs
+++ b/crates/proof-of-sql-planner/tests/evm_tests.rs
@@ -10,8 +10,8 @@ use proof_of_sql::{
                 bigint, boolean, decimal75, int, owned_table, smallint, timestamptz, tinyint,
                 varbinary, varchar,
             },
-            ColumnField, ColumnRef, ColumnType, CommitmentAccessor, LiteralValue,
-            OwnedTableTestAccessor, SchemaAccessor, TableRef, TestAccessor,
+            ColumnField, ColumnType, CommitmentAccessor, LiteralValue, OwnedTableTestAccessor,
+            SchemaAccessor, TableRef, TestAccessor, TypedColumnRef,
         },
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
@@ -109,10 +109,10 @@ fn evm_verifier_all(
 }
 
 #[expect(clippy::missing_panics_doc)]
-fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> ColumnRef {
+fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> TypedColumnRef {
     let name: Ident = name.into();
     let type_col = accessor.lookup_column(tab, &name).unwrap();
-    ColumnRef::new(tab.clone(), name, type_col)
+    TypedColumnRef::new(tab.clone(), name, type_col)
 }
 
 fn col_expr_plan(
@@ -954,12 +954,12 @@ fn we_can_have_projection_as_input_plan_for_filter() {
         vec![
             AliasedDynProofExpr {
                 expr: DynProofExpr::try_new_add(
-                    DynProofExpr::new_column(ColumnRef::new(
+                    DynProofExpr::new_column(TypedColumnRef::new(
                         t.clone(),
                         "a".into(),
                         ColumnType::BigInt,
                     )),
-                    DynProofExpr::new_column(ColumnRef::new(
+                    DynProofExpr::new_column(TypedColumnRef::new(
                         t.clone(),
                         "b".into(),
                         ColumnType::BigInt,
@@ -969,7 +969,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
                 alias: "x".into(),
             },
             AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     t.clone(),
                     "b".into(),
                     ColumnType::BigInt,
@@ -977,7 +977,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
                 alias: "y".into(),
             },
             AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     t.clone(),
                     "c".into(),
                     ColumnType::BigInt,
@@ -991,7 +991,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
     let dummy_table = TableRef::new("", "");
     let filter_results = vec![
         AliasedDynProofExpr {
-            expr: DynProofExpr::new_column(ColumnRef::new(
+            expr: DynProofExpr::new_column(TypedColumnRef::new(
                 dummy_table.clone(),
                 "x".into(),
                 ColumnType::Decimal75(Precision::new(20).unwrap(), 0),
@@ -999,7 +999,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
             alias: "x".into(),
         },
         AliasedDynProofExpr {
-            expr: DynProofExpr::new_column(ColumnRef::new(
+            expr: DynProofExpr::new_column(TypedColumnRef::new(
                 dummy_table.clone(),
                 "y".into(),
                 ColumnType::BigInt,
@@ -1007,7 +1007,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
             alias: "y".into(),
         },
         AliasedDynProofExpr {
-            expr: DynProofExpr::new_column(ColumnRef::new(
+            expr: DynProofExpr::new_column(TypedColumnRef::new(
                 dummy_table.clone(),
                 "z".into(),
                 ColumnType::BigInt,
@@ -1020,7 +1020,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
         filter_results,
         projection,
         DynProofExpr::try_new_inequality(
-            DynProofExpr::new_column(ColumnRef::new(
+            DynProofExpr::new_column(TypedColumnRef::new(
                 dummy_table.clone(),
                 "z".into(),
                 ColumnType::BigInt,

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -1,8 +1,8 @@
 use super::{Commitment, TableCommitment};
 use crate::base::{
     database::{
-        ColumnField, ColumnRef, ColumnType, CommitmentAccessor, MetadataAccessor, SchemaAccessor,
-        TableRef,
+        ColumnField, ColumnType, CommitmentAccessor, MetadataAccessor, SchemaAccessor, TableRef,
+        TypedColumnRef,
     },
     map::IndexMap,
 };
@@ -24,14 +24,14 @@ where
 {
     /// Create a new `QueryCommitments` from a collection of columns and an accessor.
     fn from_accessor_with_max_bounds(
-        columns: impl IntoIterator<Item = ColumnRef>,
+        columns: impl IntoIterator<Item = TypedColumnRef>,
         accessor: &(impl CommitmentAccessor<C> + SchemaAccessor),
     ) -> Self;
 }
 
 impl<C: Commitment> QueryCommitmentsExt<C> for QueryCommitments<C> {
     fn from_accessor_with_max_bounds(
-        columns: impl IntoIterator<Item = ColumnRef>,
+        columns: impl IntoIterator<Item = TypedColumnRef>,
         accessor: &(impl CommitmentAccessor<C> + SchemaAccessor),
     ) -> Self {
         columns
@@ -370,10 +370,10 @@ mod tests {
 
         let query_commitments = QueryCommitments::<DoryCommitment>::from_accessor_with_max_bounds(
             [
-                ColumnRef::new(table_a_id.clone(), column_a_id.clone(), ColumnType::BigInt),
-                ColumnRef::new(table_b_id.clone(), column_a_id, ColumnType::Scalar),
-                ColumnRef::new(table_a_id, column_b_id.clone(), ColumnType::VarChar),
-                ColumnRef::new(table_b_id, column_b_id, ColumnType::Int128),
+                TypedColumnRef::new(table_a_id.clone(), column_a_id.clone(), ColumnType::BigInt),
+                TypedColumnRef::new(table_b_id.clone(), column_a_id, ColumnType::Scalar),
+                TypedColumnRef::new(table_a_id, column_b_id.clone(), ColumnType::VarChar),
+                TypedColumnRef::new(table_b_id, column_b_id, ColumnType::Int128),
             ],
             &accessor,
         );

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -1,0 +1,33 @@
+use super::TableRef;
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
+
+/// Reference of a SQL column
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub struct ColumnRef {
+    column_id: Ident,
+    table_ref: TableRef,
+}
+
+impl ColumnRef {
+    /// Create a new `ColumnRef` from a table and column identifier
+    #[must_use]
+    pub fn new(table_ref: TableRef, column_id: Ident) -> Self {
+        Self {
+            column_id,
+            table_ref,
+        }
+    }
+
+    /// Returns the table reference of this column
+    #[must_use]
+    pub fn table_ref(&self) -> TableRef {
+        self.table_ref.clone()
+    }
+
+    /// Returns the column identifier of this column
+    #[must_use]
+    pub fn column_id(&self) -> Ident {
+        self.column_id.clone()
+    }
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -10,6 +10,8 @@ pub use column::Column;
 mod column_type;
 pub use column_type::ColumnType;
 
+mod column_ref;
+pub use column_ref::ColumnRef;
 mod typed_column_ref;
 pub use typed_column_ref::TypedColumnRef;
 

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -10,8 +10,8 @@ pub use column::Column;
 mod column_type;
 pub use column_type::ColumnType;
 
-mod column_ref;
-pub use column_ref::ColumnRef;
+mod typed_column_ref;
+pub use typed_column_ref::TypedColumnRef;
 
 mod column_field;
 pub use column_field::ColumnField;

--- a/crates/proof-of-sql/src/base/database/typed_column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/typed_column_ref.rs
@@ -2,16 +2,16 @@ use super::{ColumnType, TableRef};
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
-/// Reference of a SQL column
+/// Reference of a SQL column with type information
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
-pub struct ColumnRef {
+pub struct TypedColumnRef {
     column_id: Ident,
     table_ref: TableRef,
     column_type: ColumnType,
 }
 
-impl ColumnRef {
-    /// Create a new `ColumnRef` from a table, column identifier and column type
+impl TypedColumnRef {
+    /// Create a new `TypedColumnRef` from a table, column identifier and column type
     #[must_use]
     pub fn new(table_ref: TableRef, column_id: Ident, column_type: ColumnType) -> Self {
         Self {

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -1,7 +1,7 @@
 use super::{EVMProofPlanError, EVMProofPlanResult};
 use crate::{
     base::{
-        database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+        database::{ColumnType, LiteralValue, TableRef, TypedColumnRef},
         map::IndexSet,
     },
     sql::proof_exprs::{
@@ -34,7 +34,7 @@ impl EVMDynProofExpr {
     /// Try to create an `EVMDynProofExpr` from a `DynProofExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &DynProofExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         match expr {
             DynProofExpr::Column(column_expr) => {
@@ -83,7 +83,7 @@ impl EVMDynProofExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<DynProofExpr> {
         match self {
             EVMDynProofExpr::Column(column_expr) => Ok(DynProofExpr::Column(
@@ -144,13 +144,13 @@ impl EVMColumnExpr {
     /// Try to create a `EVMColumnExpr` from a `ColumnExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &ColumnExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(Self {
             column_number: column_refs
                 .get_index_of(expr.column_ref())
                 .or_else(|| {
-                    column_refs.get_index_of(&ColumnRef::new(
+                    column_refs.get_index_of(&TypedColumnRef::new(
                         TableRef::from_names(None, ""),
                         expr.column_id(),
                         expr.data_type(),
@@ -162,7 +162,7 @@ impl EVMColumnExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<ColumnExpr> {
         Ok(ColumnExpr::new(
             column_refs
@@ -210,7 +210,7 @@ impl EVMEqualsExpr {
     /// Try to create an `EVMEqualsExpr` from a `EqualsExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &EqualsExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(EVMEqualsExpr {
             lhs: Box::new(EVMDynProofExpr::try_from_proof_expr(
@@ -226,7 +226,7 @@ impl EVMEqualsExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<EqualsExpr> {
         Ok(EqualsExpr::try_new(
             Box::new(self.lhs.try_into_proof_expr(column_refs)?),
@@ -256,7 +256,7 @@ impl EVMInequalityExpr {
     /// Try to create an `EVMInequalityExpr` from a `InequalityExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &InequalityExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(EVMInequalityExpr {
             lhs: Box::new(EVMDynProofExpr::try_from_proof_expr(
@@ -273,7 +273,7 @@ impl EVMInequalityExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<InequalityExpr> {
         Ok(InequalityExpr::try_new(
             Box::new(self.lhs.try_into_proof_expr(column_refs)?),
@@ -302,7 +302,7 @@ impl EVMAddExpr {
     /// Try to create an `EVMAddExpr` from a `AddExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &AddExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(EVMAddExpr {
             lhs: Box::new(EVMDynProofExpr::try_from_proof_expr(
@@ -318,7 +318,7 @@ impl EVMAddExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<AddExpr> {
         Ok(AddExpr::try_new(
             Box::new(self.lhs.try_into_proof_expr(column_refs)?),
@@ -346,7 +346,7 @@ impl EVMSubtractExpr {
     /// Try to create an `EVMSubtractExpr` from a `SubtractExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &SubtractExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(EVMSubtractExpr {
             lhs: Box::new(EVMDynProofExpr::try_from_proof_expr(
@@ -362,7 +362,7 @@ impl EVMSubtractExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<SubtractExpr> {
         Ok(SubtractExpr::try_new(
             Box::new(self.lhs.try_into_proof_expr(column_refs)?),
@@ -390,7 +390,7 @@ impl EVMMultiplyExpr {
     /// Try to create an `EVMMultiplyExpr` from a `MultiplyExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &MultiplyExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(EVMMultiplyExpr {
             lhs: Box::new(EVMDynProofExpr::try_from_proof_expr(
@@ -406,7 +406,7 @@ impl EVMMultiplyExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<MultiplyExpr> {
         Ok(MultiplyExpr::try_new(
             Box::new(self.lhs.try_into_proof_expr(column_refs)?),
@@ -434,7 +434,7 @@ impl EVMAndExpr {
     /// Try to create an `EVMAndExpr` from a `AndExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &AndExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(EVMAndExpr {
             lhs: Box::new(EVMDynProofExpr::try_from_proof_expr(
@@ -450,7 +450,7 @@ impl EVMAndExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<AndExpr> {
         Ok(AndExpr::try_new(
             Box::new(self.lhs.try_into_proof_expr(column_refs)?),
@@ -478,7 +478,7 @@ impl EVMOrExpr {
     /// Try to create an `EVMOrExpr` from a `OrExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &OrExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(EVMOrExpr {
             lhs: Box::new(EVMDynProofExpr::try_from_proof_expr(
@@ -494,7 +494,7 @@ impl EVMOrExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<OrExpr> {
         Ok(OrExpr::try_new(
             Box::new(self.lhs.try_into_proof_expr(column_refs)?),
@@ -520,7 +520,7 @@ impl EVMNotExpr {
     /// Try to create an `EVMNotExpr` from a `NotExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &NotExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(EVMNotExpr {
             expr: Box::new(EVMDynProofExpr::try_from_proof_expr(
@@ -532,7 +532,7 @@ impl EVMNotExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<NotExpr> {
         Ok(NotExpr::try_new(Box::new(
             self.expr.try_into_proof_expr(column_refs)?,
@@ -559,7 +559,7 @@ impl EVMCastExpr {
     /// Try to create an `EVMCastExpr` from a `CastExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &CastExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(EVMCastExpr {
             from_expr: Box::new(EVMDynProofExpr::try_from_proof_expr(
@@ -572,7 +572,7 @@ impl EVMCastExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<CastExpr> {
         Ok(CastExpr::try_new(
             Box::new(self.from_expr.try_into_proof_expr(column_refs)?),
@@ -606,7 +606,7 @@ impl EVMScalingCastExpr {
     /// Try to create an `EVMScalingCastExpr` from a `ScalingCastExpr`.
     pub(crate) fn try_from_proof_expr(
         expr: &ScalingCastExpr,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         let scaling_factor = expr.scaling_factor();
         Ok(EVMScalingCastExpr {
@@ -626,7 +626,7 @@ impl EVMScalingCastExpr {
 
     pub(crate) fn try_into_proof_expr(
         &self,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<ScalingCastExpr> {
         let expr = ScalingCastExpr::try_new(
             Box::new(self.from_expr.try_into_proof_expr(column_refs)?),
@@ -685,7 +685,7 @@ mod tests {
     fn we_can_put_a_column_expr_in_evm() {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident = "a".into();
-        let column_ref = ColumnRef::new(table_ref.clone(), ident, ColumnType::BigInt);
+        let column_ref = TypedColumnRef::new(table_ref.clone(), ident, ColumnType::BigInt);
 
         let evm_column_expr = EVMColumnExpr::try_from_proof_expr(
             &ColumnExpr::new(column_ref.clone()),
@@ -705,7 +705,7 @@ mod tests {
     fn we_cannot_put_a_column_expr_in_evm_if_column_not_found() {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident = "a".into();
-        let column_ref = ColumnRef::new(table_ref.clone(), ident, ColumnType::BigInt);
+        let column_ref = TypedColumnRef::new(table_ref.clone(), ident, ColumnType::BigInt);
 
         assert_eq!(
             EVMColumnExpr::try_from_proof_expr(&ColumnExpr::new(column_ref.clone()), &indexset! {}),
@@ -716,7 +716,7 @@ mod tests {
     #[test]
     fn we_cannot_get_a_column_expr_from_evm_if_column_number_out_of_bounds() {
         let evm_column_expr = EVMColumnExpr { column_number: 0 };
-        let column_refs = IndexSet::<ColumnRef>::default();
+        let column_refs = IndexSet::<TypedColumnRef>::default();
         assert_eq!(
             evm_column_expr
                 .try_into_proof_expr(&column_refs)
@@ -929,8 +929,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
         let equals_expr = EqualsExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_b.clone())),
@@ -966,8 +966,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
         let add_expr = AddExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_b.clone())),
@@ -1001,8 +1001,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
         let subtract_expr = SubtractExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_b.clone())),
@@ -1036,8 +1036,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
         // b * 10 so we see column_number = 1
         let multiply_expr = MultiplyExpr::try_new(
@@ -1072,7 +1072,7 @@ mod tests {
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 }),
         );
-        let column_refs = IndexSet::<ColumnRef>::default();
+        let column_refs = IndexSet::<TypedColumnRef>::default();
         assert_eq!(
             evm_column_expr
                 .try_into_proof_expr(&column_refs)
@@ -1087,8 +1087,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_x = "x".into();
         let ident_y = "y".into();
-        let column_ref_x = ColumnRef::new(table_ref.clone(), ident_x, ColumnType::Boolean);
-        let column_ref_y = ColumnRef::new(table_ref.clone(), ident_y, ColumnType::Boolean);
+        let column_ref_x = TypedColumnRef::new(table_ref.clone(), ident_x, ColumnType::Boolean);
+        let column_ref_y = TypedColumnRef::new(table_ref.clone(), ident_y, ColumnType::Boolean);
 
         let and_expr = AndExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_x.clone())),
@@ -1122,7 +1122,7 @@ mod tests {
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 }),
         );
-        let column_refs = IndexSet::<ColumnRef>::default();
+        let column_refs = IndexSet::<TypedColumnRef>::default();
         assert_eq!(
             evm_and_expr.try_into_proof_expr(&column_refs).unwrap_err(),
             EVMProofPlanError::ColumnNotFound
@@ -1135,8 +1135,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_x = "x".into();
         let ident_y = "y".into();
-        let column_ref_x = ColumnRef::new(table_ref.clone(), ident_x, ColumnType::Boolean);
-        let column_ref_y = ColumnRef::new(table_ref.clone(), ident_y, ColumnType::Boolean);
+        let column_ref_x = TypedColumnRef::new(table_ref.clone(), ident_x, ColumnType::Boolean);
+        let column_ref_y = TypedColumnRef::new(table_ref.clone(), ident_y, ColumnType::Boolean);
 
         let or_expr = OrExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_x.clone())),
@@ -1170,7 +1170,7 @@ mod tests {
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 }),
         );
-        let column_refs = IndexSet::<ColumnRef>::default();
+        let column_refs = IndexSet::<TypedColumnRef>::default();
         assert_eq!(
             evm_or_expr.try_into_proof_expr(&column_refs).unwrap_err(),
             EVMProofPlanError::ColumnNotFound
@@ -1182,7 +1182,8 @@ mod tests {
     fn we_can_put_a_not_expr_in_evm() {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_flag = "flag".into();
-        let column_ref_flag = ColumnRef::new(table_ref.clone(), ident_flag, ColumnType::Boolean);
+        let column_ref_flag =
+            TypedColumnRef::new(table_ref.clone(), ident_flag, ColumnType::Boolean);
 
         let not_expr =
             NotExpr::try_new(Box::new(DynProofExpr::new_column(column_ref_flag.clone()))).unwrap();
@@ -1206,7 +1207,7 @@ mod tests {
     fn we_cannot_get_a_not_expr_from_evm_if_column_number_out_of_bounds() {
         let evm_not_expr =
             EVMNotExpr::new(EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }));
-        let column_refs = IndexSet::<ColumnRef>::default();
+        let column_refs = IndexSet::<TypedColumnRef>::default();
         assert_eq!(
             evm_not_expr.try_into_proof_expr(&column_refs).unwrap_err(),
             EVMProofPlanError::ColumnNotFound
@@ -1219,8 +1220,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
 
         let cast_expr = CastExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_b.clone())),
@@ -1254,7 +1255,7 @@ mod tests {
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
             ColumnType::BigInt,
         );
-        let column_refs = IndexSet::<ColumnRef>::default();
+        let column_refs = IndexSet::<TypedColumnRef>::default();
         assert_eq!(
             evm_cast_expr.try_into_proof_expr(&column_refs).unwrap_err(),
             EVMProofPlanError::ColumnNotFound
@@ -1312,8 +1313,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
         let inequality_expr = InequalityExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_b.clone())),
@@ -1349,8 +1350,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
 
         let scaling_cast_expr = ScalingCastExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_b.clone())),
@@ -1386,7 +1387,7 @@ mod tests {
             ColumnType::Decimal75(Precision::new(15).unwrap(), 2),
             [0, 0, 0, 100],
         );
-        let column_refs = IndexSet::<ColumnRef>::default();
+        let column_refs = IndexSet::<TypedColumnRef>::default();
         assert_eq!(
             evm_scaling_cast_expr
                 .try_into_proof_expr(&column_refs)
@@ -1400,8 +1401,8 @@ mod tests {
         let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
         let ident_a = "a".into();
         let ident_b = "b".into();
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::Int);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::Int);
 
         let evm_scaling_cast_expr = EVMScalingCastExpr::new(
             EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
@@ -1420,7 +1421,7 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_equals_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = TypedColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
 
         let expr = equal(
             DynProofExpr::new_literal(LiteralValue::BigInt(5)),
@@ -1444,7 +1445,7 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_add_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = TypedColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
 
         let expr = add(
             DynProofExpr::new_column(column_b.clone()),
@@ -1466,7 +1467,7 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_subtract_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = TypedColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
 
         let expr = subtract(
             DynProofExpr::new_column(column_b.clone()),
@@ -1488,7 +1489,7 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_multiply_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = TypedColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
 
         let expr = multiply(
             DynProofExpr::new_column(column_b.clone()),
@@ -1510,8 +1511,8 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_and_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Boolean);
-        let d = ColumnRef::new(table_ref.clone(), "d".into(), ColumnType::Boolean);
+        let c = TypedColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Boolean);
+        let d = TypedColumnRef::new(table_ref.clone(), "d".into(), ColumnType::Boolean);
 
         let expr = and(
             DynProofExpr::new_column(c.clone()),
@@ -1530,8 +1531,8 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_or_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Boolean);
-        let d = ColumnRef::new(table_ref.clone(), "d".into(), ColumnType::Boolean);
+        let c = TypedColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Boolean);
+        let d = TypedColumnRef::new(table_ref.clone(), "d".into(), ColumnType::Boolean);
 
         let expr = or(
             DynProofExpr::new_column(c.clone()),
@@ -1550,7 +1551,7 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_not_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Boolean);
+        let c = TypedColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Boolean);
 
         let expr = not(DynProofExpr::new_column(c.clone()));
         let evm = EVMDynProofExpr::try_from_proof_expr(&expr, &indexset! { c.clone() }).unwrap();
@@ -1565,7 +1566,7 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_cast_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Int);
+        let c = TypedColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Int);
 
         let expr = cast(DynProofExpr::new_column(c.clone()), ColumnType::BigInt);
         let evm = EVMDynProofExpr::try_from_proof_expr(&expr, &indexset! { c.clone() }).unwrap();
@@ -1580,7 +1581,7 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_inequality_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let column_b = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+        let column_b = TypedColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
 
         let expr = lt(
             DynProofExpr::new_column(column_b.clone()),
@@ -1603,7 +1604,7 @@ mod tests {
     #[test]
     fn we_can_put_into_evm_a_dyn_proof_expr_scaling_cast_expr() {
         let table_ref = TableRef::try_from("namespace.table").unwrap();
-        let c = ColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Int);
+        let c = TypedColumnRef::new(table_ref.clone(), "c".into(), ColumnType::Int);
 
         let expr = DynProofExpr::try_new_scaling_cast(
             DynProofExpr::new_column(c.clone()),

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -1,7 +1,7 @@
 use super::{EVMDynProofExpr, EVMProofPlanError, EVMProofPlanResult};
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, TableRef},
+        database::{ColumnField, TableRef, TypedColumnRef},
         map::IndexSet,
     },
     sql::{
@@ -40,7 +40,7 @@ impl EVMDynProofPlan {
     pub(crate) fn try_from_proof_plan(
         plan: &DynProofPlan,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         match plan {
             DynProofPlan::Empty(empty_exec) => {
@@ -92,7 +92,7 @@ impl EVMDynProofPlan {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
         output_column_names: Option<&IndexSet<String>>,
     ) -> EVMProofPlanResult<DynProofPlan> {
         match self {
@@ -164,7 +164,7 @@ impl EVMTableExec {
     pub(crate) fn try_from_proof_plan(
         plan: &TableExec,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(Self {
             table_number: table_refs
@@ -181,7 +181,7 @@ impl EVMTableExec {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<TableExec> {
         let table_ref = table_refs
             .get_index(self.table_number)
@@ -228,7 +228,7 @@ impl EVMLegacyFilterExec {
     pub(crate) fn try_from_proof_plan(
         plan: &LegacyFilterExec,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(Self {
             table_number: table_refs
@@ -246,7 +246,7 @@ impl EVMLegacyFilterExec {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
         output_column_names: Option<&IndexSet<String>>,
     ) -> EVMProofPlanResult<LegacyFilterExec> {
         let output_column_names =
@@ -286,7 +286,7 @@ impl EVMFilterExec {
     pub(crate) fn try_from_proof_plan(
         plan: &FilterExec,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         let input_result_column_refs = plan.input().get_column_result_fields_as_references();
         Ok(Self {
@@ -312,7 +312,7 @@ impl EVMFilterExec {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
         output_column_names: Option<&IndexSet<String>>,
     ) -> EVMProofPlanResult<FilterExec> {
         let output_column_names =
@@ -351,7 +351,7 @@ impl EVMProjectionExec {
     pub(crate) fn try_from_proof_plan(
         plan: &ProjectionExec,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         let input_result_column_refs = plan.input().get_column_result_fields_as_references();
         Ok(Self {
@@ -373,7 +373,7 @@ impl EVMProjectionExec {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
         output_column_names: Option<&IndexSet<String>>,
     ) -> EVMProofPlanResult<ProjectionExec> {
         let output_column_names =
@@ -411,7 +411,7 @@ impl EVMSliceExec {
     pub(crate) fn try_from_proof_plan(
         plan: &SliceExec,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         Ok(Self {
             input_plan: Box::new(EVMDynProofPlan::try_from_proof_plan(
@@ -427,7 +427,7 @@ impl EVMSliceExec {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
         output_column_names: Option<&IndexSet<String>>,
     ) -> EVMProofPlanResult<SliceExec> {
         Ok(SliceExec::new(
@@ -457,7 +457,7 @@ impl EVMGroupByExec {
     pub(crate) fn try_from_proof_plan(
         plan: &GroupByExec,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         // Map column expressions to their indices in column_refs
         let group_by_exprs = plan
@@ -494,7 +494,7 @@ impl EVMGroupByExec {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
         output_column_names: Option<&IndexSet<String>>,
     ) -> EVMProofPlanResult<GroupByExec> {
         let grouping_column_count = self.group_by_exprs.len();
@@ -569,7 +569,7 @@ impl EVMAggregateExec {
     pub(crate) fn try_from_proof_plan(
         plan: &AggregateExec,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         // Get the input result columns to use for expression conversion
         let input_result_column_refs = plan.input().get_column_result_fields_as_references();
@@ -614,7 +614,7 @@ impl EVMAggregateExec {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
         output_column_names: Option<&IndexSet<String>>,
     ) -> EVMProofPlanResult<AggregateExec> {
         let required_alias_count = self.group_by_exprs.len() + self.sum_expr.len() + 1;
@@ -684,7 +684,7 @@ impl EVMUnionExec {
     pub(crate) fn try_from_proof_plan(
         plan: &UnionExec,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         // Map column expressions to their indices in column_refs
         Ok(Self {
@@ -699,7 +699,7 @@ impl EVMUnionExec {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
         output_column_names: Option<&IndexSet<String>>,
     ) -> EVMProofPlanResult<UnionExec> {
         // We need not supply the output column names to anything other than the first input plan
@@ -732,7 +732,7 @@ impl EVMSortMergeJoinExec {
     pub(crate) fn try_from_proof_plan(
         plan: &SortMergeJoinExec,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<Self> {
         let left = Box::new(EVMDynProofPlan::try_from_proof_plan(
             plan.left_plan(),
@@ -764,7 +764,7 @@ impl EVMSortMergeJoinExec {
     pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
-        column_refs: &IndexSet<ColumnRef>,
+        column_refs: &IndexSet<TypedColumnRef>,
     ) -> EVMProofPlanResult<SortMergeJoinExec> {
         let left = Box::new(
             self.left
@@ -813,8 +813,10 @@ mod tests {
         let ident_b: Ident = "b".into();
         let alias = "alias".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a table exec to use as the input
         let column_fields = vec![
@@ -889,8 +891,10 @@ mod tests {
         let ident_a: Ident = "a".into();
         let ident_b: Ident = "b".into();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a table exec to use as the input
         let column_fields = vec![
@@ -964,8 +968,10 @@ mod tests {
         let ident_a: Ident = "a".into();
         let ident_b: Ident = "b".into();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         let column_fields = vec![
             ColumnField::new(ident_a, ColumnType::BigInt),
@@ -1039,8 +1045,8 @@ mod tests {
         let ident_b = "b".into();
         let alias = "alias".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
         let filter_exec = LegacyFilterExec::new(
             vec![AliasedDynProofExpr {
@@ -1109,8 +1115,10 @@ mod tests {
         let sum_alias = "sum_b".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a group by exec
         let group_by_exec = GroupByExec::try_new(
@@ -1198,10 +1206,12 @@ mod tests {
         let sum_alias = "sum_b".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
         let missing_column =
-            ColumnRef::new(table_ref.clone(), missing_ident.clone(), ColumnType::BigInt);
+            TypedColumnRef::new(table_ref.clone(), missing_ident.clone(), ColumnType::BigInt);
 
         // Create a group by exec with a column that doesn't exist in column_refs
         let group_by_exec = GroupByExec::try_new(
@@ -1244,8 +1254,10 @@ mod tests {
         let sum_alias = "sum_b".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a group by exec with a table that doesn't exist in table_refs
         let group_by_exec = GroupByExec::try_new(
@@ -1287,8 +1299,10 @@ mod tests {
         let sum_alias = "sum_b".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a valid group by exec first
         let group_by_exec = GroupByExec::try_new(
@@ -1343,8 +1357,10 @@ mod tests {
         let sum_alias = "sum_b".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a valid group by exec first
         let group_by_exec = GroupByExec::try_new(
@@ -1399,8 +1415,10 @@ mod tests {
         let sum_alias = "sum_b".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a valid group by exec first
         let group_by_exec = GroupByExec::try_new(
@@ -1472,16 +1490,16 @@ mod tests {
         let ident_b: Ident = "b".into();
 
         let top_column_ref_a =
-            ColumnRef::new(top_table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+            TypedColumnRef::new(top_table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
         let top_column_ref_b =
-            ColumnRef::new(top_table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+            TypedColumnRef::new(top_table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
-        let bottom_column_ref_a = ColumnRef::new(
+        let bottom_column_ref_a = TypedColumnRef::new(
             bottom_table_ref.clone(),
             ident_a.clone(),
             ColumnType::BigInt,
         );
-        let bottom_column_ref_b = ColumnRef::new(
+        let bottom_column_ref_b = TypedColumnRef::new(
             bottom_table_ref.clone(),
             ident_b.clone(),
             ColumnType::BigInt,
@@ -1499,12 +1517,12 @@ mod tests {
                 vec![AliasedDynProofExpr {
                     expr: DynProofExpr::Add(
                         AddExpr::try_new(
-                            Box::new(DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                            Box::new(DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                                 TableRef::from_names(None, ""),
                                 ident_a.clone(),
                                 ColumnType::BigInt,
                             )))),
-                            Box::new(DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                            Box::new(DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                                 TableRef::from_names(None, ""),
                                 ident_b.clone(),
                                 ColumnType::BigInt,
@@ -1523,12 +1541,12 @@ mod tests {
                 vec![AliasedDynProofExpr {
                     expr: DynProofExpr::Add(
                         AddExpr::try_new(
-                            Box::new(DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                            Box::new(DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                                 TableRef::from_names(None, ""),
                                 ident_a.clone(),
                                 ColumnType::BigInt,
                             )))),
-                            Box::new(DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                            Box::new(DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                                 TableRef::from_names(None, ""),
                                 ident_b.clone(),
                                 ColumnType::BigInt,
@@ -1583,14 +1601,14 @@ mod tests {
         let ident_c: Ident = "c".into();
 
         let left_column_ref_a =
-            ColumnRef::new(left_table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+            TypedColumnRef::new(left_table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
         let left_column_ref_b =
-            ColumnRef::new(left_table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+            TypedColumnRef::new(left_table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         let right_column_ref_a =
-            ColumnRef::new(right_table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+            TypedColumnRef::new(right_table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
         let right_column_ref_b =
-            ColumnRef::new(right_table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+            TypedColumnRef::new(right_table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create columns fields to use as the input
         let column_fields = vec![
@@ -1644,8 +1662,8 @@ mod tests {
         let ident_b = "b".into();
         let alias = "alias".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+        let column_ref_a = TypedColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = TypedColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
         // Create a table exec to use as the input
         let column_fields = vec![
@@ -1727,8 +1745,10 @@ mod tests {
         let ident_b: Ident = "b".into();
         let ident_c: Ident = "c".into();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a table exec
         let column_fields = vec![
@@ -1810,12 +1830,17 @@ mod tests {
         let alias_2 = "result_2";
         let alias_3 = "result_3";
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
-        let column_ref_c = ColumnRef::new(table_ref.clone(), ident_c.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_c =
+            TypedColumnRef::new(table_ref.clone(), ident_c.clone(), ColumnType::BigInt);
 
-        let column_ref_1 = ColumnRef::new(table_ref.clone(), alias_1.into(), ColumnType::BigInt);
-        let column_ref_2 = ColumnRef::new(table_ref.clone(), alias_2.into(), ColumnType::BigInt);
+        let column_ref_1 =
+            TypedColumnRef::new(table_ref.clone(), alias_1.into(), ColumnType::BigInt);
+        let column_ref_2 =
+            TypedColumnRef::new(table_ref.clone(), alias_2.into(), ColumnType::BigInt);
 
         // Create a table exec as the base
         let column_fields = vec![
@@ -1982,10 +2007,12 @@ mod tests {
         let missing_ident: Ident = "missing".into();
         let alias = "alias".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
         let missing_column =
-            ColumnRef::new(table_ref.clone(), missing_ident.clone(), ColumnType::BigInt);
+            TypedColumnRef::new(table_ref.clone(), missing_ident.clone(), ColumnType::BigInt);
 
         // Create a table exec to use as the input
         let column_fields = vec![
@@ -2029,10 +2056,12 @@ mod tests {
         let missing_ident: Ident = "missing".into();
         let alias = "alias".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
         let missing_column =
-            ColumnRef::new(table_ref.clone(), missing_ident.clone(), ColumnType::BigInt);
+            TypedColumnRef::new(table_ref.clone(), missing_ident.clone(), ColumnType::BigInt);
 
         // Create a table exec to use as the input
         let column_fields = vec![
@@ -2076,8 +2105,10 @@ mod tests {
         let ident_b: Ident = "b".into();
         let alias = "alias".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a table exec with a missing table reference
         let column_fields = vec![
@@ -2121,8 +2152,10 @@ mod tests {
         let sum_alias = "sum_b".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a table exec as input
         let column_fields = vec![
@@ -2132,12 +2165,12 @@ mod tests {
         let table_exec = TableExec::new(table_ref.clone(), column_fields);
 
         // Create output column refs for aggregate (these come from the table's output)
-        let output_col_a = ColumnRef::new(
+        let output_col_a = TypedColumnRef::new(
             TableRef::from_names(None, ""),
             ident_a.clone(),
             ColumnType::BigInt,
         );
-        let output_col_b = ColumnRef::new(
+        let output_col_b = TypedColumnRef::new(
             TableRef::from_names(None, ""),
             ident_b.clone(),
             ColumnType::BigInt,
@@ -2208,9 +2241,12 @@ mod tests {
         let sum_alias_c = "sum_c".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
-        let column_ref_c = ColumnRef::new(table_ref.clone(), ident_c.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_c =
+            TypedColumnRef::new(table_ref.clone(), ident_c.clone(), ColumnType::BigInt);
 
         // Create a table exec
         let column_fields = vec![
@@ -2241,17 +2277,17 @@ mod tests {
         );
 
         // Output columns from filter (used by aggregate)
-        let filter_output_col_a = ColumnRef::new(
+        let filter_output_col_a = TypedColumnRef::new(
             TableRef::from_names(None, ""),
             ident_a.clone(),
             ColumnType::BigInt,
         );
-        let filter_output_col_b = ColumnRef::new(
+        let filter_output_col_b = TypedColumnRef::new(
             TableRef::from_names(None, ""),
             ident_b.clone(),
             ColumnType::BigInt,
         );
-        let filter_output_col_c = ColumnRef::new(
+        let filter_output_col_c = TypedColumnRef::new(
             TableRef::from_names(None, ""),
             ident_c.clone(),
             ColumnType::BigInt,
@@ -2328,16 +2364,18 @@ mod tests {
         let sum_alias = "sum_b".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Output columns (from table's perspective)
-        let output_col_a = ColumnRef::new(
+        let output_col_a = TypedColumnRef::new(
             TableRef::from_names(None, ""),
             ident_a.clone(),
             ColumnType::BigInt,
         );
-        let output_col_b = ColumnRef::new(
+        let output_col_b = TypedColumnRef::new(
             TableRef::from_names(None, ""),
             ident_b.clone(),
             ColumnType::BigInt,
@@ -2383,8 +2421,10 @@ mod tests {
         let sum_alias = "sum_b".to_string();
         let count_alias = "count".to_string();
 
-        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
-        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let column_ref_a =
+            TypedColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b =
+            TypedColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
 
         // Create a table exec as input
         let column_fields = vec![
@@ -2394,12 +2434,12 @@ mod tests {
         let table_exec = TableExec::new(table_ref.clone(), column_fields);
 
         // Output columns
-        let output_col_a = ColumnRef::new(
+        let output_col_a = TypedColumnRef::new(
             TableRef::from_names(None, ""),
             ident_a.clone(),
             ColumnType::BigInt,
         );
-        let output_col_b = ColumnRef::new(
+        let output_col_b = TypedColumnRef::new(
             TableRef::from_names(None, ""),
             ident_b.clone(),
             ColumnType::BigInt,

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -2231,6 +2231,7 @@ mod tests {
         ));
     }
 
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn we_can_put_complex_aggregate_exec_in_evm() {
         let table_ref: TableRef = "namespace.table".parse().unwrap();

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+        database::{ColumnType, LiteralValue, TableRef, TypedColumnRef},
         try_standard_binary_deserialization, try_standard_binary_serialization,
     },
     sql::{
@@ -20,8 +20,8 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
     let identifier_b = "b".into();
     let identifier_alias = "alias".into();
 
-    let column_ref_a = ColumnRef::new(table_ref.clone(), identifier_a, ColumnType::BigInt);
-    let column_ref_b = ColumnRef::new(table_ref.clone(), identifier_b, ColumnType::BigInt);
+    let column_ref_a = TypedColumnRef::new(table_ref.clone(), identifier_a, ColumnType::BigInt);
+    let column_ref_b = TypedColumnRef::new(table_ref.clone(), identifier_b, ColumnType::BigInt);
 
     let plan = DynProofPlan::LegacyFilter(LegacyFilterExec::new(
         vec![AliasedDynProofExpr {
@@ -82,8 +82,8 @@ fn we_can_deserialize_proof_plan_for_simple_filter() {
     let identifier_b = "b".into();
     let identifier_alias = "alias".into();
 
-    let column_ref_a = ColumnRef::new(table_ref.clone(), identifier_a, ColumnType::BigInt);
-    let column_ref_b = ColumnRef::new(table_ref.clone(), identifier_b, ColumnType::BigInt);
+    let column_ref_a = TypedColumnRef::new(table_ref.clone(), identifier_a, ColumnType::BigInt);
+    let column_ref_b = TypedColumnRef::new(table_ref.clone(), identifier_b, ColumnType::BigInt);
 
     let expected_plan = DynProofPlan::LegacyFilter(LegacyFilterExec::new(
         vec![AliasedDynProofExpr {

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,6 +1,6 @@
 use super::{verification_builder::VerificationBuilder, FinalRoundBuilder, FirstRoundBuilder};
 use crate::base::{
-    database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+    database::{ColumnField, LiteralValue, Table, TableEvaluation, TableRef, TypedColumnRef},
     map::{IndexMap, IndexSet},
     proof::{PlaceholderResult, ProofError},
     scalar::Scalar,
@@ -26,7 +26,7 @@ pub trait ProofPlan: Debug + Send + Sync + ProverEvaluate {
     fn get_column_result_fields(&self) -> Vec<ColumnField>;
 
     /// Return all the columns referenced in the Query
-    fn get_column_references(&self) -> IndexSet<ColumnRef>;
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef>;
 
     /// Return all the tables referenced in the Query
     fn get_table_references(&self) -> IndexSet<TableRef>;

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -8,8 +8,8 @@ use crate::{
         bit::BitDistribution,
         commitment::{Commitment, CommitmentEvaluationProof, CommittableColumn},
         database::{
-            ColumnRef, CommitmentAccessor, DataAccessor, LiteralValue, MetadataAccessor,
-            OwnedTable, Table, TableRef,
+            CommitmentAccessor, DataAccessor, LiteralValue, MetadataAccessor, OwnedTable, Table,
+            TableRef, TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         math::log2_up,
@@ -124,7 +124,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
                 let idents: IndexSet<Ident> = total_col_refs
                     .iter()
                     .filter(|col_ref| col_ref.table_ref() == table_ref)
-                    .map(ColumnRef::column_id)
+                    .map(TypedColumnRef::column_id)
                     .collect();
                 (table_ref.clone(), accessor.get_table(&table_ref, &idents))
             })

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -6,8 +6,8 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             table_utility::*,
-            ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTableTestAccessor, Table,
-            TableEvaluation, TableRef,
+            ColumnField, ColumnType, LiteralValue, OwnedTableTestAccessor, Table, TableEvaluation,
+            TableRef, TypedColumnRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -111,7 +111,7 @@ impl ProofPlan for TrivialTestProofPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".into(), ColumnType::BigInt)]
     }
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         indexset! {}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
@@ -328,8 +328,8 @@ impl ProofPlan for SquareTestProofPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".into(), ColumnType::BigInt)]
     }
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        indexset! {ColumnRef::new(
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
+        indexset! {TypedColumnRef::new(
         TableRef::new("sxt", "test"),
               "x".into(),
               ColumnType::BigInt,
@@ -529,8 +529,8 @@ impl ProofPlan for DoubleSquareTestProofPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".into(), ColumnType::BigInt)]
     }
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        indexset! {ColumnRef::new(
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
+        indexset! {TypedColumnRef::new(
         TableRef::new("sxt", "test"),
               "x".into(),
               ColumnType::BigInt,
@@ -723,8 +723,8 @@ impl ProofPlan for ChallengeTestProofPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".into(), ColumnType::BigInt)]
     }
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        indexset! {ColumnRef::new(
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
+        indexset! {TypedColumnRef::new(
             TableRef::new("sxt", "test"),
             "x".into(),
             ColumnType::BigInt,
@@ -864,8 +864,8 @@ impl ProofPlan for FirstRoundSquareTestProofPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".into(), ColumnType::BigInt)]
     }
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        indexset! {ColumnRef::new(
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
+        indexset! {TypedColumnRef::new(
             TableRef::new("sxt", "test"),
             "x".into(),
             ColumnType::BigInt,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -7,8 +7,8 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             table_utility::*,
-            ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTableTestAccessor, Table,
-            TableEvaluation, TableRef,
+            ColumnField, ColumnType, LiteralValue, OwnedTableTestAccessor, Table, TableEvaluation,
+            TableRef, TypedColumnRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -85,7 +85,7 @@ impl ProofPlan for EmptyTestQueryExpr {
             .collect()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         indexset! {}
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -2,7 +2,7 @@ use super::{add_subtract_columns, DecimalProofExpr, DynProofExpr, ProofExpr};
 use crate::{
     base::{
         database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table,
+            try_add_subtract_column_types, Column, ColumnType, LiteralValue, Table, TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -110,7 +110,7 @@ impl ProofExpr for AddExpr {
         Ok(lhs_eval + rhs_eval)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -1,7 +1,7 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{can_and_or_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{can_and_or_types, Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -142,7 +142,7 @@ impl ProofExpr for AndExpr {
         Ok(lhs_and_rhs)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -2,8 +2,8 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, table_utility::*, Column, ColumnRef, ColumnType,
-            OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
+            owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
+            Table, TableRef, TableTestAccessor, TypedColumnRef,
         },
         map::indexmap,
         polynomial::MultilinearExtension,
@@ -230,8 +230,8 @@ fn we_can_verify_a_simple_proof() {
         "b".into() => Column::Boolean::<TestScalar>(rhs),
     })
     .unwrap();
-    let a = ColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
-    let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+    let a = TypedColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
+    let b = TypedColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
     let and_expr = AndExpr::try_new(
         Box::new(DynProofExpr::Column(ColumnExpr::new(a.clone()))),
         Box::new(DynProofExpr::Column(ColumnExpr::new(b.clone()))),
@@ -274,8 +274,8 @@ fn we_can_reject_a_simple_tampered_proof() {
     let t: TableRef = "sxt.t".parse().unwrap();
     let lhs = &[true, true, false, false];
     let rhs = &[true, false, true, false];
-    let a = ColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
-    let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+    let a = TypedColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
+    let b = TypedColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
     let and_expr = AndExpr::try_new(
         Box::new(DynProofExpr::Column(ColumnExpr::new(a.clone()))),
         Box::new(DynProofExpr::Column(ColumnExpr::new(b.clone()))),

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -1,7 +1,7 @@
 use super::{numerical_util::cast_column, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{try_cast_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{try_cast_types, Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -95,7 +95,7 @@ impl ProofExpr for CastExpr {
             .verifier_evaluate(builder, accessor, chi_eval, params)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.from_expr.get_column_references(columns);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -1,7 +1,7 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        database::{Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnField, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -16,25 +16,25 @@ use sqlparser::ast::Ident;
 /// Note: this is currently limited to named column expressions.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct ColumnExpr {
-    column_ref: ColumnRef,
+    column_ref: TypedColumnRef,
 }
 
 impl ColumnExpr {
     /// Create a new column expression
     #[must_use]
-    pub fn new(column_ref: ColumnRef) -> Self {
+    pub fn new(column_ref: TypedColumnRef) -> Self {
         Self { column_ref }
     }
 
     /// Return the column referenced by this [`ColumnExpr`]
     #[must_use]
-    pub fn get_column_reference(&self) -> ColumnRef {
+    pub fn get_column_reference(&self) -> TypedColumnRef {
         self.column_ref.clone()
     }
 
     /// Get the column reference
     #[must_use]
-    pub fn column_ref(&self) -> &ColumnRef {
+    pub fn column_ref(&self) -> &TypedColumnRef {
         &self.column_ref
     }
 
@@ -112,7 +112,7 @@ impl ProofExpr for ColumnExpr {
     /// Insert in the [`IndexSet`] `columns` all the column
     /// references in the `BoolExpr` or forwards the call to some
     /// subsequent `bool_expr`
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         columns.insert(self.column_ref.clone());
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -54,7 +54,7 @@ pub enum DynProofExpr {
 impl DynProofExpr {
     /// Create column expression
     #[must_use]
-    pub fn new_column(column_ref: ColumnRef) -> Self {
+    pub fn new_column(column_ref: TypedColumnRef) -> Self {
         Self::Column(ColumnExpr::new(column_ref))
     }
     /// Create logical AND expression

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -1,7 +1,7 @@
 use super::{add_subtract_columns, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{try_equals_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{try_equals_types, Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -122,7 +122,7 @@ impl ProofExpr for EqualsExpr {
         verifier_evaluate_equals_zero(builder, lhs_eval - rhs_eval, chi_eval)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -1,7 +1,7 @@
 use super::{add_subtract_columns, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{try_inequality_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{try_inequality_types, Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -153,7 +153,7 @@ impl ProofExpr for InequalityExpr {
         verifier_evaluate_sign(builder, diff_eval, chi_eval, None)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -1,7 +1,7 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -90,5 +90,5 @@ impl ProofExpr for LiteralExpr {
         Ok(chi_eval * self.value.to_scalar())
     }
 
-    fn get_column_references(&self, _columns: &mut IndexSet<ColumnRef>) {}
+    fn get_column_references(&self, _columns: &mut IndexSet<TypedColumnRef>) {}
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -1,7 +1,9 @@
 use super::{DecimalProofExpr, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{try_multiply_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            try_multiply_column_types, Column, ColumnType, LiteralValue, Table, TypedColumnRef,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -131,7 +133,7 @@ impl ProofExpr for MultiplyExpr {
         Ok(lhs_times_rhs)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -1,7 +1,7 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{can_not_type, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{can_not_type, Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -95,7 +95,7 @@ impl ProofExpr for NotExpr {
         Ok(chi_eval - eval)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.expr.get_column_references(columns);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -1,7 +1,7 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{can_and_or_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{can_and_or_types, Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -115,7 +115,7 @@ impl ProofExpr for OrExpr {
         verifier_evaluate_or(builder, &lhs, &rhs)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
@@ -1,7 +1,7 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderError, PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -145,7 +145,7 @@ impl ProofExpr for PlaceholderExpr {
         Ok(chi_eval * param_value.to_scalar::<S>())
     }
 
-    fn get_column_references(&self, _columns: &mut IndexSet<ColumnRef>) {}
+    fn get_column_references(&self, _columns: &mut IndexSet<TypedColumnRef>) {}
 }
 
 #[cfg(test)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         math::decimal::Precision,
         proof::{PlaceholderResult, ProofError},
@@ -52,7 +52,7 @@ pub trait ProofExpr: Debug + Send + Sync {
     /// Insert in the [`IndexSet`] `columns` all the column
     /// references in the `BoolExpr` or forwards the call to some
     /// subsequent `bool_expr`
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>);
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>);
 }
 
 /// A trait for `ProofExpr`s that always return a decimal type

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnType, LiteralValue, Table, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -106,7 +106,7 @@ impl ProofExpr for ScalingCastExpr {
             .map(|unscaled_eval| S::from(self.scaling_factor) * unscaled_eval)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.from_expr.get_column_references(columns);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
@@ -2,7 +2,7 @@ use super::{add_subtract_columns, DecimalProofExpr, DynProofExpr, ProofExpr};
 use crate::{
     base::{
         database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table,
+            try_add_subtract_column_types, Column, ColumnType, LiteralValue, Table, TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -111,7 +111,7 @@ impl ProofExpr for SubtractExpr {
         Ok(lhs_eval - rhs_eval)
     }
 
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<TypedColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -1,15 +1,15 @@
 use super::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr};
 use crate::base::{
-    database::{ColumnRef, ColumnType, LiteralValue, SchemaAccessor, TableRef},
+    database::{ColumnType, LiteralValue, SchemaAccessor, TableRef, TypedColumnRef},
     math::{decimal::Precision, i256::I256},
     scalar::Scalar,
 };
 use sqlparser::ast::Ident;
 
-pub fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> ColumnRef {
+pub fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> TypedColumnRef {
     let name: Ident = name.into();
     let type_col = accessor.lookup_column(tab, &name).unwrap();
-    ColumnRef::new(tab.clone(), name, type_col)
+    TypedColumnRef::new(tab.clone(), name, type_col)
 }
 
 /// # Panics
@@ -18,7 +18,11 @@ pub fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> Co
 pub fn column(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> DynProofExpr {
     let name: Ident = name.into();
     let type_col = accessor.lookup_column(tab, &name).unwrap();
-    DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(tab.clone(), name, type_col)))
+    DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
+        tab.clone(),
+        name,
+        type_col,
+    )))
 }
 
 /// # Panics

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -143,7 +143,7 @@ mod tests {
     use super::DivideAndModuloExpr;
     use crate::{
         base::{
-            database::{Column, ColumnRef, ColumnType, Table, TableRef},
+            database::{Column, ColumnType, Table, TableRef, TypedColumnRef},
             map::indexmap,
             polynomial::MultilinearExtension,
             scalar::test_scalar::TestScalar,
@@ -166,8 +166,8 @@ mod tests {
         let table_ref: TableRef = "sxt.t".parse().unwrap();
         let lhs_ident = Ident::from("lhs");
         let rhs_ident = Ident::from("rhs");
-        let lhs_ref = ColumnRef::new(table_ref.clone(), lhs_ident.clone(), ColumnType::Int128);
-        let rhs_ref = ColumnRef::new(table_ref, rhs_ident.clone(), ColumnType::Int128);
+        let lhs_ref = TypedColumnRef::new(table_ref.clone(), lhs_ident.clone(), ColumnType::Int128);
+        let rhs_ref = TypedColumnRef::new(table_ref, rhs_ident.clone(), ColumnType::Int128);
         let divide_and_modulo_expr = DivideAndModuloExpr::new(
             Box::new(DynProofExpr::Column(ColumnExpr::new(lhs_ref.clone()))),
             Box::new(DynProofExpr::Column(ColumnExpr::new(rhs_ref.clone()))),

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -7,8 +7,8 @@ use super::membership_check::{
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, table_utility::table, Column, ColumnField, ColumnRef,
-            ColumnType, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            owned_table_utility::*, table_utility::table, Column, ColumnField, ColumnType,
+            LiteralValue, Table, TableEvaluation, TableOptions, TableRef, TypedColumnRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -29,8 +29,8 @@ use sqlparser::ast::Ident;
 pub struct MembershipCheckTestPlan {
     pub source_table: TableRef,
     pub candidate_table: TableRef,
-    pub source_columns: Vec<ColumnRef>,
-    pub candidate_columns: Vec<ColumnRef>,
+    pub source_columns: Vec<TypedColumnRef>,
+    pub candidate_columns: Vec<TypedColumnRef>,
 }
 
 impl ProverEvaluate for MembershipCheckTestPlan {
@@ -148,7 +148,7 @@ impl ProofPlan for MembershipCheckTestPlan {
         )]
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         self.source_columns
             .iter()
             .chain(self.candidate_columns.iter())
@@ -223,12 +223,12 @@ mod tests {
         let plan = MembershipCheckTestPlan {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
-            source_columns: vec![ColumnRef::new(
+            source_columns: vec![TypedColumnRef::new(
                 source_table_ref,
                 "a".into(),
                 ColumnType::BigInt,
             )],
-            candidate_columns: vec![ColumnRef::new(
+            candidate_columns: vec![TypedColumnRef::new(
                 candidate_table_ref,
                 "c".into(),
                 ColumnType::BigInt,
@@ -272,14 +272,14 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+                TypedColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                TypedColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
+                TypedColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+                TypedColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
+                TypedColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
+                TypedColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
         let verifiable_res =
@@ -320,14 +320,14 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+                TypedColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                TypedColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
+                TypedColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+                TypedColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
+                TypedColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
+                TypedColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
         let verifiable_res =
@@ -362,10 +362,10 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref, "b".into(), ColumnType::BigInt),
+                TypedColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                TypedColumnRef::new(source_table_ref, "b".into(), ColumnType::BigInt),
             ],
-            candidate_columns: vec![ColumnRef::new(
+            candidate_columns: vec![TypedColumnRef::new(
                 candidate_table_ref,
                 "a".into(),
                 ColumnType::BigInt,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -6,7 +6,8 @@ use super::monotonic::{
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnField, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            TypedColumnRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -22,7 +23,7 @@ use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 pub struct MonotonicTestPlan<const STRICT: bool, const ASC: bool> {
-    pub column: ColumnRef,
+    pub column: TypedColumnRef,
 }
 
 impl<const STRICT: bool, const ASC: bool> ProverEvaluate for MonotonicTestPlan<STRICT, ASC> {
@@ -89,7 +90,7 @@ impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT
         vec![]
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         indexset! {self.column.clone()}
     }
 
@@ -140,7 +141,7 @@ mod tests {
         shall_error: bool,
     ) {
         let plan = MonotonicTestPlan::<STRICT, ASC> {
-            column: ColumnRef::new(table_ref, column_name.into(), column_type),
+            column: TypedColumnRef::new(table_ref, column_name.into(), column_type),
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, accessor, &(), &[]).unwrap();

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -4,8 +4,8 @@ use super::permutation_check::{final_round_evaluate_permutation_check, verify_pe
 use crate::{
     base::{
         database::{
-            table_utility::table_with_row_count, ColumnField, ColumnRef, LiteralValue, Table,
-            TableEvaluation, TableOptions, TableRef,
+            table_utility::table_with_row_count, ColumnField, LiteralValue, Table, TableEvaluation,
+            TableOptions, TableRef, TypedColumnRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -26,8 +26,8 @@ use sqlparser::ast::Ident;
 pub struct PermutationCheckTestPlan {
     pub source_table: TableRef,
     pub candidate_table: TableRef,
-    pub source_columns: Vec<ColumnRef>,
-    pub candidate_columns: Vec<ColumnRef>,
+    pub source_columns: Vec<TypedColumnRef>,
+    pub candidate_columns: Vec<TypedColumnRef>,
 }
 
 impl ProverEvaluate for PermutationCheckTestPlan {
@@ -114,7 +114,7 @@ impl ProofPlan for PermutationCheckTestPlan {
         Vec::<ColumnField>::new()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         self.source_columns
             .iter()
             .chain(self.candidate_columns.iter())
@@ -186,12 +186,12 @@ mod tests {
         let plan = PermutationCheckTestPlan {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
-            source_columns: vec![ColumnRef::new(
+            source_columns: vec![TypedColumnRef::new(
                 source_table_ref,
                 "a".into(),
                 ColumnType::BigInt,
             )],
-            candidate_columns: vec![ColumnRef::new(
+            candidate_columns: vec![TypedColumnRef::new(
                 candidate_table_ref,
                 "c".into(),
                 ColumnType::BigInt,
@@ -230,14 +230,14 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+                TypedColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                TypedColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
+                TypedColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+                TypedColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
+                TypedColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
+                TypedColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
         let verifiable_res =
@@ -273,14 +273,14 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+                TypedColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                TypedColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
+                TypedColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+                TypedColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
+                TypedColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
+                TypedColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
         let verifiable_res =
@@ -310,10 +310,10 @@ mod tests {
             source_table: source_table_ref.clone(),
             candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref, "b".into(), ColumnType::BigInt),
+                TypedColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                TypedColumnRef::new(source_table_ref, "b".into(), ColumnType::BigInt),
             ],
-            candidate_columns: vec![ColumnRef::new(
+            candidate_columns: vec![TypedColumnRef::new(
                 candidate_table_ref,
                 "a".into(),
                 ColumnType::BigInt,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
@@ -5,8 +5,8 @@ use super::range_check::{
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTable, Table, TableEvaluation,
-            TableRef,
+            ColumnField, ColumnType, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
+            TypedColumnRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -24,7 +24,7 @@ use sqlparser::ast::Ident;
 // A test plan for performing range checks on a specified column.
 struct RangeCheckTestPlan {
     // The column reference for the range check test.
-    column: ColumnRef,
+    column: TypedColumnRef,
 }
 
 macro_rules! handle_column_with_match {
@@ -149,7 +149,7 @@ impl ProofPlan for RangeCheckTestPlan {
         )]
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         indexset! {self.column.clone()}
     }
 
@@ -183,7 +183,9 @@ mod tests {
     use super::*;
     use crate::{
         base::{
-            database::{owned_table_utility::*, ColumnRef, ColumnType, OwnedTableTestAccessor},
+            database::{
+                owned_table_utility::*, ColumnType, OwnedTableTestAccessor, TypedColumnRef,
+            },
             math::decimal::Precision,
             posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         },
@@ -200,7 +202,7 @@ mod tests {
         accessor: &OwnedTableTestAccessor<InnerProductProof>,
     ) {
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(table_name, col_name.into(), col_type),
+            column: TypedColumnRef::new(table_name, col_name.into(), col_type),
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, accessor, &(), &[]).unwrap();
@@ -273,7 +275,7 @@ mod tests {
         let accessor =
             OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
+            column: TypedColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
@@ -303,7 +305,7 @@ mod tests {
         let accessor =
             OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
+            column: TypedColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
@@ -342,7 +344,7 @@ mod tests {
         let accessor =
             OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
+            column: TypedColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
@@ -383,7 +385,7 @@ mod tests {
         let accessor =
             OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t, "a".into(), ColumnType::Scalar),
+            column: TypedColumnRef::new(t, "a".into(), ColumnType::Scalar),
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -207,8 +207,8 @@ mod tests {
     use crate::{
         base::{
             database::{
-                table_utility::*, ColumnField, ColumnRef, ColumnType, LiteralValue, Table,
-                TableEvaluation, TableOptions, TableRef, TableTestAccessor, TestAccessor,
+                table_utility::*, ColumnField, ColumnType, LiteralValue, Table, TableEvaluation,
+                TableOptions, TableRef, TableTestAccessor, TestAccessor, TypedColumnRef,
             },
             map::{indexset, IndexMap, IndexSet},
             proof::{PlaceholderResult, ProofError},
@@ -226,8 +226,8 @@ mod tests {
 
     #[derive(Debug, Serialize)]
     pub struct ShiftTestPlan {
-        pub column: ColumnRef,
-        pub candidate_shifted_column: ColumnRef,
+        pub column: TypedColumnRef,
+        pub candidate_shifted_column: TypedColumnRef,
         /// The length can be wrong in the test plan and that should error out
         pub column_length: usize,
     }
@@ -318,7 +318,7 @@ mod tests {
             vec![]
         }
 
-        fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
             indexset! {self.column.clone(), self.candidate_shifted_column.clone()}
         }
 
@@ -372,8 +372,8 @@ mod tests {
 
         // BigInt column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-            candidate_shifted_column: ColumnRef::new(
+            column: TypedColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+            candidate_shifted_column: TypedColumnRef::new(
                 candidate_table_ref.clone(),
                 "c".into(),
                 ColumnType::BigInt,
@@ -387,8 +387,8 @@ mod tests {
 
         // Varchar column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-            candidate_shifted_column: ColumnRef::new(
+            column: TypedColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
+            candidate_shifted_column: TypedColumnRef::new(
                 candidate_table_ref.clone(),
                 "d".into(),
                 ColumnType::VarChar,
@@ -402,8 +402,8 @@ mod tests {
 
         // Boolean column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
-            candidate_shifted_column: ColumnRef::new(
+            column: TypedColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+            candidate_shifted_column: TypedColumnRef::new(
                 candidate_table_ref,
                 "e".into(),
                 ColumnType::Boolean,
@@ -443,8 +443,8 @@ mod tests {
 
         // BigInt column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-            candidate_shifted_column: ColumnRef::new(
+            column: TypedColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+            candidate_shifted_column: TypedColumnRef::new(
                 candidate_table_ref.clone(),
                 "c".into(),
                 ColumnType::BigInt,
@@ -457,8 +457,8 @@ mod tests {
 
         // Varchar column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
-            candidate_shifted_column: ColumnRef::new(
+            column: TypedColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
+            candidate_shifted_column: TypedColumnRef::new(
                 candidate_table_ref.clone(),
                 "d".into(),
                 ColumnType::VarChar,
@@ -471,8 +471,8 @@ mod tests {
 
         // Boolean column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref.clone(), "c".into(), ColumnType::Boolean),
-            candidate_shifted_column: ColumnRef::new(
+            column: TypedColumnRef::new(source_table_ref.clone(), "c".into(), ColumnType::Boolean),
+            candidate_shifted_column: TypedColumnRef::new(
                 candidate_table_ref.clone(),
                 "e".into(),
                 ColumnType::Boolean,
@@ -485,8 +485,8 @@ mod tests {
 
         // Success case: The last pair of columns is correct even though the others are not
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "d".into(), ColumnType::BigInt),
-            candidate_shifted_column: ColumnRef::new(
+            column: TypedColumnRef::new(source_table_ref, "d".into(), ColumnType::BigInt),
+            candidate_shifted_column: TypedColumnRef::new(
                 candidate_table_ref,
                 "f".into(),
                 ColumnType::BigInt,
@@ -520,8 +520,8 @@ mod tests {
 
         // BigInt column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
-            candidate_shifted_column: ColumnRef::new(
+            column: TypedColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
+            candidate_shifted_column: TypedColumnRef::new(
                 candidate_table_ref,
                 "a".into(),
                 ColumnType::BigInt,

--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
@@ -3,8 +3,8 @@ use crate::{
     base::{
         database::{
             group_by_util::{aggregate_columns, AggregatedColumns},
-            Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table, TableEvaluation,
-            TableRef,
+            Column, ColumnField, ColumnType, LiteralValue, Table, TableEvaluation, TableRef,
+            TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -233,7 +233,7 @@ impl ProofPlan for AggregateExec {
             .collect()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         self.input.get_column_references()
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+        database::{ColumnField, LiteralValue, Table, TableEvaluation, TableRef, TypedColumnRef},
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -16,7 +16,7 @@ use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 pub(crate) struct DemoMockPlan {
-    pub column: ColumnRef,
+    pub column: TypedColumnRef,
 }
 
 impl ProofPlan for DemoMockPlan {
@@ -42,7 +42,7 @@ impl ProofPlan for DemoMockPlan {
         )]
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         indexset! {self.column.clone()}
     }
 
@@ -82,7 +82,7 @@ mod tests {
     use crate::{
         base::database::{
             owned_table_utility::{bigint, owned_table},
-            ColumnRef, ColumnType, OwnedTableTestAccessor, TableRef,
+            ColumnType, OwnedTableTestAccessor, TableRef, TypedColumnRef,
         },
         sql::proof::VerifiableQueryResult,
     };
@@ -95,7 +95,7 @@ mod tests {
         let table_ref = "namespace.table_name".parse::<TableRef>().unwrap();
         let table = owned_table([bigint("column_name", [0, 1, 2, 3])]);
         let column_ref =
-            ColumnRef::new(table_ref.clone(), "column_name".into(), ColumnType::BigInt);
+            TypedColumnRef::new(table_ref.clone(), "column_name".into(), ColumnType::BigInt);
         let plan = DemoMockPlan { column: column_ref };
         let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
             table_ref,

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+        database::{ColumnField, LiteralValue, Table, TableEvaluation, TableRef, TypedColumnRef},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -177,10 +177,10 @@ impl DynProofPlan {
     }
 
     /// Returns the resulting column fields of the plan as column references
-    pub(crate) fn get_column_result_fields_as_references(&self) -> IndexSet<ColumnRef> {
+    pub(crate) fn get_column_result_fields_as_references(&self) -> IndexSet<TypedColumnRef> {
         self.get_column_result_fields()
             .into_iter()
-            .map(|f| ColumnRef::new(TableRef::from_names(None, ""), f.name(), f.data_type()))
+            .map(|f| TypedColumnRef::new(TableRef::from_names(None, ""), f.name(), f.data_type()))
             .collect()
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -1,7 +1,8 @@
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnField, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -54,7 +55,7 @@ impl ProofPlan for EmptyExec {
         Vec::new()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         IndexSet::default()
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -2,8 +2,8 @@ use super::{fold_vals, DynProofPlan};
 use crate::{
     base::{
         database::{
-            filter_util::filter_columns, Column, ColumnField, ColumnRef, LiteralValue, Table,
-            TableEvaluation, TableOptions, TableRef,
+            filter_util::filter_columns, Column, ColumnField, LiteralValue, Table, TableEvaluation,
+            TableOptions, TableRef, TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -141,7 +141,7 @@ impl ProofPlan for FilterExec {
             .collect()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         self.input.get_column_references()
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -3,8 +3,8 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType, TableRef,
-            TableTestAccessor, TestAccessor,
+            owned_table_utility::*, table_utility::*, ColumnField, ColumnType, TableRef,
+            TableTestAccessor, TestAccessor, TypedColumnRef,
         },
         try_standard_binary_deserialization, try_standard_binary_serialization,
     },
@@ -273,7 +273,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
     let projection = projection(
         vec![
             AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     t.clone(),
                     "a".into(),
                     ColumnType::BigInt,
@@ -281,7 +281,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
                 alias: "x".into(),
             },
             AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     t.clone(),
                     "b".into(),
                     ColumnType::BigInt,
@@ -289,7 +289,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
                 alias: "y".into(),
             },
             AliasedDynProofExpr {
-                expr: DynProofExpr::new_column(ColumnRef::new(
+                expr: DynProofExpr::new_column(TypedColumnRef::new(
                     t.clone(),
                     "c".into(),
                     ColumnType::Int128,
@@ -305,12 +305,12 @@ fn we_can_have_projection_as_input_plan_for_filter() {
         AliasedDynProofExpr {
             expr: DynProofExpr::Add(
                 AddExpr::try_new(
-                    Box::new(DynProofExpr::new_column(ColumnRef::new(
+                    Box::new(DynProofExpr::new_column(TypedColumnRef::new(
                         dummy_table.clone(),
                         "x".into(),
                         ColumnType::BigInt,
                     ))),
-                    Box::new(DynProofExpr::new_column(ColumnRef::new(
+                    Box::new(DynProofExpr::new_column(TypedColumnRef::new(
                         dummy_table.clone(),
                         "y".into(),
                         ColumnType::BigInt,
@@ -321,7 +321,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
             alias: "xplusy".into(),
         },
         AliasedDynProofExpr {
-            expr: DynProofExpr::new_column(ColumnRef::new(
+            expr: DynProofExpr::new_column(TypedColumnRef::new(
                 dummy_table.clone(),
                 "z".into(),
                 ColumnType::Int128,
@@ -334,7 +334,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
         filter_results,
         projection,
         gt(
-            DynProofExpr::new_column(ColumnRef::new(
+            DynProofExpr::new_column(TypedColumnRef::new(
                 dummy_table.clone(),
                 "z".into(),
                 ColumnType::Int128,

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -3,8 +3,8 @@ use crate::{
     base::{
         database::{
             group_by_util::{aggregate_columns, AggregatedColumns},
-            Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table, TableEvaluation,
-            TableRef,
+            Column, ColumnField, ColumnType, LiteralValue, Table, TableEvaluation, TableRef,
+            TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -222,7 +222,7 @@ impl ProofPlan for GroupByExec {
             .collect()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         let mut columns = IndexSet::default();
 
         for col in &self.group_by_exprs {

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
@@ -2,8 +2,8 @@ use super::fold_vals;
 use crate::{
     base::{
         database::{
-            filter_util::filter_columns, Column, ColumnField, ColumnRef, LiteralValue, Table,
-            TableEvaluation, TableOptions, TableRef,
+            filter_util::filter_columns, Column, ColumnField, LiteralValue, Table, TableEvaluation,
+            TableOptions, TableRef, TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -143,7 +143,7 @@ where
             .collect()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         let mut columns = IndexSet::default();
 
         for aliased_expr in &self.aliased_results {

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
@@ -2,9 +2,9 @@ use super::{test_utility::*, LegacyFilterExec};
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
-            LiteralValue, OwnedTable, OwnedTableTestAccessor, TableRef, TableTestAccessor,
-            TestAccessor,
+            owned_table_utility::*, table_utility::*, ColumnField, ColumnType, LiteralValue,
+            OwnedTable, OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
+            TypedColumnRef,
         },
         map::{indexmap, IndexMap, IndexSet},
         math::decimal::Precision,
@@ -32,7 +32,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     let provable_ast = LegacyFilterExec::new(
         vec![
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                     table_ref.clone(),
                     a,
                     ColumnType::BigInt,
@@ -40,7 +40,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 "a",
             ),
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                     table_ref.clone(),
                     b,
                     ColumnType::BigInt,
@@ -52,7 +52,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
             table_ref: table_ref.clone(),
         },
         DynProofExpr::try_new_equals(
-            DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+            DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                 table_ref.clone(),
                 Ident::new("c"),
                 ColumnType::BigInt,
@@ -83,7 +83,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     let provable_ast = LegacyFilterExec::new(
         vec![
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                     table_ref.clone(),
                     a,
                     ColumnType::BigInt,
@@ -91,7 +91,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 "a",
             ),
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                     table_ref.clone(),
                     f,
                     ColumnType::BigInt,
@@ -105,7 +105,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
         not(and(
             or(
                 DynProofExpr::try_new_equals(
-                    DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                    DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                         table_ref.clone(),
                         Ident::new("f"),
                         ColumnType::BigInt,
@@ -114,7 +114,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 )
                 .unwrap(),
                 DynProofExpr::try_new_equals(
-                    DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                    DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                         table_ref.clone(),
                         Ident::new("c"),
                         ColumnType::BigInt,
@@ -124,7 +124,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 .unwrap(),
             ),
             DynProofExpr::try_new_equals(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                     table_ref.clone(),
                     Ident::new("b"),
                     ColumnType::BigInt,
@@ -140,10 +140,10 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     assert_eq!(
         ref_columns,
         IndexSet::from_iter([
-            ColumnRef::new(table_ref.clone(), Ident::new("a"), ColumnType::BigInt),
-            ColumnRef::new(table_ref.clone(), Ident::new("f"), ColumnType::BigInt),
-            ColumnRef::new(table_ref.clone(), Ident::new("c"), ColumnType::BigInt),
-            ColumnRef::new(table_ref.clone(), Ident::new("b"), ColumnType::BigInt)
+            TypedColumnRef::new(table_ref.clone(), Ident::new("a"), ColumnType::BigInt),
+            TypedColumnRef::new(table_ref.clone(), Ident::new("f"), ColumnType::BigInt),
+            TypedColumnRef::new(table_ref.clone(), Ident::new("c"), ColumnType::BigInt),
+            TypedColumnRef::new(table_ref.clone(), Ident::new("b"), ColumnType::BigInt)
         ])
     );
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -2,8 +2,8 @@ use super::DynProofPlan;
 use crate::{
     base::{
         database::{
-            Column, ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions,
-            TableRef,
+            Column, ColumnField, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -95,7 +95,7 @@ impl ProofPlan for ProjectionExec {
             .collect()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         // For projections any output column reference is a reference to an input column
         self.input.get_column_references()
     }

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -2,8 +2,8 @@ use super::{test_utility::*, DynProofPlan, ProjectionExec};
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
-            OwnedTable, OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
+            owned_table_utility::*, table_utility::*, ColumnField, ColumnType, OwnedTable,
+            OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor, TypedColumnRef,
         },
         map::{indexmap, IndexMap, IndexSet},
         math::decimal::Precision,
@@ -30,7 +30,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     let provable_ast = ProjectionExec::new(
         vec![
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                     table_ref.clone(),
                     a,
                     ColumnType::BigInt,
@@ -38,7 +38,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 "a",
             ),
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                     table_ref.clone(),
                     b,
                     ColumnType::BigInt,
@@ -72,7 +72,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     let provable_ast = projection(
         vec![
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                     table_ref.clone(),
                     a,
                     ColumnType::BigInt,
@@ -80,7 +80,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 "a",
             ),
             aliased_plan(
-                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                DynProofExpr::Column(ColumnExpr::new(TypedColumnRef::new(
                     table_ref.clone(),
                     f,
                     ColumnType::BigInt,
@@ -102,8 +102,8 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     assert_eq!(
         ref_columns,
         IndexSet::from_iter([
-            ColumnRef::new(table_ref.clone(), Ident::new("a"), ColumnType::BigInt),
-            ColumnRef::new(table_ref.clone(), Ident::new("f"), ColumnType::BigInt),
+            TypedColumnRef::new(table_ref.clone(), Ident::new("a"), ColumnType::BigInt),
+            TypedColumnRef::new(table_ref.clone(), Ident::new("f"), ColumnType::BigInt),
         ])
     );
 
@@ -181,7 +181,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
 
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
-    //TODO: Remove `ColumnType` from `ColumnRef` so that we don't need an intermediate accessor
+    //TODO: Remove `ColumnType` from `TypedColumnRef` so that we don't need an intermediate accessor
     let data = owned_table([
         bigint("a", [1_i64, 4_i64, 5_i64, 2_i64, 5_i64]),
         bigint("b", [1_i64, 2, 3, 4, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -2,8 +2,8 @@ use super::DynProofPlan;
 use crate::{
     base::{
         database::{
-            filter_util::filter_columns, ColumnField, ColumnRef, LiteralValue, Table,
-            TableEvaluation, TableOptions, TableRef,
+            filter_util::filter_columns, ColumnField, LiteralValue, Table, TableEvaluation,
+            TableOptions, TableRef, TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -138,7 +138,7 @@ where
         self.input.get_column_result_fields()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         self.input.get_column_references()
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -7,7 +7,8 @@ use crate::{
                 ordered_set_union,
             },
             slice_operation::apply_slice_to_indexes,
-            ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnField, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -296,7 +297,7 @@ where
             .collect()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         self.left
             .get_column_references()
             .into_iter()

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+        database::{ColumnField, LiteralValue, Table, TableEvaluation, TableRef, TypedColumnRef},
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -76,10 +76,12 @@ impl ProofPlan for TableExec {
         self.schema.clone()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         self.schema
             .iter()
-            .map(|field| ColumnRef::new(self.table_ref.clone(), field.name(), field.data_type()))
+            .map(|field| {
+                TypedColumnRef::new(self.table_ref.clone(), field.name(), field.data_type())
+            })
             .collect()
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -2,8 +2,8 @@ use super::DynProofPlan;
 use crate::{
     base::{
         database::{
-            union_util::table_union, Column, ColumnField, ColumnRef, LiteralValue, Table,
-            TableEvaluation, TableRef,
+            union_util::table_union, Column, ColumnField, LiteralValue, Table, TableEvaluation,
+            TableRef, TypedColumnRef,
         },
         map::{IndexMap, IndexSet},
         polynomial::MultilinearExtension,
@@ -108,7 +108,7 @@ where
             .get_column_result_fields()
     }
 
-    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<TypedColumnRef> {
         self.inputs
             .iter()
             .flat_map(ProofPlan::get_column_references)

--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -73,11 +73,11 @@ pub fn scale_cast_binary_op(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::{ColumnRef, TableRef};
+    use crate::base::database::{TableRef, TypedColumnRef};
 
     #[expect(non_snake_case)]
     fn COLUMN1_BOOLEAN() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column1".into(),
             ColumnType::Boolean,
@@ -86,7 +86,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN1_SMALLINT() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column1".into(),
             ColumnType::SmallInt,
@@ -95,7 +95,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN1_DECIMAL_3_MINUS2() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column1".into(),
             ColumnType::Decimal75(
@@ -107,7 +107,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN1_DECIMAL_10_5() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column1".into(),
             ColumnType::Decimal75(
@@ -119,7 +119,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN3_DECIMAL_75_10() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column3".into(),
             ColumnType::Decimal75(
@@ -131,7 +131,7 @@ mod tests {
 
     #[expect(non_snake_case)]
     fn COLUMN2_DECIMAL_25_5() -> DynProofExpr {
-        DynProofExpr::new_column(ColumnRef::new(
+        DynProofExpr::new_column(TypedColumnRef::new(
             TableRef::from_names(Some("namespace"), "table_name"),
             "column2".into(),
             ColumnType::Decimal75(


### PR DESCRIPTION
# Rationale for this change
It is unnatural for references to a column to have its data type since we obviously never refers to `tab.col0` as `tab.col0_bigint` and allows a separate `tab.col0_int` in the same table. This PR is a simple change towards the goal of removing `ColumnType` from `ColumnRef`. The typed ones will be explicitly named that way and migration will be gradual.