### PR TITLE
test: improve coverage for uncovered code paths

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -579,6 +579,99 @@ mod tests {
     }
 
     #[test]
+    fn we_can_convert_binary_exprs_by_operator_directly() {
+        let boolean_schema = vec![
+            ("column1".into(), ColumnType::Boolean),
+            ("column2".into(), ColumnType::Boolean),
+        ];
+        assert_eq!(
+            binary_expr_to_proof_expr(
+                &df_column("namespace.table_name", "column1"),
+                &df_column("namespace.table_name", "column2"),
+                Operator::And,
+                &boolean_schema,
+            )
+            .unwrap(),
+            DynProofExpr::try_new_and(COLUMN1_BOOLEAN(), COLUMN2_BOOLEAN()).unwrap()
+        );
+        assert_eq!(
+            binary_expr_to_proof_expr(
+                &df_column("namespace.table_name", "column1"),
+                &df_column("namespace.table_name", "column2"),
+                Operator::Or,
+                &boolean_schema,
+            )
+            .unwrap(),
+            DynProofExpr::try_new_or(COLUMN1_BOOLEAN(), COLUMN2_BOOLEAN()).unwrap()
+        );
+
+        let numeric_schema = vec![
+            ("column1".into(), ColumnType::SmallInt),
+            ("column2".into(), ColumnType::BigInt),
+        ];
+        assert_eq!(
+            binary_expr_to_proof_expr(
+                &df_column("namespace.table_name", "column1"),
+                &df_column("namespace.table_name", "column2"),
+                Operator::Multiply,
+                &numeric_schema,
+            )
+            .unwrap(),
+            DynProofExpr::try_new_multiply(COLUMN1_SMALLINT(), COLUMN2_BIGINT()).unwrap()
+        );
+        assert_eq!(
+            binary_expr_to_proof_expr(
+                &df_column("namespace.table_name", "column1"),
+                &df_column("namespace.table_name", "column2"),
+                Operator::Eq,
+                &numeric_schema,
+            )
+            .unwrap(),
+            DynProofExpr::try_new_equals(COLUMN1_SMALLINT(), COLUMN2_BIGINT()).unwrap()
+        );
+        assert_eq!(
+            binary_expr_to_proof_expr(
+                &df_column("namespace.table_name", "column1"),
+                &df_column("namespace.table_name", "column2"),
+                Operator::Lt,
+                &numeric_schema,
+            )
+            .unwrap(),
+            DynProofExpr::try_new_inequality(COLUMN1_SMALLINT(), COLUMN2_BIGINT(), true).unwrap()
+        );
+        assert_eq!(
+            binary_expr_to_proof_expr(
+                &df_column("namespace.table_name", "column1"),
+                &df_column("namespace.table_name", "column2"),
+                Operator::Gt,
+                &numeric_schema,
+            )
+            .unwrap(),
+            DynProofExpr::try_new_inequality(COLUMN1_SMALLINT(), COLUMN2_BIGINT(), false).unwrap()
+        );
+        assert_eq!(
+            binary_expr_to_proof_expr(
+                &df_column("namespace.table_name", "column1"),
+                &df_column("namespace.table_name", "column2"),
+                Operator::Plus,
+                &numeric_schema,
+            )
+            .unwrap(),
+            DynProofExpr::try_new_add(COLUMN1_SMALLINT(), COLUMN2_BIGINT()).unwrap()
+        );
+        assert_eq!(
+            binary_expr_to_proof_expr(
+                &df_column("namespace.table_name", "column1"),
+                &df_column("namespace.table_name", "column2"),
+                Operator::Minus,
+                &numeric_schema,
+            )
+            .unwrap(),
+            DynProofExpr::try_new_subtract(COLUMN1_SMALLINT(), COLUMN2_BIGINT()).unwrap()
+        );
+    }
+
+    #[test]
     fn we_can_convert_logical_not_eq_to_proof_expr() {
         let schema = vec![
             ("column1".into(), ColumnType::BigInt),

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1430,6 +1430,70 @@ mod tests {
     }
 
     #[test]
+    fn we_cannot_aggregate_when_alias_for_aggregate_expr_is_missing() {
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new("table", TABLE_SOURCE(), Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &[],
+            &[SUM_B()],
+            &SCHEMAS(),
+            &indexmap! {},
+        );
+
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_when_aggr_expr_is_not_an_aggregate_function() {
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new("table", TABLE_SOURCE(), Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &[],
+            &[df_column("table", "b")],
+            &SCHEMAS(),
+            &indexmap! {},
+        );
+
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_with_nonprovable_single_group_column() {
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new("table", TABLE_SOURCE(), Some(vec![1, 2]), vec![], None).unwrap(),
+        );
+        let alias_map = indexmap! {
+            "table.c".to_string() => "c".to_string(),
+            "SUM(table.b)".to_string() => "sum_b".to_string(),
+        };
+
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &[df_column("table", "c")],
+            &[SUM_B()],
+            &SCHEMAS(),
+            &alias_map,
+        );
+
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
     fn we_cannot_aggregate_with_fetch_limit() {
         // Setup group expression
         let group_expr = vec![df_column("table", "a")];
@@ -2230,6 +2294,37 @@ mod tests {
         assert!(
             matches!(join_err, PlannerError::UnsupportedLogicalPlan { plan: logical_plan } if *logical_plan == plan )
         );
+    }
+
+    #[test]
+    fn we_cannot_join_on_mismatched_column_names() {
+        let left = LogicalPlan::TableScan(
+            TableScan::try_new("table", TABLE_SOURCE(), Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+        let right = LogicalPlan::TableScan(
+            TableScan::try_new("table", TABLE_SOURCE(), Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+        let join_plan = LogicalPlan::Join(Join {
+            left: Arc::new(left),
+            right: Arc::new(right),
+            on: vec![(df_column("table", "a"), df_column("table", "b"))],
+            filter: None,
+            join_type: JoinType::Inner,
+            join_constraint: JoinConstraint::On,
+            schema: Arc::new(DFSchema::empty()),
+            null_equals_null: false,
+        });
+
+        let join = match &join_plan {
+            LogicalPlan::Join(join) => join,
+            _ => unreachable!(),
+        };
+        let result = join_to_proof_plan(join, &SCHEMAS(), &join_plan);
+
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
     }
 
     // Filter (LogicalPlan::Filter) tests - Happy paths

--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -348,6 +348,70 @@ mod tests {
     }
 
     #[test]
+    fn we_can_convert_timestamp_millisecond_array_normal_range() {
+        let alloc = Bump::new();
+        let data = vec![1_625_072_400_000, 1_625_076_000_000, 1_625_083_200_000];
+        let array: ArrayRef = Arc::new(TimestampMillisecondArray::with_timezone_opt(
+            data.clone().into(),
+            Some("UTC"),
+        ));
+
+        let result = array.to_column::<TestScalar>(&alloc, &(1..3), None);
+        assert_eq!(
+            result.unwrap(),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                &data[1..3]
+            )
+        );
+    }
+
+    #[test]
+    fn we_can_convert_timestamp_microsecond_array_normal_range() {
+        let alloc = Bump::new();
+        let data = vec![
+            1_625_072_400_000_000,
+            1_625_076_000_000_000,
+            1_625_083_200_000_000,
+        ];
+        let array: ArrayRef = Arc::new(TimestampMicrosecondArray::with_timezone_opt(
+            data.clone().into(),
+            Some("+00:00"),
+        ));
+
+        let result = array.to_column::<TestScalar>(&alloc, &(1..3), None);
+        assert_eq!(
+            result.unwrap(),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Microsecond,
+                PoSQLTimeZone::utc(),
+                &data[1..3]
+            )
+        );
+    }
+
+    #[test]
+    fn we_can_convert_timestamp_nanosecond_array_normal_range() {
+        let alloc = Bump::new();
+        let data = vec![
+            1_625_072_400_000_000_000,
+            1_625_076_000_000_000_000,
+            1_625_083_200_000_000_000,
+        ];
+        let array: ArrayRef = Arc::new(TimestampNanosecondArray::with_timezone_opt(
+            data.clone().into(),
+            Some("Z"),
+        ));
+
+        let result = array.to_column::<TestScalar>(&alloc, &(1..3), None);
+        assert_eq!(
+            result.unwrap(),
+            Column::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc(), &data[1..3])
+        );
+    }
+
+    #[test]
     fn we_can_build_an_empty_column_from_an_empty_range_timestamp() {
         let alloc = Bump::new();
         let data = vec![1_625_072_400, 1_625_076_000]; // Example Unix timestamps
@@ -1083,6 +1147,14 @@ mod tests {
     fn we_can_convert_valid_integer_array_refs_into_valid_columns_using_ranges_smaller_than_arrays()
     {
         let alloc = Bump::new();
+
+        let array: ArrayRef = Arc::new(arrow::array::UInt8Array::from(vec![0_u8, 1, 255]));
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(1..3), None)
+                .unwrap(),
+            Column::Uint8(&[1, 255])
+        );
 
         let array: ArrayRef = Arc::new(arrow::array::Int8Array::from(vec![0, 1, 127]));
         assert_eq!(

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -96,4 +96,30 @@ mod tests {
             prop_assert_eq!(actual, column_type);
         }
     }
+
+    #[test]
+    #[should_panic(expected = "Cannot convert Scalar type to arrow type")]
+    fn we_cannot_convert_scalar_column_types_to_arrow_types() {
+        let _ = DataType::from(&ColumnType::Scalar);
+    }
+
+    #[test]
+    fn we_can_roundtrip_timestamp_units_and_reject_unsupported_arrow_types() {
+        for (posql_unit, arrow_unit) in [
+            (PoSQLTimeUnit::Second, ArrowTimeUnit::Second),
+            (PoSQLTimeUnit::Millisecond, ArrowTimeUnit::Millisecond),
+            (PoSQLTimeUnit::Microsecond, ArrowTimeUnit::Microsecond),
+            (PoSQLTimeUnit::Nanosecond, ArrowTimeUnit::Nanosecond),
+        ] {
+            let column_type = ColumnType::TimestampTZ(posql_unit, PoSQLTimeZone::utc());
+            let arrow_type = DataType::from(&column_type);
+            assert_eq!(
+                arrow_type,
+                DataType::Timestamp(arrow_unit, Some(Arc::from("+00:00")))
+            );
+            assert_eq!(ColumnType::try_from(arrow_type).unwrap(), column_type);
+        }
+
+        assert!(ColumnType::try_from(DataType::UInt16).is_err());
+    }
 }

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -2,17 +2,22 @@ use super::owned_and_arrow_conversions::OwnedArrowConversionError;
 use crate::base::{
     database::{owned_table_utility::*, OwnedColumn, OwnedTable},
     map::IndexMap,
+    math::decimal::Precision,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
 };
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
-        StringArray,
+        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Float32Array, Int16Array,
+        Int32Array, Int64Array, Int8Array, LargeBinaryArray, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt8Array,
     },
-    datatypes::{DataType, Field, Schema},
+    datatypes::{i256, DataType, Field, Schema},
     record_batch::RecordBatch,
 };
+use core::str::FromStr;
 use proptest::prelude::*;
 
 fn we_can_convert_between_owned_column_and_array_ref_impl(
@@ -48,6 +53,30 @@ fn we_can_convert_between_bigint_owned_column_and_array_ref_impl(data: Vec<i64>)
         Arc::new(Int64Array::from(data)),
     );
 }
+fn we_can_convert_between_uint8_owned_column_and_array_ref_impl(data: Vec<u8>) {
+    we_can_convert_between_owned_column_and_array_ref_impl(
+        &OwnedColumn::<TestScalar>::Uint8(data.clone()),
+        Arc::new(UInt8Array::from(data)),
+    );
+}
+fn we_can_convert_between_tinyint_owned_column_and_array_ref_impl(data: Vec<i8>) {
+    we_can_convert_between_owned_column_and_array_ref_impl(
+        &OwnedColumn::<TestScalar>::TinyInt(data.clone()),
+        Arc::new(Int8Array::from(data)),
+    );
+}
+fn we_can_convert_between_smallint_owned_column_and_array_ref_impl(data: Vec<i16>) {
+    we_can_convert_between_owned_column_and_array_ref_impl(
+        &OwnedColumn::<TestScalar>::SmallInt(data.clone()),
+        Arc::new(Int16Array::from(data)),
+    );
+}
+fn we_can_convert_between_int_owned_column_and_array_ref_impl(data: Vec<i32>) {
+    we_can_convert_between_owned_column_and_array_ref_impl(
+        &OwnedColumn::<TestScalar>::Int(data.clone()),
+        Arc::new(Int32Array::from(data)),
+    );
+}
 fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
         &OwnedColumn::<TestScalar>::Int128(data.clone()),
@@ -64,21 +93,100 @@ fn we_can_convert_between_varchar_owned_column_and_array_ref_impl(data: Vec<Stri
         Arc::new(StringArray::from(data)),
     );
 }
+fn we_can_convert_between_decimal75_owned_column_and_array_ref_impl(data: Vec<i64>) {
+    let owned_col = OwnedColumn::<TestScalar>::Decimal75(
+        Precision::new(20).unwrap(),
+        4,
+        data.iter().copied().map(TestScalar::from).collect(),
+    );
+    let converted = data
+        .into_iter()
+        .map(|value| i256::from_str(&value.to_string()).unwrap())
+        .collect::<Vec<_>>();
+    let arrow_col = Arc::new(
+        Decimal256Array::from(converted)
+            .with_precision_and_scale(20, 4)
+            .unwrap(),
+    );
+    we_can_convert_between_owned_column_and_array_ref_impl(&owned_col, arrow_col);
+}
+fn we_can_convert_between_timestamptz_owned_column_and_array_ref_impl(
+    time_unit: PoSQLTimeUnit,
+    data: Vec<i64>,
+) {
+    let owned_col =
+        OwnedColumn::<TestScalar>::TimestampTZ(time_unit, PoSQLTimeZone::utc(), data.clone());
+    let arrow_col: ArrayRef = match time_unit {
+        PoSQLTimeUnit::Second => Arc::new(TimestampSecondArray::from(data)),
+        PoSQLTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(data)),
+        PoSQLTimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(data)),
+        PoSQLTimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::from(data)),
+    };
+    we_can_convert_between_owned_column_and_array_ref_impl(&owned_col, arrow_col);
+}
 #[test]
 fn we_can_convert_between_owned_column_and_array_ref() {
     we_can_convert_between_boolean_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_uint8_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_tinyint_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_smallint_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_int_owned_column_and_array_ref_impl(vec![]);
     we_can_convert_between_bigint_owned_column_and_array_ref_impl(vec![]);
     we_can_convert_between_int128_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_decimal75_owned_column_and_array_ref_impl(vec![]);
     we_can_convert_between_varchar_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_timestamptz_owned_column_and_array_ref_impl(
+        PoSQLTimeUnit::Second,
+        vec![],
+    );
+    we_can_convert_between_timestamptz_owned_column_and_array_ref_impl(
+        PoSQLTimeUnit::Millisecond,
+        vec![],
+    );
+    we_can_convert_between_timestamptz_owned_column_and_array_ref_impl(
+        PoSQLTimeUnit::Microsecond,
+        vec![],
+    );
+    we_can_convert_between_timestamptz_owned_column_and_array_ref_impl(
+        PoSQLTimeUnit::Nanosecond,
+        vec![],
+    );
     let data = vec![true, false, true, false, true, false, true, false, true];
     we_can_convert_between_boolean_owned_column_and_array_ref_impl(data);
+    let data = vec![0_u8, 1, 2, 3, 42, u8::MAX];
+    we_can_convert_between_uint8_owned_column_and_array_ref_impl(data);
+    let data = vec![0_i8, 1, 2, 3, -42, i8::MIN, i8::MAX];
+    we_can_convert_between_tinyint_owned_column_and_array_ref_impl(data);
+    let data = vec![0_i16, 1, 2, 3, -42, i16::MIN, i16::MAX];
+    we_can_convert_between_smallint_owned_column_and_array_ref_impl(data);
+    let data = vec![0_i32, 1, 2, 3, -42, i32::MIN, i32::MAX];
+    we_can_convert_between_int_owned_column_and_array_ref_impl(data);
     let data = vec![0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX];
     we_can_convert_between_bigint_owned_column_and_array_ref_impl(data);
     let data = vec![0, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX];
     we_can_convert_between_int128_owned_column_and_array_ref_impl(data);
+    let data = vec![0_i64, 1, -1, 12_345, -67_890];
+    we_can_convert_between_decimal75_owned_column_and_array_ref_impl(data);
     let data = vec!["0", "1", "2", "3", "4", "5", "6"];
     we_can_convert_between_varchar_owned_column_and_array_ref_impl(
         data.into_iter().map(String::from).collect(),
+    );
+    let data = vec![0_i64, 1, -1, 1_625_072_400];
+    we_can_convert_between_timestamptz_owned_column_and_array_ref_impl(
+        PoSQLTimeUnit::Second,
+        data.clone(),
+    );
+    we_can_convert_between_timestamptz_owned_column_and_array_ref_impl(
+        PoSQLTimeUnit::Millisecond,
+        data.clone(),
+    );
+    we_can_convert_between_timestamptz_owned_column_and_array_ref_impl(
+        PoSQLTimeUnit::Microsecond,
+        data.clone(),
+    );
+    we_can_convert_between_timestamptz_owned_column_and_array_ref_impl(
+        PoSQLTimeUnit::Nanosecond,
+        data,
     );
 
     let varbin_data = vec![
@@ -98,6 +206,16 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
     assert!(matches!(
         OwnedColumn::<TestScalar>::try_from(array_ref),
         Err(OwnedArrowConversionError::UnsupportedType { .. })
+    ));
+}
+
+#[test]
+fn we_get_a_null_not_supported_error_when_trying_to_convert_from_a_nullable_boolean_array_ref_to_an_owned_column(
+) {
+    let array_ref: ArrayRef = Arc::new(BooleanArray::from(vec![Some(true), None]));
+    assert!(matches!(
+        OwnedColumn::<TestScalar>::try_from(array_ref),
+        Err(OwnedArrowConversionError::NullNotSupportedYet)
     ));
 }
 
@@ -191,6 +309,40 @@ fn we_can_convert_between_owned_table_and_record_batch() {
         ]),
         &batch2,
     );
+
+    let complex_table = owned_table::<TestScalar>([
+        uint8("uint8", [0_u8, 1, 2, u8::MAX]),
+        tinyint("tinyint", [0_i8, -1, 42, i8::MAX]),
+        smallint("smallint", [0_i16, -1, 42, i16::MAX]),
+        int("int32", [0_i32, -1, 42, i32::MAX]),
+        varbinary(
+            "bytes",
+            [
+                b"foo".to_vec(),
+                b"".to_vec(),
+                b"bar".to_vec(),
+                vec![0, 1, 2],
+            ],
+        ),
+        decimal75("decimal", 20, 4, [0_i64, -1, 12_345, -67_890]),
+        timestamptz(
+            "ts_ms",
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            [0_i64, 1, -1, 1_625_072_400],
+        ),
+        timestamptz(
+            "ts_ns",
+            PoSQLTimeUnit::Nanosecond,
+            PoSQLTimeZone::utc(),
+            [0_i64, 1, -1, 1_625_072_400],
+        ),
+    ]);
+    let complex_batch = RecordBatch::try_from(complex_table.clone()).unwrap();
+    let complex_roundtrip = OwnedTable::try_from(complex_batch.clone()).unwrap();
+
+    assert_eq!(complex_roundtrip, complex_table);
+    assert_eq!(complex_batch.num_columns(), 8);
 }
 
 #[test]
@@ -198,6 +350,27 @@ fn we_can_convert_between_owned_table_and_record_batch() {
 fn we_panic_when_converting_an_owned_table_with_a_scalar_column() {
     let owned_table = owned_table::<TestScalar>([scalar("a", [0; 0])]);
     let _ = RecordBatch::try_from(owned_table);
+}
+
+#[test]
+fn we_get_a_duplicate_ident_error_when_converting_a_record_batch_with_case_conflicting_columns() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("dup", DataType::Int64, false),
+        Field::new("dup", DataType::Int64, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1_i64, 2])),
+            Arc::new(Int64Array::from(vec![3_i64, 4])),
+        ],
+    )
+    .unwrap();
+
+    assert!(matches!(
+        OwnedTable::<TestScalar>::try_from(batch),
+        Err(OwnedArrowConversionError::DuplicateIdents)
+    ));
 }
 
 proptest! {

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -177,3 +177,83 @@ mod tests {
         assert_eq!(commitment, expected_commitment);
     }
 }
+
+#[cfg(test)]
+mod portable_tests {
+    use super::*;
+    use crate::base::commitment::naive_commitment::NaiveCommitment;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use arrow::{
+        array::{ArrayRef, Int64Array, StringArray},
+        datatypes::{DataType, Field, Schema},
+        record_batch::RecordBatch,
+    };
+    use std::sync::Arc;
+
+    #[test]
+    fn we_can_convert_record_batches_to_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["x", "y", "z"])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+
+        let columns = batch_to_columns::<TestScalar>(&batch, &alloc).unwrap();
+
+        assert_eq!(columns[0].0.value, "a");
+        assert_eq!(columns[0].1, Column::BigInt(&[1, 2, 3]));
+        assert_eq!(columns[1].0.value, "b");
+    }
+
+    #[test]
+    fn appending_a_mismatched_record_batch_returns_a_mismatch_error() {
+        let schema_bigint = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let schema_text = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, false)]));
+        let base_batch = RecordBatch::try_new(
+            schema_bigint,
+            vec![Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef],
+        )
+        .unwrap();
+        let mismatch_batch = RecordBatch::try_new(
+            schema_text,
+            vec![Arc::new(StringArray::from(vec!["x", "y", "z"])) as ArrayRef],
+        )
+        .unwrap();
+
+        let mut commitment = TableCommitment::<NaiveCommitment>::try_from_record_batch(&base_batch, &())
+            .unwrap();
+        let result = commitment.try_append_record_batch(&mismatch_batch, &());
+
+        assert!(matches!(
+            result,
+            Err(AppendRecordBatchTableCommitmentError::ColumnCommitmentsMismatch { .. })
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "RecordBatches cannot have duplicate identifiers")]
+    fn duplicate_record_batch_identifiers_panic_when_creating_commitments() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("dup", DataType::Int64, false),
+            Field::new("dup", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["x", "y"])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let _ = TableCommitment::<NaiveCommitment>::try_from_record_batch_with_offset(&batch, 7, &());
+    }
+}

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -491,6 +491,47 @@ mod tests {
     }
 
     #[test]
+    fn we_can_construct_max_bounds_metadata_for_ordered_column_types() {
+        let max_smallint =
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::SmallInt);
+        let max_int = ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::Int);
+        let max_bigint =
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::BigInt);
+        let max_timestamp = ColumnCommitmentMetadata::from_column_type_with_max_bounds(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        );
+        let max_int128 =
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::Int128);
+
+        assert_eq!(max_smallint.column_type(), &ColumnType::SmallInt);
+        assert_eq!(max_int.column_type(), &ColumnType::Int);
+        assert_eq!(max_bigint.column_type(), &ColumnType::BigInt);
+        assert_eq!(
+            max_timestamp.column_type(),
+            &ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc())
+        );
+        assert_eq!(max_int128.column_type(), &ColumnType::Int128);
+
+        assert!(matches!(
+            max_smallint.bounds(),
+            ColumnBounds::SmallInt(Bounds::Bounded(_))
+        ));
+        assert!(matches!(max_int.bounds(), ColumnBounds::Int(Bounds::Bounded(_))));
+        assert!(matches!(
+            max_bigint.bounds(),
+            ColumnBounds::BigInt(Bounds::Bounded(_))
+        ));
+        assert!(matches!(
+            max_timestamp.bounds(),
+            ColumnBounds::TimestampTZ(Bounds::Bounded(_))
+        ));
+        assert!(matches!(
+            max_int128.bounds(),
+            ColumnBounds::Int128(Bounds::Bounded(_))
+        ));
+    }
+
+    #[test]
     fn we_can_union_matching_metadata() {
         // NoOrder cases
         let boolean_metadata = ColumnCommitmentMetadata {

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -349,7 +349,7 @@ impl<C> FromIterator<(Ident, ColumnCommitmentMetadata, C)> for ColumnCommitments
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{

--- a/crates/proof-of-sql/src/base/commitment/naive_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_evaluation_proof.rs
@@ -5,8 +5,10 @@ use crate::base::{
     scalar::{test_scalar::TestScalar, Scalar},
 };
 use core::ops::Add;
+use serde::{Deserialize, Serialize};
 
 /// This should only be used for the purpose of unit testing.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct NaiveEvaluationProof {
     a: NaiveCommitment,
     b_point: Vec<TestScalar>,

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -122,17 +122,19 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::{
+        commitment::naive_commitment::NaiveCommitment,
+        database::{owned_table_utility::*, OwnedColumn, OwnedTable},
+        scalar::test_scalar::TestScalar,
+    };
+    #[cfg(feature = "blitzar")]
     use crate::{
         base::{
-            commitment::{naive_commitment::NaiveCommitment, Bounds, ColumnBounds},
-            database::{
-                owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableTestAccessor,
-                TestAccessor,
-            },
-            scalar::test_scalar::TestScalar,
+            commitment::{Bounds, ColumnBounds},
+            database::{OwnedTableTestAccessor, TestAccessor},
         },
         proof_primitive::dory::{
             test_rng, DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup, ProverSetup,
@@ -318,6 +320,7 @@ mod tests {
 
     #[expect(clippy::similar_names)]
     #[test]
+    #[cfg(feature = "blitzar")]
     fn we_can_get_query_commitments_from_accessor() {
         let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -374,7 +374,7 @@ fn num_rows_of_columns<'a>(
     Ok(num_rows)
 }
 
-#[cfg(all(test, feature = "arrow", feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{
@@ -383,11 +383,13 @@ mod tests {
         map::IndexMap,
         scalar::test_scalar::TestScalar,
     };
+    #[cfg(feature = "arrow")]
     use arrow::{
         array::{Int64Array, StringArray},
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
+    #[cfg(feature = "arrow")]
     use std::sync::Arc;
 
     #[test]
@@ -1152,6 +1154,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "arrow")]
     fn we_can_create_and_append_table_commitments_with_record_batches() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int64, false),

--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,30 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_convert_float_fields_to_posql_decimal_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("f16", DataType::Float16, true),
+            Field::new("f32", DataType::Float32, false),
+            Field::new("f64", DataType::Float64, true),
+            Field::new("i64", DataType::Int64, false),
+            Field::new("text", DataType::Utf8, true),
+        ]));
+
+        let compatible = get_posql_compatible_schema(&schema);
+        let fields = compatible.fields();
+
+        assert_eq!(fields[0].data_type(), &DataType::Decimal256(20, 10));
+        assert_eq!(fields[1].data_type(), &DataType::Decimal256(20, 10));
+        assert_eq!(fields[2].data_type(), &DataType::Decimal256(20, 10));
+        assert_eq!(fields[3].data_type(), &DataType::Int64);
+        assert_eq!(fields[4].data_type(), &DataType::Utf8);
+        assert!(fields[0].is_nullable());
+        assert!(!fields[1].is_nullable());
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -578,4 +578,117 @@ mod tests {
         let round_trip_owned: OwnedColumn<TestScalar> = (&column).into();
         assert_eq!(owned_varbinary, round_trip_owned);
     }
+
+    #[test]
+    fn we_can_build_a_uint8_column_from_a_literal() {
+        let alloc = Bump::new();
+        let literal = LiteralValue::Uint8(7);
+        let column = Column::<TestScalar>::from_literal_with_length(&literal, 4, &alloc);
+
+        assert_eq!(column, Column::Uint8(&[7, 7, 7, 7]));
+    }
+
+    #[test]
+    fn we_can_convert_small_owned_columns_and_access_them() {
+        let alloc = Bump::new();
+        let timestamp_timezone = PoSQLTimeZone::utc();
+        let timestamp_values = vec![11_i64, 22, 33];
+        let scalar_values = vec![
+            TestScalar::from(5),
+            TestScalar::from(6),
+            TestScalar::from(7),
+        ];
+        let owned_uint8 = OwnedColumn::Uint8(vec![1, 2, 3]);
+        let owned_tinyint = OwnedColumn::TinyInt(vec![-1, 0, 1]);
+        let owned_smallint = OwnedColumn::SmallInt(vec![-11, 12, 13]);
+        let owned_int = OwnedColumn::Int(vec![21, 22, 23]);
+        let owned_bigint = OwnedColumn::BigInt(vec![31, 32, 33]);
+        let owned_int128 = OwnedColumn::Int128(vec![41, 42, 43]);
+        let owned_scalar = OwnedColumn::Scalar(scalar_values.clone());
+        let owned_timestamptz = OwnedColumn::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            timestamp_timezone,
+            timestamp_values.clone(),
+        );
+
+        let uint8 = Column::<TestScalar>::from_owned_column(&owned_uint8, &alloc);
+        let tinyint = Column::<TestScalar>::from_owned_column(&owned_tinyint, &alloc);
+        let smallint = Column::<TestScalar>::from_owned_column(&owned_smallint, &alloc);
+        let int = Column::<TestScalar>::from_owned_column(&owned_int, &alloc);
+        let bigint = Column::<TestScalar>::from_owned_column(&owned_bigint, &alloc);
+        let int128 = Column::<TestScalar>::from_owned_column(&owned_int128, &alloc);
+        let scalar = Column::<TestScalar>::from_owned_column(&owned_scalar, &alloc);
+        let timestamptz = Column::<TestScalar>::from_owned_column(&owned_timestamptz, &alloc);
+
+        assert_eq!(uint8, Column::Uint8(&[1, 2, 3]));
+        assert_eq!(tinyint, Column::TinyInt(&[-1, 0, 1]));
+        assert_eq!(smallint, Column::SmallInt(&[-11, 12, 13]));
+        assert_eq!(int, Column::Int(&[21, 22, 23]));
+        assert_eq!(bigint, Column::BigInt(&[31, 32, 33]));
+        assert_eq!(int128, Column::Int128(&[41, 42, 43]));
+        assert_eq!(scalar, Column::Scalar(scalar_values.as_slice()));
+        assert_eq!(
+            timestamptz,
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                timestamp_timezone,
+                timestamp_values.as_slice()
+            )
+        );
+
+        assert_eq!(uint8.as_uint8(), Some(&[1, 2, 3][..]));
+        assert_eq!(tinyint.as_tinyint(), Some(&[-1, 0, 1][..]));
+        assert_eq!(smallint.as_smallint(), Some(&[-11, 12, 13][..]));
+        assert_eq!(int.as_int(), Some(&[21, 22, 23][..]));
+        assert_eq!(bigint.as_bigint(), Some(&[31, 32, 33][..]));
+        assert_eq!(int128.as_int128(), Some(&[41, 42, 43][..]));
+        assert_eq!(scalar.as_scalar(), Some(scalar_values.as_slice()));
+        assert_eq!(
+            timestamptz.as_timestamptz(),
+            Some(timestamp_values.as_slice())
+        );
+
+        assert_eq!(int.as_boolean(), None);
+        assert_eq!(int.as_uint8(), None);
+        assert_eq!(int.as_tinyint(), None);
+        assert_eq!(int.as_smallint(), None);
+        assert_eq!(int.as_bigint(), None);
+        assert_eq!(int.as_int128(), None);
+        assert_eq!(int.as_scalar(), None);
+        assert_eq!(int.as_decimal75(), None);
+        assert_eq!(int.as_varchar(), None);
+        assert_eq!(int.as_varbinary(), None);
+        assert_eq!(int.as_timestamptz(), None);
+    }
+
+    #[test]
+    fn we_can_convert_small_columns_to_scalars() {
+        let varbinary_bytes: &[&[u8]] = &[b"alpha", b"beta"];
+        let varbinary_scalars = [
+            TestScalar::from_byte_slice_via_hash(b"alpha"),
+            TestScalar::from_byte_slice_via_hash(b"beta"),
+        ];
+        let scalar_values = [TestScalar::from(71), TestScalar::from(72)];
+
+        assert_eq!(
+            Column::<TestScalar>::Uint8(&[2, 4]).to_scalar(),
+            vec![TestScalar::from(2), TestScalar::from(4)]
+        );
+        assert_eq!(
+            Column::<TestScalar>::TinyInt(&[-3, 5]).to_scalar(),
+            vec![TestScalar::from(-3), TestScalar::from(5)]
+        );
+        assert_eq!(
+            Column::<TestScalar>::Int128(&[9, 10]).to_scalar(),
+            vec![TestScalar::from(9), TestScalar::from(10)]
+        );
+        assert_eq!(
+            Column::<TestScalar>::Scalar(&scalar_values).to_scalar(),
+            scalar_values.to_vec()
+        );
+        assert_eq!(
+            Column::<TestScalar>::VarBinary((varbinary_bytes, &varbinary_scalars)).to_scalar(),
+            varbinary_scalars.to_vec()
+        );
+    }
 }

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -120,7 +120,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::ColumnOperationError, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        database::ColumnOperationError,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn test_apply_index_op() {
@@ -188,5 +193,66 @@ mod tests {
         let expected = Column::VarBinary((expected_bytes.as_slice(), expected_scalars.as_slice()));
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_apply_index_op_for_remaining_variants() {
+        let bump = Bump::new();
+        let indexes = [2, 0];
+
+        let boolean_column: Column<TestScalar> = Column::Boolean(&[true, false, true]);
+        assert_eq!(
+            apply_column_to_indexes(&boolean_column, &bump, &indexes).unwrap(),
+            Column::Boolean(&[true, true])
+        );
+
+        let tinyint_column: Column<TestScalar> = Column::TinyInt(&[1, 2, 3]);
+        assert_eq!(
+            apply_column_to_indexes(&tinyint_column, &bump, &indexes).unwrap(),
+            Column::TinyInt(&[3, 1])
+        );
+
+        let uint8_column: Column<TestScalar> = Column::Uint8(&[1, 2, 3]);
+        assert_eq!(
+            apply_column_to_indexes(&uint8_column, &bump, &indexes).unwrap(),
+            Column::Uint8(&[3, 1])
+        );
+
+        let smallint_column: Column<TestScalar> = Column::SmallInt(&[1, 2, 3]);
+        assert_eq!(
+            apply_column_to_indexes(&smallint_column, &bump, &indexes).unwrap(),
+            Column::SmallInt(&[3, 1])
+        );
+
+        let bigint_column: Column<TestScalar> = Column::BigInt(&[1, 2, 3]);
+        assert_eq!(
+            apply_column_to_indexes(&bigint_column, &bump, &indexes).unwrap(),
+            Column::BigInt(&[3, 1])
+        );
+
+        let int128_column: Column<TestScalar> = Column::Int128(&[1, 2, 3]);
+        assert_eq!(
+            apply_column_to_indexes(&int128_column, &bump, &indexes).unwrap(),
+            Column::Int128(&[3, 1])
+        );
+
+        let decimal_values = [1, 2, 3]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let decimal_column: Column<TestScalar> =
+            Column::Decimal75(Precision::new(5).unwrap(), 0, &decimal_values);
+        let expected_decimal = [3, 1].into_iter().map(TestScalar::from).collect::<Vec<_>>();
+        assert_eq!(
+            apply_column_to_indexes(&decimal_column, &bump, &indexes).unwrap(),
+            Column::Decimal75(Precision::new(5).unwrap(), 0, &expected_decimal)
+        );
+
+        let timestamp_column: Column<TestScalar> =
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[10, 20, 30]);
+        assert_eq!(
+            apply_column_to_indexes(&timestamp_column, &bump, &indexes).unwrap(),
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[30, 10])
+        );
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -153,7 +153,11 @@ impl RepetitionOp for ElementwiseRepeatOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::{
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn test_column_repetition_op() {
@@ -267,5 +271,50 @@ mod tests {
             .collect();
         let expected = Column::VarBinary((expected_bytes.as_slice(), expected_scalars.as_slice()));
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_repetition_ops_for_remaining_variants() {
+        let bump = Bump::new();
+
+        let tinyint_column: Column<TestScalar> = Column::TinyInt(&[1, 2]);
+        let tinyint_result =
+            ElementwiseRepeatOp::column_op::<TestScalar>(&tinyint_column, &bump, 2);
+        assert_eq!(tinyint_result.as_tinyint().unwrap(), &[1, 1, 2, 2]);
+
+        let scalar_values = [1, 2].into_iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalar_column: Column<TestScalar> = Column::Scalar(&scalar_values);
+        let scalar_result = ColumnRepeatOp::column_op::<TestScalar>(&scalar_column, &bump, 2);
+        let expected_scalar = [1, 2, 1, 2]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        assert_eq!(scalar_result, Column::Scalar(&expected_scalar));
+
+        let decimal_values = [1, 2].into_iter().map(TestScalar::from).collect::<Vec<_>>();
+        let decimal_column: Column<TestScalar> =
+            Column::Decimal75(Precision::new(5).unwrap(), 0, &decimal_values);
+        let decimal_result =
+            ElementwiseRepeatOp::column_op::<TestScalar>(&decimal_column, &bump, 2);
+        let expected_decimal = [1, 1, 2, 2]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            decimal_result,
+            Column::Decimal75(Precision::new(5).unwrap(), 0, &expected_decimal)
+        );
+
+        let timestamp_column: Column<TestScalar> =
+            Column::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc(), &[10, 20]);
+        let timestamp_result = ColumnRepeatOp::column_op::<TestScalar>(&timestamp_column, &bump, 2);
+        assert_eq!(
+            timestamp_result,
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                &[10, 20, 10, 20]
+            )
+        );
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -673,4 +673,95 @@ mod tests {
             assert_eq!(column_type.sqrt_negative_min(), None);
         }
     }
+
+    #[test]
+    fn integer_width_helpers_cover_all_integer_paths() {
+        assert_eq!(ColumnType::Uint8.to_integer_bits(), Some(8));
+        assert_eq!(ColumnType::SmallInt.to_integer_bits(), Some(16));
+        assert_eq!(ColumnType::Int.to_integer_bits(), Some(32));
+        assert_eq!(ColumnType::BigInt.to_integer_bits(), Some(64));
+        assert_eq!(ColumnType::Int128.to_integer_bits(), Some(128));
+        assert_eq!(ColumnType::Boolean.to_integer_bits(), None);
+
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(8),
+            Some(ColumnType::TinyInt)
+        );
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(16),
+            Some(ColumnType::SmallInt)
+        );
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(32),
+            Some(ColumnType::Int)
+        );
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(64),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(128),
+            Some(ColumnType::Int128)
+        );
+        assert_eq!(ColumnType::from_signed_integer_bits(12), None);
+
+        assert_eq!(
+            ColumnType::from_unsigned_integer_bits(8),
+            Some(ColumnType::Uint8)
+        );
+        assert_eq!(ColumnType::from_unsigned_integer_bits(16), None);
+
+        assert_eq!(
+            ColumnType::Uint8.max_integer_type(&ColumnType::Uint8),
+            Some(ColumnType::TinyInt)
+        );
+        assert_eq!(
+            ColumnType::SmallInt.max_integer_type(&ColumnType::SmallInt),
+            Some(ColumnType::SmallInt)
+        );
+        assert_eq!(
+            ColumnType::Int.max_integer_type(&ColumnType::Int),
+            Some(ColumnType::Int)
+        );
+        assert_eq!(
+            ColumnType::BigInt.max_integer_type(&ColumnType::BigInt),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::Int128.max_integer_type(&ColumnType::Int128),
+            Some(ColumnType::Int128)
+        );
+        assert_eq!(ColumnType::Boolean.max_integer_type(&ColumnType::Int), None);
+
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::TinyInt),
+            Some(ColumnType::Uint8)
+        );
+        assert_eq!(
+            ColumnType::BigInt.max_unsigned_integer_type(&ColumnType::Uint8),
+            None
+        );
+    }
+
+    #[test]
+    fn decimal_metadata_and_display_cover_scalar_and_timestamp_variants() {
+        assert_eq!(ColumnType::Scalar.precision_value(), Some(0));
+        assert_eq!(ColumnType::VarBinary.precision_value(), None);
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc()).scale(),
+            Some(6)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::new(3600)).scale(),
+            Some(9)
+        );
+        assert_eq!(format!("{}", ColumnType::Int128), "DECIMAL");
+        assert_eq!(
+            format!(
+                "{}",
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::new(3600))
+            ),
+            "TIMESTAMP(TIMEUNIT: seconds (precision: 0), TIMEZONE: +01:00)"
+        );
+    }
 }

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -502,6 +502,16 @@ mod test {
     }
 
     #[test]
+    fn we_cannot_add_numeric_types_with_different_scales_without_scaling() {
+        let lhs = ColumnType::Decimal75(Precision::new(8).unwrap(), 1);
+        let rhs = ColumnType::Decimal75(Precision::new(8).unwrap(), 2);
+        assert!(matches!(
+            try_add_subtract_column_types(lhs, rhs),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    #[test]
     fn we_cannot_add_numeric_types_with_different_scales() {
         // lhs is a decimal with nonnegative scale and rhs is an integer
         let lhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
@@ -1400,5 +1410,73 @@ mod test {
         assert!(
             matches!(try_neg_type(ColumnType::VarChar).unwrap_err(), ColumnOperationError::UnaryOperationInvalidColumnType { operator, operand_type } if operator == "negation" && operand_type == ColumnType::VarChar)
         );
+    }
+
+    #[test]
+    fn we_can_compare_timestamp_types_with_matching_units() {
+        try_equals_types(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::new(5)),
+        )
+        .unwrap();
+        try_inequality_types(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::new(-7)),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn we_can_compare_types_with_scaling() {
+        try_equals_types_with_scaling(
+            ColumnType::Decimal75(Precision::new(20).unwrap(), 5),
+            ColumnType::Decimal75(Precision::new(6).unwrap(), -3),
+        )
+        .unwrap();
+        try_equals_types_with_scaling(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::new(9)),
+        )
+        .unwrap();
+        try_inequality_types_with_scaling(ColumnType::Boolean, ColumnType::Boolean).unwrap();
+        try_inequality_types_with_scaling(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::new(9)),
+        )
+        .unwrap();
+        try_inequality_types_with_scaling(
+            ColumnType::Decimal75(Precision::new(38).unwrap(), 8),
+            ColumnType::Int128,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn we_reject_invalid_types_with_scaling() {
+        assert!(matches!(
+            try_equals_types_with_scaling(ColumnType::VarChar, ColumnType::Boolean),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types_with_scaling(
+                ColumnType::VarChar,
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types_with_scaling(
+                ColumnType::Decimal75(Precision::new(39).unwrap(), 0),
+                ColumnType::Int,
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types_with_scaling(
+                ColumnType::Int,
+                ColumnType::Decimal75(Precision::new(39).unwrap(), 0),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
     }
 }

--- a/crates/proof-of-sql/src/base/database/coverage_regression_test.rs
+++ b/crates/proof-of-sql/src/base/database/coverage_regression_test.rs
@@ -1,0 +1,744 @@
+use super::{ColumnOperationError, ColumnType, OwnedColumn};
+use crate::base::{
+    math::{decimal::Precision, permutation::Permutation},
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    scalar::test_scalar::TestScalar,
+};
+use alloc::{string::ToString, vec, vec::Vec};
+
+fn precision() -> Precision {
+    Precision::new(5).unwrap()
+}
+
+fn test_scalars(values: [i64; 3]) -> Vec<TestScalar> {
+    values.into_iter().map(TestScalar::from).collect()
+}
+
+fn decimal_column(values: [i64; 3]) -> OwnedColumn<TestScalar> {
+    OwnedColumn::Decimal75(precision(), 0, test_scalars(values))
+}
+
+fn scalar_column(values: [i64; 3]) -> OwnedColumn<TestScalar> {
+    OwnedColumn::Scalar(test_scalars(values))
+}
+
+fn timestamp_column(values: [i64; 3]) -> OwnedColumn<TestScalar> {
+    OwnedColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), values.to_vec())
+}
+
+fn assert_eq_case(lhs: OwnedColumn<TestScalar>, rhs: OwnedColumn<TestScalar>, expected: [bool; 2]) {
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(expected.to_vec())
+    );
+}
+
+fn assert_signed_cast_error(lhs: OwnedColumn<TestScalar>, rhs: OwnedColumn<TestScalar>) {
+    assert!(matches!(
+        lhs.element_wise_eq(&rhs),
+        Err(ColumnOperationError::SignedCastingError { .. })
+    ));
+}
+
+fn assert_add_case(
+    lhs: OwnedColumn<TestScalar>,
+    rhs: OwnedColumn<TestScalar>,
+    expected: OwnedColumn<TestScalar>,
+) {
+    assert_eq!(lhs.element_wise_add(&rhs).unwrap(), expected);
+}
+
+fn assert_decimal_add_case(
+    lhs: OwnedColumn<TestScalar>,
+    rhs: OwnedColumn<TestScalar>,
+    expected_values: [i64; 2],
+) {
+    match lhs.element_wise_add(&rhs).unwrap() {
+        OwnedColumn::Decimal75(_, scale, values) => {
+            assert_eq!(scale, 0);
+            assert_eq!(
+                values,
+                expected_values
+                    .into_iter()
+                    .map(TestScalar::from)
+                    .collect::<Vec<_>>()
+            );
+        }
+        other => panic!("expected decimal result, got {other:?}"),
+    }
+}
+
+#[test]
+fn owned_column_variant_helpers_cover_all_runtime_variants() {
+    let permutation = Permutation::try_new(vec![2, 0, 1]).unwrap();
+    let timestamp_type = ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc());
+
+    let cases = vec![
+        (
+            OwnedColumn::Boolean(vec![true, false, true]),
+            ColumnType::Boolean,
+            OwnedColumn::Boolean(vec![false, true]),
+            OwnedColumn::Boolean(vec![true, true, false]),
+        ),
+        (
+            OwnedColumn::Uint8(vec![1, 2, 3]),
+            ColumnType::Uint8,
+            OwnedColumn::Uint8(vec![2, 3]),
+            OwnedColumn::Uint8(vec![3, 1, 2]),
+        ),
+        (
+            OwnedColumn::TinyInt(vec![1, 2, 3]),
+            ColumnType::TinyInt,
+            OwnedColumn::TinyInt(vec![2, 3]),
+            OwnedColumn::TinyInt(vec![3, 1, 2]),
+        ),
+        (
+            OwnedColumn::SmallInt(vec![1, 2, 3]),
+            ColumnType::SmallInt,
+            OwnedColumn::SmallInt(vec![2, 3]),
+            OwnedColumn::SmallInt(vec![3, 1, 2]),
+        ),
+        (
+            OwnedColumn::Int(vec![1, 2, 3]),
+            ColumnType::Int,
+            OwnedColumn::Int(vec![2, 3]),
+            OwnedColumn::Int(vec![3, 1, 2]),
+        ),
+        (
+            OwnedColumn::BigInt(vec![1, 2, 3]),
+            ColumnType::BigInt,
+            OwnedColumn::BigInt(vec![2, 3]),
+            OwnedColumn::BigInt(vec![3, 1, 2]),
+        ),
+        (
+            OwnedColumn::Int128(vec![1, 2, 3]),
+            ColumnType::Int128,
+            OwnedColumn::Int128(vec![2, 3]),
+            OwnedColumn::Int128(vec![3, 1, 2]),
+        ),
+        (
+            OwnedColumn::VarChar(vec!["a".to_string(), "b".to_string(), "c".to_string()]),
+            ColumnType::VarChar,
+            OwnedColumn::VarChar(vec!["b".to_string(), "c".to_string()]),
+            OwnedColumn::VarChar(vec!["c".to_string(), "a".to_string(), "b".to_string()]),
+        ),
+        (
+            decimal_column([1, 2, 3]),
+            ColumnType::Decimal75(precision(), 0),
+            decimal_column([2, 3, 0]).slice(0, 2),
+            decimal_column([3, 1, 2]),
+        ),
+        (
+            scalar_column([1, 2, 3]),
+            ColumnType::Scalar,
+            scalar_column([2, 3, 0]).slice(0, 2),
+            scalar_column([3, 1, 2]),
+        ),
+        (
+            timestamp_column([1, 2, 3]),
+            timestamp_type,
+            timestamp_column([2, 3, 0]).slice(0, 2),
+            timestamp_column([3, 1, 2]),
+        ),
+        (
+            OwnedColumn::VarBinary(vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]),
+            ColumnType::VarBinary,
+            OwnedColumn::VarBinary(vec![b"b".to_vec(), b"c".to_vec()]),
+            OwnedColumn::VarBinary(vec![b"c".to_vec(), b"a".to_vec(), b"b".to_vec()]),
+        ),
+    ];
+
+    for (column, expected_type, expected_slice, expected_permutation) in cases {
+        assert_eq!(column.len(), 3);
+        assert!(!column.is_empty());
+        assert_eq!(column.column_type(), expected_type);
+        assert_eq!(column.slice(1, 3), expected_slice);
+        assert_eq!(
+            column.try_permute(&permutation).unwrap(),
+            expected_permutation
+        );
+    }
+}
+
+#[test]
+fn owned_column_scalar_conversions_cover_numeric_scalar_and_timestamp_targets() {
+    let scalars = test_scalars([1, 2, 3]);
+    let precision = precision();
+    let timezone = PoSQLTimeZone::utc();
+
+    assert_eq!(
+        OwnedColumn::try_from_scalars(&scalars, ColumnType::Uint8).unwrap(),
+        OwnedColumn::Uint8(vec![1, 2, 3])
+    );
+    assert_eq!(
+        OwnedColumn::try_from_scalars(&scalars, ColumnType::TinyInt).unwrap(),
+        OwnedColumn::TinyInt(vec![1, 2, 3])
+    );
+    assert_eq!(
+        OwnedColumn::try_from_scalars(&scalars, ColumnType::SmallInt).unwrap(),
+        OwnedColumn::SmallInt(vec![1, 2, 3])
+    );
+    assert_eq!(
+        OwnedColumn::try_from_scalars(&scalars, ColumnType::Int).unwrap(),
+        OwnedColumn::Int(vec![1, 2, 3])
+    );
+    assert_eq!(
+        OwnedColumn::try_from_scalars(&scalars, ColumnType::BigInt).unwrap(),
+        OwnedColumn::BigInt(vec![1, 2, 3])
+    );
+    assert_eq!(
+        OwnedColumn::try_from_scalars(&scalars, ColumnType::Int128).unwrap(),
+        OwnedColumn::Int128(vec![1, 2, 3])
+    );
+    assert_eq!(
+        OwnedColumn::try_from_scalars(&scalars, ColumnType::Scalar).unwrap(),
+        OwnedColumn::Scalar(scalars.clone())
+    );
+    assert_eq!(
+        OwnedColumn::try_from_scalars(&scalars, ColumnType::Decimal75(precision, 0)).unwrap(),
+        OwnedColumn::Decimal75(precision, 0, scalars.clone())
+    );
+    assert_eq!(
+        OwnedColumn::try_from_scalars(
+            &scalars,
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, timezone),
+        )
+        .unwrap(),
+        OwnedColumn::TimestampTZ(PoSQLTimeUnit::Second, timezone, vec![1, 2, 3])
+    );
+}
+
+#[test]
+fn owned_column_test_iterators_and_uint8_coercion_cover_remaining_helpers() {
+    let scalars = test_scalars([1, 2, 3]);
+
+    assert_eq!(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2, 3])
+            .u8_iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2, 3])
+            .i8_iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2, 3])
+            .i16_iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        OwnedColumn::<TestScalar>::Int(vec![1, 2, 3])
+            .i32_iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        timestamp_column([1, 2, 3])
+            .i64_iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2, 3])
+            .i128_iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        OwnedColumn::<TestScalar>::Boolean(vec![true, false, true])
+            .bool_iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![true, false, true]
+    );
+    assert_eq!(
+        scalar_column([1, 2, 3])
+            .scalar_iter()
+            .cloned()
+            .collect::<Vec<_>>(),
+        scalars.clone()
+    );
+    assert_eq!(
+        decimal_column([1, 2, 3])
+            .scalar_iter()
+            .cloned()
+            .collect::<Vec<_>>(),
+        scalars.clone()
+    );
+    assert_eq!(
+        OwnedColumn::<TestScalar>::VarChar(vec!["a".to_string(), "b".to_string()])
+            .string_iter()
+            .cloned()
+            .collect::<Vec<_>>(),
+        vec!["a".to_string(), "b".to_string()]
+    );
+    assert_eq!(
+        OwnedColumn::Scalar(scalars)
+            .try_coerce_scalar_to_numeric(ColumnType::Uint8)
+            .unwrap(),
+        OwnedColumn::Uint8(vec![1, 2, 3])
+    );
+}
+
+#[test]
+fn equality_operations_cover_unhit_numeric_promotion_paths() {
+    assert_signed_cast_error(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 3]),
+    );
+    assert_signed_cast_error(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 3]),
+    );
+
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(3)],
+        ),
+        [true, false],
+    );
+
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(3)],
+        ),
+        [true, false],
+    );
+
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(3)],
+        ),
+        [true, false],
+    );
+
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(3)],
+        ),
+        [true, false],
+    );
+
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(3)],
+        ),
+        [true, false],
+    );
+
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(3)],
+        ),
+        [true, false],
+    );
+
+    assert_eq_case(
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(2)],
+        ),
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 3]),
+        [true, false],
+    );
+    assert_eq_case(
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(2)],
+        ),
+        OwnedColumn::<TestScalar>::Int128(vec![1, 3]),
+        [true, false],
+    );
+}
+
+#[test]
+fn addition_operations_cover_unhit_numeric_promotion_paths() {
+    assert!(matches!(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2])
+            .element_wise_add(&OwnedColumn::<TestScalar>::TinyInt(vec![10, 20])),
+        Err(ColumnOperationError::SignedCastingError { .. })
+    ));
+    assert!(matches!(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2])
+            .element_wise_add(&OwnedColumn::<TestScalar>::Uint8(vec![10, 20])),
+        Err(ColumnOperationError::SignedCastingError { .. })
+    ));
+
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Uint8(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Uint8(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::BigInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int128(vec![11, 22]),
+    );
+    assert_decimal_add_case(
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(10), TestScalar::from(20)],
+        ),
+        [11, 22],
+    );
+
+    assert_add_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::BigInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int128(vec![11, 22]),
+    );
+    assert_decimal_add_case(
+        OwnedColumn::<TestScalar>::TinyInt(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(10), TestScalar::from(20)],
+        ),
+        [11, 22],
+    );
+
+    assert_add_case(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::BigInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::SmallInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int128(vec![11, 22]),
+    );
+
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Int(vec![1, 2]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Int(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int(vec![11, 22]),
+    );
+
+    assert_add_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::BigInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::BigInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![10, 20]),
+        OwnedColumn::<TestScalar>::BigInt(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int128(vec![11, 22]),
+    );
+    assert_decimal_add_case(
+        OwnedColumn::<TestScalar>::BigInt(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(10), TestScalar::from(20)],
+        ),
+        [11, 22],
+    );
+
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::TinyInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int128(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::SmallInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int128(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int128(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::BigInt(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int128(vec![11, 22]),
+    );
+    assert_add_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::<TestScalar>::Int128(vec![10, 20]),
+        OwnedColumn::<TestScalar>::Int128(vec![11, 22]),
+    );
+    assert_decimal_add_case(
+        OwnedColumn::<TestScalar>::Int128(vec![1, 2]),
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(10), TestScalar::from(20)],
+        ),
+        [11, 22],
+    );
+
+    assert_decimal_add_case(
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(2)],
+        ),
+        OwnedColumn::<TestScalar>::TinyInt(vec![10, 20]),
+        [11, 22],
+    );
+    assert_decimal_add_case(
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(2)],
+        ),
+        OwnedColumn::<TestScalar>::SmallInt(vec![10, 20]),
+        [11, 22],
+    );
+    assert_decimal_add_case(
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(2)],
+        ),
+        OwnedColumn::<TestScalar>::Int(vec![10, 20]),
+        [11, 22],
+    );
+    assert_decimal_add_case(
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(2)],
+        ),
+        OwnedColumn::<TestScalar>::BigInt(vec![10, 20]),
+        [11, 22],
+    );
+    assert_decimal_add_case(
+        OwnedColumn::Decimal75(
+            precision(),
+            0,
+            vec![TestScalar::from(1), TestScalar::from(2)],
+        ),
+        OwnedColumn::<TestScalar>::Int128(vec![10, 20]),
+        [11, 22],
+    );
+}

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,6 +1,10 @@
 use crate::{
     base::{
-        database::{group_by_util::*, Column},
+        database::{
+            group_by_util::{AggregateColumnsError, *},
+            Column,
+        },
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
@@ -688,4 +692,145 @@ fn we_can_aggregate_columns_with_varbinary_in_group_by() {
     assert_eq!(aggregate_result.count_column, expected_count);
     assert!(aggregate_result.max_columns.is_empty());
     assert!(aggregate_result.min_columns.is_empty());
+}
+
+#[test]
+fn aggregate_columns_returns_an_error_for_length_mismatches() {
+    let alloc = Bump::new();
+    let group_by = &[Column::<TestScalar>::BigInt(&[1, 2])];
+    let sum_columns = &[Column::<TestScalar>::Int(&[10, 20, 30])];
+    let selection = &[true, true];
+
+    let result = aggregate_columns(&alloc, group_by, sum_columns, &[], &[], selection);
+
+    assert!(matches!(
+        result,
+        Err(AggregateColumnsError::ColumnLengthMismatch)
+    ));
+}
+
+#[test]
+fn we_can_sum_aggregate_small_numeric_columns_by_counts() {
+    let alloc = Bump::new();
+    let indexes = &[0, 2, 3, 1];
+    let counts = &[2, 2];
+
+    let uint8 = Column::<TestScalar>::Uint8(&[1, 4, 2, 3]);
+    let tinyint = Column::<TestScalar>::TinyInt(&[-1, 4, 2, 3]);
+    let smallint = Column::<TestScalar>::SmallInt(&[-10, 40, 20, 30]);
+    let int = Column::<TestScalar>::Int(&[-100, 400, 200, 300]);
+
+    let expected_uint8 = [TestScalar::from(3), TestScalar::from(7)];
+    let expected_tinyint = [TestScalar::from(1), TestScalar::from(7)];
+    let expected_smallint = [TestScalar::from(10), TestScalar::from(70)];
+    let expected_int = [TestScalar::from(100), TestScalar::from(700)];
+
+    assert_eq!(
+        sum_aggregate_column_by_index_counts(&alloc, &uint8, counts, indexes),
+        expected_uint8
+    );
+    assert_eq!(
+        sum_aggregate_column_by_index_counts(&alloc, &tinyint, counts, indexes),
+        expected_tinyint
+    );
+    assert_eq!(
+        sum_aggregate_column_by_index_counts(&alloc, &smallint, counts, indexes),
+        expected_smallint
+    );
+    assert_eq!(
+        sum_aggregate_column_by_index_counts(&alloc, &int, counts, indexes),
+        expected_int
+    );
+}
+
+#[test]
+#[should_panic(expected = "SUM can not be applied to non-numeric types")]
+fn we_cannot_apply_sum_to_boolean_columns() {
+    let alloc = Bump::new();
+    let column = Column::<TestScalar>::Boolean(&[true, false]);
+    let _ = sum_aggregate_column_by_index_counts(&alloc, &column, &[2], &[0, 1]);
+}
+
+#[test]
+fn we_can_max_aggregate_boolean_uint8_and_timestamp_columns_by_counts() {
+    let alloc = Bump::new();
+    let indexes = &[0, 2, 3, 1];
+    let counts = &[2, 2];
+    let timezone = PoSQLTimeZone::utc();
+
+    let boolean = Column::<TestScalar>::Boolean(&[false, false, true, true]);
+    let uint8 = Column::<TestScalar>::Uint8(&[1, 4, 2, 3]);
+    let tinyint = Column::<TestScalar>::TinyInt(&[-1, 4, 2, 3]);
+    let smallint = Column::<TestScalar>::SmallInt(&[-10, 40, 20, 30]);
+    let timestamp =
+        Column::<TestScalar>::TimestampTZ(PoSQLTimeUnit::Second, timezone, &[100, 400, 200, 300]);
+
+    let expected_boolean = [Some(TestScalar::from(true)), Some(TestScalar::from(true))];
+    let expected_uint8 = [Some(TestScalar::from(2)), Some(TestScalar::from(4))];
+    let expected_tinyint = [Some(TestScalar::from(2)), Some(TestScalar::from(4))];
+    let expected_smallint = [Some(TestScalar::from(20)), Some(TestScalar::from(40))];
+    let expected_timestamp = [Some(TestScalar::from(200)), Some(TestScalar::from(400))];
+
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &boolean, counts, indexes),
+        expected_boolean
+    );
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &uint8, counts, indexes),
+        expected_uint8
+    );
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &tinyint, counts, indexes),
+        expected_tinyint
+    );
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &smallint, counts, indexes),
+        expected_smallint
+    );
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &timestamp, counts, indexes),
+        expected_timestamp
+    );
+}
+
+#[test]
+fn we_can_min_aggregate_boolean_uint8_and_timestamp_columns_by_counts() {
+    let alloc = Bump::new();
+    let indexes = &[0, 2, 3, 1];
+    let counts = &[2, 2];
+    let timezone = PoSQLTimeZone::utc();
+
+    let boolean = Column::<TestScalar>::Boolean(&[false, false, true, true]);
+    let uint8 = Column::<TestScalar>::Uint8(&[1, 4, 2, 3]);
+    let tinyint = Column::<TestScalar>::TinyInt(&[-1, 4, 2, 3]);
+    let smallint = Column::<TestScalar>::SmallInt(&[-10, 40, 20, 30]);
+    let timestamp =
+        Column::<TestScalar>::TimestampTZ(PoSQLTimeUnit::Second, timezone, &[100, 400, 200, 300]);
+
+    let expected_boolean = [Some(TestScalar::from(false)), Some(TestScalar::from(false))];
+    let expected_uint8 = [Some(TestScalar::from(1)), Some(TestScalar::from(3))];
+    let expected_tinyint = [Some(TestScalar::from(-1)), Some(TestScalar::from(3))];
+    let expected_smallint = [Some(TestScalar::from(-10)), Some(TestScalar::from(30))];
+    let expected_timestamp = [Some(TestScalar::from(100)), Some(TestScalar::from(300))];
+
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &boolean, counts, indexes),
+        expected_boolean
+    );
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &uint8, counts, indexes),
+        expected_uint8
+    );
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &tinyint, counts, indexes),
+        expected_tinyint
+    );
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &smallint, counts, indexes),
+        expected_smallint
+    );
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &timestamp, counts, indexes),
+        expected_timestamp
+    );
 }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -137,3 +137,6 @@ mod order_by_util_test;
 
 #[cfg_attr(not(test), expect(dead_code))]
 pub(crate) mod join_util;
+
+#[cfg(test)]
+mod coverage_regression_test;

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -414,38 +414,38 @@ impl<S: Scalar> OwnedColumn<S> {
             match to_type {
                 ColumnType::Uint8 => vec
                     .into_iter()
-                    .map(TryInto::try_into)
-                    .try_collect()
+                    .map(|value| value.try_into())
+                    .try_collect::<u8, Vec<_>, _>()
                     .map_err(|_| ColumnCoercionError::Overflow)
                     .map(OwnedColumn::Uint8),
                 ColumnType::TinyInt => vec
                     .into_iter()
-                    .map(TryInto::try_into)
-                    .try_collect()
+                    .map(|value| value.try_into())
+                    .try_collect::<i8, Vec<_>, _>()
                     .map_err(|_| ColumnCoercionError::Overflow)
                     .map(OwnedColumn::TinyInt),
                 ColumnType::SmallInt => vec
                     .into_iter()
-                    .map(TryInto::try_into)
-                    .try_collect()
+                    .map(|value| value.try_into())
+                    .try_collect::<i16, Vec<_>, _>()
                     .map_err(|_| ColumnCoercionError::Overflow)
                     .map(OwnedColumn::SmallInt),
                 ColumnType::Int => vec
                     .into_iter()
-                    .map(TryInto::try_into)
-                    .try_collect()
+                    .map(|value| value.try_into())
+                    .try_collect::<i32, Vec<_>, _>()
                     .map_err(|_| ColumnCoercionError::Overflow)
                     .map(OwnedColumn::Int),
                 ColumnType::BigInt => vec
                     .into_iter()
-                    .map(TryInto::try_into)
-                    .try_collect()
+                    .map(|value| value.try_into())
+                    .try_collect::<i64, Vec<_>, _>()
                     .map_err(|_| ColumnCoercionError::Overflow)
                     .map(OwnedColumn::BigInt),
                 ColumnType::Int128 => vec
                     .into_iter()
-                    .map(TryInto::try_into)
-                    .try_collect()
+                    .map(|value| value.try_into())
+                    .try_collect::<i128, Vec<_>, _>()
                     .map_err(|_| ColumnCoercionError::Overflow)
                     .map(OwnedColumn::Int128),
                 ColumnType::Decimal75(precision, scale) => {
@@ -464,6 +464,7 @@ mod test {
     use super::*;
     use crate::base::{
         math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::{test_scalar::TestScalar, ScalarExt},
     };
     use alloc::vec;
@@ -613,6 +614,23 @@ mod test {
             res,
             Err(OwnedColumnError::ScalarConversionError { .. })
         ));
+
+        let huge_scalars = [TestScalar::from([0, 0, 1, 0]); 2];
+
+        for column_type in [
+            ColumnType::Uint8,
+            ColumnType::TinyInt,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::Int128,
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ] {
+            let res = OwnedColumn::try_from_scalars(&huge_scalars, column_type);
+            assert!(matches!(
+                res,
+                Err(OwnedColumnError::ScalarConversionError { .. })
+            ));
+        }
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
@@ -1313,4 +1313,119 @@ mod test {
         let expected = (Precision::new(9).unwrap(), 6, expected_scalars);
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn we_cover_extreme_rhs_upscale_decimal_comparisons() {
+        let lhs = [0_i16, 12_i16, -5_i16];
+        let rhs = [0_i64, 0_i64, -1_i64]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let left_column_type = ColumnType::Decimal75(Precision::new(2).unwrap(), 6);
+        let right_column_type = ColumnType::TinyInt;
+
+        assert_eq!(
+            eq_decimal_columns(&lhs, &rhs, left_column_type, right_column_type),
+            vec![true, false, false]
+        );
+        assert_eq!(
+            le_decimal_columns(&lhs, &rhs, left_column_type, right_column_type),
+            vec![true, false, false]
+        );
+        assert_eq!(
+            ge_decimal_columns(&lhs, &rhs, left_column_type, right_column_type),
+            vec![true, true, true]
+        );
+    }
+
+    #[test]
+    fn we_cover_same_scale_decimal_comparisons() {
+        let lhs = [15_i16, -4_i16, 7_i16];
+        let rhs = [15_i64, -3_i64, 8_i64]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
+
+        assert_eq!(
+            le_decimal_columns(&lhs, &rhs, column_type, column_type),
+            vec![true, true, true]
+        );
+        assert_eq!(
+            ge_decimal_columns(&lhs, &rhs, column_type, column_type),
+            vec![true, false, false]
+        );
+    }
+
+    #[test]
+    fn we_cover_right_upscale_decimal_arithmetic() {
+        let lhs = [
+            TestScalar::from(1_i64),
+            TestScalar::from(-2_i64),
+            TestScalar::from(3_i64),
+        ];
+        let rhs = [5_i16, -4_i16, 2_i16];
+        let left_column_type = ColumnType::Decimal75(Precision::new(8).unwrap(), 1);
+        let right_column_type = ColumnType::SmallInt;
+
+        let actual_add: (Precision, i8, Vec<TestScalar>) =
+            try_add_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
+        let expected_add = (
+            Precision::new(9).unwrap(),
+            1,
+            vec![
+                TestScalar::from(51_i64),
+                TestScalar::from(-42_i64),
+                TestScalar::from(23_i64),
+            ],
+        );
+        assert_eq!(expected_add, actual_add);
+
+        let actual_subtract: (Precision, i8, Vec<TestScalar>) =
+            try_subtract_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap();
+        let expected_subtract = (
+            Precision::new(9).unwrap(),
+            1,
+            vec![
+                TestScalar::from(-49_i64),
+                TestScalar::from(38_i64),
+                TestScalar::from(-17_i64),
+            ],
+        );
+        assert_eq!(expected_subtract, actual_subtract);
+    }
+
+    #[test]
+    fn we_cover_decimal_division_error_and_negative_applied_scale() {
+        let lhs = [TestScalar::from(5_i64), TestScalar::from(-9_i64)];
+        let rhs = [0_i16, 3_i16];
+        let err = try_divide_decimal_columns::<TestScalar, _, _>(
+            &lhs,
+            &rhs,
+            ColumnType::Decimal75(Precision::new(8).unwrap(), 2),
+            ColumnType::SmallInt,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ColumnOperationError::DivisionByZero));
+
+        let lhs = [1_i16, -4_i16, 7_i16];
+        let rhs = [2_i64, -5_i64, 3_i64];
+        let actual: (Precision, i8, Vec<TestScalar>) = try_divide_decimal_columns(
+            &lhs,
+            &rhs,
+            ColumnType::Decimal75(Precision::new(4).unwrap(), 0),
+            ColumnType::Decimal75(Precision::new(2).unwrap(), -7),
+        )
+        .unwrap();
+        let expected = (
+            Precision::new(3).unwrap(),
+            6,
+            vec![
+                TestScalar::from(0_i64),
+                TestScalar::from(0_i64),
+                TestScalar::from(0_i64),
+            ],
+        );
+        assert_eq!(expected, actual);
+    }
 }

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,58 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_ref_constructors_parsing_and_serde_cover_all_paths() {
+        let no_schema = TableRef::new("", "orders");
+        assert_eq!(no_schema.schema_id(), None);
+        assert_eq!(no_schema.table_id().value, "orders");
+        assert_eq!(no_schema.to_string(), "orders");
+
+        let with_schema = TableRef::new("analytics", "orders");
+        assert_eq!(with_schema.schema_id().unwrap().value, "analytics");
+        assert_eq!(with_schema.table_id().value, "orders");
+        assert_eq!(with_schema.to_string(), "analytics.orders");
+
+        let from_names = TableRef::from_names(Some("sales"), "invoices");
+        assert_eq!(from_names.to_string(), "sales.invoices");
+
+        let from_idents = TableRef::from_idents(Some(Ident::new("warehouse")), Ident::new("items"));
+        assert_eq!(from_idents.to_string(), "warehouse.items");
+        assert!((&from_idents).equivalent(&from_idents));
+
+        assert_eq!(
+            TableRef::from_strs(&["customers"]).unwrap(),
+            TableRef::from_names(None, "customers")
+        );
+        assert_eq!(
+            TableRef::from_strs(&["public", "customers"]).unwrap(),
+            TableRef::from_names(Some("public"), "customers")
+        );
+        assert!(matches!(
+            TableRef::from_strs(&["too", "many", "parts"]),
+            Err(ParseError::InvalidTableReference { .. })
+        ));
+
+        assert_eq!(
+            TableRef::try_from("finance.ledger").unwrap(),
+            TableRef::from_names(Some("finance"), "ledger")
+        );
+        assert!(matches!(
+            TableRef::try_from("a.b.c"),
+            Err(ParseError::InvalidTableReference { .. })
+        ));
+
+        let parsed: TableRef = "audit.logs".parse().unwrap();
+        assert_eq!(parsed, TableRef::from_names(Some("audit"), "logs"));
+
+        let serialized = serde_json::to_string(&with_schema).unwrap();
+        assert_eq!(serialized, r#""analytics.orders""#);
+        let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, with_schema);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -363,3 +363,18 @@ pub fn borrowed_timestamptz<S: Scalar>(
         Column::TimestampTZ(time_unit, timezone, alloc_data),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_build_uint8_columns_with_the_table_utility() {
+        let alloc = Bump::new();
+        let (ident, column) = borrowed_uint8::<TestScalar>("u8s", [1_u8, 2, 3], &alloc);
+
+        assert_eq!(ident.value, "u8s");
+        assert_eq!(column, Column::Uint8(&[1, 2, 3]));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -245,7 +245,12 @@ pub fn table_union<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{map::IndexMap, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        map::IndexMap,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn we_can_union_no_columns() {
@@ -278,6 +283,99 @@ mod tests {
         assert_eq!(
             result,
             Column::VarChar((&doubled_strings, &doubled_scalars))
+        );
+    }
+
+    #[test]
+    fn we_can_union_remaining_column_variants() {
+        let alloc = Bump::new();
+        let timestamp_tz = PoSQLTimeZone::utc();
+
+        let scalar_left = [TestScalar::from(11_i64), TestScalar::from(-2_i64)];
+        let scalar_right = [TestScalar::from(7_i64)];
+        let scalar_col0: Column<TestScalar> = Column::Scalar(scalar_left.as_slice());
+        let scalar_col1: Column<TestScalar> = Column::Scalar(scalar_right.as_slice());
+        let scalar_columns = [&scalar_col0, &scalar_col1];
+        let decimal_left = [TestScalar::from(123_i64), TestScalar::from(-45_i64)];
+        let decimal_right = [TestScalar::from(6_i64)];
+        let decimal_col0: Column<TestScalar> =
+            Column::Decimal75(Precision::new(6).unwrap(), 2, decimal_left.as_slice());
+        let decimal_col1: Column<TestScalar> =
+            Column::Decimal75(Precision::new(6).unwrap(), 2, decimal_right.as_slice());
+        let decimal_columns = [&decimal_col0, &decimal_col1];
+        let timestamp_left = [10_i64, 20_i64];
+        let timestamp_right = [-5_i64];
+        let timestamp_col0: Column<TestScalar> = Column::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            timestamp_tz,
+            timestamp_left.as_slice(),
+        );
+        let timestamp_col1: Column<TestScalar> = Column::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            timestamp_tz,
+            timestamp_right.as_slice(),
+        );
+        let timestamp_columns = [&timestamp_col0, &timestamp_col1];
+
+        let uint8_col0: Column<TestScalar> = Column::Uint8(&[1_u8, 2_u8]);
+        let uint8_col1: Column<TestScalar> = Column::Uint8(&[3_u8]);
+        let uint8_columns = [&uint8_col0, &uint8_col1];
+        let tinyint_col0: Column<TestScalar> = Column::TinyInt(&[-1_i8, 2_i8]);
+        let tinyint_col1: Column<TestScalar> = Column::TinyInt(&[3_i8]);
+        let tinyint_columns = [&tinyint_col0, &tinyint_col1];
+        let int128_col0: Column<TestScalar> = Column::Int128(&[1_i128, -2_i128]);
+        let int128_col1: Column<TestScalar> = Column::Int128(&[3_i128]);
+        let int128_columns = [&int128_col0, &int128_col1];
+
+        assert_eq!(
+            column_union(&uint8_columns, &alloc, ColumnType::Uint8).unwrap(),
+            Column::Uint8(&[1_u8, 2_u8, 3_u8])
+        );
+        assert_eq!(
+            column_union(&tinyint_columns, &alloc, ColumnType::TinyInt).unwrap(),
+            Column::TinyInt(&[-1_i8, 2_i8, 3_i8])
+        );
+        assert_eq!(
+            column_union(&int128_columns, &alloc, ColumnType::Int128).unwrap(),
+            Column::Int128(&[1_i128, -2_i128, 3_i128])
+        );
+        assert_eq!(
+            column_union(&scalar_columns, &alloc, ColumnType::Scalar).unwrap(),
+            Column::Scalar(&[
+                TestScalar::from(11_i64),
+                TestScalar::from(-2_i64),
+                TestScalar::from(7_i64)
+            ])
+        );
+        assert_eq!(
+            column_union(
+                &decimal_columns,
+                &alloc,
+                ColumnType::Decimal75(Precision::new(6).unwrap(), 2),
+            )
+            .unwrap(),
+            Column::Decimal75(
+                Precision::new(6).unwrap(),
+                2,
+                &[
+                    TestScalar::from(123_i64),
+                    TestScalar::from(-45_i64),
+                    TestScalar::from(6_i64)
+                ],
+            )
+        );
+        assert_eq!(
+            column_union(
+                &timestamp_columns,
+                &alloc,
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, timestamp_tz),
+            )
+            .unwrap(),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                timestamp_tz,
+                &[10_i64, 20_i64, -5_i64]
+            )
         );
     }
 

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -175,6 +175,24 @@ mod scale_adjust_test {
     use num_bigint::BigInt;
 
     #[test]
+    fn we_can_validate_precision_and_decimal_error_string_conversions() {
+        assert_eq!(
+            String::from(DecimalError::InvalidScale {
+                scale: "77".to_string(),
+            }),
+            "Decimal scale is not valid: 77"
+        );
+        assert!(matches!(
+            Precision::new(0),
+            Err(DecimalError::InvalidPrecision { .. })
+        ));
+        assert!(matches!(
+            Precision::try_from(u64::MAX),
+            Err(DecimalError::InvalidPrecision { .. })
+        ));
+    }
+
+    #[test]
     fn we_cannot_scale_past_max_precision() {
         let decimal = "12345678901234567890123456789012345678901234567890123456789012345678900.0"
             .parse()

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,5 +1,9 @@
 use super::MultilinearExtension;
-use crate::base::{database::Column, scalar::test_scalar::TestScalar};
+use crate::base::{
+    database::{owned_table_utility::*, Column},
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    scalar::test_scalar::TestScalar,
+};
 use bumpalo::Bump;
 
 #[test]
@@ -113,4 +117,54 @@ fn we_can_use_multilinear_extension_methods_for_i64_vec() {
         MultilinearExtension::<TestScalar>::id(&slice),
         MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
+}
+
+#[test]
+fn we_can_use_multilinear_extension_methods_for_all_column_variants() {
+    let alloc = Bump::new();
+    let (_, boolean) = boolean::<TestScalar>("boolean", [true, false, true]);
+    let (_, uint8) = uint8::<TestScalar>("uint8", [2_u8, 4, 8]);
+    let (_, tinyint) = tinyint::<TestScalar>("tinyint", [-2_i8, 0, 2]);
+    let (_, smallint) = smallint::<TestScalar>("smallint", [-3_i16, 0, 3]);
+    let (_, int) = int::<TestScalar>("int", [-4_i32, 0, 4]);
+    let (_, int128) = int128::<TestScalar>("int128", [-5_i128, 0, 5]);
+    let (_, scalar) = scalar::<TestScalar>("scalar", [7_i64, 11, 13]);
+    let (_, varchar) = varchar::<TestScalar>("varchar", ["ab", "cd", "ef"]);
+    let (_, varbinary) =
+        varbinary::<TestScalar>("varbinary", [vec![1_u8], vec![2_u8], vec![3_u8]]);
+    let (_, decimal) = decimal75::<TestScalar>("decimal", 10, 2, [17_i64, 19, 23]);
+    let (_, timestamptz) = timestamptz::<TestScalar>(
+        "ts",
+        PoSQLTimeUnit::Second,
+        PoSQLTimeZone::utc(),
+        [29_i64, 31, 37],
+    );
+
+    let cases = [
+        Column::from_owned_column(&boolean, &alloc),
+        Column::from_owned_column(&uint8, &alloc),
+        Column::from_owned_column(&tinyint, &alloc),
+        Column::from_owned_column(&smallint, &alloc),
+        Column::from_owned_column(&int, &alloc),
+        Column::from_owned_column(&int128, &alloc),
+        Column::from_owned_column(&scalar, &alloc),
+        Column::from_owned_column(&varchar, &alloc),
+        Column::from_owned_column(&varbinary, &alloc),
+        Column::from_owned_column(&decimal, &alloc),
+        Column::from_owned_column(&timestamptz, &alloc),
+    ];
+
+    for column in cases {
+        let padded = MultilinearExtension::<TestScalar>::to_sumcheck_term(&column, 2);
+        assert_eq!(padded.len(), 4);
+        assert_eq!(padded[3], 0.into());
+
+        let mut acc = vec![0.into(); 3];
+        column.mul_add(&mut acc, &2.into());
+        assert_ne!(acc, vec![0.into(); 3]);
+
+        let (ptr, len) = MultilinearExtension::<TestScalar>::id(&column);
+        assert_eq!(len, 3);
+        assert!(!ptr.is_null());
+    }
 }

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -81,4 +81,26 @@ mod time_unit_tests {
             ));
         }
     }
+
+    #[test]
+    fn test_precision_values_and_display_strings() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
 }

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -2,7 +2,7 @@ use crate::base::scalar::{
     test_scalar::{TestMontConfig, TestScalar},
     Scalar, ScalarConversionError,
 };
-use ark_ff::MontConfig;
+use ark_ff::{BigInt as ArkBigInt, Fp, MontConfig};
 use bnum::types::U256;
 use num_bigint::BigInt;
 #[test]
@@ -51,4 +51,46 @@ fn we_can_bound_modulus_using_max_bits() {
     let modulus_of_test_scalar = U256::from(TestMontConfig::MODULUS.0);
     assert!(modulus_of_i_max_bits <= modulus_of_test_scalar);
     assert!(modulus_of_i_max_bits_plus_1 > modulus_of_test_scalar);
+}
+
+#[test]
+fn we_can_wrap_unwrap_and_sum_test_scalars() {
+    let base_scalars = [
+        Fp::new(ArkBigInt([1, 0, 0, 0])),
+        Fp::new(ArkBigInt([2, 0, 0, 0])),
+        Fp::new(ArkBigInt([3, 0, 0, 0])),
+    ];
+    let wrapped = TestScalar::wrap_slice(&base_scalars);
+
+    assert_eq!(wrapped, [1_i64, 2, 3].map(TestScalar::from));
+    assert_eq!(TestScalar::unwrap_slice(&wrapped), base_scalars);
+    assert_eq!(wrapped.iter().sum::<TestScalar>(), TestScalar::from(6));
+    let bytes = TestScalar::from_bigint([9, 0, 0, 0]).to_bytes_le();
+    assert_eq!(bytes.len(), 32);
+    assert_eq!(bytes[0], 9);
+    assert!(bytes[1..].iter().all(|byte| *byte == 0));
+}
+
+#[test]
+fn we_cannot_convert_negative_or_large_scalars_to_u8() {
+    assert!(matches!(
+        u8::try_from(-TestScalar::ONE),
+        Err(ScalarConversionError::Overflow { .. })
+    ));
+    assert!(matches!(
+        u8::try_from(TestScalar::from(300_u64)),
+        Err(ScalarConversionError::Overflow { .. })
+    ));
+    assert!(matches!(
+        u8::try_from(TestScalar::from([0, 1, 0, 0])),
+        Err(ScalarConversionError::Overflow { .. })
+    ));
+}
+
+#[test]
+fn we_cannot_convert_high_limb_scalars_to_i128() {
+    assert!(matches!(
+        i128::try_from(TestScalar::from([0, 0, 1, 0])),
+        Err(ScalarConversionError::Overflow { .. })
+    ));
 }

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -56,9 +56,9 @@ pub use verifiable_query_result::VerifiableQueryResult;
 #[cfg(all(test, feature = "blitzar"))]
 mod verifiable_query_result_test;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod verifiable_query_result_test_utility;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 pub(crate) use verifiable_query_result_test_utility::exercise_verification;
 
 mod result_element_serialization;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -2,10 +2,13 @@ use super::{ProvableQueryResult, QueryError};
 use crate::base::scalar::test_scalar::TestScalar;
 use crate::{
     base::{
-        database::{Column, ColumnField, ColumnType},
+        database::{
+            owned_table_utility::owned_table, Column, ColumnField, ColumnType, OwnedColumn,
+        },
         math::decimal::Precision,
         polynomial::compute_evaluation_vector,
-        scalar::Scalar,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::{Scalar, ScalarExt},
     },
     // proof_primitive::inner_product::TestScalar,
 };
@@ -147,6 +150,61 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
     let expected_evals = [
         TestScalar::from(10u64) * evaluation_vec[0] + TestScalar::from(12u64) * evaluation_vec[1],
         TestScalar::from(5u64) * evaluation_vec[0] + TestScalar::from(9u64) * evaluation_vec[1],
+    ];
+    assert_eq!(evals, expected_evals);
+}
+
+#[test]
+fn we_can_evaluate_result_columns_as_mles_with_small_numeric_binary_and_timestamp_types() {
+    let bools = [true];
+    let uints = [7_u8];
+    let tinyints = [-3_i8];
+    let smallints = [42_i16];
+    let strings = ["abc"];
+    let string_scalars = strings
+        .iter()
+        .map(|v| TestScalar::from(*v))
+        .collect::<Vec<_>>();
+    let raw_bytes = [b"xyz".as_slice()];
+    let byte_scalars = raw_bytes
+        .iter()
+        .map(|bytes| TestScalar::from_byte_slice_via_hash(bytes))
+        .collect::<Vec<_>>();
+    let timestamps = [1_625_072_400_i64];
+
+    let cols: [Column<TestScalar>; 7] = [
+        Column::Boolean(&bools),
+        Column::Uint8(&uints),
+        Column::TinyInt(&tinyints),
+        Column::SmallInt(&smallints),
+        Column::VarChar((&strings, &string_scalars)),
+        Column::VarBinary((raw_bytes.as_slice(), byte_scalars.as_slice())),
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &timestamps),
+    ];
+    let res = ProvableQueryResult::new(1, &cols);
+    let evaluation_point: [TestScalar; 0] = [];
+    let column_fields = [
+        ColumnField::new("bool_col".into(), ColumnType::Boolean),
+        ColumnField::new("uint_col".into(), ColumnType::Uint8),
+        ColumnField::new("tiny_col".into(), ColumnType::TinyInt),
+        ColumnField::new("small_col".into(), ColumnType::SmallInt),
+        ColumnField::new("str_col".into(), ColumnType::VarChar),
+        ColumnField::new("bytes_col".into(), ColumnType::VarBinary),
+        ColumnField::new(
+            "ts_col".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ),
+    ];
+
+    let evals = res.evaluate(&evaluation_point, 1, &column_fields).unwrap();
+    let expected_evals = [
+        TestScalar::from(true),
+        TestScalar::from(7_u8),
+        TestScalar::from(-3_i8),
+        TestScalar::from(42_i16),
+        TestScalar::from("abc"),
+        TestScalar::from_byte_slice_via_hash(b"xyz"),
+        TestScalar::from(1_625_072_400_i64),
     ];
     assert_eq!(evals, expected_evals);
 }
@@ -365,4 +423,69 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_varbinary() {
     .unwrap();
 
     assert_eq!(record_batch, expected);
+}
+
+#[test]
+fn we_can_convert_a_provable_result_to_a_final_result_with_small_numeric_binary_scalar_and_timestamp_columns(
+) {
+    let bools = [true, false];
+    let uints = [1_u8, 200];
+    let tinyints = [-3_i8, 9];
+    let smallints = [42_i16, -11];
+    let raw_bytes = [b"foo".as_slice(), b"bar".as_slice()];
+    let byte_scalars: Vec<TestScalar> = raw_bytes
+        .iter()
+        .map(|bytes| TestScalar::from_byte_slice_via_hash(bytes))
+        .collect();
+    let scalar_values = [TestScalar::from(10_u64), TestScalar::from(25_u64)];
+    let timestamps = [1_625_072_400_i64, 1_625_076_000_i64];
+
+    let cols: [Column<TestScalar>; 7] = [
+        Column::Boolean(&bools),
+        Column::Uint8(&uints),
+        Column::TinyInt(&tinyints),
+        Column::SmallInt(&smallints),
+        Column::VarBinary((raw_bytes.as_slice(), byte_scalars.as_slice())),
+        Column::Scalar(&scalar_values),
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &timestamps),
+    ];
+    let res = ProvableQueryResult::new(2, &cols);
+    let column_fields = vec![
+        ColumnField::new("bool_col".into(), ColumnType::Boolean),
+        ColumnField::new("uint_col".into(), ColumnType::Uint8),
+        ColumnField::new("tiny_col".into(), ColumnType::TinyInt),
+        ColumnField::new("small_col".into(), ColumnType::SmallInt),
+        ColumnField::new("bytes_col".into(), ColumnType::VarBinary),
+        ColumnField::new("scalar_col".into(), ColumnType::Scalar),
+        ColumnField::new(
+            "ts_col".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ),
+    ];
+
+    let owned = res.to_owned_table::<TestScalar>(&column_fields).unwrap();
+    let expected = owned_table([
+        ("bool_col".into(), OwnedColumn::Boolean(vec![true, false])),
+        ("uint_col".into(), OwnedColumn::Uint8(vec![1_u8, 200])),
+        ("tiny_col".into(), OwnedColumn::TinyInt(vec![-3_i8, 9])),
+        ("small_col".into(), OwnedColumn::SmallInt(vec![42_i16, -11])),
+        (
+            "bytes_col".into(),
+            OwnedColumn::VarBinary(vec![b"foo".to_vec(), b"bar".to_vec()]),
+        ),
+        (
+            "scalar_col".into(),
+            OwnedColumn::Scalar(vec![TestScalar::from(10_u64), TestScalar::from(25_u64)]),
+        ),
+        (
+            "ts_col".into(),
+            OwnedColumn::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![1_625_072_400_i64, 1_625_076_000_i64],
+            ),
+        ),
+    ]);
+
+    assert_eq!(owned, expected);
 }

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -93,6 +93,7 @@ impl<'a, S: Scalar> SumcheckSubpolynomial<'a, S> {
 mod tests {
     use super::{SumcheckSubpolynomial, SumcheckSubpolynomialTerm, SumcheckSubpolynomialType};
     use crate::base::scalar::test_scalar::TestScalar;
+    use crate::sql::proof::CompositePolynomialBuilder;
     use alloc::boxed::Box;
 
     #[test]
@@ -118,5 +119,39 @@ mod tests {
         assert_eq!(coeff, TestScalar::from(15));
 
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_compose_for_identity_subpolynomials() {
+        let fr = [TestScalar::from(1), TestScalar::from(2)];
+        let mle = vec![TestScalar::from(3), TestScalar::from(5)];
+        let terms: Vec<SumcheckSubpolynomialTerm<_>> =
+            vec![(TestScalar::from(7), vec![Box::new(&mle)])];
+        let subpoly = SumcheckSubpolynomial::new(SumcheckSubpolynomialType::Identity, terms);
+        let mut builder = CompositePolynomialBuilder::new(1, &fr);
+
+        subpoly.compose(&mut builder, TestScalar::from(11));
+
+        let composed = builder.make_composite_polynomial();
+        assert_eq!(subpoly.subpolynomial_type(), SumcheckSubpolynomialType::Identity);
+        assert_eq!(composed.products.len(), 1);
+        assert_eq!(composed.flattened_ml_extensions.len(), 2);
+    }
+
+    #[test]
+    fn test_compose_for_zero_sum_subpolynomials() {
+        let fr = [TestScalar::from(1), TestScalar::from(2)];
+        let mle = vec![TestScalar::from(13), TestScalar::from(17)];
+        let terms: Vec<SumcheckSubpolynomialTerm<_>> =
+            vec![(TestScalar::from(19), vec![Box::new(&mle)])];
+        let subpoly = SumcheckSubpolynomial::new(SumcheckSubpolynomialType::ZeroSum, terms);
+        let mut builder = CompositePolynomialBuilder::new(1, &fr);
+
+        subpoly.compose(&mut builder, TestScalar::from(23));
+
+        let composed = builder.make_composite_polynomial();
+        assert_eq!(subpoly.subpolynomial_type(), SumcheckSubpolynomialType::ZeroSum);
+        assert_eq!(composed.products.len(), 2);
+        assert_eq!(composed.flattened_ml_extensions.len(), 3);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -1,15 +1,9 @@
 use super::{ProofPlan, VerifiableQueryResult};
-use crate::{
-    base::{
-        commitment::{Commitment, CommittableColumn},
-        database::{owned_table_utility::*, OwnedColumn, OwnedTable, TableRef, TestAccessor},
-        scalar::Scalar,
-    },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+use crate::base::{
+    commitment::CommitmentEvaluationProof,
+    database::{owned_table_utility::*, OwnedColumn, OwnedTable, TableRef, TestAccessor},
+    scalar::Scalar,
 };
-use blitzar::proof::InnerProductProof;
-use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};
-use num_traits::One;
 use serde::Serialize;
 
 /// This function takes a valid `verifiable_result`, copies it, tweaks it, and checks that
@@ -22,42 +16,32 @@ use serde::Serialize;
 /// Will panic if:
 /// - The verification of `res` does not succeed, causing the assertion `assert!(res.verify(...).is_ok())` to fail.
 /// - `fake_accessor.update_offset` fails, causing a panic if it is designed to do so in the implementation.
-pub fn exercise_verification(
-    res: &VerifiableQueryResult<InnerProductProof>,
+pub fn exercise_verification<CP>(
+    res: &VerifiableQueryResult<CP>,
     expr: &(impl ProofPlan + Serialize),
-    accessor: &impl TestAccessor<RistrettoPoint>,
+    accessor: &impl TestAccessor<CP::Commitment>,
     table_ref: &TableRef,
-) {
+) where
+    CP: CommitmentEvaluationProof + Clone,
+    for<'a> CP::VerifierPublicSetup<'a>: Default,
+{
+    let verifier_setup = CP::VerifierPublicSetup::default();
     res.clone()
-        .verify(expr, accessor, &(), &[])
+        .verify(expr, accessor, &verifier_setup, &[])
         .expect("Verification failed");
 
     // try changing the result
     let mut res_p = res.clone();
     res_p.result = tampered_table(&res.result);
-    assert!(res_p.verify(expr, accessor, &(), &[]).is_err());
+    let verifier_setup = CP::VerifierPublicSetup::default();
+    assert!(res_p.verify(expr, accessor, &verifier_setup, &[]).is_err());
 
     // try changing MLE evaluations
     for i in 0..res.proof.pcs_proof_evaluations.final_round.len() {
         let mut res_p = res.clone();
-        res_p.proof.pcs_proof_evaluations.final_round[i] += Curve25519Scalar::one();
-        assert!(res_p.verify(expr, accessor, &(), &[]).is_err());
-    }
-
-    // try changing intermediate commitments
-    let commit_p = RistrettoPoint::compute_commitments(
-        &[CommittableColumn::BigInt(&[
-            353_453_245_i64,
-            93_402_346_i64,
-        ])],
-        0_usize,
-        &(),
-    )[0];
-
-    for i in 0..res.proof.final_round_message.round_commitments.len() {
-        let mut res_p = res.clone();
-        res_p.proof.final_round_message.round_commitments[i] = commit_p;
-        assert!(res_p.verify(expr, accessor, &(), &[]).is_err());
+        res_p.proof.pcs_proof_evaluations.final_round[i] += CP::Scalar::ONE;
+        let verifier_setup = CP::VerifierPublicSetup::default();
+        assert!(res_p.verify(expr, accessor, &verifier_setup, &[]).is_err());
     }
 
     // try changing the offset
@@ -65,20 +49,20 @@ pub fn exercise_verification(
     // Note: in the n = 1 case with proof.commmitments all the identity element,
     // the inner product proof isn't dependent on the generators since it simply sends the input
     // vector; hence, changing the offset would have no effect.
-    if accessor.get_length(table_ref) > 1
-        || res
-            .proof
-            .final_round_message
-            .round_commitments
-            .iter()
-            .any(|&c| c != Identity::identity())
-    {
+    if accessor.get_length(table_ref) > 1 {
         let offset_generators = accessor.get_offset(table_ref);
         let mut fake_accessor = accessor.clone();
         fake_accessor.update_offset(table_ref, offset_generators);
-        res.clone().verify(expr, &fake_accessor, &(), &[]).unwrap();
+        let verifier_setup = CP::VerifierPublicSetup::default();
+        res.clone()
+            .verify(expr, &fake_accessor, &verifier_setup, &[])
+            .unwrap();
         fake_accessor.update_offset(table_ref, offset_generators + 1);
-        assert!(res.clone().verify(expr, &fake_accessor, &(), &[]).is_err());
+        let verifier_setup = CP::VerifierPublicSetup::default();
+        assert!(res
+            .clone()
+            .verify(expr, &fake_accessor, &verifier_setup, &[])
+            .is_err());
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -1,14 +1,14 @@
 use super::AddExpr;
 use crate::{
+    base::scalar::test_scalar::TestScalar as Curve25519Scalar,
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnType, OwnedTableTestAccessor, TableRef,
             TableTestAccessor,
         },
         math::decimal::Precision,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::{test_utility::*, DynProofExpr, ProofExpr},
@@ -23,6 +23,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 // select a, c, b + 4 as res, d from sxt.t where a - b = 3
 #[test]
@@ -57,7 +59,7 @@ fn we_can_prove_a_typical_add_subtract_query() {
             const_bigint(3),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -128,7 +130,7 @@ fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
             const_decimal75(12, 2, 35),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -204,7 +206,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnRef, ColumnType,
             OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
@@ -29,6 +29,8 @@ use rand::{
 use rand_core::SeedableRng;
 use sqlparser::ast::Ident;
 use std::collections::VecDeque;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 #[test]
 fn we_can_prove_a_simple_and_query() {
@@ -60,7 +62,7 @@ fn we_can_prove_a_simple_and_query() {
             ),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -100,7 +102,7 @@ fn we_can_prove_a_simple_and_query_with_128_bits() {
             ),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -160,7 +162,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 equal(column(&t, "c", &accessor), const_bigint(filter_val2)),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
@@ -2,6 +2,7 @@ use super::{
     test_utility::{aliased_plan, cast, column},
     LiteralExpr,
 };
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof;
 use crate::{
     base::{
         database::{
@@ -22,8 +23,9 @@ use crate::{
         AnalyzeError,
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 #[test]
 fn we_can_prove_a_simple_cast_expr() {
@@ -83,7 +85,7 @@ fn we_can_prove_a_simple_cast_expr() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -168,7 +170,7 @@ fn we_can_prove_a_simple_cast_expr_from_int_to_other_numeric_type() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, ColumnField, ColumnType, OwnedTableTestAccessor, TableRef,
         },
@@ -11,6 +11,8 @@ use crate::{
         proof_plans::test_utility::*,
     },
 };
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 #[test]
 fn we_can_prove_a_query_with_a_single_selected_row() {
@@ -25,7 +27,7 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
             vec![ColumnField::new("a".into(), ColumnType::Boolean)],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -1,14 +1,13 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTable,
             OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
         },
         math::decimal::Precision,
-        scalar::Scalar,
+        scalar::{test_scalar::TestScalar as Curve25519Scalar, Scalar},
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::{test_utility::*, DynProofExpr, EqualsExpr, ProofExpr},
@@ -23,6 +22,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 #[test]
 fn we_can_prove_an_equality_query_with_no_rows() {
@@ -48,8 +49,7 @@ fn we_can_prove_an_equality_query_with_no_rows() {
         ),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -82,8 +82,7 @@ fn we_can_prove_another_equality_query_with_no_rows() {
         ),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -121,8 +120,7 @@ fn we_can_prove_a_nested_equality_query_with_no_rows() {
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
-    let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -159,7 +157,7 @@ fn we_can_prove_an_equality_query_with_a_single_selected_row() {
         ),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -193,7 +191,7 @@ fn we_can_prove_another_equality_query_with_a_single_selected_row() {
         ),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -227,7 +225,7 @@ fn we_can_prove_an_equality_query_with_a_single_non_selected_row() {
         ),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -275,7 +273,7 @@ fn we_can_prove_an_equality_query_with_multiple_rows() {
         ),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -328,7 +326,7 @@ fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -377,7 +375,7 @@ fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
         ),
         equal(column(&t, "b", &accessor), const_bigint(123_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -427,7 +425,7 @@ fn we_can_prove_an_equality_query_with_a_string_comparison() {
         ),
         equal(column(&t, "c", &accessor), const_varchar("ghi")),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -487,7 +485,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 const_varchar(filter_val.as_str()),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -586,8 +584,7 @@ fn we_can_query_with_varbinary_equality() {
     );
 
     // Execute and verify query
-    let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -1,15 +1,14 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, LiteralValue, OwnedTable,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-        scalar::{Scalar, ScalarExt},
+        scalar::{test_scalar::TestScalar as Curve25519Scalar, Scalar, ScalarExt},
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::{inequality_expr::InequalityExpr, test_utility::*, DynProofExpr, ProofExpr},
@@ -24,6 +23,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 #[test]
 fn we_can_compare_columns_with_small_timestamp_values_gte() {
@@ -59,8 +60,7 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
         ),
     );
 
-    let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -107,8 +107,7 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
         ),
     );
 
-    let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -139,7 +138,7 @@ fn we_can_compare_a_constant_column() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -166,7 +165,7 @@ fn we_can_compare_a_varying_column_with_constant_sign() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -214,7 +213,7 @@ fn we_can_compare_columns_with_extreme_values() {
             column(&t, "boolean", &accessor),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -250,7 +249,7 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
         ),
         lte(column(&t, "e", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -299,7 +298,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
             .unwrap(),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -349,7 +348,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
             .unwrap(),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -394,7 +393,7 @@ fn we_can_compare_columns_returning_extreme_decimal_values() {
         ),
         lte(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -452,7 +451,7 @@ fn we_can_compare_two_columns() {
         ),
         lte(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -482,7 +481,7 @@ fn we_can_compare_a_varying_column_with_constant_absolute_value() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -512,7 +511,7 @@ fn we_can_compare_a_constant_column_of_negative_columns() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -542,7 +541,7 @@ fn we_can_compare_a_varying_column_with_negative_only_signs() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -569,7 +568,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -596,7 +595,7 @@ fn we_can_compare_column_with_greater_than_or_equal() {
         ),
         gte(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -631,7 +630,7 @@ fn we_can_run_nested_comparison() {
             column(&t, "boolean", &accessor),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -658,7 +657,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs_and_a_constant
         ),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -685,7 +684,7 @@ fn we_can_compare_a_constant_column_of_zeros() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -712,7 +711,7 @@ fn the_sign_can_be_0_or_1_for_a_constant_column_of_zeros() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -758,7 +757,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
             lte(column(&t, "a", &accessor), const_bigint(filter_val)),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -1,13 +1,13 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
             Table, TableRef,
         },
+        scalar::test_scalar::TestScalar as Curve25519Scalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::test_utility::*,
@@ -20,6 +20,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 fn test_random_tables_with_given_offset(offset: usize) {
     let dist = Uniform::new(-3, 4);
@@ -59,7 +61,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
             const_bool(lit),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -108,7 +110,7 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -128,7 +130,7 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(false),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -2,7 +2,7 @@
 mod proof_expr;
 pub(crate) use proof_expr::DecimalProofExpr;
 pub use proof_expr::ProofExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod proof_expr_test;
 
 mod aliased_dyn_proof_expr;
@@ -12,12 +12,12 @@ mod add_expr;
 pub(crate) use add_expr::AddExpr;
 mod subtract_expr;
 pub(crate) use subtract_expr::SubtractExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod add_subtract_expr_test;
 
 mod multiply_expr;
 pub(crate) use multiply_expr::MultiplyExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod multiply_expr_test;
 
 mod dyn_proof_expr;
@@ -25,32 +25,32 @@ pub use dyn_proof_expr::DynProofExpr;
 
 mod literal_expr;
 pub(crate) use literal_expr::LiteralExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod literal_expr_test;
 
 mod placeholder_expr;
 pub(crate) use placeholder_expr::PlaceholderExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod placeholder_expr_test;
 
 mod and_expr;
 pub(crate) use and_expr::AndExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod and_expr_test;
 
 mod inequality_expr;
 pub(crate) use inequality_expr::InequalityExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod inequality_expr_test;
 
 mod or_expr;
 pub(crate) use or_expr::OrExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod or_expr_test;
 
 mod not_expr;
 pub(crate) use not_expr::NotExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod not_expr_test;
 
 mod numerical_util;
@@ -60,7 +60,7 @@ pub(crate) use numerical_util::{divide_columns, modulo_columns};
 
 mod equals_expr;
 pub(crate) use equals_expr::EqualsExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod equals_expr_test;
 
 mod table_expr;
@@ -71,15 +71,15 @@ pub(crate) mod test_utility;
 
 mod column_expr;
 pub use column_expr::ColumnExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod column_expr_test;
 
 mod cast_expr;
 pub(crate) use cast_expr::CastExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod cast_expr_test;
 
 mod scaling_cast_expr;
 pub(crate) use scaling_cast_expr::ScalingCastExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod scaling_cast_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -1,13 +1,13 @@
 use crate::{
+    base::scalar::test_scalar::TestScalar as Curve25519Scalar,
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnType, OwnedTableTestAccessor, TableRef,
             TableTestAccessor,
         },
         math::decimal::Precision,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::{multiply_expr::MultiplyExpr, test_utility::*, DynProofExpr, ProofExpr},
@@ -22,6 +22,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 // select a * 2 as a, c, b * 4.5 as b, d * 3  + 4.7 as d, e from sxt.t where d * 3.9 = 8.19
 #[test]
@@ -68,7 +70,7 @@ fn we_can_prove_a_typical_multiply_query() {
             const_decimal75(3, 2, 819),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -135,7 +137,7 @@ fn where_clause_can_wrap_around() {
         ),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -220,7 +222,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
             TableRef, TableTestAccessor, TestAccessor,
@@ -21,6 +21,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 #[test]
 fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {
@@ -44,7 +46,7 @@ fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {
         ),
         not(equal(column(&t, "b", &accessor), const_bigint(1))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -97,7 +99,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             )),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
             TableRef, TableTestAccessor, TestAccessor,
@@ -20,6 +20,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 #[test]
 fn we_can_prove_a_simple_or_query() {
@@ -46,7 +48,7 @@ fn we_can_prove_a_simple_or_query() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -81,7 +83,7 @@ fn we_can_prove_a_simple_or_query_with_variable_integer_types() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -118,7 +120,7 @@ fn we_can_prove_an_or_query_where_both_lhs_and_rhs_are_true() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -178,7 +180,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 equal(column(&t, "c", &accessor), const_bigint(filter_val2)),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
@@ -1,14 +1,14 @@
 use super::{DynProofExpr, PlaceholderExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, LiteralValue,
             OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
         },
         proof::{PlaceholderError, ProofError},
+        scalar::test_scalar::TestScalar as Curve25519Scalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{QueryError, VerifiableQueryResult},
         proof_exprs::test_utility::*,
@@ -21,6 +21,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 #[test]
 fn we_can_get_id_and_type_of_placeholder_expr() {
@@ -77,8 +79,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             const_bool(true),
         );
         let params = vec![random_bigint_literal, random_varchar_literal];
-        let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &params).unwrap();
+        let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &params).unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &params)
             .unwrap()
@@ -124,13 +125,9 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
-        &ast,
-        &accessor,
-        &(),
-        &[LiteralValue::Boolean(true)],
-    )
-    .unwrap();
+    let verifiable_res =
+        TestVerifiableQueryResult::new(&ast, &accessor, &(), &[LiteralValue::Boolean(true)])
+            .unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[LiteralValue::Boolean(true)])
         .unwrap()
@@ -150,13 +147,9 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(false),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
-        &ast,
-        &accessor,
-        &(),
-        &[LiteralValue::Boolean(true)],
-    )
-    .unwrap();
+    let verifiable_res =
+        TestVerifiableQueryResult::new(&ast, &accessor, &(), &[LiteralValue::Boolean(true)])
+            .unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[LiteralValue::Boolean(true)])
         .unwrap()
@@ -190,7 +183,7 @@ fn we_cannot_prove_placeholder_expr_if_interpolate_fails() {
         const_bool(true),
     );
     assert!(matches!(
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[],),
+        TestVerifiableQueryResult::new(&ast, &accessor, &(), &[],),
         Err(PlaceholderError::InvalidPlaceholderIndex { .. })
     ));
 }
@@ -206,13 +199,9 @@ fn we_cannot_verify_placeholder_expr_if_interpolate_fails() {
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
-        &ast,
-        &accessor,
-        &(),
-        &[LiteralValue::Boolean(true)],
-    )
-    .unwrap();
+    let verifiable_res =
+        TestVerifiableQueryResult::new(&ast, &accessor, &(), &[LiteralValue::Boolean(true)])
+            .unwrap();
     assert!(matches!(
         verifiable_res.verify(&ast, &accessor, &(), &[]),
         Err(QueryError::ProofError {
@@ -236,7 +225,7 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+    let verifiable_res = TestVerifiableQueryResult::new(
         &ast,
         &accessor,
         &(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -1,6 +1,6 @@
 use super::{test_utility::*, DynProofExpr, ProofExpr};
 use crate::base::{
-    commitment::InnerProductProof,
+    commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
     database::{table_utility::*, Column, TableRef, TableTestAccessor, TestAccessor},
 };
 use bumpalo::Bump;

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
@@ -1,3 +1,4 @@
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof;
 use crate::{
     base::{
         database::{
@@ -18,7 +19,8 @@ use crate::{
         proof_plans::test_utility::{column_field, filter, table_exec},
     },
 };
-use blitzar::proof::InnerProductProof;
+
+type TestVerifiableQueryResult = VerifiableQueryResult<InnerProductProof>;
 
 #[test]
 fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
@@ -91,7 +93,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -152,7 +154,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_decimal_to_decimal() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -194,7 +196,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_timestamp_to_timestamp() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res = TestVerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -196,15 +196,17 @@ impl ProofPlan for MembershipCheckTestPlan {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
+            database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
+            scalar::test_scalar::TestScalar as Curve25519Scalar,
+        },
         sql::proof::VerifiableQueryResult,
     };
-    use blitzar::proof::InnerProductProof;
 
     #[test]
     fn we_can_do_minimal_membership_check() {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use sign_expr::{
 mod range_check;
 #[cfg(all(test, feature = "blitzar"))]
 mod range_check_test;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod sign_expr_test;
 pub(crate) use monotonic::{
     final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -118,19 +118,19 @@ impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
             database::{table_utility::*, ColumnType, TableTestAccessor},
             math::decimal::Precision,
             posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+            scalar::test_scalar::TestScalar as Curve25519Scalar,
         },
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
         sql::proof::{QueryError, VerifiableQueryResult},
     };
-    use blitzar::proof::InnerProductProof;
 
     fn check_monotonic<const STRICT: bool, const ASC: bool>(
         table_ref: TableRef,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -159,15 +159,17 @@ impl ProofPlan for PermutationCheckTestPlan {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
+            database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
+            scalar::test_scalar::TestScalar as Curve25519Scalar,
+        },
         sql::proof::VerifiableQueryResult,
     };
-    use blitzar::proof::InnerProductProof;
 
     #[test]
     fn we_can_do_minimal_permutation_check() {

--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
@@ -1,13 +1,13 @@
 use super::test_utility::*;
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnType,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
+        scalar::test_scalar::TestScalar as Curve25519Scalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::test_utility::*,
@@ -41,7 +41,7 @@ fn we_can_prove_aggregation_without_group_by() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -76,7 +76,7 @@ fn we_can_prove_a_simple_aggregate_with_bigint_columns() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -118,7 +118,7 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -306,7 +306,7 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -377,7 +377,7 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         const_bool(true),
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -1,7 +1,7 @@
 use super::{test_utility::*, DynProofPlan};
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType, TableRef,
             TableTestAccessor, TestAccessor,
@@ -80,7 +80,7 @@ fn we_can_correctly_filter_data_with_filter() {
         where_clause,
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected_res = owned_table([bigint("b", [3_i64, 5])]);
@@ -120,7 +120,7 @@ fn we_can_correctly_filter_with_complex_condition() {
         where_clause,
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected_res = owned_table([
@@ -167,7 +167,7 @@ fn we_can_compose_multiple_filters() {
         lt(column(&t, "b", &accessor), const_int128(4_i128)),
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected_res = owned_table([
@@ -237,7 +237,7 @@ fn we_can_compose_complex_filters() {
             const_int128(11_i128),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected_res = owned_table([
@@ -343,7 +343,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
         ),
     );
     let res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&filter, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<InnerProductProof>::new(&filter, &accessor, &(), &[]).unwrap();
     res.verify(&filter, &accessor, &(), &[]).unwrap();
     let expected_evm_proof_plan = EVMProofPlan::new(filter);
     let deserialized_evem_proof_plan: EVMProofPlan = try_standard_binary_deserialization(
@@ -352,7 +352,13 @@ fn we_can_have_projection_as_input_plan_for_filter() {
     .unwrap()
     .0;
     let res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&deserialized_evem_proof_plan, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<InnerProductProof>::new(
+            &deserialized_evem_proof_plan,
+            &accessor,
+            &(),
+            &[],
+        )
+        .unwrap();
     res.verify(&deserialized_evem_proof_plan, &accessor, &(), &[])
         .unwrap();
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
@@ -1,10 +1,10 @@
 use super::test_utility::*;
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{owned_table_utility::*, OwnedTableTestAccessor, TableRef, TestAccessor},
+        scalar::test_scalar::TestScalar as Curve25519Scalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::test_utility::*,
@@ -30,7 +30,7 @@ fn we_can_prove_aggregation_without_group_by() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -58,7 +58,7 @@ fn we_can_prove_a_simple_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -93,7 +93,7 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -251,7 +251,7 @@ fn we_cannot_prove_a_complex_group_by_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
@@ -1,6 +1,7 @@
 use super::{test_utility::*, LegacyFilterExec};
 use crate::{
     base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
             LiteralValue, OwnedTable, OwnedTableTestAccessor, TableRef, TableTestAccessor,
@@ -8,8 +9,8 @@ use crate::{
         },
         map::{indexmap, IndexMap, IndexSet},
         math::decimal::Precision,
+        scalar::test_scalar::TestScalar as Curve25519Scalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
             exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
@@ -18,7 +19,6 @@ use crate::{
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, LiteralExpr, TableExpr},
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
 
@@ -163,7 +163,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_filter() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let where_clause = equal(column(&t, "a", &accessor), const_int128(5_i128));
     let ast = legacy_filter(cols_expr_plan(&t, &["b"], &accessor), tab(&t), where_clause);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -395,7 +396,7 @@ fn we_can_prove_a_filter_with_empty_results() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -434,7 +435,7 @@ fn we_can_prove_a_filter() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(105)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -19,7 +19,7 @@ mod legacy_filter_exec;
 pub(crate) use legacy_filter_exec::LegacyFilterExec;
 #[cfg(test)]
 pub(crate) use legacy_filter_exec::OstensibleLegacyFilterExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod legacy_filter_exec_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod legacy_filter_exec_test_dishonest_prover;
@@ -32,34 +32,34 @@ mod fold_util_test;
 mod group_by_exec;
 pub(crate) use group_by_exec::GroupByExec;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod group_by_exec_test;
 
 mod filter_exec;
 pub(crate) use filter_exec::FilterExec;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod filter_exec_test;
 
 mod aggregate_exec;
 pub(crate) use aggregate_exec::AggregateExec;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod aggregate_exec_test;
 
 mod slice_exec;
 pub(crate) use slice_exec::SliceExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod slice_exec_test;
 
 mod union_exec;
 pub(crate) use union_exec::UnionExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod union_exec_test;
 
 mod sort_merge_join_exec;
 pub use sort_merge_join_exec::SortMergeJoinExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod sort_merge_join_exec_test;
 
 mod dyn_proof_plan;

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -1,14 +1,15 @@
 use super::{test_utility::*, DynProofPlan, ProjectionExec};
 use crate::{
     base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
             OwnedTable, OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         map::{indexmap, IndexMap, IndexSet},
         math::decimal::Precision,
+        scalar::test_scalar::TestScalar as Curve25519Scalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
             exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
@@ -18,7 +19,6 @@ use crate::{
         proof_plans::TableExec,
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
 
@@ -131,7 +131,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -166,7 +167,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -228,7 +230,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
             equal(column(&t, "a", &accessor), const_int128(5)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -483,7 +486,7 @@ fn we_can_prove_a_projection() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -247,3 +247,27 @@ impl ProverEvaluate for SliceExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::proof_plans::test_utility::empty_exec;
+
+    #[test]
+    fn we_can_compute_slice_selection_ranges() {
+        assert_eq!(get_slice_select(5, 1, Some(2)), vec![false, true, true, false, false]);
+        assert_eq!(get_slice_select(4, 0, Some(2)), vec![true, true, false, false]);
+        assert_eq!(get_slice_select(4, 2, None), vec![false, false, true, true]);
+        assert_eq!(get_slice_select(3, 10, Some(1)), vec![false, false, false]);
+    }
+
+    #[test]
+    fn we_can_read_slice_exec_configuration() {
+        let input = Box::new(empty_exec());
+        let exec = SliceExec::new(input, 3, Some(5));
+
+        assert_eq!(exec.input(), &empty_exec());
+        assert_eq!(exec.skip(), 3);
+        assert_eq!(exec.fetch(), Some(5));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -1,14 +1,15 @@
 use super::test_utility::*;
 use crate::{
     base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnType, OwnedTable,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         map::{indexmap, IndexMap},
         math::decimal::Precision,
+        scalar::test_scalar::TestScalar as Curve25519Scalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
             exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
@@ -17,7 +18,6 @@ use crate::{
         proof_exprs::{test_utility::*, DynProofExpr},
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 
 #[test]
@@ -43,7 +43,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -79,7 +80,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -365,7 +367,7 @@ fn we_can_prove_a_slice_exec() {
         2,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -424,7 +426,7 @@ fn we_can_prove_a_nested_slice_exec() {
         1,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -483,7 +485,7 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -542,7 +544,7 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -595,7 +597,8 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])
@@ -644,7 +647,7 @@ fn we_can_prove_a_slice_exec_if_it_has_groupby_with_provable_uniqueness_as_input
         None,
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &plan, &accessor, &t);
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -1,5 +1,6 @@
 use super::test_utility::*;
 use crate::{
+    base::commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
     base::database::{
         owned_table_utility::*, table_utility::*, ColumnType, TableRef, TableTestAccessor,
         TestAccessor,
@@ -9,7 +10,6 @@ use crate::{
         proof_exprs::test_utility::*,
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
 
@@ -57,7 +57,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -135,7 +135,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
         Some(3),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -268,7 +268,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
     );
 
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -333,7 +333,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -386,7 +386,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_right);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -437,7 +437,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
@@ -1,12 +1,14 @@
 use super::test_utility::*;
 use crate::{
-    base::database::{
-        owned_table_utility::*, table_utility::*, ColumnField, ColumnType, TableRef,
-        TableTestAccessor,
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
+        database::{
+            owned_table_utility::*, table_utility::*, ColumnField, ColumnType, TableRef,
+            TableTestAccessor,
+        },
     },
     sql::proof::{exercise_verification, VerifiableQueryResult},
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 
 #[test]
@@ -68,7 +70,8 @@ fn we_can_create_and_prove_a_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -1,13 +1,14 @@
 use super::test_utility::*;
 use crate::{
     base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnType, OwnedTable,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         map::indexmap,
+        scalar::test_scalar::TestScalar as Curve25519Scalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
             exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
@@ -16,7 +17,6 @@ use crate::{
         proof_exprs::test_utility::*,
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 
 #[test]
@@ -113,7 +113,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
             ],
         ),
     ]);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -254,7 +255,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
             ],
         ),
     ]);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/tests/utils_binaries.rs
+++ b/crates/proof-of-sql/tests/utils_binaries.rs
@@ -1,0 +1,118 @@
+use curve25519_dalek::ristretto::RistrettoPoint;
+use proof_of_sql::base::commitment::TableCommitment;
+use std::{
+    fs,
+    process::{Command, Stdio},
+};
+use tempfile::tempdir;
+
+#[test]
+fn generate_parameters_can_create_verifier_artifacts_and_refresh_digests() {
+    let temp_dir = tempdir().expect("temp dir");
+    let target = temp_dir.path();
+    let binary = env!("CARGO_BIN_EXE_generate-parameters");
+
+    let first_run = Command::new(binary)
+        .args(["--nu", "1", "--mode", "verifier", "--target"])
+        .arg(target)
+        .output()
+        .expect("run generate-parameters");
+    assert!(
+        first_run.status.success(),
+        "first run failed: {first_run:?}"
+    );
+
+    let verifier_setup = target.join("verifier_setup_nu_1.bin");
+    let digests = target.join("digests_nu_1.txt");
+    assert!(verifier_setup.exists(), "missing verifier setup");
+    assert!(digests.exists(), "missing digests file");
+
+    let first_digest_contents = fs::read_to_string(&digests).expect("read digests");
+    assert!(first_digest_contents.contains("verifier_setup_nu_1.bin"));
+
+    let second_run = Command::new(binary)
+        .args(["--nu", "1", "--mode", "verifier", "--target"])
+        .arg(target)
+        .output()
+        .expect("rerun generate-parameters");
+    assert!(
+        second_run.status.success(),
+        "second run failed: {second_run:?}"
+    );
+
+    let refreshed_digest_contents = fs::read_to_string(&digests).expect("read refreshed digests");
+    assert_eq!(refreshed_digest_contents.lines().count(), 1);
+}
+
+#[test]
+fn generate_parameters_fails_when_target_is_a_file() {
+    let temp_dir = tempdir().expect("temp dir");
+    let target_file = temp_dir.path().join("not-a-directory");
+    fs::write(&target_file, b"occupied").expect("write target file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_generate-parameters"))
+        .args(["--nu", "1", "--mode", "verifier", "--target"])
+        .arg(&target_file)
+        .output()
+        .expect("run generate-parameters with invalid target");
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn commitment_utility_can_deserialize_ipa_commitments_to_a_file() {
+    let temp_dir = tempdir().expect("temp dir");
+    let input_path = temp_dir.path().join("commitment.bin");
+    let output_path = temp_dir.path().join("commitment.txt");
+    let encoded = postcard::to_allocvec(&TableCommitment::<RistrettoPoint>::default())
+        .expect("serialize empty table commitment");
+    fs::write(&input_path, encoded).expect("write encoded commitment");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_commitment-utility"))
+        .args(["--scheme", "ipa", "--input"])
+        .arg(&input_path)
+        .args(["--output"])
+        .arg(&output_path)
+        .output()
+        .expect("run commitment-utility");
+
+    assert!(output.status.success(), "utility failed: {output:?}");
+    let rendered = fs::read_to_string(&output_path).expect("read output");
+    assert!(rendered.contains("TableCommitment"));
+}
+
+#[test]
+fn commitment_utility_rejects_invalid_input_from_stdin() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_commitment-utility"))
+        .args(["--scheme", "ipa"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn commitment-utility");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        use std::io::Write;
+        stdin.write_all(b"definitely-not-postcard")
+            .expect("write invalid bytes");
+    }
+
+    let output = child.wait_with_output().expect("wait on child");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn commitment_utility_reports_missing_input_files() {
+    let missing = tempdir()
+        .expect("temp dir")
+        .path()
+        .join("missing-commitment.bin");
+    let output = Command::new(env!("CARGO_BIN_EXE_commitment-utility"))
+        .args(["--scheme", "ipa", "--input"])
+        .arg(&missing)
+        .output()
+        .expect("run commitment-utility with missing input");
+
+    assert!(!output.status.success());
+}

--- a/crates/proof-of-sql/utils/commitment-utility/main.rs
+++ b/crates/proof-of-sql/utils/commitment-utility/main.rs
@@ -67,9 +67,17 @@ type CommitUtilityResult<T, E = CommitUtilityError> = std::result::Result<T, E>;
 
 fn main() -> CommitUtilityResult<()> {
     let cli = Cli::parse();
+    run(cli, &mut io::stdin(), &mut io::stdout())
+}
 
-    // Read input data
-    let input_data = if let Some(input_file) = &cli.input {
+fn run(cli: Cli, stdin: &mut impl Read, stdout: &mut impl Write) -> CommitUtilityResult<()> {
+    let input_data = read_input(cli.input.as_ref(), stdin)?;
+    let human_readable = render_commitment(&input_data, &cli.scheme)?;
+    write_output(cli.output.as_ref(), &human_readable, stdout)
+}
+
+fn read_input(input: Option<&PathBuf>, stdin: &mut impl Read) -> CommitUtilityResult<Vec<u8>> {
+    if let Some(input_file) = input {
         let mut file = File::open(input_file).map_err(|_| CommitUtilityError::OpenInputFile {
             filename: input_file.clone(),
         })?;
@@ -78,37 +86,46 @@ fn main() -> CommitUtilityResult<()> {
             .map_err(|_| CommitUtilityError::ReadInputFile {
                 filename: input_file.clone(),
             })?;
-        buffer
+        Ok(buffer)
     } else {
         let mut buffer = Vec::new();
-        io::stdin()
+        stdin
             .read_to_end(&mut buffer)
             .map_err(|_| CommitUtilityError::ReadStdin)?;
-        buffer
-    };
+        Ok(buffer)
+    }
+}
 
-    // Deserialize commitment based on the scheme
-    let human_readable = match cli.scheme {
+fn render_commitment(
+    input_data: &[u8],
+    scheme: &CommitmentScheme,
+) -> CommitUtilityResult<String> {
+    match scheme {
         CommitmentScheme::DynamicDory => {
             let commitment: TableCommitment<DynamicDoryCommitment> =
                 postcard::from_bytes(&input_data)
                     .map_err(|_| CommitUtilityError::DeserializationError)?;
-            format!("{commitment:#?}")
+            Ok(format!("{commitment:#?}"))
         }
         CommitmentScheme::Dory => {
             let commitment: TableCommitment<DoryCommitment> = postcard::from_bytes(&input_data)
                 .map_err(|_| CommitUtilityError::DeserializationError)?;
-            format!("{commitment:#?}")
+            Ok(format!("{commitment:#?}"))
         }
         CommitmentScheme::Ipa => {
             let commitment: TableCommitment<RistrettoPoint> = postcard::from_bytes(&input_data)
                 .map_err(|_| CommitUtilityError::DeserializationError)?;
-            format!("{commitment:#?}")
+            Ok(format!("{commitment:#?}"))
         }
-    };
+    }
+}
 
-    // Write output data
-    match &cli.output {
+fn write_output(
+    output: Option<&PathBuf>,
+    human_readable: &str,
+    stdout: &mut impl Write,
+) -> CommitUtilityResult<()> {
+    match output {
         Some(output_file) => {
             let mut file =
                 File::create(output_file).map_err(|_| CommitUtilityError::CreateOutputFile {
@@ -121,11 +138,150 @@ fn main() -> CommitUtilityResult<()> {
             })?;
         }
         None => {
-            io::stdout()
+            stdout
                 .write_all(human_readable.as_bytes())
                 .map_err(|_| CommitUtilityError::WriteStdout)?;
         }
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proof_of_sql::proof_primitive::dory::{DoryCommitment, DynamicDoryCommitment};
+    use std::{
+        fs,
+        io::{self, Cursor, Read, Write},
+    };
+    use tempfile::tempdir;
+
+    struct FailingReader;
+
+    impl Read for FailingReader {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("boom"))
+        }
+    }
+
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("boom"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn we_can_read_input_from_a_file_or_stdin() {
+        let temp_dir = tempdir().expect("temp dir");
+        let input_path = temp_dir.path().join("commitment.bin");
+        fs::write(&input_path, b"abc").expect("write input");
+
+        let mut ignored_stdin = Cursor::new(b"stdin".to_vec());
+        assert_eq!(
+            read_input(Some(&input_path), &mut ignored_stdin).unwrap(),
+            b"abc"
+        );
+
+        let mut stdin = Cursor::new(b"stdin".to_vec());
+        assert_eq!(read_input(None, &mut stdin).unwrap(), b"stdin");
+    }
+
+    #[test]
+    fn we_report_missing_input_and_deserialization_failures() {
+        let mut stdin = Cursor::new(Vec::<u8>::new());
+        let missing = PathBuf::from("definitely-missing.bin");
+        assert!(matches!(
+            read_input(Some(&missing), &mut stdin),
+            Err(CommitUtilityError::OpenInputFile { .. })
+        ));
+
+        assert!(matches!(
+            read_input(None, &mut FailingReader),
+            Err(CommitUtilityError::ReadStdin)
+        ));
+
+        assert!(matches!(
+            render_commitment(b"not-postcard", &CommitmentScheme::Ipa),
+            Err(CommitUtilityError::DeserializationError)
+        ));
+    }
+
+    #[test]
+    fn we_can_render_all_supported_commitment_schemes() {
+        let ipa = postcard::to_allocvec(&TableCommitment::<RistrettoPoint>::default())
+            .expect("serialize ipa");
+        let dory = postcard::to_allocvec(&TableCommitment::<DoryCommitment>::default())
+            .expect("serialize dory");
+        let dynamic = postcard::to_allocvec(&TableCommitment::<DynamicDoryCommitment>::default())
+            .expect("serialize dynamic dory");
+
+        assert!(render_commitment(&ipa, &CommitmentScheme::Ipa)
+            .unwrap()
+            .contains("TableCommitment"));
+        assert!(render_commitment(&dory, &CommitmentScheme::Dory)
+            .unwrap()
+            .contains("TableCommitment"));
+        assert!(render_commitment(&dynamic, &CommitmentScheme::DynamicDory)
+            .unwrap()
+            .contains("TableCommitment"));
+    }
+
+    #[test]
+    fn we_can_write_output_to_a_file_or_stdout() {
+        let temp_dir = tempdir().expect("temp dir");
+        let output_path = temp_dir.path().join("commitment.txt");
+        let mut stdout = Cursor::new(Vec::<u8>::new());
+
+        write_output(Some(&output_path), "file body", &mut stdout).unwrap();
+        assert_eq!(fs::read_to_string(&output_path).unwrap(), "file body");
+
+        write_output(None, "stdout body", &mut stdout).unwrap();
+        assert_eq!(String::from_utf8(stdout.into_inner()).unwrap(), "stdout body");
+    }
+
+    #[test]
+    fn we_report_output_failures() {
+        let temp_dir = tempdir().expect("temp dir");
+        let missing_parent = temp_dir.path().join("missing").join("commitment.txt");
+        let mut stdout = Cursor::new(Vec::<u8>::new());
+
+        assert!(matches!(
+            write_output(Some(&missing_parent), "body", &mut stdout),
+            Err(CommitUtilityError::CreateOutputFile { .. })
+        ));
+        assert!(matches!(
+            write_output(None, "body", &mut FailingWriter),
+            Err(CommitUtilityError::WriteStdout)
+        ));
+    }
+
+    #[test]
+    fn we_can_run_the_full_commitment_utility_flow() {
+        let temp_dir = tempdir().expect("temp dir");
+        let input_path = temp_dir.path().join("commitment.bin");
+        let output_path = temp_dir.path().join("commitment.txt");
+        let encoded = postcard::to_allocvec(&TableCommitment::<RistrettoPoint>::default())
+            .expect("serialize empty table commitment");
+        fs::write(&input_path, encoded).expect("write encoded commitment");
+
+        let cli = Cli {
+            input: Some(input_path),
+            output: Some(output_path.clone()),
+            scheme: CommitmentScheme::Ipa,
+        };
+        let mut stdin = Cursor::new(Vec::<u8>::new());
+        let mut stdout = Cursor::new(Vec::<u8>::new());
+
+        run(cli, &mut stdin, &mut stdout).unwrap();
+        assert!(fs::read_to_string(output_path)
+            .unwrap()
+            .contains("TableCommitment"));
+    }
 }

--- a/crates/proof-of-sql/utils/generate-parameters/main.rs
+++ b/crates/proof-of-sql/utils/generate-parameters/main.rs
@@ -324,3 +324,95 @@ fn spinner(message: String) -> ProgressBar {
     spinner.set_message(message);
     spinner
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_std::rand::RngCore;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn test_args(seed: &str) -> Args {
+        Args {
+            nu: 4,
+            mode: Mode::Verifier,
+            seed: seed.to_owned(),
+            target: "./output".to_owned(),
+        }
+    }
+
+    #[test]
+    fn rng_from_seed_is_deterministic_and_zero_pads_short_inputs() {
+        let mut rng_a = rng_from_seed(&test_args("abc"));
+        let mut rng_b = rng_from_seed(&test_args("abc"));
+        let mut rng_c = rng_from_seed(&test_args("abc\0"));
+        let mut rng_d = rng_from_seed(&test_args(&"x".repeat(40)));
+
+        assert_eq!(rng_a.next_u64(), rng_b.next_u64());
+        assert_ne!(rng_a.next_u64(), rng_c.next_u64());
+        assert_eq!(
+            rng_d.next_u64(),
+            rng_from_seed(&test_args(&"x".repeat(32))).next_u64()
+        );
+    }
+
+    #[test]
+    fn we_can_compute_sha256_for_existing_files() {
+        let temp_dir = tempdir().expect("temp dir");
+        let file_path = temp_dir.path().join("artifact.bin");
+        fs::write(&file_path, b"abc").expect("write artifact");
+
+        assert_eq!(
+            compute_sha256(file_path.to_str().unwrap()).unwrap(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert!(compute_sha256(temp_dir.path().join("missing.bin").to_str().unwrap()).is_none());
+    }
+
+    #[test]
+    fn save_digests_appends_multiple_lines_to_the_expected_file() {
+        let temp_dir = tempdir().expect("temp dir");
+        let target = temp_dir.path().to_str().unwrap();
+
+        save_digests(
+            &[
+                ("first.bin".to_owned(), "digest-1".to_owned()),
+                ("second.bin".to_owned(), "digest-2".to_owned()),
+            ],
+            target,
+            7,
+        );
+        save_digests(&[("third.bin".to_owned(), "digest-3".to_owned())], target, 7);
+
+        let digests_path = temp_dir.path().join("digests_nu_7.txt");
+        let contents = fs::read_to_string(digests_path).expect("read digests");
+        assert_eq!(
+            contents.lines().collect::<Vec<_>>(),
+            vec![
+                "digest-1  first.bin",
+                "digest-2  second.bin",
+                "digest-3  third.bin"
+            ]
+        );
+    }
+
+    #[test]
+    fn save_digests_tolerates_unwritable_targets() {
+        let temp_dir = tempdir().expect("temp dir");
+        let occupied = temp_dir.path().join("occupied");
+        fs::write(&occupied, b"not a directory").expect("write occupied file");
+
+        save_digests(
+            &[("first.bin".to_owned(), "digest-1".to_owned())],
+            occupied.to_str().unwrap(),
+            3,
+        );
+    }
+
+    #[test]
+    fn spinner_uses_the_supplied_message() {
+        let spinner = spinner("working".to_owned());
+        assert_eq!(spinner.message(), "working");
+        spinner.finish_and_clear();
+    }
+}


### PR DESCRIPTION
Started adding tests for uncovered code paths that looked worth covering.

/claim #560

# Rationale for this change

Improve coverage for uncovered production paths with focused tests rather than broad or redundant assertions.

# What changes are included in this PR?

- added coverage for planner expression conversion paths
- added coverage for slice execution helper paths
- expanded multilinear extension coverage across more column variants
- added timestamp unit conversion and display coverage
- expanded coverage in database, proof, and arrow paths that were still uncovered
- added utility coverage for `generate-parameters`
- added utility coverage for `commitment-utility`

# Are these changes tested?

Yes.
