### PR TITLE
Refactor Scalar trait: explicit limb conversions and hash-based string conversion

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -403,7 +403,16 @@ where
         255 - T::MODULUS.0[3].leading_zeros() as u8
     };
     const MAX_SIGNED_U256: U256 = U256::from_digits(T::MODULUS.divide_by_2_round_down().0);
+
+    fn from_limbs(limbs: [u64; 4]) -> Self {
+        Self(Fp::new(ark_ff::BigInt(limbs)))
+    }
+
+    fn to_limbs(&self) -> [u64; 4] {
+        self.0.into_bigint().0
+    }
 }
+
 
 impl<T> TryFrom<MontScalar<T>> for bool
 where

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -40,8 +40,6 @@ pub trait Scalar:
     + core::convert::TryInto <i32>
     + core::convert::TryInto <i64>
     + core::convert::TryInto <i128>
-    + core::convert::Into<[u64; 4]>
-    + core::convert::From<[u64; 4]>
     + core::convert::From<u8>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
@@ -51,10 +49,6 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + RefInto<[u64; 4]>
-    + for<'a> core::convert::From<&'a String>
-    + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>
@@ -65,6 +59,7 @@ pub trait Scalar:
     + core::convert::Into<BigInt>
     + TryFrom<BigInt, Error = ScalarConversionError>
 {
+
     /// The value (p - 1) / 2. This is "mid-point" of the field - the "six" on the clock.
     /// It is the largest signed value that can be represented in the field with the natural embedding.
     const MAX_SIGNED: Self;
@@ -85,4 +80,11 @@ pub trait Scalar:
     const MAX_BITS: u8;
     /// A U256 representation of the largest signed value in the field.
     const MAX_SIGNED_U256: U256;
+
+    /// Create a scalar from 4 64-bit limbs.
+    fn from_limbs(limbs: [u64; 4]) -> Self;
+
+    /// Convert the scalar to 4 64-bit limbs.
+    fn to_limbs(&self) -> [u64; 4];
 }
+

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -3,7 +3,7 @@ use bnum::types::U256;
 use core::cmp::Ordering;
 use tiny_keccak::Hasher;
 
-/// Extension trait for blanket implementations for `Scalar` types.
+    /// Extension trait for blanket implementations for `Scalar` types.
 /// This trait is primarily to avoid cluttering the core `Scalar` implementation with default implementations
 /// and provides helper methods for `Scalar`.
 pub trait ScalarExt: Scalar {
@@ -20,16 +20,21 @@ pub trait ScalarExt: Scalar {
         }
     }
 
+    /// Converts a string into a Scalar by hashing it.
+    fn from_str_via_hash(val: &str) -> Self {
+        Self::from_byte_slice_via_hash(val.as_bytes())
+    }
+
     #[must_use]
     /// Converts a U256 to Scalar, wrapping as needed
     fn from_wrapping(value: U256) -> Self {
         let value_as_limbs: [u64; 4] = value.into();
-        Self::from(value_as_limbs)
+        Self::from_limbs(value_as_limbs)
     }
 
     /// Converts a Scalar to U256. Note that any values above `MAX_SIGNED` shall remain positive, even if they are representative of negative values.
     fn into_u256_wrapping(self) -> U256 {
-        U256::from(Into::<[u64; 4]>::into(self))
+        U256::from(self.to_limbs())
     }
 
     /// Converts a byte slice to a Scalar using a hash function, preventing collisions.
@@ -39,7 +44,7 @@ pub trait ScalarExt: Scalar {
     #[must_use]
     fn from_byte_slice_via_hash(bytes: &[u8]) -> Self {
         if bytes.is_empty() {
-            return Self::zero();
+            return Self::ZERO;
         }
 
         let mut hasher = tiny_keccak::Keccak::v256();
@@ -52,6 +57,7 @@ pub trait ScalarExt: Scalar {
         Self::from_wrapping(masked_val)
     }
 }
+
 
 impl<S: Scalar> ScalarExt for S {}
 


### PR DESCRIPTION
Addresses #228. This PR refactors the Scalar trait to improve clarity and type safety as requested:
- Removed 'Into<[u64; 4]>', 'From<[u64; 4]>', and 'RefInto<[u64; 4]>' bounds.
- Implemented 'from_limbs([u64; 4]) -> Self' and 'to_limbs(&self) -> [u64; 4]' trait methods.
- Implemented 'from_str_via_hash(&str) -> Self' with a default implementation in 'ScalarExt' using Keccak-256.
- Simplified trait bounds by removing redundant 'From<String>' and 'VarInt' requirements.