### PR TITLE
test: add coverage for missing Column variants in filter_util and order_by_util

### DIFF
--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,6 +1,7 @@
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
@@ -117,4 +118,85 @@ fn we_can_filter_columns_with_varbinary() {
             Column::BigInt(&[10, 30, 40]),
         ]
     );
+}
+
+#[test]
+fn we_can_filter_boolean_columns() {
+    let selection = vec![true, false, true, false, true];
+    let columns = vec![Column::<TestScalar>::Boolean(&[true, false, true, true, false])];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 3);
+    assert_eq!(result, vec![Column::Boolean(&[true, true, false])]);
+}
+
+#[test]
+fn we_can_filter_uint8_columns() {
+    let selection = vec![true, false, true, false, true];
+    let columns = vec![Column::<TestScalar>::Uint8(&[10u8, 20, 30, 40, 50])];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 3);
+    assert_eq!(result, vec![Column::Uint8(&[10u8, 30, 50])]);
+}
+
+#[test]
+fn we_can_filter_tinyint_columns() {
+    let selection = vec![true, false, true, false, true];
+    let columns = vec![Column::<TestScalar>::TinyInt(&[-1i8, 2, -3, 4, -5])];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 3);
+    assert_eq!(result, vec![Column::TinyInt(&[-1i8, -3, -5])]);
+}
+
+#[test]
+fn we_can_filter_smallint_columns() {
+    let selection = vec![true, false, true, false, true];
+    let columns = vec![Column::<TestScalar>::SmallInt(&[100i16, 200, 300, 400, 500])];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 3);
+    assert_eq!(result, vec![Column::SmallInt(&[100i16, 300, 500])]);
+}
+
+#[test]
+fn we_can_filter_int_columns() {
+    let selection = vec![true, false, true, false, true];
+    let columns = vec![Column::<TestScalar>::Int(&[1000i32, 2000, 3000, 4000, 5000])];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 3);
+    assert_eq!(result, vec![Column::Int(&[1000i32, 3000, 5000])]);
+}
+
+#[test]
+fn we_can_filter_timestamp_columns() {
+    let selection = vec![true, false, true, false, true];
+    let timestamps = [1_000i64, 2_000, 3_000, 4_000, 5_000];
+    let columns = vec![Column::<TestScalar>::TimestampTZ(
+        PoSQLTimeUnit::Second,
+        PoSQLTimeZone::utc(),
+        &timestamps,
+    )];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 3);
+    assert_eq!(
+        result,
+        vec![Column::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            &[1_000i64, 3_000, 5_000]
+        )]
+    );
+}
+
+#[test]
+#[should_panic]
+fn we_cannot_filter_columns_with_mismatched_selection_length() {
+    let columns = vec![Column::<TestScalar>::BigInt(&[1, 2, 3])];
+    let selection = vec![true, false]; // length 2, column length 3
+    let alloc = Bump::new();
+    let _ = filter_columns(&alloc, &columns, &selection);
 }

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
         database::{order_by_util::*, Column, ColumnType, TableOperationError},
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
@@ -187,4 +189,139 @@ fn we_can_compare_indexes_by_columns_for_varbinary_columns() {
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Equal); // "baz" vs "baz"
     assert_eq!(compare_indexes_by_columns(columns, 3, 4), Ordering::Greater); // "baz" vs "bar"
     assert_eq!(compare_indexes_by_columns(columns, 1, 4), Ordering::Equal); // "bar" vs "bar"
+}
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_boolean_columns() {
+    let slice = &[true, false, true, false];
+    let column = Column::Boolean::<TestScalar>(slice);
+    let columns = &[column];
+    // true > false
+    assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
+    // false < true
+    assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
+    // true == true
+    assert_eq!(compare_indexes_by_columns(columns, 0, 2), Ordering::Equal);
+    // false == false
+    assert_eq!(compare_indexes_by_columns(columns, 1, 3), Ordering::Equal);
+}
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_uint8_columns() {
+    let slice = &[10u8, 20, 10, 30];
+    let column = Column::Uint8::<TestScalar>(slice);
+    let columns = &[column];
+    assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Less);
+    assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Greater);
+    assert_eq!(compare_indexes_by_columns(columns, 0, 2), Ordering::Equal);
+}
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_tinyint_columns() {
+    let slice = &[-5i8, 0, 5, 0];
+    let column = Column::TinyInt::<TestScalar>(slice);
+    let columns = &[column];
+    assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Less);
+    assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
+    assert_eq!(compare_indexes_by_columns(columns, 2, 0), Ordering::Greater);
+    assert_eq!(compare_indexes_by_columns(columns, 1, 3), Ordering::Equal);
+}
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_smallint_columns() {
+    let slice = &[100i16, 200, 100, -50];
+    let column = Column::SmallInt::<TestScalar>(slice);
+    let columns = &[column];
+    assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Less);
+    assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Greater);
+    assert_eq!(compare_indexes_by_columns(columns, 0, 2), Ordering::Equal);
+    assert_eq!(compare_indexes_by_columns(columns, 3, 0), Ordering::Less);
+}
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_int_columns() {
+    let slice = &[1000i32, 2000, 1000, -500];
+    let column = Column::Int::<TestScalar>(slice);
+    let columns = &[column];
+    assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Less);
+    assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Greater);
+    assert_eq!(compare_indexes_by_columns(columns, 0, 2), Ordering::Equal);
+    assert_eq!(compare_indexes_by_columns(columns, 3, 0), Ordering::Less);
+}
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_decimal75_columns() {
+    let precision = Precision::new(10).unwrap();
+    let scale = 2i8;
+    let vals: Vec<TestScalar> = [100i64, 200, 100, 50]
+        .iter()
+        .map(|&v| TestScalar::from(v))
+        .collect();
+    let column = Column::Decimal75(precision, scale, &vals);
+    let columns = &[column];
+    assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Less);
+    assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Greater);
+    assert_eq!(compare_indexes_by_columns(columns, 0, 2), Ordering::Equal);
+    assert_eq!(compare_indexes_by_columns(columns, 3, 0), Ordering::Less);
+}
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_timestamp_columns() {
+    let timestamps = [1_000i64, 2_000, 1_000, 500];
+    let column =
+        Column::TimestampTZ::<TestScalar>(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &timestamps);
+    let columns = &[column];
+    assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Less);
+    assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Greater);
+    assert_eq!(compare_indexes_by_columns(columns, 0, 2), Ordering::Equal);
+    assert_eq!(compare_indexes_by_columns(columns, 3, 0), Ordering::Less);
+}
+
+#[test]
+fn we_can_compare_single_row_of_tables_for_timestamp_columns() {
+    let left_timestamps = [1_000i64, 2_000, 3_000];
+    let right_timestamps = [2_000i64, 2_000, 1_000];
+    let left_col = Column::TimestampTZ::<TestScalar>(
+        PoSQLTimeUnit::Second,
+        PoSQLTimeZone::utc(),
+        &left_timestamps,
+    );
+    let right_col = Column::TimestampTZ::<TestScalar>(
+        PoSQLTimeUnit::Second,
+        PoSQLTimeZone::utc(),
+        &right_timestamps,
+    );
+    let left = &[left_col];
+    let right = &[right_col];
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 0, 0).unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 1, 1).unwrap(),
+        Ordering::Equal
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 2, 2).unwrap(),
+        Ordering::Greater
+    );
+}
+
+#[test]
+fn we_cannot_compare_single_row_of_tables_with_incompatible_timestamp_and_bigint() {
+    let left_col = Column::TimestampTZ::<TestScalar>(
+        PoSQLTimeUnit::Second,
+        PoSQLTimeZone::utc(),
+        &[1_000i64],
+    );
+    let right_col = Column::BigInt::<TestScalar>(&[1_000i64]);
+    let left = &[left_col];
+    let right = &[right_col];
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 0, 0),
+        Err(TableOperationError::JoinIncompatibleTypes {
+            left_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            right_type: ColumnType::BigInt,
+        })
+    );
 }


### PR DESCRIPTION
/claim #560

## Summary

Adds **16 targeted tests** covering previously uncovered `Column` variant branches in
`filter_util` and `order_by_util`. Zero overlap with open PRs #1143, #1149, or #1153 —
each of those targets `base/database` type scaffolding, `arrow`, and `commitment` modules.
This PR focuses exclusively on the core filtering and ordering logic.

## Root cause of missing coverage

`filter_column_by_index` and `compare_indexes_by_columns` have match arms for every
`Column` variant. The existing test files exercised `BigInt`, `Int128`, `VarChar`,
`VarBinary`, `Scalar`, and `Decimal75`, but six variants (`Boolean`, `Uint8`, `TinyInt`,
`SmallInt`, `Int`, `TimestampTZ`) had zero test coverage, along with the panic path in
`filter_columns` and the `TimestampTZ` paths in `compare_single_row_of_tables`.

## Files changed

| File | New tests | Newly covered branches |
|---|---|---|
| `filter_util_test.rs` | 7 | `Boolean`, `Uint8`, `TinyInt`, `SmallInt`, `Int`, `TimestampTZ` arms in `filter_column_by_index`; panic on length mismatch |
| `order_by_util_test.rs` | 9 | `Boolean`, `Uint8`, `TinyInt`, `SmallInt`, `Int`, `Decimal75`, `TimestampTZ` arms in `compare_indexes_by_columns`; `TimestampTZ` happy path and `TimestampTZ`/`BigInt` error path in `compare_single_row_of_tables` |

## Verification

```
cargo test -p proof-of-sql filter_util
# test result: ok. 11 passed; 0 failed

cargo test -p proof-of-sql order_by_util
# test result: ok. 16 passed; 0 failed
```

All pre-existing tests continue to pass. No production code changed.

## Risks / follow-ups

None. Tests are purely additive, covering deterministic pure functions with no external dependencies.