### PR TITLE
test: add coverage for column comparison and arithmetic operation modules

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_arithmetic_operation_test.rs
+++ b/crates/proof-of-sql/src/base/database/column_arithmetic_operation_test.rs
@@ -1,0 +1,502 @@
+use crate::base::{
+    database::{ColumnOperationError, ColumnType, OwnedColumn},
+    scalar::test_scalar::TestScalar,
+};
+
+// ── AddOp ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn we_can_add_uint8_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Uint8(vec![4u8, 5, 6]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::Uint8(vec![5, 7, 9])
+    );
+}
+
+#[test]
+fn we_can_add_tinyint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![-1i8, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![4i8, -5, 6]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::TinyInt(vec![3, -3, 9])
+    );
+}
+
+#[test]
+fn we_can_add_smallint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![10i16, 20, 30]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![5i16, 5, 5]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::SmallInt(vec![15, 25, 35])
+    );
+}
+
+#[test]
+fn we_can_add_int_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int(vec![100i32, 200, 300]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![1i32, 2, 3]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::Int(vec![101, 202, 303])
+    );
+}
+
+#[test]
+fn we_can_add_bigint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![10i64, 20, 30]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::BigInt(vec![11, 22, 33])
+    );
+}
+
+#[test]
+fn we_can_add_int128_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int128(vec![1i128, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Int128(vec![10i128, 20, 30]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::Int128(vec![11, 22, 33])
+    );
+}
+
+#[test]
+fn we_can_add_mixed_integer_columns() {
+    // Uint8 + SmallInt → SmallInt (left upcast)
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![10i16, 20, 30]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::SmallInt(vec![11, 22, 33])
+    );
+
+    // TinyInt + BigInt → BigInt (left upcast)
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8, -2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![100i64, 200, 300]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::BigInt(vec![101, 198, 303])
+    );
+
+    // SmallInt + Int → Int (left upcast)
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![5i16, 10, 15]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![100i32, 200, 300]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::Int(vec![105, 210, 315])
+    );
+
+    // BigInt + SmallInt → BigInt (right upcast)
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1000i64, 2000, 3000]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![1i16, 2, 3]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs).unwrap(),
+        OwnedColumn::BigInt(vec![1001, 2002, 3003])
+    );
+}
+
+#[test]
+fn we_cannot_add_columns_with_different_lengths() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs),
+        Err(ColumnOperationError::DifferentColumnLength {
+            len_a: 3,
+            len_b: 2,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_add_uint8_with_tinyint() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8]);
+    assert_eq!(
+        lhs.element_wise_add(&rhs),
+        Err(ColumnOperationError::SignedCastingError {
+            left_type: ColumnType::Uint8,
+            right_type: ColumnType::TinyInt,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_add_incompatible_column_types() {
+    let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1]);
+    assert!(matches!(
+        lhs.element_wise_add(&rhs),
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}
+
+#[test]
+fn we_cannot_add_bigint_overflow() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![i64::MAX]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64]);
+    assert!(matches!(
+        lhs.element_wise_add(&rhs),
+        Err(ColumnOperationError::IntegerOverflow { .. })
+    ));
+}
+
+// ── SubOp ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn we_can_sub_uint8_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![10u8, 5, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8, 2, 3]);
+    assert_eq!(
+        lhs.element_wise_sub(&rhs).unwrap(),
+        OwnedColumn::Uint8(vec![9, 3, 0])
+    );
+}
+
+#[test]
+fn we_can_sub_tinyint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![5i8, -2, 10]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![3i8, -5, 10]);
+    assert_eq!(
+        lhs.element_wise_sub(&rhs).unwrap(),
+        OwnedColumn::TinyInt(vec![2, 3, 0])
+    );
+}
+
+#[test]
+fn we_can_sub_smallint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![20i16, 10, 5]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![5i16, 5, 5]);
+    assert_eq!(
+        lhs.element_wise_sub(&rhs).unwrap(),
+        OwnedColumn::SmallInt(vec![15, 5, 0])
+    );
+}
+
+#[test]
+fn we_can_sub_int_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int(vec![100i32, 200, 300]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![10i32, 20, 300]);
+    assert_eq!(
+        lhs.element_wise_sub(&rhs).unwrap(),
+        OwnedColumn::Int(vec![90, 180, 0])
+    );
+}
+
+#[test]
+fn we_can_sub_bigint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![100i64, 200, 300]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64, 2, 3]);
+    assert_eq!(
+        lhs.element_wise_sub(&rhs).unwrap(),
+        OwnedColumn::BigInt(vec![99, 198, 297])
+    );
+}
+
+#[test]
+fn we_can_sub_int128_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int128(vec![100i128, 200, 300]);
+    let rhs = OwnedColumn::<TestScalar>::Int128(vec![1i128, 2, 3]);
+    assert_eq!(
+        lhs.element_wise_sub(&rhs).unwrap(),
+        OwnedColumn::Int128(vec![99, 198, 297])
+    );
+}
+
+#[test]
+fn we_can_sub_mixed_integer_columns() {
+    // SmallInt - Int → Int (left upcast)
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![5i16, 10, 15]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![1i32, 2, 15]);
+    assert_eq!(
+        lhs.element_wise_sub(&rhs).unwrap(),
+        OwnedColumn::Int(vec![4, 8, 0])
+    );
+}
+
+#[test]
+fn we_cannot_sub_columns_with_different_lengths() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1]);
+    assert_eq!(
+        lhs.element_wise_sub(&rhs),
+        Err(ColumnOperationError::DifferentColumnLength {
+            len_a: 2,
+            len_b: 1,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_sub_uint8_with_tinyint() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![5u8]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8]);
+    assert_eq!(
+        lhs.element_wise_sub(&rhs),
+        Err(ColumnOperationError::SignedCastingError {
+            left_type: ColumnType::Uint8,
+            right_type: ColumnType::TinyInt,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_sub_bigint_overflow() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![i64::MIN]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64]);
+    assert!(matches!(
+        lhs.element_wise_sub(&rhs),
+        Err(ColumnOperationError::IntegerOverflow { .. })
+    ));
+}
+
+// ── MulOp ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn we_can_mul_uint8_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![2u8, 3, 4]);
+    let rhs = OwnedColumn::<TestScalar>::Uint8(vec![3u8, 3, 0]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs).unwrap(),
+        OwnedColumn::Uint8(vec![6, 9, 0])
+    );
+}
+
+#[test]
+fn we_can_mul_tinyint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![2i8, -3, 4]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![3i8, 2, 0]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs).unwrap(),
+        OwnedColumn::TinyInt(vec![6, -6, 0])
+    );
+}
+
+#[test]
+fn we_can_mul_smallint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![10i16, 20, 5]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![2i16, 3, 0]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs).unwrap(),
+        OwnedColumn::SmallInt(vec![20, 60, 0])
+    );
+}
+
+#[test]
+fn we_can_mul_int_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int(vec![10i32, 20, 30]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![2i32, 3, 0]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs).unwrap(),
+        OwnedColumn::Int(vec![20, 60, 0])
+    );
+}
+
+#[test]
+fn we_can_mul_bigint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![10i64, 20, 30]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![2i64, 3, 0]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs).unwrap(),
+        OwnedColumn::BigInt(vec![20, 60, 0])
+    );
+}
+
+#[test]
+fn we_can_mul_int128_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int128(vec![10i128, 20, 30]);
+    let rhs = OwnedColumn::<TestScalar>::Int128(vec![2i128, 3, 0]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs).unwrap(),
+        OwnedColumn::Int128(vec![20, 60, 0])
+    );
+}
+
+#[test]
+fn we_can_mul_mixed_integer_columns() {
+    // Uint8 * BigInt → BigInt (left upcast)
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![2u8, 3, 4]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![10i64, 20, 0]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs).unwrap(),
+        OwnedColumn::BigInt(vec![20, 60, 0])
+    );
+
+    // Int128 * TinyInt → Int128 (right upcast)
+    let lhs = OwnedColumn::<TestScalar>::Int128(vec![100i128, 200, 300]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![2i8, 3, 0]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs).unwrap(),
+        OwnedColumn::Int128(vec![200, 600, 0])
+    );
+}
+
+#[test]
+fn we_cannot_mul_columns_with_different_lengths() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs),
+        Err(ColumnOperationError::DifferentColumnLength {
+            len_a: 3,
+            len_b: 2,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_mul_uint8_with_tinyint() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![2u8]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![3i8]);
+    assert_eq!(
+        lhs.element_wise_mul(&rhs),
+        Err(ColumnOperationError::SignedCastingError {
+            left_type: ColumnType::Uint8,
+            right_type: ColumnType::TinyInt,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_mul_incompatible_column_types() {
+    let lhs = OwnedColumn::<TestScalar>::VarChar(vec!["a".into()]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1]);
+    assert!(matches!(
+        lhs.element_wise_mul(&rhs),
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}
+
+#[test]
+fn we_cannot_mul_bigint_overflow() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![i64::MAX]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![2i64]);
+    assert!(matches!(
+        lhs.element_wise_mul(&rhs),
+        Err(ColumnOperationError::IntegerOverflow { .. })
+    ));
+}
+
+// ── DivOp ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn we_can_div_uint8_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![10u8, 9, 6]);
+    let rhs = OwnedColumn::<TestScalar>::Uint8(vec![2u8, 3, 6]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs).unwrap(),
+        OwnedColumn::Uint8(vec![5, 3, 1])
+    );
+}
+
+#[test]
+fn we_can_div_tinyint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![10i8, -9, 6]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![2i8, 3, 6]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs).unwrap(),
+        OwnedColumn::TinyInt(vec![5, -3, 1])
+    );
+}
+
+#[test]
+fn we_can_div_smallint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![20i16, 15, 0]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![4i16, 5, 7]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs).unwrap(),
+        OwnedColumn::SmallInt(vec![5, 3, 0])
+    );
+}
+
+#[test]
+fn we_can_div_int_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int(vec![100i32, 200, 0]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![10i32, 20, 5]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs).unwrap(),
+        OwnedColumn::Int(vec![10, 10, 0])
+    );
+}
+
+#[test]
+fn we_can_div_bigint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![100i64, 200, 300]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![10i64, 10, 10]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs).unwrap(),
+        OwnedColumn::BigInt(vec![10, 20, 30])
+    );
+}
+
+#[test]
+fn we_can_div_int128_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int128(vec![100i128, 200, 300]);
+    let rhs = OwnedColumn::<TestScalar>::Int128(vec![10i128, 10, 10]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs).unwrap(),
+        OwnedColumn::Int128(vec![10, 20, 30])
+    );
+}
+
+#[test]
+fn we_can_div_mixed_integer_columns() {
+    // TinyInt / SmallInt → SmallInt (left upcast)
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![10i8, 9, 6]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![2i16, 3, 6]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs).unwrap(),
+        OwnedColumn::SmallInt(vec![5, 3, 1])
+    );
+}
+
+#[test]
+fn we_cannot_div_columns_with_different_lengths() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![10, 20]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![2]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs),
+        Err(ColumnOperationError::DifferentColumnLength {
+            len_a: 2,
+            len_b: 1,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_div_by_zero() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![10i64, 20]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![2i64, 0]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs),
+        Err(ColumnOperationError::DivisionByZero)
+    );
+}
+
+#[test]
+fn we_cannot_div_uint8_with_tinyint() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![10u8]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![2i8]);
+    assert_eq!(
+        lhs.element_wise_div(&rhs),
+        Err(ColumnOperationError::SignedCastingError {
+            left_type: ColumnType::Uint8,
+            right_type: ColumnType::TinyInt,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_div_incompatible_column_types() {
+    let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1]);
+    assert!(matches!(
+        lhs.element_wise_div(&rhs),
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}

--- a/crates/proof-of-sql/src/base/database/column_comparison_operation_test.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation_test.rs
@@ -1,0 +1,363 @@
+use crate::base::{
+    database::{ColumnOperationError, ColumnType, OwnedColumn},
+    scalar::test_scalar::TestScalar,
+};
+
+// ── EqualOp ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn we_can_eq_boolean_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true, false]);
+    let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true, true, false, false]);
+    let result = lhs.element_wise_eq(&rhs).unwrap();
+    assert_eq!(
+        result,
+        OwnedColumn::Boolean(vec![true, false, false, true])
+    );
+}
+
+#[test]
+fn we_can_eq_uint8_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Uint8(vec![1, 3, 3]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, true])
+    );
+}
+
+#[test]
+fn we_can_eq_tinyint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![-1, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![-1, 3, 3]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, true])
+    );
+}
+
+#[test]
+fn we_can_eq_smallint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![100, 200, 300]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![100, 300, 300]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, true])
+    );
+}
+
+#[test]
+fn we_can_eq_int_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int(vec![1000, 2000, 3000]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![1000, 3000, 3000]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, true])
+    );
+}
+
+#[test]
+fn we_can_eq_bigint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 4]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, true, false])
+    );
+}
+
+#[test]
+fn we_can_eq_int128_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int128(vec![1, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Int128(vec![1, 2, 4]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, true, false])
+    );
+}
+
+#[test]
+fn we_can_eq_varchar_columns() {
+    let lhs = OwnedColumn::<TestScalar>::VarChar(vec!["a".into(), "b".into(), "c".into()]);
+    let rhs = OwnedColumn::<TestScalar>::VarChar(vec!["a".into(), "x".into(), "c".into()]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, true])
+    );
+}
+
+#[test]
+fn we_can_eq_mixed_integer_columns() {
+    // Uint8 == BigInt (left upcast)
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64, 3, 3]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, true])
+    );
+
+    // TinyInt == SmallInt (left upcast)
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![1i16, 2, 4]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, true, false])
+    );
+
+    // SmallInt == Int (left upcast)
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![10i16, 20, 30]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![10i32, 99, 30]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, true])
+    );
+
+    // BigInt == TinyInt (right upcast)
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![5i64, 6, 7]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![5i8, 7, 7]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, true])
+    );
+}
+
+#[test]
+fn we_cannot_eq_columns_with_different_lengths() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs),
+        Err(ColumnOperationError::DifferentColumnLength {
+            len_a: 3,
+            len_b: 2,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_eq_incompatible_column_types() {
+    let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1]);
+    assert!(matches!(
+        lhs.element_wise_eq(&rhs),
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}
+
+#[test]
+fn we_cannot_eq_uint8_with_tinyint() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8]);
+    assert_eq!(
+        lhs.element_wise_eq(&rhs),
+        Err(ColumnOperationError::SignedCastingError {
+            left_type: ColumnType::Uint8,
+            right_type: ColumnType::TinyInt,
+        })
+    );
+}
+
+// ── LessThanOp ───────────────────────────────────────────────────────────────
+
+#[test]
+fn we_can_lt_bigint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 5, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![2, 5, 1]);
+    assert_eq!(
+        lhs.element_wise_lt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_lt_int_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int(vec![1i32, 5, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![2i32, 5, 1]);
+    assert_eq!(
+        lhs.element_wise_lt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_lt_smallint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![1i16, 5, 3]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![2i16, 5, 1]);
+    assert_eq!(
+        lhs.element_wise_lt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_lt_tinyint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![-5i8, 0, 5]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![0i8, 0, 3]);
+    assert_eq!(
+        lhs.element_wise_lt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_lt_uint8_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8, 5, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Uint8(vec![2u8, 5, 1]);
+    assert_eq!(
+        lhs.element_wise_lt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_lt_int128_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int128(vec![1, 5, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Int128(vec![2, 5, 1]);
+    assert_eq!(
+        lhs.element_wise_lt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_lt_mixed_integer_columns() {
+    // SmallInt < BigInt
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![1i16, 5, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![2i64, 5, 1]);
+    assert_eq!(
+        lhs.element_wise_lt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_cannot_lt_varchar_columns() {
+    let lhs = OwnedColumn::<TestScalar>::VarChar(vec!["a".into()]);
+    let rhs = OwnedColumn::<TestScalar>::VarChar(vec!["b".into()]);
+    assert!(matches!(
+        lhs.element_wise_lt(&rhs),
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}
+
+#[test]
+fn we_cannot_lt_uint8_with_tinyint() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8]);
+    assert_eq!(
+        lhs.element_wise_lt(&rhs),
+        Err(ColumnOperationError::SignedCastingError {
+            left_type: ColumnType::Uint8,
+            right_type: ColumnType::TinyInt,
+        })
+    );
+}
+
+// ── GreaterThanOp ─────────────────────────────────────────────────────────────
+
+#[test]
+fn we_can_gt_bigint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![5, 1, 3]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![2, 5, 3]);
+    assert_eq!(
+        lhs.element_wise_gt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_gt_int_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int(vec![5i32, 1, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Int(vec![2i32, 5, 3]);
+    assert_eq!(
+        lhs.element_wise_gt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_gt_smallint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![5i16, 1, 3]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![2i16, 5, 3]);
+    assert_eq!(
+        lhs.element_wise_gt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_gt_tinyint_columns() {
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![5i8, -1, 3]);
+    let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![2i8, 5, 3]);
+    assert_eq!(
+        lhs.element_wise_gt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_gt_uint8_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Uint8(vec![5u8, 1, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Uint8(vec![2u8, 5, 3]);
+    assert_eq!(
+        lhs.element_wise_gt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_gt_int128_columns() {
+    let lhs = OwnedColumn::<TestScalar>::Int128(vec![5, 1, 3]);
+    let rhs = OwnedColumn::<TestScalar>::Int128(vec![2, 5, 3]);
+    assert_eq!(
+        lhs.element_wise_gt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_can_gt_mixed_integer_columns() {
+    // BigInt > SmallInt (right upcast)
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![5i64, 1, 3]);
+    let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![2i16, 5, 3]);
+    assert_eq!(
+        lhs.element_wise_gt(&rhs).unwrap(),
+        OwnedColumn::Boolean(vec![true, false, false])
+    );
+}
+
+#[test]
+fn we_cannot_gt_varchar_columns() {
+    let lhs = OwnedColumn::<TestScalar>::VarChar(vec!["b".into()]);
+    let rhs = OwnedColumn::<TestScalar>::VarChar(vec!["a".into()]);
+    assert!(matches!(
+        lhs.element_wise_gt(&rhs),
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}
+
+#[test]
+fn we_cannot_gt_tinyint_with_uint8() {
+    let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8]);
+    let rhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8]);
+    assert_eq!(
+        lhs.element_wise_gt(&rhs),
+        Err(ColumnOperationError::SignedCastingError {
+            left_type: ColumnType::TinyInt,
+            right_type: ColumnType::Uint8,
+        })
+    );
+}
+
+#[test]
+fn we_cannot_gt_columns_with_different_lengths() {
+    let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1, 2]);
+    let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1]);
+    assert_eq!(
+        lhs.element_wise_gt(&rhs),
+        Err(ColumnOperationError::DifferentColumnLength {
+            len_a: 2,
+            len_b: 1,
+        })
+    );
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -34,9 +34,13 @@ pub use column_type_operation::{
 
 mod column_arithmetic_operation;
 pub(super) use column_arithmetic_operation::{AddOp, ArithmeticOp, DivOp, MulOp, SubOp};
+#[cfg(test)]
+mod column_arithmetic_operation_test;
 
 mod column_comparison_operation;
 pub(super) use column_comparison_operation::{ComparisonOp, EqualOp, GreaterThanOp, LessThanOp};
+#[cfg(test)]
+mod column_comparison_operation_test;
 
 mod column_index_operation;
 pub(super) use column_index_operation::apply_column_to_indexes;


### PR DESCRIPTION
/claim #560

## Summary

Adds two new dedicated test modules targeting previously untested execution logic in the column operations layer:

- **`column_comparison_operation_test`** — 31 tests covering `EqualOp`, `LessThanOp`, `GreaterThanOp` across all integer column variants (Uint8, TinyInt, SmallInt, Int, BigInt, Int128), VarChar equality, mixed-type upcasting, `SignedCastingError` for Uint8↔TinyInt, `BinaryOperationInvalidColumnType` for VarChar with `<`/`>`, and `DifferentColumnLength` errors.
- **`column_arithmetic_operation_test`** — 43 tests covering `AddOp`, `SubOp`, `MulOp`, `DivOp` across all integer column variants, mixed-type upcasting (left and right), `SignedCastingError`, `IntegerOverflow`, `DivisionByZero`, `BinaryOperationInvalidColumnType`, and `DifferentColumnLength` errors.

## Files changed

- `crates/proof-of-sql/src/base/database/column_comparison_operation_test.rs` — new file (31 tests)
- `crates/proof-of-sql/src/base/database/column_arithmetic_operation_test.rs` — new file (43 tests)
- `crates/proof-of-sql/src/base/database/mod.rs` — registered both test modules under `#[cfg(test)]`

## Verification

```
cargo test -p proof-of-sql base::database::column_comparison_operation_test
# test result: ok. 31 passed; 0 failed

cargo test -p proof-of-sql base::database::column_arithmetic_operation_test
# test result: ok. 43 passed; 0 failed
```

No warnings. No changes to production code.