### PR TITLE
fix: permutation check

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -1,12 +1,9 @@
-use super::{slice_operation::apply_slice_to_indexes, Column, ColumnOperationResult, ColumnType};
+use super::{slice_operation::apply_slice_to_indexes, Column, ColumnOperationResult};
 use crate::base::scalar::Scalar;
 use bumpalo::Bump;
 
 /// Apply a `Column` to a vector of indexes, returning a new `Column` with the
 /// values at the given indexes. Repetitions are allowed.
-///
-/// # Panics
-/// Panics if any of the indexes are out of bounds.
 pub(crate) fn apply_column_to_indexes<'a, S>(
     column: &Column<'a, S>,
     alloc: &'a Bump,
@@ -15,76 +12,48 @@ pub(crate) fn apply_column_to_indexes<'a, S>(
 where
     S: Scalar,
 {
-    match column.column_type() {
-        ColumnType::Boolean => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_boolean().expect("Column types should match"),
-                indexes,
-            )?;
+    match column {
+        Column::Boolean(values) => {
+            let raw_values = apply_slice_to_indexes(values, indexes)?;
             Ok(Column::Boolean(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
-        ColumnType::TinyInt => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_tinyint().expect("Column types should match"),
-                indexes,
-            )?;
+        Column::TinyInt(values) => {
+            let raw_values = apply_slice_to_indexes(values, indexes)?;
             Ok(Column::TinyInt(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
-        ColumnType::Uint8 => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_uint8().expect("Column types should match"),
-                indexes,
-            )?;
+        Column::Uint8(values) => {
+            let raw_values = apply_slice_to_indexes(values, indexes)?;
             Ok(Column::Uint8(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
-        ColumnType::SmallInt => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_smallint().expect("Column types should match"),
-                indexes,
-            )?;
+        Column::SmallInt(values) => {
+            let raw_values = apply_slice_to_indexes(values, indexes)?;
             Ok(Column::SmallInt(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
-        ColumnType::Int => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_int().expect("Column types should match"),
-                indexes,
-            )?;
+        Column::Int(values) => {
+            let raw_values = apply_slice_to_indexes(values, indexes)?;
             Ok(Column::Int(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
-        ColumnType::BigInt => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_bigint().expect("Column types should match"),
-                indexes,
-            )?;
+        Column::BigInt(values) => {
+            let raw_values = apply_slice_to_indexes(values, indexes)?;
             Ok(Column::BigInt(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
-        ColumnType::Int128 => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_int128().expect("Column types should match"),
-                indexes,
-            )?;
+        Column::Int128(values) => {
+            let raw_values = apply_slice_to_indexes(values, indexes)?;
             Ok(Column::Int128(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
-        ColumnType::Scalar => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_scalar().expect("Column types should match"),
-                indexes,
-            )?;
+        Column::Scalar(values) => {
+            let raw_values = apply_slice_to_indexes(values, indexes)?;
             Ok(Column::Scalar(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
-        ColumnType::Decimal75(precision, scale) => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_decimal75().expect("Column types should match"),
-                indexes,
-            )?;
+        Column::Decimal75(precision, scale, values) => {
+            let raw_values = apply_slice_to_indexes(values, indexes)?;
             Ok(Column::Decimal75(
-                precision,
-                scale,
+                *precision,
+                *scale,
                 alloc.alloc_slice_copy(&raw_values) as &[_],
             ))
         }
-        ColumnType::VarChar => {
-            let (raw_values, raw_scalars) = column.as_varchar().expect("Column types should match");
+        Column::VarChar((raw_values, raw_scalars)) => {
             let raw_values = apply_slice_to_indexes(raw_values, indexes)?;
             let scalars = apply_slice_to_indexes(raw_scalars, indexes)?;
             Ok(Column::VarChar((
@@ -92,10 +61,7 @@ where
                 alloc.alloc_slice_copy(&scalars) as &[_],
             )))
         }
-
-        ColumnType::VarBinary => {
-            let (raw_values, raw_scalars) =
-                column.as_varbinary().expect("Column types should match");
+        Column::VarBinary((raw_values, raw_scalars)) => {
             let raw_values = apply_slice_to_indexes(raw_values, indexes)?;
             let scalars = apply_slice_to_indexes(raw_scalars, indexes)?;
             Ok(Column::VarBinary((
@@ -103,14 +69,11 @@ where
                 alloc.alloc_slice_copy(&scalars) as &[_],
             )))
         }
-        ColumnType::TimestampTZ(tu, tz) => {
-            let raw_values = apply_slice_to_indexes(
-                column.as_timestamptz().expect("Column types should match"),
-                indexes,
-            )?;
+        Column::TimestampTZ(tu, tz, raw_values) => {
+            let raw_values = apply_slice_to_indexes(raw_values, indexes)?;
             Ok(Column::TimestampTZ(
-                tu,
-                tz,
+                *tu,
+                *tz,
                 alloc.alloc_slice_copy(&raw_values) as &[_],
             ))
         }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -39,7 +39,7 @@ mod column_comparison_operation;
 pub(super) use column_comparison_operation::{ComparisonOp, EqualOp, GreaterThanOp, LessThanOp};
 
 mod column_index_operation;
-pub(super) use column_index_operation::apply_column_to_indexes;
+pub(crate) use column_index_operation::apply_column_to_indexes;
 
 mod column_repetition_operation;
 pub(super) use column_repetition_operation::{ColumnRepeatOp, ElementwiseRepeatOp, RepetitionOp};

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
@@ -1,19 +1,62 @@
 use crate::{
-    base::{database::Column, proof::ProofError, scalar::Scalar, slice_ops},
+    base::{
+        database::{apply_column_to_indexes, Column},
+        proof::ProofError,
+        scalar::Scalar,
+    },
     sql::{
-        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
-        proof_plans::{fold_columns, fold_vals},
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder,
+        },
+        proof_gadgets::fold_log_expr::FoldLogExpr,
     },
 };
-use alloc::{boxed::Box, vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
-use num_traits::{One, Zero};
+use itertools::Itertools;
+
+/// Perform first round evaluation of the permutation check.
+///
+/// # Panics
+/// Panics if the number of columns is zero.
+/// Panics if the relevant columns do not all have the same length.
+pub(crate) fn first_round_evaluate_permutation_check<'a, S: Scalar>(
+    builder: &mut FirstRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    chi: &'a [bool],
+    columns: &[Column<'a, S>],
+    permutation: &[usize],
+) -> Vec<Column<'a, S>> {
+    assert!(
+        !columns.is_empty(),
+        "The number of columns should be greater than 0"
+    );
+    let table_length = chi.len();
+    assert!(
+        core::iter::once(table_length)
+            .chain(columns.iter().map(Column::len))
+            .chain(core::iter::once(permutation.len()))
+            .all_equal(),
+        "The length of all relevant columns should be the same"
+    );
+    let permuted_columns = columns.iter().map(|column| {
+        apply_column_to_indexes(column, alloc, permutation)
+            .expect("Permutation confirmed to be valid at this point")
+    });
+    for column in permuted_columns.clone() {
+        builder.produce_intermediate_mle(column);
+    }
+
+    builder.request_post_result_challenges(2);
+
+    permuted_columns.collect()
+}
 
 /// Perform final round evaluation of the permutation check.
 ///
 /// # Panics
-/// Panics if the number of source and candidate columns are not equal
-/// or if the number of columns is zero.
+/// Panics if the number of columns is zero.
+/// Panics if the relevant columns do not all have the same length.
 pub(crate) fn final_round_evaluate_permutation_check<'a, S: Scalar>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
@@ -21,33 +64,38 @@ pub(crate) fn final_round_evaluate_permutation_check<'a, S: Scalar>(
     beta: S,
     chi: &'a [bool],
     columns: &[Column<'a, S>],
-    candidate_subset: &[Column<'a, S>],
-) {
-    assert_eq!(
-        columns.len(),
-        candidate_subset.len(),
-        "The number of source and candidate columns should be equal"
-    );
+    permutation: &[usize],
+) -> Vec<Column<'a, S>> {
     assert!(
         !columns.is_empty(),
-        "The number of source columns should be greater than 0"
+        "The number of columns should be greater than 0"
     );
-    // Fold the columns
-    let c_fold = alloc.alloc_slice_fill_copy(chi.len(), Zero::zero());
-    fold_columns(c_fold, alpha, beta, columns);
-    let d_fold = alloc.alloc_slice_fill_copy(chi.len(), Zero::zero());
-    fold_columns(d_fold, alpha, beta, candidate_subset);
+    let table_length = chi.len();
+    assert!(
+        core::iter::once(table_length)
+            .chain(columns.iter().map(Column::len))
+            .chain(core::iter::once(permutation.len()))
+            .all_equal(),
+        "The length of all relevant columns should be the same"
+    );
+    let permuted_columns = columns
+        .iter()
+        .map(|column| {
+            apply_column_to_indexes(column, alloc, permutation)
+                .expect("Permutation confirmed to be valid at this point")
+        })
+        .collect::<Vec<_>>();
 
-    let c_star = alloc.alloc_slice_copy(c_fold);
-    slice_ops::add_const::<S, S>(c_star, One::one());
-    slice_ops::batch_inversion(c_star);
-
-    let d_star = alloc.alloc_slice_copy(d_fold);
-    slice_ops::add_const::<S, S>(d_star, One::one());
-    slice_ops::batch_inversion(d_star);
-
-    builder.produce_intermediate_mle(c_star as &[_]);
-    builder.produce_intermediate_mle(d_star as &[_]);
+    let fold_gadget = FoldLogExpr::new(alpha, beta);
+    let (c_star, _) =
+        fold_gadget.final_round_evaluate_with_chi(builder, alloc, columns, table_length, chi);
+    let (d_star, _) = fold_gadget.final_round_evaluate_with_chi(
+        builder,
+        alloc,
+        &permuted_columns,
+        table_length,
+        chi,
+    );
 
     // sum c_star - d_star = 0
     builder.produce_sumcheck_subpolynomial(
@@ -58,31 +106,7 @@ pub(crate) fn final_round_evaluate_permutation_check<'a, S: Scalar>(
         ],
     );
 
-    // c_star + c_fold * c_star - chi = 0
-    builder.produce_sumcheck_subpolynomial(
-        SumcheckSubpolynomialType::Identity,
-        vec![
-            (S::one(), vec![Box::new(c_star as &[_])]),
-            (
-                S::one(),
-                vec![Box::new(c_star as &[_]), Box::new(c_fold as &[_])],
-            ),
-            (-S::one(), vec![Box::new(chi as &[_])]),
-        ],
-    );
-
-    // d_star + d_fold * d_star - chi = 0
-    builder.produce_sumcheck_subpolynomial(
-        SumcheckSubpolynomialType::Identity,
-        vec![
-            (S::one(), vec![Box::new(d_star as &[_])]),
-            (
-                S::one(),
-                vec![Box::new(d_star as &[_]), Box::new(d_fold as &[_])],
-            ),
-            (-S::one(), vec![Box::new(chi as &[_])]),
-        ],
-    );
+    permuted_columns
 }
 
 pub(crate) fn verify_permutation_check<S: Scalar>(
@@ -91,18 +115,17 @@ pub(crate) fn verify_permutation_check<S: Scalar>(
     beta: S,
     chi_eval: S,
     column_evals: &[S],
-    candidate_evals: &[S],
-) -> Result<(), ProofError> {
-    // Check that the source and candidate columns have the same amount of columns
-    if column_evals.len() != candidate_evals.len() {
-        return Err(ProofError::VerificationError {
-            error: "The number of source and candidate columns should be equal",
-        });
-    }
-    let c_fold_eval = fold_vals(beta, column_evals);
-    let d_fold_eval = fold_vals(beta, candidate_evals);
-    let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;
-    let d_star_eval = builder.try_consume_final_round_mle_evaluation()?;
+) -> Result<Vec<S>, ProofError> {
+    let permuted_column_evals =
+        builder.try_consume_first_round_mle_evaluations(column_evals.len())?;
+
+    let fold_gadget = FoldLogExpr::new(alpha, beta);
+    let c_star_eval = fold_gadget
+        .verify_evaluate(builder, column_evals, chi_eval)?
+        .0;
+    let d_star_eval = fold_gadget
+        .verify_evaluate(builder, &permuted_column_evals, chi_eval)?
+        .0;
 
     // sum c_star - d_star = 0
     builder.try_produce_sumcheck_subpolynomial_evaluation(
@@ -111,21 +134,7 @@ pub(crate) fn verify_permutation_check<S: Scalar>(
         1,
     )?;
 
-    // c_star + c_fold * c_star - chi = 0
-    builder.try_produce_sumcheck_subpolynomial_evaluation(
-        SumcheckSubpolynomialType::Identity,
-        (S::ONE + alpha * c_fold_eval) * c_star_eval - chi_eval,
-        2,
-    )?;
-
-    // d_star + d_fold * d_star - chi = 0
-    builder.try_produce_sumcheck_subpolynomial_evaluation(
-        SumcheckSubpolynomialType::Identity,
-        (S::ONE + alpha * d_fold_eval) * d_star_eval - chi_eval,
-        2,
-    )?;
-
-    Ok(())
+    Ok(permuted_column_evals)
 }
 
 #[cfg(test)]
@@ -137,9 +146,12 @@ mod tests {
             polynomial::MultilinearExtension,
             scalar::{test_scalar::TestScalar, Scalar},
         },
-        sql::proof::{
-            mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
-            FirstRoundBuilder,
+        sql::{
+            proof::{
+                mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
+                FirstRoundBuilder,
+            },
+            proof_gadgets::permutation_check::first_round_evaluate_permutation_check,
         },
     };
     use bumpalo::Bump;
@@ -149,10 +161,17 @@ mod tests {
     fn we_can_do_permutation_check() {
         let alloc = Bump::new();
         let column = borrowed_bigint::<TestScalar>("a", [1, 2, 3], &alloc).1;
-        let candidate_table = borrowed_bigint::<TestScalar>("c", [2, 3, 1], &alloc).1;
-        let first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(3);
+        let permutation = vec![1usize, 2, 0];
+        let mut first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(3);
         let mut final_round_builder: FinalRoundBuilder<TestScalar> =
             FinalRoundBuilder::new(3, VecDeque::new());
+        first_round_evaluate_permutation_check(
+            &mut first_round_builder,
+            &alloc,
+            &[true, true, true],
+            &[column],
+            &permutation,
+        );
         final_round_evaluate_permutation_check(
             &mut final_round_builder,
             &alloc,
@@ -160,13 +179,13 @@ mod tests {
             TestScalar::TEN,
             &[true, true, true],
             &[column],
-            &[candidate_table],
+            &permutation,
         );
         let verification_builder = run_verify_for_each_row(
             3,
             &first_round_builder,
             &final_round_builder,
-            Vec::new(),
+            vec![TestScalar::TWO, TestScalar::TEN],
             3,
             |verification_builder, chi_eval, evaluation_point| {
                 verify_permutation_check(
@@ -175,7 +194,6 @@ mod tests {
                     TestScalar::TEN,
                     chi_eval,
                     &[column.inner_product(evaluation_point)],
-                    &[candidate_table.inner_product(evaluation_point)],
                 )
                 .unwrap();
             },

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -11,8 +11,11 @@ use crate::{
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::proof::{
-        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+        },
+        proof_gadgets::permutation_check::first_round_evaluate_permutation_check,
     },
 };
 use bumpalo::{
@@ -25,9 +28,8 @@ use sqlparser::ast::Ident;
 #[derive(Debug, Serialize)]
 pub struct PermutationCheckTestPlan {
     pub source_table: TableRef,
-    pub candidate_table: TableRef,
     pub source_columns: Vec<ColumnRef>,
-    pub candidate_columns: Vec<ColumnRef>,
+    pub permutation: Vec<usize>,
 }
 
 impl ProverEvaluate for PermutationCheckTestPlan {
@@ -35,22 +37,6 @@ impl ProverEvaluate for PermutationCheckTestPlan {
     fn first_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FirstRoundBuilder<'a, S>,
-        _alloc: &'a Bump,
-        table_map: &IndexMap<TableRef, Table<'a, S>>,
-        _params: &[LiteralValue],
-    ) -> PlaceholderResult<Table<'a, S>> {
-        // Get the tables from the map using the table reference
-        let source_table: &Table<'a, S> =
-            table_map.get(&self.source_table).expect("Table not found");
-        // Produce chi evaluation length
-        builder.produce_chi_evaluation_length(source_table.num_rows());
-        builder.request_post_result_challenges(2);
-        Ok(table_with_row_count([], 0))
-    }
-
-    fn final_round_evaluate<'a, S: Scalar>(
-        &self,
-        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
@@ -59,11 +45,6 @@ impl ProverEvaluate for PermutationCheckTestPlan {
         for col_ref in &self.source_columns {
             assert_eq!(self.source_table, col_ref.table_ref(), "Table not found");
         }
-        // Check that the candidate columns belong to the candidate table
-        for col_ref in &self.candidate_columns {
-            assert_eq!(self.candidate_table, col_ref.table_ref(), "Table not found");
-        }
-        // Get the table from the map using the table reference
         let source_table: &Table<'a, S> =
             table_map.get(&self.source_table).expect("Table not found");
         let source_columns = self
@@ -78,18 +59,40 @@ impl ProverEvaluate for PermutationCheckTestPlan {
                 col
             })
             .collect_in::<BumpVec<_>>(alloc);
-        let candidate_table = table_map
-            .get(&self.candidate_table)
-            .expect("Table not found");
-        let candidate_columns = self
-            .candidate_columns
+        // Produce chi evaluation length
+        builder.produce_chi_evaluation_length(source_table.num_rows());
+        first_round_evaluate_permutation_check(
+            builder,
+            alloc,
+            alloc.alloc_slice_fill_copy(source_table.num_rows(), true),
+            &source_columns,
+            &self.permutation,
+        );
+        Ok(table_with_row_count([], 0))
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
+    ) -> PlaceholderResult<Table<'a, S>> {
+        // Check that the source columns belong to the source table
+        for col_ref in &self.source_columns {
+            assert_eq!(self.source_table, col_ref.table_ref(), "Table not found");
+        }
+        // Get the table from the map using the table reference
+        let source_table: &Table<'a, S> =
+            table_map.get(&self.source_table).expect("Table not found");
+        let source_columns = self
+            .source_columns
             .iter()
             .map(|col_ref| {
-                let col = *(candidate_table
+                let col = *(source_table
                     .inner_table()
                     .get(&col_ref.column_id())
                     .expect("Column not found in table"));
-                builder.produce_intermediate_mle(col);
                 col
             })
             .collect_in::<BumpVec<_>>(alloc);
@@ -103,7 +106,7 @@ impl ProverEvaluate for PermutationCheckTestPlan {
             beta,
             alloc.alloc_slice_fill_copy(source_table.num_rows(), true),
             &source_columns,
-            &candidate_columns,
+            &self.permutation,
         );
         Ok(table_with_row_count([], 0))
     }
@@ -117,14 +120,14 @@ impl ProofPlan for PermutationCheckTestPlan {
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         self.source_columns
             .iter()
-            .chain(self.candidate_columns.iter())
+            .chain(self.source_columns.iter())
             .cloned()
             .collect()
     }
 
     #[doc = "Return all the tables referenced in the Query"]
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        indexset! {self.source_table.clone(), self.candidate_table.clone()}
+        indexset! {self.source_table.clone()}
     }
 
     #[doc = "Form components needed to verify and proof store into `VerificationBuilder`"]
@@ -140,21 +143,11 @@ impl ProofPlan for PermutationCheckTestPlan {
         let beta = builder.try_consume_post_result_challenge()?;
         let num_columns = self.source_columns.len();
         // Get the columns
-        let column_evals = builder.try_consume_final_round_mle_evaluations(num_columns)?;
-        // Get the target columns
-        let candidate_permutation_evals =
-            builder.try_consume_final_round_mle_evaluations(num_columns)?;
+        let column_evals = builder.try_consume_first_round_mle_evaluations(num_columns)?;
         // Get the chi evaluations
         let chi_eval = builder.try_consume_chi_evaluation()?.0;
         // Evaluate the verifier
-        verify_permutation_check(
-            builder,
-            alpha,
-            beta,
-            chi_eval,
-            &column_evals,
-            &candidate_permutation_evals,
-        )?;
+        verify_permutation_check(builder, alpha, beta, chi_eval, &column_evals)?;
         Ok(TableEvaluation::new(vec![], (S::ZERO, 0)))
     }
 }
@@ -163,7 +156,7 @@ impl ProofPlan for PermutationCheckTestPlan {
 mod tests {
     use super::*;
     use crate::{
-        base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
+        base::database::{table_utility::*, ColumnType, TableTestAccessor},
         proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
         sql::proof::VerifiableQueryResult,
     };
@@ -173,29 +166,22 @@ mod tests {
     fn we_can_do_minimal_permutation_check() {
         let alloc = Bump::new();
         let source_table = table([borrowed_bigint("a", [1, 2, 3], &alloc)]);
-        let candidate_table = table([borrowed_bigint("c", [2, 3, 1], &alloc)]);
+        let permutation = vec![1usize, 2, 0];
         let source_table_ref = TableRef::new("sxt", "source_table");
-        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = PermutationCheckTestPlan {
             source_table: source_table_ref.clone(),
-            candidate_table: candidate_table_ref.clone(),
             source_columns: vec![ColumnRef::new(
                 source_table_ref,
                 "a".into(),
                 ColumnType::BigInt,
             )],
-            candidate_columns: vec![ColumnRef::new(
-                candidate_table_ref,
-                "c".into(),
-                ColumnType::BigInt,
-            )],
+            permutation,
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
@@ -211,34 +197,22 @@ mod tests {
             borrowed_boolean("c", [true, false, true], &alloc),
             borrowed_bigint("d", [5, 6, 7], &alloc),
         ]);
-        let candidate_table = table([
-            borrowed_bigint("c", [2, 3, 1], &alloc),
-            borrowed_varchar("d", ["and", "Time", "Space"], &alloc),
-            borrowed_boolean("e", [false, true, true], &alloc),
-            borrowed_bigint("f", [5, 6, 7], &alloc),
-        ]);
         let source_table_ref = TableRef::new("sxt", "source_table");
-        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let permutation = vec![1usize, 2, 0];
+        let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = PermutationCheckTestPlan {
             source_table: source_table_ref.clone(),
-            candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
                 ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
                 ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
                 ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
             ],
-            candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
-            ],
+            permutation,
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
@@ -254,34 +228,21 @@ mod tests {
             borrowed_boolean("c", [true; 0], &alloc),
             borrowed_bigint("d", [0_i64; 0], &alloc),
         ]);
-        let candidate_table = table([
-            borrowed_bigint("c", [0_i64; 0], &alloc),
-            borrowed_varchar("d", [""; 0], &alloc),
-            borrowed_boolean("e", [true; 0], &alloc),
-            borrowed_bigint("f", [0_i64; 0], &alloc),
-        ]);
         let source_table_ref = TableRef::new("sxt", "source_table");
-        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = PermutationCheckTestPlan {
             source_table: source_table_ref.clone(),
-            candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
                 ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
                 ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
                 ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
             ],
-            candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
-                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
-            ],
+            permutation: vec![],
         };
         let verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
@@ -289,162 +250,72 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "The number of source and candidate columns should be equal")]
-    fn we_cannot_do_permutation_check_if_source_and_candidate_have_different_number_of_columns() {
-        let alloc = Bump::new();
-        let source_table = table([
-            borrowed_bigint("a", [1, 2], &alloc),
-            borrowed_bigint("b", [3, 4], &alloc),
-        ]);
-        let candidate_table = table([borrowed_bigint("a", [1, 2], &alloc)]);
-        let source_table_ref = TableRef::new("sxt", "source_table");
-        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref.clone(),
-            source_table,
-            0,
-            (),
-        );
-        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
-        let plan = PermutationCheckTestPlan {
-            source_table: source_table_ref.clone(),
-            candidate_table: candidate_table_ref.clone(),
-            source_columns: vec![
-                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref, "b".into(), ColumnType::BigInt),
-            ],
-            candidate_columns: vec![ColumnRef::new(
-                candidate_table_ref,
-                "a".into(),
-                ColumnType::BigInt,
-            )],
-        };
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "The number of source columns should be greater than 0")]
-    fn we_can_do_permutation_check_if_there_are_no_columns_in_the_tables() {
+    #[should_panic(expected = "The number of columns should be greater than 0")]
+    fn we_cannot_do_permutation_check_if_there_are_no_columns_in_the_tables() {
         let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(5) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
-            IndexMap::default(),
-            TableOptions { row_count: Some(4) },
-        )
-        .unwrap();
         let source_table_ref = TableRef::new("sxt", "source_table");
-        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = PermutationCheckTestPlan {
             source_table: source_table_ref,
-            candidate_table: candidate_table_ref,
             source_columns: vec![],
-            candidate_columns: vec![],
+            permutation: vec![0, 1, 2, 3, 4],
         };
         let _verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "The number of source columns should be greater than 0")]
-    fn we_cannot_do_permutation_check_if_there_are_no_columns_in_the_tables_and_candidate_has_no_rows_either(
-    ) {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
-            IndexMap::default(),
-            TableOptions { row_count: Some(5) },
-        )
-        .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
-            IndexMap::default(),
-            TableOptions { row_count: Some(0) },
-        )
-        .unwrap();
-        let source_table_ref = TableRef::new("sxt", "source_table");
-        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref.clone(),
-            source_table,
-            0,
-            (),
-        );
-        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
-        let plan = PermutationCheckTestPlan {
-            source_table: source_table_ref,
-            candidate_table: candidate_table_ref,
-            source_columns: vec![],
-            candidate_columns: vec![],
-        };
-        let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "The number of source columns should be greater than 0")]
+    #[should_panic(expected = "The number of columns should be greater than 0")]
     fn we_cannot_do_permutation_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
         let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
-            IndexMap::default(),
-            TableOptions { row_count: Some(0) },
-        )
-        .unwrap();
         let source_table_ref = TableRef::new("sxt", "source_table");
-        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = PermutationCheckTestPlan {
             source_table: source_table_ref,
-            candidate_table: candidate_table_ref,
             source_columns: vec![],
-            candidate_columns: vec![],
+            permutation: vec![],
         };
         let _verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "The number of source columns should be greater than 0")]
+    #[should_panic(expected = "The number of columns should be greater than 0")]
     fn we_cannot_do_permutation_check_if_no_column_is_selected() {
         let alloc = Bump::new();
         let source_table = table([
             borrowed_bigint("a", [1, 2], &alloc),
             borrowed_bigint("b", [3, 4], &alloc),
         ]);
-        let candidate_table = table([
-            borrowed_bigint("a", [1, 2], &alloc),
-            borrowed_bigint("b", [3, 4], &alloc),
-        ]);
         let source_table_ref = TableRef::new("sxt", "source_table");
-        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = PermutationCheckTestPlan {
             source_table: source_table_ref,
-            candidate_table: candidate_table_ref,
             source_columns: vec![],
-            candidate_columns: vec![],
+            permutation: vec![],
         };
         let _verifiable_res =
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We should be able to support ORDER BY pretty easily. Permutation check is one of necessary steps to making that happen.

# What changes are included in this PR?

- Simplify `apply_column_to_indexes`.
- Commit to the permuted columns in the first round. This ensures that the challenges that are being used in the final round are challenges of the permuted columns.

# Are these changes tested?
Yes
