### PR TITLE
fix: support timestamps in planner more effectively

### DIFF
--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -81,6 +81,9 @@ pub(crate) fn scalar_value_to_literal_value(value: ScalarValue) -> PlannerResult
             PoSQLTimeZone::utc(),
             v,
         )),
+        ScalarValue::TimestampMillisecond(Some(v), Some(tz)) if tz.to_string() == "+00:00" => Ok(
+            LiteralValue::TimeStampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc(), v),
+        ),
         ScalarValue::TimestampMicrosecond(Some(v), None) => Ok(LiteralValue::TimeStampTZ(
             PoSQLTimeUnit::Microsecond,
             PoSQLTimeZone::utc(),
@@ -336,6 +339,18 @@ mod tests {
 
         // TimestampMillisecond
         let value = ScalarValue::TimestampMillisecond(Some(1_741_236_192_004_i64), None);
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::TimeStampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                1_741_236_192_004_i64
+            )
+        );
+
+        // TimestampMillisecond
+        let value =
+            ScalarValue::TimestampMillisecond(Some(1_741_236_192_004_i64), Some("+00:00".into()));
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::TimeStampTZ(

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -483,6 +483,37 @@ fn test_coin() {
 }
 
 #[test]
+fn test_timestamp() {
+    let alloc = Bump::new();
+    let sql = "SELECT CAST(timestamp as bigint) AS cast_timestamp FROM transactions WHERE timestamp <= '2026-03-01';";
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "transactions") => table(
+            vec![
+                borrowed_timestamptz("timestamp", PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc(), [1_740_787_100_000, 1_840_787_300_000], &alloc),
+            ]
+        )
+    };
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![owned_table([bigint(
+        "cast_timestamp",
+        [1_740_787_100_000i64],
+    )])];
+
+    // Create public parameters for DynamicDoryEvaluationProof
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[LiteralValue::VarChar("0x2".to_string())],
+    );
+}
+
+#[test]
 fn test_join() {
     let alloc = Bump::new();
     let sql = "SELECT column1, column2, column3 FROM table1 JOIN table2 ON table1.common_column = table2.common_column JOIN table3 on table3.another_column = table2.another_column;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This allows us to cover milliseconds/utc timestamps more effectively. We miss some pattern matching right now.

# What changes are included in this PR?

Supporting timestamps as intended.

# Are these changes tested?
Yes.
