### PR TITLE
test: add comprehensive tests for TableRef

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,200 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_create_table_ref_with_schema_and_table() {
+        let table_ref = TableRef::new("my_schema", "my_table");
+        assert_eq!(table_ref.schema_id().unwrap().value, "my_schema");
+        assert_eq!(table_ref.table_id().value, "my_table");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_with_empty_schema() {
+        let table_ref = TableRef::new("", "my_table");
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "my_table");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_names_with_none_schema() {
+        let table_ref = TableRef::from_names(None, "my_table");
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "my_table");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_names_with_some_schema() {
+        let table_ref = TableRef::from_names(Some("public"), "users");
+        assert_eq!(table_ref.schema_id().unwrap().value, "public");
+        assert_eq!(table_ref.table_id().value, "users");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_idents() {
+        let schema_ident = Ident::new("analytics");
+        let table_ident = Ident::new("events");
+        let table_ref = TableRef::from_idents(Some(schema_ident.clone()), table_ident.clone());
+        assert_eq!(table_ref.schema_id().unwrap().value, "analytics");
+        assert_eq!(table_ref.table_id().value, "events");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_idents_with_none_schema() {
+        let table_ident = Ident::new("events");
+        let table_ref = TableRef::from_idents(None, table_ident.clone());
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "events");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_single_component_strs() {
+        let components: Vec<&str> = vec!["my_table"];
+        let table_ref = TableRef::from_strs(&components).unwrap();
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "my_table");
+    }
+
+    #[test]
+    fn we_can_create_table_ref_from_two_component_strs() {
+        let components: Vec<&str> = vec!["my_schema", "my_table"];
+        let table_ref = TableRef::from_strs(&components).unwrap();
+        assert_eq!(table_ref.schema_id().unwrap().value, "my_schema");
+        assert_eq!(table_ref.table_id().value, "my_table");
+    }
+
+    #[test]
+    fn we_cannot_create_table_ref_from_three_component_strs() {
+        let components: Vec<&str> = vec!["a", "b", "c"];
+        let result = TableRef::from_strs(&components);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn we_cannot_create_table_ref_from_empty_strs() {
+        let components: Vec<&str> = vec![];
+        let result = TableRef::from_strs(&components);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn we_can_try_from_dotted_string() {
+        let table_ref = TableRef::try_from("schema.table").unwrap();
+        assert_eq!(table_ref.schema_id().unwrap().value, "schema");
+        assert_eq!(table_ref.table_id().value, "table");
+    }
+
+    #[test]
+    fn we_can_try_from_simple_string() {
+        let table_ref = TableRef::try_from("users").unwrap();
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "users");
+    }
+
+    #[test]
+    fn we_cannot_try_from_triple_dotted_string() {
+        let result = TableRef::try_from("a.b.c");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn we_can_parse_table_ref_from_str() {
+        let table_ref: TableRef = "public.users".parse().unwrap();
+        assert_eq!(table_ref.schema_id().unwrap().value, "public");
+        assert_eq!(table_ref.table_id().value, "users");
+    }
+
+    #[test]
+    fn we_can_display_table_ref_with_schema() {
+        let table_ref = TableRef::new("public", "users");
+        assert_eq!(table_ref.to_string(), "public.users");
+    }
+
+    #[test]
+    fn we_can_display_table_ref_without_schema() {
+        let table_ref = TableRef::new("", "users");
+        assert_eq!(table_ref.to_string(), "users");
+    }
+
+    #[test]
+    fn we_can_roundtrip_serde_json() {
+        let table_ref = TableRef::new("my_schema", "my_table");
+        let json = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(json, "\"my_schema.my_table\"");
+        let deserialized: TableRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(table_ref, deserialized);
+    }
+
+    #[test]
+    fn we_can_roundtrip_serde_json_without_schema() {
+        let table_ref = TableRef::new("", "my_table");
+        let json = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(json, "\"my_table\"");
+        let deserialized: TableRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(table_ref, deserialized);
+    }
+
+    #[test]
+    fn equivalent_ref_matches() {
+        let table_ref = TableRef::new("schema", "table");
+        let ref_to_table_ref = &table_ref;
+        assert!(Equivalent::<TableRef>::equivalent(
+            &ref_to_table_ref,
+            &table_ref
+        ));
+    }
+
+    #[test]
+    fn equivalent_ref_does_not_match_different_table() {
+        let table_ref_a = TableRef::new("schema", "table_a");
+        let table_ref_b = TableRef::new("schema", "table_b");
+        let ref_to_a = &table_ref_a;
+        assert!(!Equivalent::<TableRef>::equivalent(
+            &ref_to_a,
+            &table_ref_b
+        ));
+    }
+
+    #[test]
+    fn equivalent_ref_does_not_match_different_schema() {
+        let table_ref_a = TableRef::new("schema_a", "table");
+        let table_ref_b = TableRef::new("schema_b", "table");
+        let ref_to_a = &table_ref_a;
+        assert!(!Equivalent::<TableRef>::equivalent(
+            &ref_to_a,
+            &table_ref_b
+        ));
+    }
+
+    #[test]
+    fn equivalent_ref_does_not_match_none_vs_some_schema() {
+        let table_ref_no_schema = TableRef::new("", "table");
+        let table_ref_with_schema = TableRef::new("schema", "table");
+        let ref_to_no_schema = &table_ref_no_schema;
+        assert!(!Equivalent::<TableRef>::equivalent(
+            &ref_to_no_schema,
+            &table_ref_with_schema
+        ));
+    }
+
+    #[test]
+    fn table_ref_clone_preserves_equality() {
+        let table_ref = TableRef::new("schema", "table");
+        let cloned = table_ref.clone();
+        assert_eq!(table_ref, cloned);
+    }
+
+    #[test]
+    fn table_ref_debug_output_is_meaningful() {
+        let table_ref = TableRef::new("schema", "table");
+        let debug_str = format!("{:?}", table_ref);
+        assert!(debug_str.contains("TableRef"));
+        assert!(debug_str.contains("schema"));
+        assert!(debug_str.contains("table"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds 20 unit tests for `TableRef` in `crates/proof-of-sql/src/base/database/table_ref.rs`.

Previously, the `TableRef` struct had zero test coverage despite containing meaningful logic for construction, parsing, display, and serialization.

## Tests Added

- **Construction**: `new()`, `from_names()`, `from_idents()`, `from_strs()` with various inputs including empty schemas
- **Parsing**: `TryFrom<&str>` and `FromStr` for dotted strings (e.g., `schema.table`), simple strings, and error cases
- **Display**: Formatting with and without schema
- **Serialization**: Serde JSON round-trip for both schema-qualified and simple table refs
- **Equivalence**: `Equivalent` trait behavior for reference comparison (matching, mismatched schema/table, none vs some schema)
- **Derive traits**: Clone preserves equality, Debug output is meaningful
- **Error handling**: Too many components in `from_strs()`, empty components, triple-dotted strings

Relates to #560

## Testing

Tests follow existing patterns in the codebase (e.g., `owned_table_test.rs`, `columnar_value.rs` tests). All tests use standard `assert_eq!`, `assert!`, and pattern matching — no external dependencies beyond what's already in the module.