### PR TITLE
test: add metadata coverage for database refs

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,36 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn we_can_build_and_query_column_fields() {
+        let field = ColumnField::new(Ident::new("amount"), ColumnType::BigInt);
+
+        assert_eq!(field.name(), Ident::new("amount"));
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn we_can_hash_compare_and_serialize_column_fields() {
+        let first = ColumnField::new(Ident::new("id"), ColumnType::Int);
+        let same = ColumnField::new(Ident::new("id"), ColumnType::Int);
+        let different = ColumnField::new(Ident::new("created_at"), ColumnType::BigInt);
+
+        assert_eq!(first, same);
+        assert_ne!(first, different);
+
+        let mut set = HashSet::new();
+        set.insert(first.clone());
+        assert!(set.contains(&same));
+        assert!(!set.contains(&different));
+
+        let json = serde_json::to_string(&first).unwrap();
+        let round_trip: ColumnField = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip, first);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,51 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn we_can_build_and_query_column_refs() {
+        let table_ref = TableRef::new("public", "employees");
+        let column_ref =
+            ColumnRef::new(table_ref.clone(), Ident::new("salary"), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), Ident::new("salary"));
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+    }
+
+    #[test]
+    fn we_can_hash_compare_and_serialize_column_refs() {
+        let first = ColumnRef::new(
+            TableRef::new("public", "employees"),
+            Ident::new("id"),
+            ColumnType::Int,
+        );
+        let same = ColumnRef::new(
+            TableRef::new("public", "employees"),
+            Ident::new("id"),
+            ColumnType::Int,
+        );
+        let different = ColumnRef::new(
+            TableRef::new("public", "employees"),
+            Ident::new("department_id"),
+            ColumnType::Int,
+        );
+
+        assert_eq!(first, same);
+        assert_ne!(first, different);
+
+        let mut set = HashSet::new();
+        set.insert(first.clone());
+        assert!(set.contains(&same));
+        assert!(!set.contains(&different));
+
+        let json = serde_json::to_string(&first).unwrap();
+        let round_trip: ColumnRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip, first);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,83 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::Equivalent;
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn we_can_build_table_refs_from_names_and_idents() {
+        let without_schema = TableRef::new("", "employees");
+        assert_eq!(without_schema.schema_id(), None);
+        assert_eq!(without_schema.table_id(), &Ident::new("employees"));
+        assert_eq!(without_schema.to_string(), "employees");
+
+        let with_schema = TableRef::new("public", "employees");
+        assert_eq!(with_schema.schema_id(), Some(&Ident::new("public")));
+        assert_eq!(with_schema.table_id(), &Ident::new("employees"));
+        assert_eq!(with_schema.to_string(), "public.employees");
+
+        let from_names = TableRef::from_names(Some("sales"), "orders");
+        assert_eq!(from_names.schema_id(), Some(&Ident::new("sales")));
+        assert_eq!(from_names.table_id(), &Ident::new("orders"));
+
+        let from_idents = TableRef::from_idents(Some(Ident::new("hr")), Ident::new("people"));
+        assert_eq!(from_idents.schema_id(), Some(&Ident::new("hr")));
+        assert_eq!(from_idents.table_id(), &Ident::new("people"));
+    }
+
+    #[test]
+    fn we_can_parse_table_refs_from_slices_and_strings() {
+        let single = TableRef::from_strs(&["employees"]).unwrap();
+        assert_eq!(single.schema_id(), None);
+        assert_eq!(single.table_id(), &Ident::new("employees"));
+
+        let qualified = TableRef::from_strs(&["public", "employees"]).unwrap();
+        assert_eq!(qualified.schema_id(), Some(&Ident::new("public")));
+        assert_eq!(qualified.table_id(), &Ident::new("employees"));
+
+        let from_try_from = TableRef::try_from("analytics.events").unwrap();
+        assert_eq!(from_try_from.schema_id(), Some(&Ident::new("analytics")));
+        assert_eq!(from_try_from.table_id(), &Ident::new("events"));
+
+        let from_str = "events".parse::<TableRef>().unwrap();
+        assert_eq!(from_str.schema_id(), None);
+        assert_eq!(from_str.table_id(), &Ident::new("events"));
+    }
+
+    #[test]
+    fn we_reject_invalid_table_ref_shapes() {
+        let err = TableRef::from_strs(&["a", "b", "c"]).unwrap_err();
+        assert_eq!(
+            err,
+            ParseError::InvalidTableReference {
+                table_reference: "a,b,c".to_string(),
+            }
+        );
+
+        let err = TableRef::try_from("a.b.c").unwrap_err();
+        assert_eq!(
+            err,
+            ParseError::InvalidTableReference {
+                table_reference: "a.b.c".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn we_support_equivalence_and_serde_round_trips() {
+        let expected = TableRef::new("public", "employees");
+        let borrowed = &expected;
+        let parsed = TableRef::try_from("public.employees").unwrap();
+
+        assert!(borrowed.equivalent(&parsed));
+
+        let json = serde_json::to_string(&expected).unwrap();
+        assert_eq!(json, "\"public.employees\"");
+        let round_trip: TableRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip, expected);
+    }
+}


### PR DESCRIPTION
Fixes #560.

## Summary
- add focused unit coverage for the core database metadata reference types
- cover `TableRef` construction, parsing, display, equivalence, and serde round-trips
- cover `ColumnRef` getters, equality/hash behavior, and serde round-trips
- cover `ColumnField` getters, equality/hash behavior, and serde round-trips

## Validation
- ran `rustfmt` on the touched files
- attempted `cargo test -p proof-of-sql --lib table_ref --no-default-features --features test`
- local cargo execution on this Windows host is currently blocked by missing linker / CRT setup, so remote CI is the source of truth for compile validation on this PR

/claim #560