### PR TITLE
refactor: use `ColumnId`

### DIFF
--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -13,7 +13,9 @@ use datafusion::{
 };
 use indexmap::{IndexMap, IndexSet};
 use proof_of_sql::{
-    base::database::{ColumnField, ColumnRef, ColumnType, LiteralValue, SchemaAccessor, TableRef},
+    base::database::{
+        ColumnField, ColumnId, ColumnRef, ColumnType, LiteralValue, SchemaAccessor, TableRef,
+    },
     sql::{
         proof::ProofPlan,
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr},
@@ -49,7 +51,10 @@ fn get_aliased_dyn_proof_exprs(
                     input_column_name.clone(),
                     *data_type,
                 ));
-                Ok(AliasedDynProofExpr { expr, alias })
+                Ok(AliasedDynProofExpr {
+                    expr,
+                    alias: alias.into(),
+                })
             },
         )
         .collect::<PlannerResult<Vec<_>>>()
@@ -187,11 +192,13 @@ fn aggregate_to_proof_plan(
             let aggregate_alias: Ident = aggregate_alias.to_string().as_str().into();
             let aggregate_proof_expr = expr_to_proof_expr(e, &input_schema)?;
             let name_string = e.clone().unalias().display_name()?;
-            let alias = alias_map.get(&name_string).ok_or_else(|| {
-                PlannerError::UnsupportedLogicalPlan {
+            let alias: ColumnId = alias_map
+                .get(&name_string)
+                .ok_or_else(|| PlannerError::UnsupportedLogicalPlan {
                     plan: Box::new(input.clone()),
-                }
-            })?;
+                })?
+                .as_str()
+                .into();
             let proof_expr = DynProofExpr::new_column(ColumnRef::new(
                 dummy_table_ref.clone(),
                 aggregate_alias.clone(),
@@ -200,11 +207,11 @@ fn aggregate_to_proof_plan(
             Ok((
                 AliasedDynProofExpr {
                     expr: aggregate_proof_expr,
-                    alias: aggregate_alias,
+                    alias: aggregate_alias.into(),
                 },
                 AliasedDynProofExpr {
                     expr: proof_expr,
-                    alias: alias.as_str().into(),
+                    alias,
                 },
             ))
         })
@@ -255,11 +262,11 @@ fn aggregate_to_proof_plan(
             (
                 AliasedDynProofExpr {
                     expr: expr.clone(),
-                    alias: inner_alias,
+                    alias: inner_alias.into(),
                 },
                 AliasedDynProofExpr {
                     expr: proof_expr,
-                    alias: alias.clone(),
+                    alias: alias.into(),
                 },
             )
         })
@@ -271,7 +278,7 @@ fn aggregate_to_proof_plan(
         .as_str()
         .into();
     let count_exprs = count_aliases.into_iter().map(|alias| AliasedDynProofExpr {
-        alias: alias.clone(),
+        alias: alias.into(),
         expr: DynProofExpr::new_column(ColumnRef::new(
             dummy_table_ref.clone(),
             inner_count_alias.clone(),
@@ -451,7 +458,7 @@ pub fn logical_plan_to_proof_plan(
                             alias.clone(),
                             field.data_type(),
                         )),
-                        alias,
+                        alias: alias.into(),
                     })
                 })
                 .collect::<PlannerResult<Vec<_>>>()?;

--- a/crates/proof-of-sql-planner/tests/evm_tests.rs
+++ b/crates/proof-of-sql-planner/tests/evm_tests.rs
@@ -41,7 +41,7 @@ fn evm_verifier_with_extra_args(
     let commitments = plan
         .get_column_references()
         .into_iter()
-        .map(|c| accessor.get_commitment(&c.table_ref(), &c.column_id()))
+        .map(|c| accessor.get_commitment(&c.table_ref(), &c.column_name()))
         .flat_map(|c| {
             c.commitment
                 .into_affine()

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -42,7 +42,10 @@ impl<C: Commitment> QueryCommitmentsExt<C> for QueryCommitments<C> {
                     table_columns
                         .entry(column.table_ref())
                         .or_default()
-                        .push(ColumnField::new(column.column_id(), *column.column_type()));
+                        .push(ColumnField::new(
+                            column.column_name(),
+                            *column.column_type(),
+                        ));
                     table_columns
                 },
             )

--- a/crates/proof-of-sql/src/base/database/accessor.rs
+++ b/crates/proof-of-sql/src/base/database/accessor.rs
@@ -103,7 +103,7 @@ pub trait DataAccessor<S: Scalar>: MetadataAccessor {
         } else {
             Table::<S>::try_from_iter(column_ids.into_iter().map(|column_id| {
                 let column = self.get_column(table_ref, column_id);
-                (column_id.clone(), column)
+                (column_id.into(), column)
             }))
         }
         .expect("Failed to create table from table and column references")

--- a/crates/proof-of-sql/src/base/database/column_id.rs
+++ b/crates/proof-of-sql/src/base/database/column_id.rs
@@ -1,0 +1,58 @@
+use crate::base::database::TableRef;
+use alloc::string::String;
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
+
+/// column identifier with qualifier
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub struct ColumnId {
+    name: Ident,
+    qualifier: Option<TableRef>,
+}
+
+impl ColumnId {
+    /// Create new `ColumnId`
+    #[must_use]
+    pub fn new(name: Ident, qualifier: Option<TableRef>) -> Self {
+        Self { name, qualifier }
+    }
+
+    /// Get the name of the column
+    #[must_use]
+    pub fn name(&self) -> &Ident {
+        &self.name
+    }
+}
+
+impl From<Ident> for ColumnId {
+    fn from(value: Ident) -> Self {
+        ColumnId {
+            name: value,
+            qualifier: None,
+        }
+    }
+}
+
+impl From<&Ident> for ColumnId {
+    fn from(value: &Ident) -> Self {
+        value.clone().into()
+    }
+}
+
+impl From<&str> for ColumnId {
+    fn from(value: &str) -> Self {
+        ColumnId {
+            name: value.into(),
+            qualifier: None,
+        }
+    }
+}
+
+impl From<&String> for ColumnId {
+    fn from(value: &String) -> Self {
+        ColumnId {
+            name: Ident::new(value),
+            qualifier: None,
+        }
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -1,4 +1,5 @@
 use super::{ColumnType, TableRef};
+use crate::base::database::ColumnId;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -27,10 +28,16 @@ impl ColumnRef {
         self.table_ref.clone()
     }
 
+    /// Returns the column name
+    #[must_use]
+    pub fn column_name(&self) -> Ident {
+        self.column_id.clone()
+    }
+
     /// Returns the column identifier of this column
     #[must_use]
-    pub fn column_id(&self) -> Ident {
-        self.column_id.clone()
+    pub fn column_id(&self) -> ColumnId {
+        ColumnId::new(self.column_id.clone(), None)
     }
 
     /// Returns the column type of this column

--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -459,7 +459,10 @@ pub fn apply_sort_merge_join_indexes<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::Column, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        database::{Column, ColumnId},
+        scalar::test_scalar::TestScalar,
+    };
     use sqlparser::ast::Ident;
 
     #[test]
@@ -471,16 +474,16 @@ mod tests {
         let d: Ident = "d".into();
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[1_i16, 2, 3])),
-                (b.clone(), Column::Int(&[4_i32, 5, 6])),
+                (a.clone().into(), Column::SmallInt(&[1_i16, 2, 3])),
+                (b.clone().into(), Column::Int(&[4_i32, 5, 6])),
             ],
             TableOptions::default(),
         )
         .expect("Table creation should not fail");
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[7_i64, 8, 9])),
-                (d.clone(), Column::Int128(&[10_i128, 11, 12])),
+                (c.clone().into(), Column::BigInt(&[7_i64, 8, 9])),
+                (d.clone().into(), Column::Int128(&[10_i128, 11, 12])),
             ],
             TableOptions::default(),
         )
@@ -489,23 +492,32 @@ mod tests {
         assert_eq!(result.num_rows(), 9);
         assert_eq!(result.num_columns(), 4);
         assert_eq!(
-            result.inner_table()[&a].as_smallint().unwrap(),
+            result.inner_table()[&ColumnId::from(a.clone())]
+                .as_smallint()
+                .unwrap(),
             &[1_i16, 2, 3, 1, 2, 3, 1, 2, 3]
         );
         assert_eq!(
-            result.inner_table()[&b].as_int().unwrap(),
+            result.inner_table()[&ColumnId::from(b.clone())]
+                .as_int()
+                .unwrap(),
             &[4_i32, 5, 6, 4, 5, 6, 4, 5, 6]
         );
         assert_eq!(
-            result.inner_table()[&c].as_bigint().unwrap(),
+            result.inner_table()[&ColumnId::from(c.clone())]
+                .as_bigint()
+                .unwrap(),
             &[7_i64, 7, 7, 8, 8, 8, 9, 9, 9]
         );
         assert_eq!(
-            result.inner_table()[&d].as_int128().unwrap(),
+            result.inner_table()[&ColumnId::from(d.clone())]
+                .as_int128()
+                .unwrap(),
             &[10_i128, 10, 10, 11, 11, 11, 12, 12, 12]
         );
     }
 
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn we_can_do_cross_joins_if_one_table_has_no_rows() {
         let bump = Bump::new();
@@ -517,16 +529,16 @@ mod tests {
         // Right table has no rows
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[1_i16, 2, 3])),
-                (b.clone(), Column::Int(&[4_i32, 5, 6])),
+                (a.clone().into(), Column::SmallInt(&[1_i16, 2, 3])),
+                (b.clone().into(), Column::Int(&[4_i32, 5, 6])),
             ],
             TableOptions::default(),
         )
         .expect("Table creation should not fail");
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[0_i64; 0])),
-                (d.clone(), Column::Int128(&[0_i128; 0])),
+                (c.clone().into(), Column::BigInt(&[0_i64; 0])),
+                (d.clone().into(), Column::Int128(&[0_i128; 0])),
             ],
             TableOptions::default(),
         )
@@ -534,24 +546,44 @@ mod tests {
         let result = cross_join(&left, &right, &bump);
         assert_eq!(result.num_rows(), 0);
         assert_eq!(result.num_columns(), 4);
-        assert_eq!(result.inner_table()[&a].as_smallint().unwrap(), &[0_i16; 0]);
-        assert_eq!(result.inner_table()[&b].as_int().unwrap(), &[0_i32; 0]);
-        assert_eq!(result.inner_table()[&c].as_bigint().unwrap(), &[0_i64; 0]);
-        assert_eq!(result.inner_table()[&d].as_int128().unwrap(), &[0_i128; 0]);
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(a.clone())]
+                .as_smallint()
+                .unwrap(),
+            &[0_i16; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(b.clone())]
+                .as_int()
+                .unwrap(),
+            &[0_i32; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(c.clone())]
+                .as_bigint()
+                .unwrap(),
+            &[0_i64; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(d.clone())]
+                .as_int128()
+                .unwrap(),
+            &[0_i128; 0]
+        );
 
         // Left table has no rows
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[0_i16; 0])),
-                (b.clone(), Column::Int(&[0_i32; 0])),
+                (a.clone().into(), Column::SmallInt(&[0_i16; 0])),
+                (b.clone().into(), Column::Int(&[0_i32; 0])),
             ],
             TableOptions::default(),
         )
         .expect("Table creation should not fail");
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[7_i64, 8, 9])),
-                (d.clone(), Column::Int128(&[10_i128, 11, 12])),
+                (c.clone().into(), Column::BigInt(&[7_i64, 8, 9])),
+                (d.clone().into(), Column::Int128(&[10_i128, 11, 12])),
             ],
             TableOptions::default(),
         )
@@ -559,24 +591,44 @@ mod tests {
         let result = cross_join(&left, &right, &bump);
         assert_eq!(result.num_rows(), 0);
         assert_eq!(result.num_columns(), 4);
-        assert_eq!(result.inner_table()[&a].as_smallint().unwrap(), &[0_i16; 0]);
-        assert_eq!(result.inner_table()[&b].as_int().unwrap(), &[0_i32; 0]);
-        assert_eq!(result.inner_table()[&c].as_bigint().unwrap(), &[0_i64; 0]);
-        assert_eq!(result.inner_table()[&d].as_int128().unwrap(), &[0_i128; 0]);
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(a.clone())]
+                .as_smallint()
+                .unwrap(),
+            &[0_i16; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(b.clone())]
+                .as_int()
+                .unwrap(),
+            &[0_i32; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(c.clone())]
+                .as_bigint()
+                .unwrap(),
+            &[0_i64; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(d.clone())]
+                .as_int128()
+                .unwrap(),
+            &[0_i128; 0]
+        );
 
         // Both tables have no rows
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[0_i16; 0])),
-                (b.clone(), Column::Int(&[0_i32; 0])),
+                (a.clone().into(), Column::SmallInt(&[0_i16; 0])),
+                (b.clone().into(), Column::Int(&[0_i32; 0])),
             ],
             TableOptions::default(),
         )
         .expect("Table creation should not fail");
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[0_i64; 0])),
-                (d.clone(), Column::Int128(&[0_i128; 0])),
+                (c.clone().into(), Column::BigInt(&[0_i64; 0])),
+                (d.clone().into(), Column::Int128(&[0_i128; 0])),
             ],
             TableOptions::default(),
         )
@@ -584,10 +636,30 @@ mod tests {
         let result = cross_join(&left, &right, &bump);
         assert_eq!(result.num_rows(), 0);
         assert_eq!(result.num_columns(), 4);
-        assert_eq!(result.inner_table()[&a].as_smallint().unwrap(), &[0_i16; 0]);
-        assert_eq!(result.inner_table()[&b].as_int().unwrap(), &[0_i32; 0]);
-        assert_eq!(result.inner_table()[&c].as_bigint().unwrap(), &[0_i64; 0]);
-        assert_eq!(result.inner_table()[&d].as_int128().unwrap(), &[0_i128; 0]);
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(a.clone())]
+                .as_smallint()
+                .unwrap(),
+            &[0_i16; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(b.clone())]
+                .as_int()
+                .unwrap(),
+            &[0_i32; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(c.clone())]
+                .as_bigint()
+                .unwrap(),
+            &[0_i64; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(d.clone())]
+                .as_int128()
+                .unwrap(),
+            &[0_i128; 0]
+        );
     }
 
     #[test]
@@ -604,8 +676,8 @@ mod tests {
 
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[7_i64, 8])),
-                (d.clone(), Column::Int128(&[10_i128, 11])),
+                (c.clone().into(), Column::BigInt(&[7_i64, 8])),
+                (d.clone().into(), Column::Int128(&[10_i128, 11])),
             ],
             TableOptions::default(),
         )
@@ -615,19 +687,23 @@ mod tests {
         assert_eq!(result.num_rows(), 4);
         assert_eq!(result.num_columns(), 2);
         assert_eq!(
-            result.inner_table()[&c].as_bigint().unwrap(),
+            result.inner_table()[&ColumnId::from(c.clone())]
+                .as_bigint()
+                .unwrap(),
             &[7_i64, 7, 8, 8]
         );
         assert_eq!(
-            result.inner_table()[&d].as_int128().unwrap(),
+            result.inner_table()[&ColumnId::from(d.clone())]
+                .as_int128()
+                .unwrap(),
             &[10_i128, 10, 11, 11]
         );
 
         // Right table has no columns
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[1_i16, 2])),
-                (b.clone(), Column::Int(&[4_i32, 5])),
+                (a.clone().into(), Column::SmallInt(&[1_i16, 2])),
+                (b.clone().into(), Column::Int(&[4_i32, 5])),
             ],
             TableOptions::default(),
         )
@@ -638,8 +714,18 @@ mod tests {
         let result = cross_join(&left, &right, &bump);
         assert_eq!(result.num_rows(), 0);
         assert_eq!(result.num_columns(), 2);
-        assert_eq!(result.inner_table()[&a].as_smallint().unwrap(), &[0_i16; 0]);
-        assert_eq!(result.inner_table()[&b].as_int().unwrap(), &[0_i32; 0]);
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(a.clone())]
+                .as_smallint()
+                .unwrap(),
+            &[0_i16; 0]
+        );
+        assert_eq!(
+            result.inner_table()[&ColumnId::from(b.clone())]
+                .as_int()
+                .unwrap(),
+            &[0_i32; 0]
+        );
 
         // Both tables have no columns
         let left =
@@ -789,9 +875,12 @@ mod tests {
 
         let tab = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7, 4])),
-                (b.clone(), Column::Int(&[3_i32, 15, 9, 14, 15, 7, 4])),
-                (c.clone(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
+                (
+                    a.clone().into(),
+                    Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7, 4]),
+                ),
+                (b.clone().into(), Column::Int(&[3_i32, 15, 9, 14, 15, 7, 4])),
+                (c.clone().into(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
             ],
             TableOptions::default(),
         )
@@ -813,9 +902,12 @@ mod tests {
 
         let tab = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7, 4])),
-                (b.clone(), Column::Int(&[3_i32, 15, 9, 14, 15, 7, 4])),
-                (c.clone(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
+                (
+                    a.clone().into(),
+                    Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7, 4]),
+                ),
+                (b.clone().into(), Column::Int(&[3_i32, 15, 9, 14, 15, 7, 4])),
+                (c.clone().into(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
             ],
             TableOptions::default(),
         )
@@ -836,9 +928,9 @@ mod tests {
 
         let tab = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[0_i16; 0])),
-                (b.clone(), Column::Int(&[0_i32; 0])),
-                (c.clone(), Column::BigInt(&[0_i64; 0])),
+                (a.clone().into(), Column::SmallInt(&[0_i16; 0])),
+                (b.clone().into(), Column::Int(&[0_i32; 0])),
+                (c.clone().into(), Column::BigInt(&[0_i64; 0])),
             ],
             TableOptions::default(),
         )
@@ -875,9 +967,12 @@ mod tests {
 
         let tab = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7, 4])),
-                (b.clone(), Column::Int(&[3_i32, 15, 9, 14, 15, 7, 4])),
-                (c.clone(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
+                (
+                    a.clone().into(),
+                    Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7, 4]),
+                ),
+                (b.clone().into(), Column::Int(&[3_i32, 15, 9, 14, 15, 7, 4])),
+                (c.clone().into(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
             ],
             TableOptions::default(),
         )
@@ -937,16 +1032,16 @@ mod tests {
 
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7])),
-                (b.clone(), Column::Int(&[3_i32, 5, 9, 4, 5, 7])),
+                (a.clone().into(), Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7])),
+                (b.clone().into(), Column::Int(&[3_i32, 5, 9, 4, 5, 7])),
             ],
             TableOptions::default(),
         )
         .expect("Table creation should not fail");
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
-                (b.clone(), Column::Int(&[10_i32, 11, 6, 5, 5, 4, 8])),
+                (c.clone().into(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
+                (b.clone().into(), Column::Int(&[10_i32, 11, 6, 5, 5, 4, 8])),
             ],
             TableOptions::default(),
         )
@@ -989,16 +1084,16 @@ mod tests {
 
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7])),
-                (b.clone(), Column::Int(&[3_i32, 15, 9, 14, 15, 7])),
+                (a.clone().into(), Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7])),
+                (b.clone().into(), Column::Int(&[3_i32, 15, 9, 14, 15, 7])),
             ],
             TableOptions::default(),
         )
         .expect("Table creation should not fail");
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
-                (b.clone(), Column::Int(&[10_i32, 11, 6, 5, 5, 4, 8])),
+                (c.clone().into(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
+                (b.clone().into(), Column::Int(&[10_i32, 11, 6, 5, 5, 4, 8])),
             ],
             TableOptions::default(),
         )
@@ -1042,16 +1137,16 @@ mod tests {
         // Right table has no rows
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7])),
-                (b.clone(), Column::Int(&[3_i32, 15, 9, 14, 15, 7])),
+                (a.clone().into(), Column::SmallInt(&[8_i16, 2, 5, 1, 3, 7])),
+                (b.clone().into(), Column::Int(&[3_i32, 15, 9, 14, 15, 7])),
             ],
             TableOptions::default(),
         )
         .expect("Table creation should not fail");
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[0_i64; 0])),
-                (b.clone(), Column::Int(&[0_i32; 0])),
+                (c.clone().into(), Column::BigInt(&[0_i64; 0])),
+                (b.clone().into(), Column::Int(&[0_i32; 0])),
             ],
             TableOptions::default(),
         )
@@ -1084,16 +1179,16 @@ mod tests {
         // Left table has no rows
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[0_i16; 0])),
-                (b.clone(), Column::Int(&[0_i32; 0])),
+                (a.clone().into(), Column::SmallInt(&[0_i16; 0])),
+                (b.clone().into(), Column::Int(&[0_i32; 0])),
             ],
             TableOptions::default(),
         )
         .expect("Table creation should not fail");
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
-                (b.clone(), Column::Int(&[10_i32, 11, 6, 5, 5, 4, 8])),
+                (c.clone().into(), Column::BigInt(&[1_i64, 2, 7, 8, 9, 7, 2])),
+                (b.clone().into(), Column::Int(&[10_i32, 11, 6, 5, 5, 4, 8])),
             ],
             TableOptions::default(),
         )
@@ -1126,16 +1221,16 @@ mod tests {
         // Both tables have no rows
         let left = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (a.clone(), Column::SmallInt(&[0_i16; 0])),
-                (b.clone(), Column::Int(&[0_i32; 0])),
+                (a.clone().into(), Column::SmallInt(&[0_i16; 0])),
+                (b.clone().into(), Column::Int(&[0_i32; 0])),
             ],
             TableOptions::default(),
         )
         .expect("Table creation should not fail");
         let right = Table::<'_, TestScalar>::try_from_iter_with_options(
             vec![
-                (c.clone(), Column::BigInt(&[0_i64; 0])),
-                (b.clone(), Column::Int(&[0_i32; 0])),
+                (c.clone().into(), Column::BigInt(&[0_i64; 0])),
+                (b.clone().into(), Column::Int(&[0_i32; 0])),
             ],
             TableOptions::default(),
         )

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -16,6 +16,9 @@ pub use column_ref::ColumnRef;
 mod column_field;
 pub use column_field::ColumnField;
 
+mod column_id;
+pub use column_id::ColumnId;
+
 #[cfg_attr(not(test), expect(dead_code))]
 pub(crate) mod slice_operation;
 

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -173,7 +173,7 @@ impl<'a, S: Scalar> From<&Table<'a, S>> for OwnedTable<S> {
             value
                 .inner_table()
                 .iter()
-                .map(|(name, column)| (name.clone(), OwnedColumn::from(column))),
+                .map(|(name, column)| (name.name().clone(), OwnedColumn::from(column))),
         )
         .expect("Tables should not have columns with differing lengths")
     }
@@ -185,7 +185,7 @@ impl<'a, S: Scalar> From<Table<'a, S>> for OwnedTable<S> {
             value
                 .into_inner()
                 .into_iter()
-                .map(|(name, column)| (name, OwnedColumn::from(&column))),
+                .map(|(name, column)| (name.name().clone(), OwnedColumn::from(&column))),
         )
         .expect("Tables should not have columns with differing lengths")
     }

--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -1,9 +1,8 @@
 use super::{Column, ColumnField};
-use crate::base::{map::IndexMap, scalar::Scalar};
+use crate::base::{database::ColumnId, map::IndexMap, scalar::Scalar};
 use alloc::vec::Vec;
 use bumpalo::Bump;
 use snafu::Snafu;
-use sqlparser::ast::Ident;
 
 /// Options for creating a table.
 /// Inspired by [`RecordBatchOptions`](https://docs.rs/arrow/latest/arrow/record_batch/struct.RecordBatchOptions.html)
@@ -43,18 +42,18 @@ pub enum TableError {
 /// This is the analog of an arrow [`RecordBatch`](arrow::record_batch::RecordBatch).
 #[derive(Debug, Clone, Eq)]
 pub struct Table<'a, S: Scalar> {
-    table: IndexMap<Ident, Column<'a, S>>,
+    table: IndexMap<ColumnId, Column<'a, S>>,
     row_count: usize,
 }
 impl<'a, S: Scalar> Table<'a, S> {
     /// Creates a new [`Table`] with the given columns and default [`TableOptions`].
-    pub fn try_new(table: IndexMap<Ident, Column<'a, S>>) -> Result<Self, TableError> {
+    pub fn try_new(table: IndexMap<ColumnId, Column<'a, S>>) -> Result<Self, TableError> {
         Self::try_new_with_options(table, TableOptions::default())
     }
 
     /// Creates a new [`Table`] with the given columns and with [`TableOptions`].
     pub fn try_new_with_options(
-        table: IndexMap<Ident, Column<'a, S>>,
+        table: IndexMap<ColumnId, Column<'a, S>>,
         options: TableOptions,
     ) -> Result<Self, TableError> {
         match (table.is_empty(), options.row_count) {
@@ -79,14 +78,14 @@ impl<'a, S: Scalar> Table<'a, S> {
     }
 
     /// Creates a new [`Table`] from an iterator of `(Ident, Column)` pairs with default [`TableOptions`].
-    pub fn try_from_iter<T: IntoIterator<Item = (Ident, Column<'a, S>)>>(
+    pub fn try_from_iter<T: IntoIterator<Item = (ColumnId, Column<'a, S>)>>(
         iter: T,
     ) -> Result<Self, TableError> {
         Self::try_from_iter_with_options(iter, TableOptions::default())
     }
 
     /// Creates a new [`Table`] from an iterator of `(Ident, Column)` pairs with [`TableOptions`].
-    pub fn try_from_iter_with_options<T: IntoIterator<Item = (Ident, Column<'a, S>)>>(
+    pub fn try_from_iter_with_options<T: IntoIterator<Item = (ColumnId, Column<'a, S>)>>(
         iter: T,
         options: TableOptions,
     ) -> Result<Self, TableError> {
@@ -110,12 +109,12 @@ impl<'a, S: Scalar> Table<'a, S> {
     }
     /// Returns the columns of this table as an `IndexMap`
     #[must_use]
-    pub fn into_inner(self) -> IndexMap<Ident, Column<'a, S>> {
+    pub fn into_inner(self) -> IndexMap<ColumnId, Column<'a, S>> {
         self.table
     }
     /// Returns the columns of this table as an `IndexMap`
     #[must_use]
-    pub fn inner_table(&self) -> &IndexMap<Ident, Column<'a, S>> {
+    pub fn inner_table(&self) -> &IndexMap<ColumnId, Column<'a, S>> {
         &self.table
     }
     /// Return the schema of this table as a `Vec` of `ColumnField`s
@@ -123,11 +122,11 @@ impl<'a, S: Scalar> Table<'a, S> {
     pub fn schema(&self) -> Vec<ColumnField> {
         self.table
             .iter()
-            .map(|(name, column)| ColumnField::new(name.clone(), column.column_type()))
+            .map(|(name, column)| ColumnField::new(name.name().clone(), column.column_type()))
             .collect()
     }
     /// Returns the columns of this table as an Iterator
-    pub fn column_names(&self) -> impl Iterator<Item = &Ident> {
+    pub fn column_names(&self) -> impl Iterator<Item = &ColumnId> {
         self.table.keys()
     }
     /// Returns the columns of this table as an Iterator
@@ -143,7 +142,7 @@ impl<'a, S: Scalar> Table<'a, S> {
     #[must_use]
     pub fn add_rho_column(mut self, alloc: &'a Bump) -> Self {
         self.table
-            .insert(Ident::new("rho"), Column::rho(self.row_count, alloc));
+            .insert("rho".into(), Column::rho(self.row_count, alloc));
         self
     }
 }
@@ -165,6 +164,7 @@ impl<S: Scalar> PartialEq for Table<'_, S> {
 impl<'a, S: Scalar> core::ops::Index<&str> for Table<'a, S> {
     type Output = Column<'a, S>;
     fn index(&self, index: &str) -> &Self::Output {
-        self.table.get(&Ident::new(index)).unwrap()
+        let column_id: ColumnId = index.into();
+        self.table.get(&column_id).unwrap()
     }
 }

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -114,11 +114,11 @@ fn we_can_create_an_empty_table_with_some_columns() {
         borrowed_boolean("boolean", [true; 0], &alloc),
     ]);
     let mut table = IndexMap::default();
-    table.insert(Ident::new("bigint"), Column::BigInt(&[]));
-    table.insert(Ident::new("decimal"), Column::Int128(&[]));
-    table.insert(Ident::new("varchar"), Column::VarChar((&[], &[])));
-    table.insert(Ident::new("scalar"), Column::Scalar(&[]));
-    table.insert(Ident::new("boolean"), Column::Boolean(&[]));
+    table.insert(Ident::new("bigint").into(), Column::BigInt(&[]));
+    table.insert(Ident::new("decimal").into(), Column::Int128(&[]));
+    table.insert(Ident::new("varchar").into(), Column::VarChar((&[], &[])));
+    table.insert(Ident::new("scalar").into(), Column::Scalar(&[]));
+    table.insert(Ident::new("boolean").into(), Column::Boolean(&[]));
     assert_eq!(borrowed_table.into_inner(), table);
 }
 
@@ -161,15 +161,15 @@ fn we_can_create_a_table_with_data() {
 
     let time_stamp_data = alloc.alloc_slice_copy(&[0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]);
     expected_table.insert(
-        Ident::new("time_stamp"),
+        Ident::new("time_stamp").into(),
         Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), time_stamp_data),
     );
 
     let bigint_data = alloc.alloc_slice_copy(&[0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]);
-    expected_table.insert(Ident::new("bigint"), Column::BigInt(bigint_data));
+    expected_table.insert(Ident::new("bigint").into(), Column::BigInt(bigint_data));
 
     let decimal_data = alloc.alloc_slice_copy(&[0_i128, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX]);
-    expected_table.insert(Ident::new("decimal"), Column::Int128(decimal_data));
+    expected_table.insert(Ident::new("decimal").into(), Column::Int128(decimal_data));
 
     let varchar_data: Vec<&str> = ["0", "1", "2", "3", "4", "5", "6", "7", "8"]
         .iter()
@@ -179,17 +179,17 @@ fn we_can_create_a_table_with_data() {
     let varchar_scalars: Vec<TestScalar> = varchar_data.iter().map(Into::into).collect();
     let varchar_scalars_slice = alloc.alloc_slice_clone(&varchar_scalars);
     expected_table.insert(
-        Ident::new("varchar"),
+        Ident::new("varchar").into(),
         Column::VarChar((varchar_str_slice, varchar_scalars_slice)),
     );
 
     let scalar_data: Vec<TestScalar> = (0..=8).map(TestScalar::from).collect();
     let scalar_slice = alloc.alloc_slice_copy(&scalar_data);
-    expected_table.insert(Ident::new("scalar"), Column::Scalar(scalar_slice));
+    expected_table.insert(Ident::new("scalar").into(), Column::Scalar(scalar_slice));
 
     let boolean_data =
         alloc.alloc_slice_copy(&[true, false, true, false, true, false, true, false, true]);
-    expected_table.insert(Ident::new("boolean"), Column::Boolean(boolean_data));
+    expected_table.insert(Ident::new("boolean").into(), Column::Boolean(boolean_data));
 
     assert_eq!(borrowed_table.into_inner(), expected_table);
 }

--- a/crates/proof-of-sql/src/base/database/table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
+    database::ColumnId,
     map::IndexMap,
 };
 use alloc::vec::Vec;
@@ -55,7 +56,7 @@ impl<'a, CP: CommitmentEvaluationProof> TestAccessor<CP::Commitment> for TableTe
             .unwrap()
             .0
             .column_names()
-            .map(|ident| ident.value.as_str())
+            .map(|ident| ident.name().value.as_str())
             .collect()
     }
 
@@ -76,13 +77,14 @@ impl<'a, CP: CommitmentEvaluationProof> TestAccessor<CP::Commitment> for TableTe
 /// indicating that an invalid column reference was provided.
 impl<'a, CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for TableTestAccessor<'a, CP> {
     fn get_column(&self, table_ref: &TableRef, column_id: &Ident) -> Column<'a, CP::Scalar> {
+        let column_id: ColumnId = column_id.into();
         *self
             .tables
             .get(table_ref)
             .unwrap()
             .0
             .inner_table()
-            .get(column_id)
+            .get(&column_id)
             .unwrap()
     }
 }
@@ -95,8 +97,9 @@ impl<CP: CommitmentEvaluationProof> CommitmentAccessor<CP::Commitment>
     for TableTestAccessor<'_, CP>
 {
     fn get_commitment(&self, table_ref: &TableRef, column_id: &Ident) -> CP::Commitment {
+        let column_id: ColumnId = column_id.into();
         let (table, offset) = self.tables.get(table_ref).unwrap();
-        let borrowed_column = table.inner_table().get(column_id).unwrap();
+        let borrowed_column = table.inner_table().get(&column_id).unwrap();
         Vec::<CP::Commitment>::from_columns_with_offset(
             [borrowed_column],
             *offset,
@@ -123,12 +126,13 @@ impl<CP: CommitmentEvaluationProof> MetadataAccessor for TableTestAccessor<'_, C
 }
 impl<CP: CommitmentEvaluationProof> SchemaAccessor for TableTestAccessor<'_, CP> {
     fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
+        let column_id: ColumnId = column_id.into();
         Some(
             self.tables
                 .get(table_ref)?
                 .0
                 .inner_table()
-                .get(column_id)?
+                .get(&column_id)?
                 .column_type(),
         )
     }
@@ -143,7 +147,7 @@ impl<CP: CommitmentEvaluationProof> SchemaAccessor for TableTestAccessor<'_, CP>
             .0
             .inner_table()
             .iter()
-            .map(|(id, col)| (id.clone(), col.column_type()))
+            .map(|(id, col)| (id.clone().name().clone(), col.column_type()))
             .collect()
     }
 }

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -229,7 +229,10 @@ fn we_can_access_schema_and_column_names() {
             ("b".into(), ColumnType::VarChar)
         ]
     );
-    assert_eq!(accessor.get_column_names(&table_ref_1), vec!["a", "b"]);
+    assert_eq!(
+        accessor.get_column_names(&table_ref_1),
+        vec!["a".to_string(), "b".to_string()]
+    );
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -19,12 +19,12 @@
 //! ```
 use super::{Column, Table, TableOptions};
 use crate::base::{
+    database::ColumnId,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::Scalar,
 };
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
-use sqlparser::ast::Ident;
 
 /// Creates an [`Table`] from a list of `(Ident, Column)` pairs.
 /// This is a convenience wrapper around [`Table::try_from_iter`] primarily for use in tests and
@@ -52,7 +52,7 @@ use sqlparser::ast::Ident;
 /// # Panics
 /// - Panics if converting the iterator into an `Table<'a, S>` fails.
 pub fn table<'a, S: Scalar>(
-    iter: impl IntoIterator<Item = (Ident, Column<'a, S>)>,
+    iter: impl IntoIterator<Item = (ColumnId, Column<'a, S>)>,
 ) -> Table<'a, S> {
     Table::try_from_iter(iter).unwrap()
 }
@@ -64,7 +64,7 @@ pub fn table<'a, S: Scalar>(
 /// # Panics
 /// - Panics if the given row count doesn't match the number of rows in any of the columns.
 pub fn table_with_row_count<'a, S: Scalar>(
-    iter: impl IntoIterator<Item = (Ident, Column<'a, S>)>,
+    iter: impl IntoIterator<Item = (ColumnId, Column<'a, S>)>,
     row_count: usize,
 ) -> Table<'a, S> {
     Table::try_from_iter_with_options(iter, TableOptions::new(Some(row_count))).unwrap()
@@ -84,10 +84,10 @@ pub fn table_with_row_count<'a, S: Scalar>(
 /// ]);
 ///```
 pub fn borrowed_uint8<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     data: impl IntoIterator<Item = impl Into<u8>>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let transformed_data: Vec<u8> = data.into_iter().map(Into::into).collect();
     let alloc_data = alloc.alloc_slice_copy(&transformed_data);
     (name.into(), Column::Uint8(alloc_data))
@@ -107,10 +107,10 @@ pub fn borrowed_uint8<S: Scalar>(
 /// ]);
 ///```
 pub fn borrowed_tinyint<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     data: impl IntoIterator<Item = impl Into<i8>>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let transformed_data: Vec<i8> = data.into_iter().map(Into::into).collect();
     let alloc_data = alloc.alloc_slice_copy(&transformed_data);
     (name.into(), Column::TinyInt(alloc_data))
@@ -132,10 +132,10 @@ pub fn borrowed_tinyint<S: Scalar>(
 /// ```
 ///
 pub fn borrowed_smallint<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     data: impl IntoIterator<Item = impl Into<i16>>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let transformed_data: Vec<i16> = data.into_iter().map(Into::into).collect();
     let alloc_data = alloc.alloc_slice_copy(&transformed_data);
     (name.into(), Column::SmallInt(alloc_data))
@@ -157,10 +157,10 @@ pub fn borrowed_smallint<S: Scalar>(
 /// ```
 ///
 pub fn borrowed_int<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     data: impl IntoIterator<Item = impl Into<i32>>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let transformed_data: Vec<i32> = data.into_iter().map(Into::into).collect();
     let alloc_data = alloc.alloc_slice_copy(&transformed_data);
     (name.into(), Column::Int(alloc_data))
@@ -181,10 +181,10 @@ pub fn borrowed_int<S: Scalar>(
 /// ]);
 /// ```
 pub fn borrowed_bigint<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     data: impl IntoIterator<Item = impl Into<i64>>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let transformed_data: Vec<i64> = data.into_iter().map(Into::into).collect();
     let alloc_data = alloc.alloc_slice_copy(&transformed_data);
     (name.into(), Column::BigInt(alloc_data))
@@ -205,10 +205,10 @@ pub fn borrowed_bigint<S: Scalar>(
 /// ]);
 /// ```
 pub fn borrowed_boolean<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     data: impl IntoIterator<Item = impl Into<bool>>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let transformed_data: Vec<bool> = data.into_iter().map(Into::into).collect();
     let alloc_data = alloc.alloc_slice_copy(&transformed_data);
     (name.into(), Column::Boolean(alloc_data))
@@ -229,10 +229,10 @@ pub fn borrowed_boolean<S: Scalar>(
 /// ]);
 /// ```
 pub fn borrowed_int128<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     data: impl IntoIterator<Item = impl Into<i128>>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let transformed_data: Vec<i128> = data.into_iter().map(Into::into).collect();
     let alloc_data = alloc.alloc_slice_copy(&transformed_data);
     (name.into(), Column::Int128(alloc_data))
@@ -253,10 +253,10 @@ pub fn borrowed_int128<S: Scalar>(
 /// ]);
 /// ```
 pub fn borrowed_scalar<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     data: impl IntoIterator<Item = impl Into<S>>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let transformed_data: Vec<S> = data.into_iter().map(Into::into).collect();
     let alloc_data = alloc.alloc_slice_copy(&transformed_data);
     (name.into(), Column::Scalar(alloc_data))
@@ -276,10 +276,10 @@ pub fn borrowed_scalar<S: Scalar>(
 /// ]);
 /// ```
 pub fn borrowed_varchar<'a, S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     data: impl IntoIterator<Item = impl Into<String>>,
     alloc: &'a Bump,
-) -> (Ident, Column<'a, S>) {
+) -> (ColumnId, Column<'a, S>) {
     let strings: Vec<&'a str> = data
         .into_iter()
         .map(|item| {
@@ -309,12 +309,12 @@ pub fn borrowed_varchar<'a, S: Scalar>(
 /// # Panics
 /// - Panics if creating the `Precision` from the specified precision value fails.
 pub fn borrowed_decimal75<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     precision: u8,
     scale: i8,
     data: impl IntoIterator<Item = impl Into<S>>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let transformed_data: Vec<S> = data.into_iter().map(Into::into).collect();
     let alloc_data = alloc.alloc_slice_copy(&transformed_data);
     (
@@ -350,12 +350,12 @@ pub fn borrowed_decimal75<S: Scalar>(
 /// ]);
 /// ```
 pub fn borrowed_timestamptz<S: Scalar>(
-    name: impl Into<Ident>,
+    name: impl Into<ColumnId>,
     time_unit: PoSQLTimeUnit,
     timezone: PoSQLTimeZone,
     data: impl IntoIterator<Item = i64>,
     alloc: &Bump,
-) -> (Ident, Column<'_, S>) {
+) -> (ColumnId, Column<'_, S>) {
     let vec_data: Vec<i64> = data.into_iter().collect();
     let alloc_data = alloc.alloc_slice_copy(&vec_data);
     (

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -232,7 +232,7 @@ pub fn table_union<'a, S: Scalar>(
                 .map(|table| table.column(i).expect("Schemas should be compatible"))
                 .collect();
             (
-                field.name(),
+                field.name().into(),
                 column_union(&columns, alloc, field.data_type()).expect("Failed to union columns"),
             )
         }),

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -152,7 +152,7 @@ impl EVMColumnExpr {
                 .or_else(|| {
                     column_refs.get_index_of(&ColumnRef::new(
                         TableRef::from_names(None, ""),
-                        expr.column_id(),
+                        expr.column_name(),
                         expr.data_type(),
                     ))
                 })

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -193,7 +193,7 @@ impl EVMTableExec {
         let schema = column_refs
             .iter()
             .filter(|col_ref| col_ref.table_ref() == table_ref.clone())
-            .map(|col_ref| ColumnField::new(col_ref.column_id(), *col_ref.column_type()))
+            .map(|col_ref| ColumnField::new(col_ref.column_name(), *col_ref.column_type()))
             .collect();
 
         Ok(TableExec::new(table_ref, schema))
@@ -281,7 +281,7 @@ impl EVMLegacyFilterExec {
                 .map(|(expr, name)| {
                     Ok(AliasedDynProofExpr {
                         expr: expr.try_into_proof_expr(column_refs)?,
-                        alias: Ident::new(name),
+                        alias: name.into(),
                     })
                 })
                 .collect::<EVMProofPlanResult<Vec<_>>>()?,
@@ -351,7 +351,7 @@ impl EVMFilterExec {
                 .map(|(expr, name)| {
                     Ok(AliasedDynProofExpr {
                         expr: expr.try_into_proof_expr(&input_result_column_refs)?,
-                        alias: Ident::new(name),
+                        alias: name.into(),
                     })
                 })
                 .collect::<EVMProofPlanResult<Vec<_>>>()?,
@@ -412,7 +412,7 @@ impl EVMProjectionExec {
                 .map(|(expr, name)| {
                     Ok(AliasedDynProofExpr {
                         expr: expr.try_into_proof_expr(&input_result_column_refs)?,
-                        alias: Ident::new(name),
+                        alias: (&name).into(),
                     })
                 })
                 .collect::<EVMProofPlanResult<Vec<_>>>()?,
@@ -546,7 +546,7 @@ impl EVMGroupByExec {
                 |(expr, alias_name)| -> EVMProofPlanResult<AliasedDynProofExpr> {
                     Ok(AliasedDynProofExpr {
                         expr: expr.try_into_proof_expr(column_refs)?,
-                        alias: Ident::new(alias_name),
+                        alias: alias_name.into(),
                     })
                 },
             )
@@ -660,7 +660,7 @@ impl EVMAggregateExec {
             .map(|(expr, alias_name)| {
                 Ok(AliasedDynProofExpr {
                     expr: expr.try_into_proof_expr(&input_result_column_refs)?,
-                    alias: Ident::new(alias_name),
+                    alias: alias_name.into(),
                 })
             })
             .collect::<EVMProofPlanResult<Vec<_>>>()?;
@@ -673,7 +673,7 @@ impl EVMAggregateExec {
             .map(|(expr, alias_name)| {
                 Ok(AliasedDynProofExpr {
                     expr: expr.try_into_proof_expr(&input_result_column_refs)?,
-                    alias: Ident::new(alias_name),
+                    alias: alias_name.into(),
                 })
             })
             .collect::<EVMProofPlanResult<Vec<_>>>()?;
@@ -854,7 +854,7 @@ mod tests {
         let projection_exec = ProjectionExec::new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(alias.clone()),
+                alias: (&alias).into(),
             }],
             Box::new(DynProofPlan::Table(table_exec)),
         );
@@ -1072,7 +1072,7 @@ mod tests {
         let filter_exec = LegacyFilterExec::new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(alias.clone()),
+                alias: (&alias).into(),
             }],
             TableExpr {
                 table_ref: table_ref.clone(),
@@ -1144,7 +1144,7 @@ mod tests {
             vec![ColumnExpr::new(column_ref_a.clone())],
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(sum_alias.clone()),
+                alias: (&sum_alias).into(),
             }],
             Ident::new(count_alias.clone()),
             TableExpr {
@@ -1235,7 +1235,7 @@ mod tests {
             vec![ColumnExpr::new(missing_column)],
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(sum_alias),
+                alias: (&sum_alias).into(),
             }],
             Ident::new(count_alias),
             TableExpr {
@@ -1279,7 +1279,7 @@ mod tests {
             vec![ColumnExpr::new(column_ref_a.clone())],
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(sum_alias),
+                alias: (&sum_alias).into(),
             }],
             Ident::new(count_alias),
             TableExpr {
@@ -1322,7 +1322,7 @@ mod tests {
             vec![ColumnExpr::new(column_ref_a.clone())],
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(sum_alias.clone()),
+                alias: (&sum_alias).into(),
             }],
             Ident::new(count_alias.clone()),
             TableExpr {
@@ -1378,7 +1378,7 @@ mod tests {
             vec![ColumnExpr::new(column_ref_a.clone())],
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(sum_alias.clone()),
+                alias: (&sum_alias).into(),
             }],
             Ident::new(count_alias.clone()),
             TableExpr {
@@ -1434,7 +1434,7 @@ mod tests {
             vec![ColumnExpr::new(column_ref_a.clone())],
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(sum_alias.clone()),
+                alias: (&sum_alias).into(),
             }],
             Ident::new(count_alias.clone()),
             TableExpr {
@@ -1685,7 +1685,7 @@ mod tests {
         let filter_exec = FilterExec::new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(alias.clone()),
+                alias: (&alias).into(),
             }],
             Box::new(DynProofPlan::Table(table_exec)),
             DynProofExpr::Equals(
@@ -1772,11 +1772,11 @@ mod tests {
             vec![
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone())),
-                    alias: ident_a.clone(),
+                    alias: (&ident_a).into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                    alias: ident_c.clone(),
+                    alias: (&ident_c).into(),
                 },
             ],
             Box::new(DynProofPlan::Slice(slice_exec)),
@@ -1857,15 +1857,15 @@ mod tests {
             vec![
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone())),
-                    alias: Ident::new(alias_1),
+                    alias: alias_1.into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                    alias: ident_b.clone(),
+                    alias: (&ident_b).into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_c.clone())),
-                    alias: ident_c.clone(),
+                    alias: (&ident_c).into(),
                 },
             ],
             Box::new(DynProofPlan::Table(table_exec)),
@@ -1885,15 +1885,15 @@ mod tests {
             vec![
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_1.clone())),
-                    alias: ident_a.clone(),
+                    alias: (&ident_a).into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                    alias: Ident::new(alias_2),
+                    alias: alias_2.into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_c.clone())),
-                    alias: ident_c.clone(),
+                    alias: (&ident_c).into(),
                 },
             ],
             Box::new(DynProofPlan::Filter(filter_1)),
@@ -1913,15 +1913,15 @@ mod tests {
             vec![
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone())),
-                    alias: ident_a.clone(),
+                    alias: (&ident_a).into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_2.clone())),
-                    alias: ident_b.clone(),
+                    alias: (&ident_b).into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_c.clone())),
-                    alias: Ident::new(alias_3),
+                    alias: alias_3.into(),
                 },
             ],
             Box::new(DynProofPlan::Filter(filter_2)),
@@ -2025,7 +2025,7 @@ mod tests {
         let filter_exec = FilterExec::new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(alias),
+                alias: (&alias).into(),
             }],
             Box::new(DynProofPlan::Table(table_exec)),
             DynProofExpr::Equals(
@@ -2072,7 +2072,7 @@ mod tests {
         let filter_exec = FilterExec::new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(missing_column)),
-                alias: Ident::new(alias),
+                alias: (&alias).into(),
             }],
             Box::new(DynProofPlan::Table(table_exec)),
             DynProofExpr::Equals(
@@ -2117,7 +2117,7 @@ mod tests {
         let filter_exec = FilterExec::new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                alias: Ident::new(alias),
+                alias: (&alias).into(),
             }],
             Box::new(DynProofPlan::Table(table_exec)),
             DynProofExpr::Equals(
@@ -2174,11 +2174,11 @@ mod tests {
         let aggregate_exec = AggregateExec::try_new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(output_col_a.clone())),
-                alias: ident_a.clone(),
+                alias: (&ident_a).into(),
             }],
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(output_col_b.clone())),
-                alias: Ident::new(sum_alias.clone()),
+                alias: (&sum_alias).into(),
             }],
             Ident::new(count_alias.clone()),
             Box::new(DynProofPlan::Table(table_exec)),
@@ -2252,15 +2252,15 @@ mod tests {
             vec![
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone())),
-                    alias: ident_a.clone(),
+                    alias: (&ident_a).into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
-                    alias: ident_b.clone(),
+                    alias: (&ident_b).into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(column_ref_c.clone())),
-                    alias: ident_c.clone(),
+                    alias: (&ident_c).into(),
                 },
             ],
             Box::new(DynProofPlan::Table(table_exec)),
@@ -2288,16 +2288,16 @@ mod tests {
         let aggregate_exec = AggregateExec::try_new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(filter_output_col_a.clone())),
-                alias: ident_a.clone(),
+                alias: (&ident_a).into(),
             }],
             vec![
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(filter_output_col_b.clone())),
-                    alias: Ident::new(sum_alias_b.clone()),
+                    alias: (&sum_alias_b).into(),
                 },
                 AliasedDynProofExpr {
                     expr: DynProofExpr::Column(ColumnExpr::new(filter_output_col_c.clone())),
-                    alias: Ident::new(sum_alias_c.clone()),
+                    alias: (&sum_alias_c).into(),
                 },
             ],
             Ident::new(count_alias.clone()),
@@ -2381,11 +2381,11 @@ mod tests {
         let aggregate_exec = AggregateExec::try_new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(output_col_a)),
-                alias: ident_a.clone(),
+                alias: ident_a.into(),
             }],
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(output_col_b)),
-                alias: Ident::new(sum_alias),
+                alias: (&sum_alias).into(),
             }],
             Ident::new(count_alias),
             Box::new(DynProofPlan::Table(table_exec)),
@@ -2436,11 +2436,11 @@ mod tests {
         let aggregate_exec = AggregateExec::try_new(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(output_col_a)),
-                alias: ident_a.clone(),
+                alias: (&ident_a).into(),
             }],
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::Column(ColumnExpr::new(output_col_b)),
-                alias: Ident::new(sum_alias.clone()),
+                alias: (&sum_alias).into(),
             }],
             Ident::new(count_alias.clone()),
             Box::new(DynProofPlan::Table(table_exec)),

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -2,7 +2,8 @@ use super::{plans::EVMDynProofPlan, EVMProofPlanError, EVMProofPlanResult};
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, ColumnType, LiteralValue, Table, TableEvaluation, TableRef,
+            ColumnField, ColumnId, ColumnRef, ColumnType, LiteralValue, Table, TableEvaluation,
+            TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -81,7 +82,7 @@ impl TryFrom<&EVMProofPlan> for CompactPlan {
                     .ok_or(EVMProofPlanError::TableNotFound)?;
                 Ok((
                     table_index,
-                    column_ref.column_id().to_string(),
+                    column_ref.column_name().to_string(),
                     *column_ref.column_type(),
                 ))
             })
@@ -152,7 +153,7 @@ impl ProofPlan for EVMProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -161,6 +162,9 @@ impl ProofPlan for EVMProofPlan {
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         self.inner().get_column_result_fields()
+    }
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.inner().get_column_identifiers()
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         self.inner().get_column_references()

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -77,7 +77,7 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
     let plan = DynProofPlan::Filter(FilterExec::new(
         vec![AliasedDynProofExpr {
             expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b)),
-            alias: identifier_alias,
+            alias: identifier_alias.into(),
         }],
         Box::new(DynProofPlan::Table(table_exec)),
         DynProofExpr::Equals(
@@ -121,7 +121,7 @@ fn we_can_deserialize_proof_plan_for_simple_filter() {
     let expected_plan = DynProofPlan::Filter(FilterExec::new(
         vec![AliasedDynProofExpr {
             expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b)),
-            alias: Ident::new("alias"),
+            alias: "alias".into(),
         }],
         Box::new(DynProofPlan::Table(table_exec)),
         DynProofExpr::Equals(

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,6 +1,6 @@
 use super::{verification_builder::VerificationBuilder, FinalRoundBuilder, FirstRoundBuilder};
 use crate::base::{
-    database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+    database::{ColumnField, ColumnId, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
     map::{IndexMap, IndexSet},
     proof::{PlaceholderResult, ProofError},
     scalar::Scalar,
@@ -8,7 +8,6 @@ use crate::base::{
 use alloc::vec::Vec;
 use bumpalo::Bump;
 use core::fmt::Debug;
-use sqlparser::ast::Ident;
 
 /// Provable nodes in the provable AST.
 #[enum_dispatch::enum_dispatch(DynProofPlan)]
@@ -17,13 +16,16 @@ pub trait ProofPlan: Debug + Send + Sync + ProverEvaluate {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError>;
 
     /// Return all the result column fields
     fn get_column_result_fields(&self) -> Vec<ColumnField>;
+
+    /// Return all the column identifiers
+    fn get_column_identifiers(&self) -> Vec<ColumnId>;
 
     /// Return all the columns referenced in the Query
     fn get_column_references(&self) -> IndexSet<ColumnRef>;

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -124,7 +124,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
                 let idents: IndexSet<Ident> = total_col_refs
                     .iter()
                     .filter(|col_ref| col_ref.table_ref() == table_ref)
-                    .map(ColumnRef::column_id)
+                    .map(ColumnRef::column_name)
                     .collect();
                 (table_ref.clone(), accessor.get_table(&table_ref, &idents))
             })
@@ -168,7 +168,9 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
                 .get_column_references()
                 .into_iter()
                 .map(|col| {
-                    CommittableColumn::from(accessor.get_column(&col.table_ref(), &col.column_id()))
+                    CommittableColumn::from(
+                        accessor.get_column(&col.table_ref(), &col.column_name()),
+                    )
                 })
                 .collect_vec(),
             min_row_num,
@@ -253,7 +255,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             .iter()
             .map(|col_ref| {
                 accessor
-                    .get_column(&col_ref.table_ref(), &col_ref.column_id())
+                    .get_column(&col_ref.table_ref(), &col_ref.column_name())
                     .inner_product(&evaluation_vec)
             })
             .collect();
@@ -283,7 +285,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let column_ref_mles: Vec<_> = total_col_refs
             .into_iter()
             .map(|c| {
-                Box::new(accessor.get_column(&c.table_ref(), &c.column_id()))
+                Box::new(accessor.get_column(&c.table_ref(), &c.column_name()))
                     as Box<dyn MultilinearExtension<_>>
             })
             .collect();
@@ -374,7 +376,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         for commitment in expr
             .get_column_references()
             .into_iter()
-            .map(|col| accessor.get_commitment(&col.table_ref(), &col.column_id()))
+            .map(|col| accessor.get_commitment(&col.table_ref(), &col.column_name()))
         {
             transcript.extend_serialize_as_le(&commitment);
         }
@@ -485,7 +487,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             .chain(
                 column_references
                     .iter()
-                    .map(|col| accessor.get_commitment(&col.table_ref(), &col.column_id())),
+                    .map(|col| accessor.get_commitment(&col.table_ref(), &col.column_name())),
             )
             .chain(self.final_round_message.round_commitments.iter().cloned())
             .collect();

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -6,8 +6,8 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             table_utility::*,
-            ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTableTestAccessor, Table,
-            TableEvaluation, TableRef,
+            ColumnField, ColumnId, ColumnRef, ColumnType, LiteralValue, OwnedTableTestAccessor,
+            Table, TableEvaluation, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -18,7 +18,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
-use sqlparser::ast::Ident;
 
 /// Type to allow us to prove and verify an artificial polynomial where we prove
 /// that every entry in the result is zero
@@ -88,7 +87,7 @@ impl ProofPlan for TrivialTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        _accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -116,6 +115,10 @@ impl ProofPlan for TrivialTestProofPlan {
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset![TableRef::new("sxt", "test")]
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        vec!["a1".into()]
     }
 }
 
@@ -282,11 +285,12 @@ impl ProverEvaluate for SquareTestProofPlan {
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
     ) -> PlaceholderResult<Table<'a, S>> {
+        let column_id: ColumnId = "x".into();
         let x = *table_map
             .get(&TableRef::new("sxt", "test"))
             .unwrap()
             .inner_table()
-            .get(&Ident::new("x"))
+            .get(&column_id)
             .unwrap();
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         builder.produce_intermediate_mle(res);
@@ -304,15 +308,16 @@ impl ProofPlan for SquareTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
+        let column_id: ColumnId = "x".into();
         let x_eval = S::from(self.anchored_commit_multiplier)
             * *accessor
                 .get(&TableRef::new("sxt", "test"))
                 .unwrap()
-                .get(&Ident::new("x"))
+                .get(&column_id)
                 .unwrap();
         let res_eval = builder.try_consume_final_round_mle_evaluation()?;
         builder.try_produce_sumcheck_subpolynomial_evaluation(
@@ -337,6 +342,10 @@ impl ProofPlan for SquareTestProofPlan {
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset![TableRef::new("sxt", "test")]
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        vec!["a1".into()]
     }
 }
 
@@ -461,11 +470,12 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
     ) -> PlaceholderResult<Table<'a, S>> {
+        let column_id: ColumnId = "x".into();
         let x = *table_map
             .get(&TableRef::new("sxt", "test"))
             .unwrap()
             .inner_table()
-            .get(&Ident::new("x"))
+            .get(&column_id)
             .unwrap();
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         let z: &[_] = alloc.alloc_slice_copy(&self.z);
@@ -496,14 +506,15 @@ impl ProofPlan for DoubleSquareTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
+        let column_id: ColumnId = "x".into();
         let x_eval = *accessor
             .get(&TableRef::new("sxt", "test"))
             .unwrap()
-            .get(&Ident::new("x"))
+            .get(&column_id)
             .unwrap();
         let z_eval = builder.try_consume_final_round_mle_evaluation()?;
         let res_eval = builder.try_consume_final_round_mle_evaluation()?;
@@ -538,6 +549,10 @@ impl ProofPlan for DoubleSquareTestProofPlan {
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset![TableRef::new("sxt", "test")]
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        vec!["a1".into()]
     }
 }
 
@@ -674,11 +689,12 @@ impl ProverEvaluate for ChallengeTestProofPlan {
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
     ) -> PlaceholderResult<Table<'a, S>> {
+        let column_id: ColumnId = "x".into();
         let x = *table_map
             .get(&TableRef::new("sxt", "test"))
             .unwrap()
             .inner_table()
-            .get(&Ident::new("x"))
+            .get(&column_id)
             .unwrap();
         let res: &[_] = alloc.alloc_slice_copy(&[9, 25]);
         let alpha = builder.consume_post_result_challenge();
@@ -698,16 +714,17 @@ impl ProofPlan for ChallengeTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
+        let column_id: ColumnId = "x".into();
         let alpha = builder.try_consume_post_result_challenge()?;
         let _beta = builder.try_consume_post_result_challenge()?;
         let x_eval = *accessor
             .get(&TableRef::new("sxt", "test"))
             .unwrap()
-            .get(&Ident::new("x"))
+            .get(&column_id)
             .unwrap();
         let res_eval = builder.try_consume_final_round_mle_evaluation()?;
         builder.try_produce_sumcheck_subpolynomial_evaluation(
@@ -732,6 +749,9 @@ impl ProofPlan for ChallengeTestProofPlan {
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset![TableRef::new("sxt", "test")]
+    }
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        vec!["a1".into()]
     }
 }
 
@@ -816,11 +836,12 @@ impl ProverEvaluate for FirstRoundSquareTestProofPlan {
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
     ) -> PlaceholderResult<Table<'a, S>> {
+        let column_id: ColumnId = "x".into();
         let x = *table_map
             .get(&TableRef::new("sxt", "test"))
             .unwrap()
             .inner_table()
-            .get(&Ident::new("x"))
+            .get(&column_id)
             .unwrap();
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         builder.produce_intermediate_mle(res);
@@ -838,15 +859,16 @@ impl ProofPlan for FirstRoundSquareTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
+        let column_id: ColumnId = "x".into();
         let x_eval = S::from(self.anchored_commit_multiplier)
             * *accessor
                 .get(&TableRef::new("sxt", "test"))
                 .unwrap()
-                .get(&Ident::new("x"))
+                .get(&column_id)
                 .unwrap();
         let first_round_res_eval = builder.try_consume_first_round_mle_evaluation()?;
         let final_round_res_eval = builder.try_consume_final_round_mle_evaluation()?;
@@ -873,6 +895,9 @@ impl ProofPlan for FirstRoundSquareTestProofPlan {
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset![TableRef::new("sxt", "test")]
+    }
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        vec!["a1".into()]
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -7,8 +7,8 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             table_utility::*,
-            ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTableTestAccessor, Table,
-            TableEvaluation, TableRef,
+            ColumnField, ColumnId, ColumnRef, ColumnType, LiteralValue, OwnedTableTestAccessor,
+            Table, TableEvaluation, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -18,7 +18,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
-use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize, Default)]
 pub(super) struct EmptyTestQueryExpr {
@@ -65,7 +64,7 @@ impl ProofPlan for EmptyTestQueryExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        _accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -91,6 +90,12 @@ impl ProofPlan for EmptyTestQueryExpr {
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset![TableRef::new("sxt", "test")]
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        (1..=self.columns)
+            .map(|i| (&format!("a{i}")).into())
+            .collect()
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -2,7 +2,8 @@ use super::{add_subtract_columns, DecimalProofExpr, DynProofExpr, ProofExpr};
 use crate::{
     base::{
         database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table,
+            try_add_subtract_column_types, Column, ColumnId, ColumnRef, ColumnType, LiteralValue,
+            Table,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -17,7 +18,6 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable numerical `+` expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -97,7 +97,7 @@ impl ProofExpr for AddExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -1,6 +1,6 @@
 use super::DynProofExpr;
+use crate::base::database::ColumnId;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// A `DynProofExpr` with an alias.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -8,5 +8,5 @@ pub struct AliasedDynProofExpr {
     /// The `DynProofExpr` to alias.
     pub expr: DynProofExpr,
     /// The alias for the expression.
-    pub alias: Ident,
+    pub alias: ColumnId,
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -1,7 +1,9 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{can_and_or_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            can_and_or_types, Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -15,7 +17,6 @@ use crate::{
 use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable logical AND expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -117,7 +118,7 @@ impl ProofExpr for AndExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -1,7 +1,7 @@
 use super::{numerical_util::cast_column, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{try_cast_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{try_cast_types, Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -14,7 +14,6 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable CAST expression
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -87,7 +86,7 @@ impl ProofExpr for CastExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -1,7 +1,7 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        database::{Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnField, ColumnId, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -41,12 +41,21 @@ impl ColumnExpr {
     /// Wrap the column output name and its type within the [`ColumnField`]
     #[must_use]
     pub fn get_column_field(&self) -> ColumnField {
-        ColumnField::new(self.column_ref.column_id(), *self.column_ref.column_type())
+        ColumnField::new(
+            self.column_ref.column_name(),
+            *self.column_ref.column_type(),
+        )
+    }
+
+    /// Get the column name
+    #[must_use]
+    pub fn column_name(&self) -> Ident {
+        self.column_ref.column_name()
     }
 
     /// Get the column identifier
     #[must_use]
-    pub fn column_id(&self) -> Ident {
+    pub fn column_id(&self) -> ColumnId {
         self.column_ref.column_id()
     }
 
@@ -98,7 +107,7 @@ impl ProofExpr for ColumnExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         _builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         _chi_eval: S,
         _params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -18,7 +18,6 @@ use alloc::boxed::Box;
 use bumpalo::Bump;
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Enum of AST column expression types that implement `ProofExpr`. Is itself a `ProofExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -1,7 +1,9 @@
 use super::{add_subtract_columns, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{try_equals_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            try_equals_types, Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -16,7 +18,6 @@ use crate::{
 use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable AST expression for an equals expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -109,7 +110,7 @@ impl ProofExpr for EqualsExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -1,7 +1,9 @@
 use super::{add_subtract_columns, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{try_inequality_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            try_inequality_types, Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -18,7 +20,6 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable AST expression for an inequality expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -133,7 +134,7 @@ impl ProofExpr for InequalityExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -1,7 +1,7 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -11,7 +11,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable CONST expression
 ///
@@ -83,7 +82,7 @@ impl ProofExpr for LiteralExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         _builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<Ident, S>,
+        _accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         _params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -1,7 +1,9 @@
 use super::{DecimalProofExpr, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{try_multiply_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            try_multiply_column_types, Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -16,7 +18,6 @@ use crate::{
 use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable numerical * expression
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -106,7 +107,7 @@ impl ProofExpr for MultiplyExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -1,7 +1,7 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{can_not_type, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{can_not_type, Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -15,7 +15,6 @@ use crate::{
 use alloc::boxed::Box;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable logical NOT expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -85,7 +84,7 @@ impl ProofExpr for NotExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -1,7 +1,9 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{can_and_or_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            can_and_or_types, Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -15,7 +17,6 @@ use crate::{
 use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable logical OR expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -101,7 +102,7 @@ impl ProofExpr for OrExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
@@ -1,7 +1,7 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderError, PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -11,7 +11,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable placeholder expression, that is, a placeholder in a SQL query
 ///
@@ -137,7 +136,7 @@ impl ProofExpr for PlaceholderExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         _builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<Ident, S>,
+        _accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         math::decimal::Precision,
         proof::{PlaceholderResult, ProofError},
@@ -10,7 +10,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use core::fmt::Debug;
-use sqlparser::ast::Ident;
 
 /// Provable AST column expression that evaluates to a `Column`
 #[enum_dispatch::enum_dispatch(DynProofExpr)]
@@ -44,7 +43,7 @@ pub trait ProofExpr: Debug + Send + Sync {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError>;

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnId, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -17,7 +17,6 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ScalingCastExpr {
@@ -97,7 +96,7 @@ impl ProofExpr for ScalingCastExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
@@ -2,7 +2,8 @@ use super::{add_subtract_columns, DecimalProofExpr, DynProofExpr, ProofExpr};
 use crate::{
     base::{
         database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table,
+            try_add_subtract_column_types, Column, ColumnId, ColumnRef, ColumnType, LiteralValue,
+            Table,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -17,7 +18,6 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable numerical `-` expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -98,7 +98,7 @@ impl ProofExpr for SubtractExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{Column, LiteralValue, Table},
+        database::{Column, ColumnId, LiteralValue, Table},
         map::IndexMap,
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -14,7 +14,6 @@ use crate::{
 use alloc::boxed::Box;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// TODO: This struct is only partially complete. This should not be used yet. Several constraints still need to be added.
 /// A gadget for proving divide and modulo expressions in tandem.
@@ -119,7 +118,7 @@ impl DivideAndModuloExpr {
     fn verifier_evaluate<S: Scalar, B: VerificationBuilder<S>>(
         &self,
         builder: &mut B,
-        accessor: &IndexMap<Ident, S>,
+        accessor: &IndexMap<ColumnId, S>,
         one_eval: S,
         params: &[LiteralValue],
     ) -> Result<(S, S), ProofError> {
@@ -177,8 +176,8 @@ mod tests {
         let first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(lhs.len());
         let mut final_round_builder = FinalRoundBuilder::new(lhs.len(), VecDeque::new());
         let table = Table::try_new(indexmap! {
-            lhs_ident => Column::Int128::<TestScalar>(lhs),
-            rhs_ident => Column::Int128::<TestScalar>(rhs),
+            lhs_ident.into() => Column::Int128::<TestScalar>(lhs),
+            rhs_ident.into() => Column::Int128::<TestScalar>(rhs),
         })
         .unwrap();
         divide_and_modulo_expr

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -7,7 +7,7 @@ use super::membership_check::{
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, table_utility::table, Column, ColumnField, ColumnRef,
+            owned_table_utility::*, table_utility::table, Column, ColumnField, ColumnId, ColumnRef,
             ColumnType, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
@@ -70,7 +70,7 @@ impl ProverEvaluate for MembershipCheckTestPlan {
         );
         builder.request_post_result_challenges(2);
         Ok(table([(
-            Ident::new("multiplicities"),
+            "multiplicities".into(),
             Column::Int128(multiplicities),
         )]))
     }
@@ -134,7 +134,7 @@ impl ProverEvaluate for MembershipCheckTestPlan {
             &candidate_columns,
         );
         Ok(table([(
-            Ident::new("multiplicities"),
+            "multiplicities".into(),
             Column::Int128(multiplicities),
         )]))
     }
@@ -146,6 +146,10 @@ impl ProofPlan for MembershipCheckTestPlan {
             Ident::new("multiplicities"),
             ColumnType::Int128,
         )]
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        vec!["multiplicities".into()]
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
@@ -166,7 +170,7 @@ impl ProofPlan for MembershipCheckTestPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        _accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -6,7 +6,8 @@ use super::monotonic::{
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnField, ColumnId, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions,
+            TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -18,7 +19,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
-use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 pub struct MonotonicTestPlan<const STRICT: bool, const ASC: bool> {
@@ -89,6 +89,10 @@ impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT
         vec![]
     }
 
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        vec![]
+    }
+
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         indexset! {self.column.clone()}
     }
@@ -102,7 +106,7 @@ impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        _accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -4,8 +4,8 @@ use super::permutation_check::{final_round_evaluate_permutation_check, verify_pe
 use crate::{
     base::{
         database::{
-            table_utility::table_with_row_count, ColumnField, ColumnRef, LiteralValue, Table,
-            TableEvaluation, TableOptions, TableRef,
+            table_utility::table_with_row_count, ColumnField, ColumnId, ColumnRef, LiteralValue,
+            Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -20,7 +20,6 @@ use bumpalo::{
     Bump,
 };
 use serde::Serialize;
-use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 pub struct PermutationCheckTestPlan {
@@ -131,7 +130,7 @@ impl ProofPlan for PermutationCheckTestPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        _accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -156,6 +155,10 @@ impl ProofPlan for PermutationCheckTestPlan {
             &candidate_permutation_evals,
         )?;
         Ok(TableEvaluation::new(vec![], (S::ZERO, 0)))
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        Vec::new()
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
@@ -5,8 +5,8 @@ use super::range_check::{
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTable, Table, TableEvaluation,
-            TableRef,
+            ColumnField, ColumnId, ColumnRef, ColumnType, LiteralValue, OwnedTable, Table,
+            TableEvaluation, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -18,7 +18,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
-use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 // A test plan for performing range checks on a specified column.
@@ -144,7 +143,7 @@ impl ProverEvaluate for RangeCheckTestPlan {
 impl ProofPlan for RangeCheckTestPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new(
-            self.column.column_id(),
+            self.column.column_name(),
             *self.column.column_type(),
         )]
     }
@@ -162,7 +161,7 @@ impl ProofPlan for RangeCheckTestPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -175,6 +174,10 @@ impl ProofPlan for RangeCheckTestPlan {
             vec![accessor[&self.column.table_ref()][&self.column.column_id()]],
             chi_eval_map[&self.column.table_ref()],
         ))
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        vec![self.column.column_id()]
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -207,8 +207,8 @@ mod tests {
     use crate::{
         base::{
             database::{
-                table_utility::*, ColumnField, ColumnRef, ColumnType, LiteralValue, Table,
-                TableEvaluation, TableOptions, TableRef, TableTestAccessor, TestAccessor,
+                table_utility::*, ColumnField, ColumnId, ColumnRef, ColumnType, LiteralValue,
+                Table, TableEvaluation, TableOptions, TableRef, TableTestAccessor, TestAccessor,
             },
             map::{indexset, IndexMap, IndexSet},
             proof::{PlaceholderResult, ProofError},
@@ -222,7 +222,6 @@ mod tests {
     use blitzar::proof::InnerProductProof;
     use bumpalo::Bump;
     use serde::Serialize;
-    use sqlparser::ast::Ident;
 
     #[derive(Debug, Serialize)]
     pub struct ShiftTestPlan {
@@ -331,7 +330,7 @@ mod tests {
         fn verifier_evaluate<S: Scalar>(
             &self,
             builder: &mut impl VerificationBuilder<S>,
-            _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+            _accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
             _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
             _params: &[LiteralValue],
         ) -> Result<TableEvaluation<S>, ProofError> {
@@ -344,6 +343,10 @@ mod tests {
             // Evaluate the verifier
             verify_shift(builder, alpha, beta, column_eval, chi_n_eval)?;
             Ok(TableEvaluation::new(vec![], (S::zero(), 0)))
+        }
+
+        fn get_column_identifiers(&self) -> Vec<ColumnId> {
+            vec![]
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
@@ -3,8 +3,8 @@ use crate::{
     base::{
         database::{
             group_by_util::{aggregate_columns, AggregatedColumns},
-            Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table, TableEvaluation,
-            TableRef,
+            Column, ColumnField, ColumnId, ColumnRef, ColumnType, LiteralValue, Table,
+            TableEvaluation, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -120,7 +120,7 @@ impl ProofPlan for AggregateExec {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -131,12 +131,11 @@ impl ProofPlan for AggregateExec {
             .verifier_evaluate(builder, accessor, chi_eval_map, params)?;
         let input_chi_eval = input_eval.chi_eval();
         // Build new accessors
-        let input_schema = self.input.get_column_result_fields();
+        let input_schema = self.input.get_column_identifiers();
         // Check for tables - this is just error handling, we don't need the table ref
         let accessor = input_schema
-            .iter()
-            .zip(input_eval.column_evals())
-            .map(|(field, eval)| (field.name().clone(), *eval))
+            .into_iter()
+            .zip(input_eval.column_evals().iter().copied())
             .collect::<IndexMap<_, _>>();
 
         // Compute g_in_star
@@ -221,15 +220,34 @@ impl ProofPlan for AggregateExec {
         self.group_by_exprs
             .iter()
             .map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+                ColumnField::new(
+                    aliased_expr.alias.name().clone(),
+                    aliased_expr.expr.data_type(),
+                )
             })
             .chain(self.sum_expr.iter().map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+                ColumnField::new(
+                    aliased_expr.alias.name().clone(),
+                    aliased_expr.expr.data_type(),
+                )
             }))
             .chain(iter::once(ColumnField::new(
                 self.count_alias.clone(),
                 ColumnType::BigInt,
             )))
+            .collect()
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.group_by_exprs
+            .iter()
+            .map(|aliased_expr| aliased_expr.alias.clone())
+            .chain(
+                self.sum_expr
+                    .iter()
+                    .map(|aliased_expr| aliased_expr.alias.clone()),
+            )
+            .chain(iter::once((&self.count_alias).into()))
             .collect()
     }
 
@@ -313,15 +331,12 @@ impl ProverEvaluate for AggregateExec {
             .map(|col| Column::Scalar(col))
             .chain(iter::once(Column::BigInt(count_column)));
         let res = Table::<'a, S>::try_from_iter(
-            self.get_column_result_fields()
-                .into_iter()
-                .map(|field| field.name())
-                .zip(
-                    group_by_result_columns
-                        .iter()
-                        .copied()
-                        .chain(sum_result_columns_iter.clone()),
-                ),
+            self.get_column_identifiers().into_iter().zip(
+                group_by_result_columns
+                    .iter()
+                    .copied()
+                    .chain(sum_result_columns_iter.clone()),
+            ),
         )
         .expect("Failed to create table from column references");
         // Prove result uniqueness if possible
@@ -458,9 +473,8 @@ impl ProverEvaluate for AggregateExec {
             .chain(sum_result_columns_iter.clone())
             .chain(iter::once(Column::BigInt(count_column)));
         let res = Table::<'a, S>::try_from_iter(
-            self.get_column_result_fields()
+            self.get_column_identifiers()
                 .into_iter()
-                .map(|field| field.name())
                 .zip(columns.clone()),
         )
         .expect("Failed to create table from column references");

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+        database::{
+            ColumnField, ColumnId, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef,
+        },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -12,7 +14,6 @@ use crate::{
 use alloc::vec::Vec;
 use bumpalo::Bump;
 use serde::Serialize;
-use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 pub(crate) struct DemoMockPlan {
@@ -23,7 +24,7 @@ impl ProofPlan for DemoMockPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         _builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -37,7 +38,7 @@ impl ProofPlan for DemoMockPlan {
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new(
-            self.column.column_id(),
+            self.column.column_name(),
             *self.column.column_type(),
         )]
     }
@@ -48,6 +49,10 @@ impl ProofPlan for DemoMockPlan {
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset! {self.column.table_ref()}
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        vec![self.column.column_id()]
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -4,7 +4,9 @@ use super::{
 };
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+        database::{
+            ColumnField, ColumnId, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -1,7 +1,8 @@
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnField, ColumnId, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions,
+            TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -15,7 +16,6 @@ use crate::{
 use alloc::vec::Vec;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Source [`ProofPlan`] for (sub)queries without table source such as `SELECT "No table here" as msg;`
 /// Inspired by [`DataFusion EmptyExec`](https://docs.rs/datafusion/latest/datafusion/physical_plan/empty/struct.EmptyExec.html)
@@ -40,7 +40,7 @@ impl ProofPlan for EmptyExec {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        _accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -60,6 +60,10 @@ impl ProofPlan for EmptyExec {
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
         IndexSet::default()
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        Vec::new()
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -2,8 +2,8 @@ use super::{fold_vals, DynProofPlan};
 use crate::{
     base::{
         database::{
-            filter_util::filter_columns, Column, ColumnField, ColumnRef, LiteralValue, Table,
-            TableEvaluation, TableOptions, TableRef,
+            filter_util::filter_columns, Column, ColumnField, ColumnId, ColumnRef, LiteralValue,
+            Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -21,7 +21,6 @@ use crate::{
 use alloc::{boxed::Box, vec::Vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable expressions for queries of the form
 /// ```ignore
@@ -70,7 +69,7 @@ impl ProofPlan for FilterExec {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -83,10 +82,9 @@ impl ProofPlan for FilterExec {
         let input_chi_eval = input_eval.chi();
 
         // Build new accessors
-        let input_schema = self.input.get_column_result_fields();
+        let input_schema = self.input.get_column_identifiers();
         let accessor = input_schema
-            .iter()
-            .map(ColumnField::name)
+            .into_iter()
             .zip(input_eval.column_evals().iter().copied())
             .collect::<IndexMap<_, _>>();
 
@@ -136,7 +134,10 @@ impl ProofPlan for FilterExec {
         self.aliased_results
             .iter()
             .map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+                ColumnField::new(
+                    aliased_expr.alias.name().clone(),
+                    aliased_expr.expr.data_type(),
+                )
             })
             .collect()
     }
@@ -147,6 +148,13 @@ impl ProofPlan for FilterExec {
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
         self.input.get_table_references()
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.aliased_results
+            .iter()
+            .map(|expr| expr.alias.clone())
+            .collect()
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -3,8 +3,8 @@ use crate::{
     base::{
         database::{
             group_by_util::{aggregate_columns, AggregatedColumns},
-            Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table, TableEvaluation,
-            TableRef,
+            Column, ColumnField, ColumnId, ColumnRef, ColumnType, LiteralValue, Table,
+            TableEvaluation, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -118,7 +118,7 @@ impl ProofPlan for GroupByExec {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -213,7 +213,10 @@ impl ProofPlan for GroupByExec {
             .iter()
             .map(|col| col.get_column_field())
             .chain(self.sum_expr.iter().map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+                ColumnField::new(
+                    aliased_expr.alias.name().clone(),
+                    aliased_expr.expr.data_type(),
+                )
             }))
             .chain(iter::once(ColumnField::new(
                 self.count_alias.clone(),
@@ -239,6 +242,19 @@ impl ProofPlan for GroupByExec {
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
         IndexSet::from_iter([self.table.table_ref.clone()])
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.group_by_exprs
+            .iter()
+            .map(ColumnExpr::column_id)
+            .chain(
+                self.sum_expr
+                    .iter()
+                    .map(|aliased_expr| aliased_expr.alias.clone()),
+            )
+            .chain(iter::once((&self.count_alias).into()))
+            .collect()
     }
 }
 
@@ -305,15 +321,12 @@ impl ProverEvaluate for GroupByExec {
             .map(|col| Column::Scalar(col))
             .chain(iter::once(Column::BigInt(count_column)));
         let res = Table::<'a, S>::try_from_iter(
-            self.get_column_result_fields()
-                .into_iter()
-                .map(|field| field.name())
-                .zip(
-                    group_by_result_columns
-                        .iter()
-                        .copied()
-                        .chain(sum_result_columns_iter.clone()),
-                ),
+            self.get_column_identifiers().into_iter().zip(
+                group_by_result_columns
+                    .iter()
+                    .copied()
+                    .chain(sum_result_columns_iter.clone()),
+            ),
         )
         .expect("Failed to create table from column references");
         // Prove result uniqueness if possible
@@ -444,9 +457,8 @@ impl ProverEvaluate for GroupByExec {
             .chain(sum_result_columns_iter.clone())
             .chain(iter::once(Column::BigInt(count_column)));
         let res = Table::<'a, S>::try_from_iter(
-            self.get_column_result_fields()
+            self.get_column_identifiers()
                 .into_iter()
-                .map(|field| field.name())
                 .zip(columns.clone()),
         )
         .expect("Failed to create table from column references");

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
@@ -2,8 +2,8 @@ use super::fold_vals;
 use crate::{
     base::{
         database::{
-            filter_util::filter_columns, Column, ColumnField, ColumnRef, LiteralValue, Table,
-            TableEvaluation, TableOptions, TableRef,
+            filter_util::filter_columns, Column, ColumnField, ColumnId, ColumnRef, LiteralValue,
+            Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -23,7 +23,6 @@ use alloc::vec::Vec;
 use bumpalo::Bump;
 use core::marker::PhantomData;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable expressions for queries of the form
 /// ```ignore
@@ -78,7 +77,7 @@ where
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -138,7 +137,10 @@ where
         self.aliased_results
             .iter()
             .map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+                ColumnField::new(
+                    aliased_expr.alias.name().clone(),
+                    aliased_expr.expr.data_type(),
+                )
             })
             .collect()
     }
@@ -157,6 +159,13 @@ where
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
         IndexSet::from_iter([self.table.table_ref.clone()])
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.aliased_results
+            .iter()
+            .map(|aliased_expr| aliased_expr.alias.clone())
+            .collect()
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -2,8 +2,8 @@ use super::DynProofPlan;
 use crate::{
     base::{
         database::{
-            Column, ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions,
-            TableRef,
+            Column, ColumnField, ColumnId, ColumnRef, LiteralValue, Table, TableEvaluation,
+            TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -20,7 +20,6 @@ use crate::{
 use alloc::{boxed::Box, vec::Vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Provable expressions for queries of the form
 /// ```ignore
@@ -56,7 +55,7 @@ impl ProofPlan for ProjectionExec {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -68,11 +67,10 @@ impl ProofPlan for ProjectionExec {
         // Build new accessors
         // TODO: Make this work with inputs with multiple tables such as join
         // and union results
-        let input_schema = self.input.get_column_result_fields();
+        let input_schema = self.input.get_column_identifiers();
         let current_accessor = input_schema
-            .iter()
-            .zip(input_eval.column_evals())
-            .map(|(field, eval)| (field.name().clone(), *eval))
+            .into_iter()
+            .zip(input_eval.column_evals().iter().copied())
             .collect::<IndexMap<_, _>>();
         let output_column_evals = self
             .aliased_results
@@ -90,7 +88,10 @@ impl ProofPlan for ProjectionExec {
         self.aliased_results
             .iter()
             .map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+                ColumnField::new(
+                    aliased_expr.alias.name().clone(),
+                    aliased_expr.expr.data_type(),
+                )
             })
             .collect()
     }
@@ -102,6 +103,13 @@ impl ProofPlan for ProjectionExec {
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
         self.input.get_table_references()
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.aliased_results
+            .iter()
+            .map(|expr| expr.alias.clone())
+            .collect()
     }
 }
 
@@ -128,7 +136,7 @@ impl ProverEvaluate for ProjectionExec {
             .aliased_results
             .iter()
             .map(
-                |aliased_expr| -> PlaceholderResult<(Ident, Column<'a, S>)> {
+                |aliased_expr| -> PlaceholderResult<(ColumnId, Column<'a, S>)> {
                     Ok((
                         aliased_expr.alias.clone(),
                         aliased_expr
@@ -171,7 +179,7 @@ impl ProverEvaluate for ProjectionExec {
             .aliased_results
             .iter()
             .map(
-                |aliased_expr| -> PlaceholderResult<(Ident, Column<'a, S>)> {
+                |aliased_expr| -> PlaceholderResult<(ColumnId, Column<'a, S>)> {
                     Ok((
                         aliased_expr.alias.clone(),
                         aliased_expr

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -2,7 +2,7 @@ use super::DynProofPlan;
 use crate::{
     base::{
         database::{
-            filter_util::filter_columns, ColumnField, ColumnRef, LiteralValue, Table,
+            filter_util::filter_columns, ColumnField, ColumnId, ColumnRef, LiteralValue, Table,
             TableEvaluation, TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
@@ -23,7 +23,6 @@ use bumpalo::Bump;
 use core::iter::repeat;
 use itertools::repeat_n;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// `ProofPlan` for queries of the form
 /// ```ignore
@@ -74,7 +73,7 @@ where
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -145,6 +144,10 @@ where
     fn get_table_references(&self) -> IndexSet<TableRef> {
         self.input.get_table_references()
     }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.input.get_column_identifiers()
+    }
 }
 
 impl ProverEvaluate for SliceExec {
@@ -181,9 +184,8 @@ impl ProverEvaluate for SliceExec {
             builder.produce_intermediate_mle(column);
         });
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.get_column_result_fields()
+            self.get_column_identifiers()
                 .into_iter()
-                .map(|expr| expr.name())
                 .zip(filtered_columns),
             TableOptions::new(Some(output_length)),
         )
@@ -234,9 +236,8 @@ impl ProverEvaluate for SliceExec {
             result_len,
         );
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.get_column_result_fields()
+            self.get_column_identifiers()
                 .into_iter()
-                .map(|expr| expr.name())
                 .zip(filtered_columns),
             TableOptions::new(Some(output_length)),
         )

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -7,7 +7,8 @@ use crate::{
                 ordered_set_union,
             },
             slice_operation::apply_slice_to_indexes,
-            ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnField, ColumnId, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions,
+            TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -145,7 +146,7 @@ where
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -311,6 +312,10 @@ where
             .chain(self.right.get_table_references())
             .collect()
     }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.result_idents.iter().map(ColumnId::from).collect()
+    }
 }
 
 impl ProverEvaluate for SortMergeJoinExec {
@@ -427,7 +432,7 @@ impl ProverEvaluate for SortMergeJoinExec {
         let tab = Table::try_from_iter_with_options(
             self.result_idents
                 .iter()
-                .cloned()
+                .map(ColumnId::from)
                 .zip_eq(join_left_right_columns.result_columns()),
             TableOptions::new(Some(num_rows_res)),
         )
@@ -577,7 +582,7 @@ impl ProverEvaluate for SortMergeJoinExec {
         Ok(Table::try_from_iter_with_options(
             self.result_idents
                 .iter()
-                .cloned()
+                .map(ColumnId::from)
                 .zip_eq(join_left_right_columns.result_columns()),
             TableOptions::new(Some(num_rows_res)),
         )

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+        database::{
+            ColumnField, ColumnId, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef,
+        },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -13,7 +15,6 @@ use crate::{
 use alloc::vec::Vec;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// Source [`ProofPlan`] for (sub)queries with table source such as `SELECT col from tab;`
 /// Inspired by `DataFusion` data source [`ExecutionPlan`]s such as [`ArrowExec`] and [`CsvExec`].
@@ -51,7 +52,7 @@ impl ProofPlan for TableExec {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -59,10 +60,11 @@ impl ProofPlan for TableExec {
             .schema
             .iter()
             .map(|field| {
+                let column_id: ColumnId = field.name().into();
                 *accessor
                     .get(self.table_ref())
                     .expect("Table does not exist")
-                    .get(&field.name())
+                    .get(&column_id)
                     .expect("Column does not exist")
             })
             .collect::<Vec<_>>();
@@ -85,6 +87,13 @@ impl ProofPlan for TableExec {
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset! {self.table_ref.clone()}
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.schema
+            .iter()
+            .map(|field| field.name().into())
+            .collect()
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -2,7 +2,7 @@ use super::DynProofPlan;
 use crate::{
     base::{
         database::{
-            union_util::table_union, Column, ColumnField, ColumnRef, LiteralValue, Table,
+            union_util::table_union, Column, ColumnField, ColumnId, ColumnRef, LiteralValue, Table,
             TableEvaluation, TableRef,
         },
         map::{IndexMap, IndexSet},
@@ -22,7 +22,6 @@ use crate::{
 use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
 
 /// `ProofPlan` for queries of the form
 /// ```ignore
@@ -58,7 +57,7 @@ where
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        accessor: &IndexMap<TableRef, IndexMap<ColumnId, S>>,
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
@@ -120,6 +119,13 @@ where
             .iter()
             .flat_map(ProofPlan::get_table_references)
             .collect()
+    }
+
+    fn get_column_identifiers(&self) -> Vec<ColumnId> {
+        self.inputs
+            .first()
+            .expect("Union inputs should not be empty")
+            .get_column_identifiers()
     }
 }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
