### PR TITLE
test: improve coverage for base types and error paths

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,98 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::math::decimal::Precision;
+    use crate::base::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+
+    #[test]
+    fn we_can_create_and_access_column_field() {
+        let field = ColumnField::new("age".into(), ColumnType::Int);
+        assert_eq!(field.name(), "age".into());
+        assert_eq!(field.data_type(), ColumnType::Int);
+    }
+
+    #[test]
+    fn we_can_create_column_field_with_various_types() {
+        let types_and_names = [
+            ("bool_col", ColumnType::Boolean),
+            ("u8_col", ColumnType::Uint8),
+            ("tiny_col", ColumnType::TinyInt),
+            ("small_col", ColumnType::SmallInt),
+            ("int_col", ColumnType::Int),
+            ("big_col", ColumnType::BigInt),
+            ("i128_col", ColumnType::Int128),
+            ("varchar_col", ColumnType::VarChar),
+            ("binary_col", ColumnType::VarBinary),
+            ("scalar_col", ColumnType::Scalar),
+            (
+                "decimal_col",
+                ColumnType::Decimal75(Precision::new(38).unwrap(), 10),
+            ),
+            (
+                "ts_col",
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+            ),
+        ];
+
+        for (name, col_type) in types_and_names {
+            let field = ColumnField::new(name.into(), col_type);
+            assert_eq!(field.name(), name.into());
+            assert_eq!(field.data_type(), col_type);
+        }
+    }
+
+    #[test]
+    fn column_fields_with_same_data_are_equal() {
+        let a = ColumnField::new("x".into(), ColumnType::BigInt);
+        let b = ColumnField::new("x".into(), ColumnType::BigInt);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn column_fields_with_different_names_are_not_equal() {
+        let a = ColumnField::new("x".into(), ColumnType::BigInt);
+        let b = ColumnField::new("y".into(), ColumnType::BigInt);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn column_fields_with_different_types_are_not_equal() {
+        let a = ColumnField::new("x".into(), ColumnType::BigInt);
+        let b = ColumnField::new("x".into(), ColumnType::Int);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn we_can_clone_column_field() {
+        let original = ColumnField::new("col".into(), ColumnType::VarChar);
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn we_can_serialize_and_deserialize_column_field() {
+        let field = ColumnField::new("amount".into(), ColumnType::Int128);
+        let json = serde_json::to_string(&field).unwrap();
+        let deserialized: ColumnField = serde_json::from_str(&json).unwrap();
+        assert_eq!(field, deserialized);
+    }
+
+    #[test]
+    fn we_can_hash_column_field() {
+        use core::hash::{Hash, Hasher};
+        let field = ColumnField::new("col".into(), ColumnType::Int);
+        let mut hasher = ahash::AHasher::default();
+        field.hash(&mut hasher);
+        let hash1 = hasher.finish();
+
+        let mut hasher2 = ahash::AHasher::default();
+        field.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,129 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_create_and_access_column_ref() {
+        let table_ref = TableRef::new("schema", "table");
+        let column_ref = ColumnRef::new(table_ref.clone(), "col_a".into(), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), "col_a".into());
+        assert_eq!(*column_ref.column_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn we_can_create_column_ref_with_various_types() {
+        let table_ref = TableRef::new("ns", "tbl");
+
+        for column_type in [
+            ColumnType::Boolean,
+            ColumnType::Uint8,
+            ColumnType::TinyInt,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::BigInt,
+            ColumnType::Int128,
+            ColumnType::VarChar,
+            ColumnType::VarBinary,
+            ColumnType::Scalar,
+        ] {
+            let col_ref = ColumnRef::new(table_ref.clone(), "c".into(), column_type);
+            assert_eq!(*col_ref.column_type(), column_type);
+        }
+    }
+
+    #[test]
+    fn column_refs_with_same_data_are_equal() {
+        let a = ColumnRef::new(
+            TableRef::new("s", "t"),
+            "x".into(),
+            ColumnType::Int,
+        );
+        let b = ColumnRef::new(
+            TableRef::new("s", "t"),
+            "x".into(),
+            ColumnType::Int,
+        );
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn column_refs_with_different_names_are_not_equal() {
+        let a = ColumnRef::new(
+            TableRef::new("s", "t"),
+            "x".into(),
+            ColumnType::Int,
+        );
+        let b = ColumnRef::new(
+            TableRef::new("s", "t"),
+            "y".into(),
+            ColumnType::Int,
+        );
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn column_refs_with_different_types_are_not_equal() {
+        let a = ColumnRef::new(
+            TableRef::new("s", "t"),
+            "x".into(),
+            ColumnType::Int,
+        );
+        let b = ColumnRef::new(
+            TableRef::new("s", "t"),
+            "x".into(),
+            ColumnType::BigInt,
+        );
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn column_refs_with_different_tables_are_not_equal() {
+        let a = ColumnRef::new(
+            TableRef::new("s", "t1"),
+            "x".into(),
+            ColumnType::Int,
+        );
+        let b = ColumnRef::new(
+            TableRef::new("s", "t2"),
+            "x".into(),
+            ColumnType::Int,
+        );
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn we_can_clone_column_ref() {
+        let original = ColumnRef::new(
+            TableRef::new("schema", "table"),
+            "col".into(),
+            ColumnType::VarChar,
+        );
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn we_can_hash_column_ref() {
+        use core::hash::{Hash, Hasher};
+        let col_ref = ColumnRef::new(
+            TableRef::new("s", "t"),
+            "c".into(),
+            ColumnType::Int,
+        );
+        let mut hasher = ahash::AHasher::default();
+        col_ref.hash(&mut hasher);
+        let hash1 = hasher.finish();
+
+        let mut hasher2 = ahash::AHasher::default();
+        col_ref.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -673,4 +673,239 @@ mod tests {
             assert_eq!(column_type.sqrt_negative_min(), None);
         }
     }
+
+    #[test]
+    fn column_type_display_covers_all_variants() {
+        use alloc::format;
+
+        assert_eq!(format!("{}", ColumnType::Boolean), "BOOLEAN");
+        assert_eq!(format!("{}", ColumnType::Uint8), "UINT8");
+        assert_eq!(format!("{}", ColumnType::TinyInt), "TINYINT");
+        assert_eq!(format!("{}", ColumnType::SmallInt), "SMALLINT");
+        assert_eq!(format!("{}", ColumnType::Int), "INT");
+        assert_eq!(format!("{}", ColumnType::BigInt), "BIGINT");
+        assert_eq!(format!("{}", ColumnType::Int128), "DECIMAL");
+        assert_eq!(format!("{}", ColumnType::VarChar), "VARCHAR");
+        assert_eq!(format!("{}", ColumnType::VarBinary), "BINARY");
+        assert_eq!(format!("{}", ColumnType::Scalar), "SCALAR");
+        assert_eq!(
+            format!(
+                "{}",
+                ColumnType::Decimal75(Precision::new(38).unwrap(), 10)
+            ),
+            "DECIMAL75(PRECISION: 38, SCALE: 10)"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc())
+            ),
+            "TIMESTAMP(TIMEUNIT: nanoseconds (precision: 9), TIMEZONE: +00:00)"
+        );
+    }
+
+    #[test]
+    fn column_type_is_signed_covers_all_variants() {
+        assert!(ColumnType::TinyInt.is_signed());
+        assert!(ColumnType::SmallInt.is_signed());
+        assert!(ColumnType::Int.is_signed());
+        assert!(ColumnType::BigInt.is_signed());
+        assert!(ColumnType::Int128.is_signed());
+        assert!(ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).is_signed());
+
+        assert!(!ColumnType::Boolean.is_signed());
+        assert!(!ColumnType::Uint8.is_signed());
+        assert!(!ColumnType::VarChar.is_signed());
+        assert!(!ColumnType::VarBinary.is_signed());
+        assert!(!ColumnType::Scalar.is_signed());
+        assert!(!ColumnType::Decimal75(Precision::new(1).unwrap(), 0).is_signed());
+    }
+
+    #[test]
+    fn column_type_byte_size_covers_all_variants() {
+        assert_eq!(ColumnType::Boolean.byte_size(), 1);
+        assert_eq!(ColumnType::Uint8.byte_size(), 1);
+        assert_eq!(ColumnType::TinyInt.byte_size(), 1);
+        assert_eq!(ColumnType::SmallInt.byte_size(), 2);
+        assert_eq!(ColumnType::Int.byte_size(), 4);
+        assert_eq!(ColumnType::BigInt.byte_size(), 8);
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).byte_size(),
+            8
+        );
+        assert_eq!(ColumnType::Int128.byte_size(), 16);
+        assert_eq!(ColumnType::Scalar.byte_size(), 32);
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(1).unwrap(), 0).byte_size(),
+            32
+        );
+        assert_eq!(ColumnType::VarChar.byte_size(), 32);
+        assert_eq!(ColumnType::VarBinary.byte_size(), 32);
+    }
+
+    #[test]
+    fn column_type_bit_size_is_eight_times_byte_size() {
+        let types = [
+            ColumnType::Boolean,
+            ColumnType::Uint8,
+            ColumnType::TinyInt,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::BigInt,
+            ColumnType::Int128,
+            ColumnType::Scalar,
+            ColumnType::VarChar,
+            ColumnType::VarBinary,
+        ];
+        for ct in types {
+            assert_eq!(ct.bit_size(), ct.byte_size() as u32 * 8);
+        }
+    }
+
+    #[test]
+    fn column_type_is_numeric_covers_all_variants() {
+        assert!(ColumnType::Uint8.is_numeric());
+        assert!(ColumnType::TinyInt.is_numeric());
+        assert!(ColumnType::SmallInt.is_numeric());
+        assert!(ColumnType::Int.is_numeric());
+        assert!(ColumnType::BigInt.is_numeric());
+        assert!(ColumnType::Int128.is_numeric());
+        assert!(ColumnType::Scalar.is_numeric());
+        assert!(ColumnType::Decimal75(Precision::new(1).unwrap(), 0).is_numeric());
+
+        assert!(!ColumnType::Boolean.is_numeric());
+        assert!(!ColumnType::VarChar.is_numeric());
+        assert!(!ColumnType::VarBinary.is_numeric());
+        assert!(
+            !ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).is_numeric()
+        );
+    }
+
+    #[test]
+    fn column_type_is_integer_covers_all_variants() {
+        assert!(ColumnType::Uint8.is_integer());
+        assert!(ColumnType::TinyInt.is_integer());
+        assert!(ColumnType::SmallInt.is_integer());
+        assert!(ColumnType::Int.is_integer());
+        assert!(ColumnType::BigInt.is_integer());
+        assert!(ColumnType::Int128.is_integer());
+
+        assert!(!ColumnType::Boolean.is_integer());
+        assert!(!ColumnType::VarChar.is_integer());
+        assert!(!ColumnType::VarBinary.is_integer());
+        assert!(!ColumnType::Scalar.is_integer());
+        assert!(!ColumnType::Decimal75(Precision::new(1).unwrap(), 0).is_integer());
+        assert!(
+            !ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).is_integer()
+        );
+    }
+
+    #[test]
+    fn column_type_precision_value_covers_all_variants() {
+        assert_eq!(ColumnType::Uint8.precision_value(), Some(3));
+        assert_eq!(ColumnType::TinyInt.precision_value(), Some(3));
+        assert_eq!(ColumnType::SmallInt.precision_value(), Some(5));
+        assert_eq!(ColumnType::Int.precision_value(), Some(10));
+        assert_eq!(ColumnType::BigInt.precision_value(), Some(19));
+        assert_eq!(ColumnType::Int128.precision_value(), Some(39));
+        assert_eq!(ColumnType::Scalar.precision_value(), Some(0));
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(42).unwrap(), 5).precision_value(),
+            Some(42)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).precision_value(),
+            Some(19)
+        );
+        assert_eq!(ColumnType::Boolean.precision_value(), None);
+        assert_eq!(ColumnType::VarChar.precision_value(), None);
+        assert_eq!(ColumnType::VarBinary.precision_value(), None);
+    }
+
+    #[test]
+    fn column_type_scale_covers_all_variants() {
+        assert_eq!(ColumnType::TinyInt.scale(), Some(0));
+        assert_eq!(ColumnType::Uint8.scale(), Some(0));
+        assert_eq!(ColumnType::SmallInt.scale(), Some(0));
+        assert_eq!(ColumnType::Int.scale(), Some(0));
+        assert_eq!(ColumnType::BigInt.scale(), Some(0));
+        assert_eq!(ColumnType::Int128.scale(), Some(0));
+        assert_eq!(ColumnType::Scalar.scale(), Some(0));
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 5).scale(),
+            Some(5)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).scale(),
+            Some(0)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()).scale(),
+            Some(3)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc()).scale(),
+            Some(6)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc()).scale(),
+            Some(9)
+        );
+        assert_eq!(ColumnType::Boolean.scale(), None);
+        assert_eq!(ColumnType::VarChar.scale(), None);
+        assert_eq!(ColumnType::VarBinary.scale(), None);
+    }
+
+    #[test]
+    fn column_type_max_integer_type_returns_larger_type() {
+        assert_eq!(
+            ColumnType::TinyInt.max_integer_type(&ColumnType::BigInt),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::Int128.max_integer_type(&ColumnType::SmallInt),
+            Some(ColumnType::Int128)
+        );
+        assert_eq!(
+            ColumnType::Int.max_integer_type(&ColumnType::Int),
+            Some(ColumnType::Int)
+        );
+    }
+
+    #[test]
+    fn column_type_max_integer_type_returns_none_for_non_integers() {
+        assert_eq!(
+            ColumnType::Boolean.max_integer_type(&ColumnType::Int),
+            None
+        );
+        assert_eq!(
+            ColumnType::Int.max_integer_type(&ColumnType::VarChar),
+            None
+        );
+    }
+
+    #[test]
+    fn column_type_max_unsigned_integer_type_returns_uint8_for_small_ints() {
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::TinyInt),
+            Some(ColumnType::Uint8)
+        );
+    }
+
+    #[test]
+    fn column_type_max_unsigned_integer_type_returns_none_for_larger_ints() {
+        // There's no unsigned type for 16+ bits, so this returns None
+        assert_eq!(
+            ColumnType::SmallInt.max_unsigned_integer_type(&ColumnType::Int),
+            None
+        );
+    }
+
+    #[test]
+    fn column_type_max_unsigned_integer_type_returns_none_for_non_integers() {
+        assert_eq!(
+            ColumnType::VarChar.max_unsigned_integer_type(&ColumnType::Int),
+            None
+        );
+    }
 }

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -94,11 +94,128 @@ impl LiteralValue {
 #[cfg(test)]
 mod tests {
     use crate::base::{
-        database::LiteralValue,
+        database::{ColumnType, LiteralValue},
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         try_standard_binary_serialization,
     };
+
+    #[test]
+    fn we_can_convert_boolean_literal_to_scalar() {
+        use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+        let val = LiteralValue::Boolean(true);
+        let scalar: TestScalar = val.to_scalar();
+        assert_eq!(scalar, TestScalar::ONE);
+
+        let val = LiteralValue::Boolean(false);
+        let scalar: TestScalar = val.to_scalar();
+        assert_eq!(scalar, TestScalar::ZERO);
+    }
+
+    #[test]
+    fn we_can_convert_integer_literals_to_scalar() {
+        use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+
+        let val = LiteralValue::Uint8(42);
+        assert_eq!(val.to_scalar::<TestScalar>(), TestScalar::from(42u8));
+
+        let val = LiteralValue::TinyInt(-7);
+        assert_eq!(val.to_scalar::<TestScalar>(), TestScalar::from(-7i8));
+
+        let val = LiteralValue::SmallInt(300);
+        assert_eq!(val.to_scalar::<TestScalar>(), TestScalar::from(300i16));
+
+        let val = LiteralValue::Int(-100_000);
+        assert_eq!(val.to_scalar::<TestScalar>(), TestScalar::from(-100_000i32));
+
+        let val = LiteralValue::BigInt(9_000_000_000);
+        assert_eq!(val.to_scalar::<TestScalar>(), TestScalar::from(9_000_000_000i64));
+
+        let val = LiteralValue::Int128(i128::MAX);
+        assert_eq!(val.to_scalar::<TestScalar>(), TestScalar::from(i128::MAX));
+    }
+
+    #[test]
+    fn we_can_convert_varchar_literal_to_scalar() {
+        use crate::base::scalar::test_scalar::TestScalar;
+        let val = LiteralValue::VarChar("hello".to_string());
+        let scalar: TestScalar = val.to_scalar();
+        let expected: TestScalar = "hello".into();
+        assert_eq!(scalar, expected);
+    }
+
+    #[test]
+    fn we_can_convert_varbinary_literal_to_scalar() {
+        use crate::base::scalar::{test_scalar::TestScalar, ScalarExt};
+        let data = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let val = LiteralValue::VarBinary(data.clone());
+        let scalar: TestScalar = val.to_scalar();
+        let expected = TestScalar::from_byte_slice_via_hash(&data);
+        assert_eq!(scalar, expected);
+    }
+
+    #[test]
+    fn we_can_convert_timestamp_literal_to_scalar() {
+        use crate::base::scalar::test_scalar::TestScalar;
+        let val = LiteralValue::TimeStampTZ(
+            PoSQLTimeUnit::Nanosecond,
+            PoSQLTimeZone::utc(),
+            1_000_000_000,
+        );
+        let scalar: TestScalar = val.to_scalar();
+        assert_eq!(scalar, TestScalar::from(1_000_000_000i64));
+    }
+
+    #[test]
+    fn we_can_convert_scalar_literal_to_scalar() {
+        use crate::base::scalar::test_scalar::TestScalar;
+        let limbs = [1u64, 2, 3, 4];
+        let val = LiteralValue::Scalar(limbs);
+        let scalar: TestScalar = val.to_scalar();
+        assert_eq!(scalar, TestScalar::from(limbs));
+    }
+
+    #[test]
+    fn we_can_convert_decimal75_literal_to_scalar() {
+        use crate::base::{math::i256::I256, scalar::test_scalar::TestScalar};
+        let i256_val = I256::from(12345i32);
+        let val = LiteralValue::Decimal75(Precision::new(10).unwrap(), 2, i256_val);
+        let scalar: TestScalar = val.to_scalar();
+        assert_eq!(scalar, i256_val.into_scalar::<TestScalar>());
+    }
+
+    #[test]
+    fn we_can_get_column_type_of_all_literal_variants() {
+        use crate::base::math::i256::I256;
+        assert_eq!(LiteralValue::Boolean(true).column_type(), ColumnType::Boolean);
+        assert_eq!(LiteralValue::Uint8(0).column_type(), ColumnType::Uint8);
+        assert_eq!(LiteralValue::TinyInt(0).column_type(), ColumnType::TinyInt);
+        assert_eq!(LiteralValue::SmallInt(0).column_type(), ColumnType::SmallInt);
+        assert_eq!(LiteralValue::Int(0).column_type(), ColumnType::Int);
+        assert_eq!(LiteralValue::BigInt(0).column_type(), ColumnType::BigInt);
+        assert_eq!(LiteralValue::Int128(0).column_type(), ColumnType::Int128);
+        assert_eq!(
+            LiteralValue::VarChar("".to_string()).column_type(),
+            ColumnType::VarChar
+        );
+        assert_eq!(
+            LiteralValue::VarBinary(vec![]).column_type(),
+            ColumnType::VarBinary
+        );
+        assert_eq!(
+            LiteralValue::Scalar([0; 4]).column_type(),
+            ColumnType::Scalar
+        );
+        let precision = Precision::new(10).unwrap();
+        assert_eq!(
+            LiteralValue::Decimal75(precision, 5, I256::from(0i32)).column_type(),
+            ColumnType::Decimal75(precision, 5)
+        );
+        assert_eq!(
+            LiteralValue::TimeStampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), 0).column_type(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc())
+        );
+    }
 
     /// This allows us to reuse code within solidity more safely
     #[test]

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,78 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_create_and_access_table_evaluation() {
+        let column_evals = vec![TestScalar::from(1), TestScalar::from(2), TestScalar::from(3)];
+        let chi = (TestScalar::from(42), 5);
+        let eval = TableEvaluation::new(column_evals.clone(), chi);
+
+        assert_eq!(eval.column_evals(), &column_evals);
+        assert_eq!(eval.chi_eval(), TestScalar::from(42));
+        assert_eq!(eval.chi(), (TestScalar::from(42), 5));
+    }
+
+    #[test]
+    fn we_can_create_table_evaluation_with_empty_columns() {
+        let eval = TableEvaluation::<TestScalar>::new(vec![], (TestScalar::ZERO, 0));
+
+        assert_eq!(eval.column_evals(), &[] as &[TestScalar]);
+        assert_eq!(eval.chi_eval(), TestScalar::ZERO);
+        assert_eq!(eval.chi(), (TestScalar::ZERO, 0));
+    }
+
+    #[test]
+    fn table_evaluations_with_same_data_are_equal() {
+        let eval_a = TableEvaluation::new(
+            vec![TestScalar::from(10)],
+            (TestScalar::from(5), 3),
+        );
+        let eval_b = TableEvaluation::new(
+            vec![TestScalar::from(10)],
+            (TestScalar::from(5), 3),
+        );
+        assert_eq!(eval_a, eval_b);
+    }
+
+    #[test]
+    fn table_evaluations_with_different_data_are_not_equal() {
+        let eval_a = TableEvaluation::new(
+            vec![TestScalar::from(10)],
+            (TestScalar::from(5), 3),
+        );
+        let eval_b = TableEvaluation::new(
+            vec![TestScalar::from(20)],
+            (TestScalar::from(5), 3),
+        );
+        assert_ne!(eval_a, eval_b);
+    }
+
+    #[test]
+    fn table_evaluations_with_different_chi_are_not_equal() {
+        let eval_a = TableEvaluation::new(
+            vec![TestScalar::from(10)],
+            (TestScalar::from(5), 3),
+        );
+        let eval_b = TableEvaluation::new(
+            vec![TestScalar::from(10)],
+            (TestScalar::from(7), 3),
+        );
+        assert_ne!(eval_a, eval_b);
+    }
+
+    #[test]
+    fn we_can_clone_table_evaluation() {
+        let eval = TableEvaluation::new(
+            vec![TestScalar::from(1), TestScalar::from(2)],
+            (TestScalar::from(99), 10),
+        );
+        let cloned = eval.clone();
+        assert_eq!(eval, cloned);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,151 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{format, string::ToString};
+
+    #[test]
+    fn we_can_create_table_ref_with_schema() {
+        let table_ref = TableRef::new("my_schema", "my_table");
+        assert_eq!(table_ref.schema_id().unwrap().value, "my_schema");
+        assert_eq!(table_ref.table_id().value, "my_table");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_without_schema() {
+        let table_ref = TableRef::new("", "my_table");
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "my_table");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_names_with_schema() {
+        let table_ref = TableRef::from_names(Some("ns"), "tbl");
+        assert_eq!(table_ref.schema_id().unwrap().value, "ns");
+        assert_eq!(table_ref.table_id().value, "tbl");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_names_without_schema() {
+        let table_ref = TableRef::from_names(None, "tbl");
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "tbl");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_idents() {
+        let schema_ident = Ident::new("schema_name".to_string());
+        let table_ident = Ident::new("table_name".to_string());
+        let table_ref = TableRef::from_idents(Some(schema_ident.clone()), table_ident.clone());
+        assert_eq!(table_ref.schema_id(), Some(&schema_ident));
+        assert_eq!(table_ref.table_id(), &table_ident);
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_idents_without_schema() {
+        let table_ident = Ident::new("table_name".to_string());
+        let table_ref = TableRef::from_idents(None, table_ident.clone());
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id(), &table_ident);
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_single_str_component() {
+        let table_ref = TableRef::from_strs(&["my_table"]).unwrap();
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "my_table");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_two_str_components() {
+        let table_ref = TableRef::from_strs(&["my_schema", "my_table"]).unwrap();
+        assert_eq!(table_ref.schema_id().unwrap().value, "my_schema");
+        assert_eq!(table_ref.table_id().value, "my_table");
+    }
+
+    #[test]
+    fn we_cannot_create_table_ref_from_zero_str_components() {
+        let result = TableRef::from_strs::<&str>(&[]);
+        assert!(matches!(result, Err(ParseError::InvalidTableReference { .. })));
+    }
+
+    #[test]
+    fn we_cannot_create_table_ref_from_three_str_components() {
+        let result = TableRef::from_strs(&["a", "b", "c"]);
+        assert!(matches!(result, Err(ParseError::InvalidTableReference { .. })));
+    }
+
+    #[test]
+    fn we_can_parse_table_ref_from_dot_separated_string() {
+        let table_ref: TableRef = "schema.table".try_into().unwrap();
+        assert_eq!(table_ref.schema_id().unwrap().value, "schema");
+        assert_eq!(table_ref.table_id().value, "table");
+    }
+
+    #[test]
+    fn we_can_parse_table_ref_from_single_name() {
+        let table_ref: TableRef = "just_table".try_into().unwrap();
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "just_table");
+    }
+
+    #[test]
+    fn we_cannot_parse_table_ref_from_triple_dotted_string() {
+        let result: Result<TableRef, _> = "a.b.c".try_into();
+        assert!(matches!(result, Err(ParseError::InvalidTableReference { .. })));
+    }
+
+    #[test]
+    fn we_can_parse_table_ref_using_from_str() {
+        let table_ref: TableRef = "ns.tbl".parse().unwrap();
+        assert_eq!(table_ref.schema_id().unwrap().value, "ns");
+        assert_eq!(table_ref.table_id().value, "tbl");
+    }
+
+    #[test]
+    fn we_can_display_table_ref_with_schema() {
+        let table_ref = TableRef::new("schema", "table");
+        assert_eq!(format!("{table_ref}"), "schema.table");
+    }
+
+    #[test]
+    fn we_can_display_table_ref_without_schema() {
+        let table_ref = TableRef::new("", "table");
+        assert_eq!(format!("{table_ref}"), "table");
+    }
+
+    #[test]
+    fn we_can_serialize_and_deserialize_table_ref_with_schema() {
+        let table_ref = TableRef::new("ns", "tbl");
+        let json = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(json, r#""ns.tbl""#);
+        let deserialized: TableRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, table_ref);
+    }
+
+    #[test]
+    fn we_can_serialize_and_deserialize_table_ref_without_schema() {
+        let table_ref = TableRef::new("", "tbl");
+        let json = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(json, r#""tbl""#);
+        let deserialized: TableRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, table_ref);
+    }
+
+    #[test]
+    fn table_ref_equivalent_trait_works() {
+        let a = TableRef::new("s", "t");
+        let b = TableRef::new("s", "t");
+        assert!(Equivalent::equivalent(&&a, &b));
+    }
+
+    #[test]
+    fn table_ref_equivalent_trait_detects_difference() {
+        let a = TableRef::new("s", "t1");
+        let b = TableRef::new("s", "t2");
+        assert!(!Equivalent::equivalent(&&a, &b));
+    }
+}

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -5,7 +5,7 @@ use ark_ff::MontConfig;
 ///
 /// low is the lower bytes of the u256 number (from 0 to 127 bits)
 /// high is the upper bytes of the u256 number (from 128 to 255 bits)
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct U256 {
     pub low: u128,
     pub high: u128,
@@ -33,5 +33,60 @@ impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
     fn from(val: &U256) -> Self {
         let bytes = [val.low.to_le_bytes(), val.high.to_le_bytes()].concat();
         MontScalar::<T>::from_le_bytes_mod_order(&bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_construct_u256_from_words() {
+        let val = U256::from_words(42, 0);
+        assert_eq!(val.low, 42);
+        assert_eq!(val.high, 0);
+    }
+
+    #[test]
+    fn u256_equality_works() {
+        let a = U256::from_words(1, 2);
+        let b = U256::from_words(1, 2);
+        let c = U256::from_words(1, 3);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn u256_copy_clone_works() {
+        let a = U256::from_words(100, 200);
+        let b = a;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn we_can_convert_scalar_to_u256_and_back() {
+        let scalar = TestScalar::from(12345u64);
+        let u256_val: U256 = U256::from(&scalar);
+        let back: TestScalar = MontScalar::from(&u256_val);
+        assert_eq!(scalar, back);
+    }
+
+    #[test]
+    fn we_can_convert_zero_scalar_to_u256_and_back() {
+        let scalar = TestScalar::from(0u64);
+        let u256_val: U256 = U256::from(&scalar);
+        let back: TestScalar = MontScalar::from(&u256_val);
+        assert_eq!(scalar, back);
+    }
+
+    #[test]
+    fn we_can_convert_u256_with_high_bits_to_scalar() {
+        let u256_val = U256::from_words(0, 1);
+        let scalar: TestScalar = MontScalar::from(&u256_val);
+        // Verify roundtrip preserves the value mod the scalar field order
+        let back: U256 = U256::from(&scalar);
+        let back_scalar: TestScalar = MontScalar::from(&back);
+        assert_eq!(scalar, back_scalar);
     }
 }

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,71 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_invalid_timezone_error() {
+        let error = PoSQLTimestampError::InvalidTimezone {
+            timezone: "Mars/Olympus".to_string(),
+        };
+        let msg = error.to_string();
+        assert!(msg.contains("Mars/Olympus"));
+    }
+
+    #[test]
+    fn we_can_display_invalid_timezone_offset_error() {
+        let error = PoSQLTimestampError::InvalidTimezoneOffset;
+        let msg = error.to_string();
+        assert!(msg.contains("invalid timezone offset"));
+    }
+
+    #[test]
+    fn we_can_display_invalid_time_unit_error() {
+        let error = PoSQLTimestampError::InvalidTimeUnit {
+            error: "bad unit".to_string(),
+        };
+        let msg = error.to_string();
+        assert!(msg.contains("Invalid time unit"));
+    }
+
+    #[test]
+    fn we_can_display_unsupported_precision_error() {
+        let error = PoSQLTimestampError::UnsupportedPrecision {
+            error: "12".to_string(),
+        };
+        let msg = error.to_string();
+        assert!(msg.contains("12"));
+    }
+
+    #[test]
+    fn we_can_convert_posql_timestamp_error_to_string() {
+        let error = PoSQLTimestampError::InvalidTimezoneOffset;
+        let s: String = error.into();
+        assert!(s.contains("invalid timezone offset"));
+    }
+
+    #[test]
+    fn posql_timestamp_errors_with_same_data_are_equal() {
+        let a = PoSQLTimestampError::InvalidTimezone {
+            timezone: "foo".to_string(),
+        };
+        let b = PoSQLTimestampError::InvalidTimezone {
+            timezone: "foo".to_string(),
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn posql_timestamp_errors_with_different_data_are_not_equal() {
+        let a = PoSQLTimestampError::InvalidTimezone {
+            timezone: "foo".to_string(),
+        };
+        let b = PoSQLTimestampError::InvalidTimezone {
+            timezone: "bar".to_string(),
+        };
+        assert_ne!(a, b);
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -119,4 +119,58 @@ mod timezone_parsing_tests {
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
         ));
     }
+
+    #[test]
+    fn we_can_parse_utc_variants() {
+        for tz_str in ["Z", "UTC", "00:00", "+00:00", "0:00", "+0:00"] {
+            let timezone_as_str: Option<Arc<str>> = Some(tz_str.into());
+            let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+            assert_eq!(timezone, PoSQLTimeZone::utc());
+        }
+    }
+
+    #[test]
+    fn we_can_parse_positive_offset() {
+        let timezone_as_str: Option<Arc<str>> = Some("+05:30".into());
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+        assert_eq!(timezone.offset(), 5 * 3600 + 30 * 60);
+    }
+
+    #[test]
+    fn we_cannot_parse_invalid_offset_chars() {
+        // Invalid hours (non-digit)
+        let timezone_as_str: Option<Arc<str>> = Some("+XX:00".into());
+        let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();
+        assert!(matches!(
+            timezone_err,
+            PoSQLTimestampError::InvalidTimezoneOffset
+        ));
+
+        // Invalid minutes (non-digit)
+        let timezone_as_str: Option<Arc<str>> = Some("+01:YY".into());
+        let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();
+        assert!(matches!(
+            timezone_err,
+            PoSQLTimestampError::InvalidTimezoneOffset
+        ));
+    }
+
+    #[test]
+    fn we_can_get_offset_of_timezone() {
+        let tz = PoSQLTimeZone::new(3600);
+        assert_eq!(tz.offset(), 3600);
+
+        let tz = PoSQLTimeZone::new(-7200);
+        assert_eq!(tz.offset(), -7200);
+
+        let tz = PoSQLTimeZone::utc();
+        assert_eq!(tz.offset(), 0);
+    }
+
+    #[test]
+    fn we_can_clone_and_copy_timezone() {
+        let tz = PoSQLTimeZone::new(1800);
+        let cloned = tz;
+        assert_eq!(tz, cloned);
+    }
 }

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -69,6 +69,35 @@ mod time_unit_tests {
     }
 
     #[test]
+    fn test_time_unit_to_u64() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn test_time_unit_display() {
+        use alloc::format;
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Second),
+            "seconds (precision: 0)"
+        );
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Millisecond),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Microsecond),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Nanosecond),
+            "nanoseconds (precision: 9)"
+        );
+    }
+
+    #[test]
     fn test_invalid_precision() {
         let invalid_precisions = [
             "1", "2", "4", "5", "7", "8", "10", "zero", "three", "cat", "-1", "-2",

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,181 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+
+    // ProofError Display tests
+    #[test]
+    fn proof_error_verification_displays_correctly() {
+        let err = ProofError::VerificationError {
+            error: "checksum mismatch",
+        };
+        assert_eq!(format!("{err}"), "Verification error: checksum mismatch");
+    }
+
+    #[test]
+    fn proof_error_unsupported_plan_displays_correctly() {
+        let err = ProofError::UnsupportedQueryPlan {
+            error: "nested subquery",
+        };
+        assert_eq!(
+            format!("{err}"),
+            "Unsupported query plan: nested subquery"
+        );
+    }
+
+    #[test]
+    fn proof_error_invalid_type_coercion_displays_correctly() {
+        let err = ProofError::InvalidTypeCoercion;
+        assert_eq!(
+            format!("{err}"),
+            "Result does not match query: type mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_error_field_names_mismatch_displays_correctly() {
+        let err = ProofError::FieldNamesMismatch;
+        assert_eq!(
+            format!("{err}"),
+            "Result does not match query: field names mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_error_field_count_mismatch_displays_correctly() {
+        let err = ProofError::FieldCountMismatch;
+        assert_eq!(
+            format!("{err}"),
+            "Result does not match query: field count mismatch"
+        );
+    }
+
+    // ProofSizeMismatch Display tests
+    #[test]
+    fn proof_size_mismatch_sumcheck_too_small_displays_correctly() {
+        let err = ProofSizeMismatch::SumcheckProofTooSmall;
+        assert_eq!(format!("{err}"), "Sumcheck proof is too small");
+    }
+
+    #[test]
+    fn proof_size_mismatch_too_few_mle_displays_correctly() {
+        let err = ProofSizeMismatch::TooFewMLEEvaluations;
+        assert_eq!(format!("{err}"), "Proof has too few MLE evaluations");
+    }
+
+    #[test]
+    fn proof_size_mismatch_post_result_count_displays_correctly() {
+        let err = ProofSizeMismatch::PostResultCountMismatch;
+        assert_eq!(format!("{err}"), "Post result challenge count mismatch");
+    }
+
+    #[test]
+    fn proof_size_mismatch_constraint_count_displays_correctly() {
+        let err = ProofSizeMismatch::ConstraintCountMismatch;
+        assert_eq!(format!("{err}"), "Constraint count mismatch");
+    }
+
+    #[test]
+    fn proof_size_mismatch_too_few_bit_distributions_displays_correctly() {
+        let err = ProofSizeMismatch::TooFewBitDistributions;
+        assert_eq!(format!("{err}"), "Proof has too few bit distributions");
+    }
+
+    #[test]
+    fn proof_size_mismatch_too_few_chi_lengths_displays_correctly() {
+        let err = ProofSizeMismatch::TooFewChiLengths;
+        assert_eq!(format!("{err}"), "Proof has too few one lengths");
+    }
+
+    #[test]
+    fn proof_size_mismatch_too_few_rho_lengths_displays_correctly() {
+        let err = ProofSizeMismatch::TooFewRhoLengths;
+        assert_eq!(format!("{err}"), "Proof has too few rho lengths");
+    }
+
+    #[test]
+    fn proof_size_mismatch_too_few_sumcheck_variables_displays_correctly() {
+        let err = ProofSizeMismatch::TooFewSumcheckVariables;
+        assert_eq!(format!("{err}"), "Proof has too few sumcheck variables");
+    }
+
+    #[test]
+    fn proof_size_mismatch_chi_length_not_found_displays_correctly() {
+        let err = ProofSizeMismatch::ChiLengthNotFound;
+        assert_eq!(format!("{err}"), "Proof doesn't have requested one length");
+    }
+
+    #[test]
+    fn proof_size_mismatch_rho_length_not_found_displays_correctly() {
+        let err = ProofSizeMismatch::RhoLengthNotFound;
+        assert_eq!(
+            format!("{err}"),
+            "Proof doesn't have requested rho length"
+        );
+    }
+
+    #[test]
+    fn proof_size_mismatch_converts_to_proof_error() {
+        let size_err = ProofSizeMismatch::SumcheckProofTooSmall;
+        let proof_err: ProofError = size_err.into();
+        assert!(matches!(proof_err, ProofError::ProofSizeMismatch { .. }));
+    }
+
+    // PlaceholderError tests
+    #[test]
+    fn placeholder_error_invalid_index_displays_correctly() {
+        let err = PlaceholderError::InvalidPlaceholderIndex {
+            index: 5,
+            num_params: 3,
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("5"));
+        assert!(msg.contains("3"));
+    }
+
+    #[test]
+    fn placeholder_error_invalid_type_displays_correctly() {
+        let err = PlaceholderError::InvalidPlaceholderType {
+            index: 1,
+            expected: ColumnType::Int,
+            actual: ColumnType::VarChar,
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("1"));
+        assert!(msg.contains("INT"));
+        assert!(msg.contains("VARCHAR"));
+    }
+
+    #[test]
+    fn placeholder_error_zero_id_displays_correctly() {
+        let err = PlaceholderError::ZeroPlaceholderId;
+        assert_eq!(
+            format!("{err}"),
+            "Placeholder id must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn placeholder_errors_with_same_data_are_equal() {
+        let a = PlaceholderError::InvalidPlaceholderIndex {
+            index: 1,
+            num_params: 2,
+        };
+        let b = PlaceholderError::InvalidPlaceholderIndex {
+            index: 1,
+            num_params: 2,
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn placeholder_error_converts_to_proof_error() {
+        let placeholder_err = PlaceholderError::ZeroPlaceholderId;
+        let proof_err: ProofError = placeholder_err.into();
+        assert!(matches!(proof_err, ProofError::PlaceholderError { .. }));
+    }
+}

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,62 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{format, string::ToString};
+
+    #[test]
+    fn analyze_error_invalid_data_type_displays_correctly() {
+        let err = AnalyzeError::InvalidDataType {
+            expr_type: ColumnType::VarChar,
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("VARCHAR"));
+        assert!(msg.contains("not valid"));
+    }
+
+    #[test]
+    fn analyze_error_data_type_mismatch_displays_correctly() {
+        let err = AnalyzeError::DataTypeMismatch {
+            left_type: "INT".to_string(),
+            right_type: "VARCHAR".to_string(),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("INT"));
+        assert!(msg.contains("VARCHAR"));
+    }
+
+    #[test]
+    fn analyze_error_different_column_length_displays_correctly() {
+        let err = AnalyzeError::DifferentColumnLength { len_a: 5, len_b: 10 };
+        let msg = format!("{err}");
+        assert!(msg.contains("5"));
+        assert!(msg.contains("10"));
+    }
+
+    #[test]
+    fn analyze_error_not_enough_input_plans_displays_correctly() {
+        let err = AnalyzeError::NotEnoughInputPlans;
+        assert_eq!(format!("{err}"), "Not enough input plans");
+    }
+
+    #[test]
+    fn analyze_error_converts_to_string() {
+        let err = AnalyzeError::NotEnoughInputPlans;
+        let s: String = err.into();
+        assert_eq!(s, "Not enough input plans");
+    }
+
+    #[test]
+    fn intermediate_decimal_error_converts_to_analyze_error() {
+        use crate::base::math::decimal::IntermediateDecimalError;
+        let decimal_err = IntermediateDecimalError::LossyCast;
+        let analyze_err: AnalyzeError = decimal_err.into();
+        assert!(matches!(
+            analyze_err,
+            AnalyzeError::DecimalConversionError { .. }
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,67 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+
+    #[test]
+    fn we_can_convert_overflow_coercion_error_to_query_error() {
+        let coercion_error = TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::Overflow,
+        };
+        let query_error: QueryError = coercion_error.into();
+        assert!(matches!(query_error, QueryError::Overflow));
+    }
+
+    #[test]
+    fn we_can_convert_invalid_type_coercion_error_to_query_error() {
+        let coercion_error = TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::InvalidTypeCoercion,
+        };
+        let query_error: QueryError = coercion_error.into();
+        assert!(matches!(query_error, QueryError::ProofError { .. }));
+    }
+
+    #[test]
+    fn we_can_convert_name_mismatch_to_query_error() {
+        let coercion_error = TableCoercionError::NameMismatch;
+        let query_error: QueryError = coercion_error.into();
+        assert!(matches!(query_error, QueryError::ProofError { .. }));
+    }
+
+    #[test]
+    fn we_can_convert_column_count_mismatch_to_query_error() {
+        let coercion_error = TableCoercionError::ColumnCountMismatch;
+        let query_error: QueryError = coercion_error.into();
+        assert!(matches!(query_error, QueryError::ProofError { .. }));
+    }
+
+    #[test]
+    fn query_error_displays_correctly() {
+        assert_eq!(format!("{}", QueryError::Overflow), "Overflow error");
+        assert_eq!(format!("{}", QueryError::InvalidString), "String decode error");
+        assert_eq!(
+            format!("{}", QueryError::MiscellaneousDecodingError),
+            "Miscellaneous decoding error"
+        );
+        assert_eq!(
+            format!("{}", QueryError::MiscellaneousEvaluationError),
+            "Miscellaneous evaluation error"
+        );
+        assert_eq!(
+            format!("{}", QueryError::InvalidColumnCount),
+            "Invalid number of columns"
+        );
+    }
+
+    #[test]
+    fn we_can_convert_proof_error_to_query_error() {
+        let proof_error = ProofError::InvalidTypeCoercion;
+        let query_error: QueryError = proof_error.into();
+        let msg = format!("{query_error}");
+        assert!(msg.contains("type mismatch"));
+    }
+}


### PR DESCRIPTION
Contributes to #560

## Summary

Add comprehensive test coverage for previously untested code paths across 13 files, targeting base types, error Display impls, and query result conversion paths.

/claim #560

## What's covered

**Base database types (no tests previously):**
- `ColumnField`: constructor, accessors, equality, serialization, hashing
- `ColumnRef`: constructor, accessors, equality, cloning, hashing  
- `TableEvaluation`: constructor, accessors, equality, cloning
- `TableRef`: `from_strs`, `from_idents`, `TryFrom`/`FromStr` parsing, `Display`, `Serialize`/`Deserialize` roundtrip, `Equivalent` trait

**ColumnType Display and method coverage:**
- `Display` for all 12 variants (previously untested — `Uint8`, `VarBinary`, `Decimal75`, `TimestampTZ` etc.)
- `is_signed`, `byte_size`, `bit_size`, `is_numeric`, `is_integer` for all variants
- `precision_value`, `scale` for all variants including all `TimestampTZ` time units
- `max_integer_type`, `max_unsigned_integer_type` edge cases

**LiteralValue coverage:**
- `to_scalar` for all 12 variants (Boolean, Uint8, TinyInt, SmallInt, Int, BigInt, Int128, VarChar, VarBinary, Decimal75, TimeStampTZ, Scalar)
- `column_type` for all 12 variants

**Error type Display coverage (all previously untested):**
- `ProofError`: all 5 variants
- `ProofSizeMismatch`: all 10 variants + conversion to `ProofError`
- `PlaceholderError`: all 3 variants + equality + conversion to `ProofError`
- `AnalyzeError`: all variants + `From` conversions
- `QueryError`: all variants + all 4 branches of `From<TableCoercionError>`
- `PoSQLTimestampError`: all 4 variants + `From<Error> for String`

**Time types:**
- `PoSQLTimeUnit`: `Display` for all 4 variants, `From<PoSQLTimeUnit> for u64`
- `PoSQLTimeZone`: UTC variant parsing, positive offset, invalid offset chars, offset accessor

**Encoding:**
- `U256`: constructor, equality, copy, scalar roundtrip (also derives `Debug`)

## Rationale

Focuses on code paths that are guaranteed to be uncovered: files that had zero `#[cfg(test)]` modules, `Display`/`From` impls that were never exercised, and accessor methods on types used widely but tested only indirectly.

## Test plan

- [x] All 1073 tests pass locally with `--no-default-features --features "test,std"`
- [ ] CI coverage check passes (threshold: 94% line coverage)