### PR TITLE
feat!: replace VarInt for MontScalar with blanket impl<S: Scalar> VarInt for S

### DIFF
--- a/crates/proof-of-sql-benches/benches/bench_append_rows.rs
+++ b/crates/proof-of-sql-benches/benches/bench_append_rows.rs
@@ -98,27 +98,32 @@ pub fn generate_random_owned_table<S: Scalar>(
         let identifier = format!("column_{}", rng.gen::<u32>());
 
         match column_type {
-            "bigint" => columns.push(bigint(&*identifier, vec![rng.gen::<i64>(); num_rows])),
-            "boolean" => columns.push(boolean(
+            "bigint" => columns.push(bigint::<S>(&*identifier, vec![rng.gen::<i64>(); num_rows])),
+            "boolean" => columns.push(boolean::<S>(
                 &*identifier,
                 generate_random_boolean_vector(num_rows),
             )),
-            "int128" => columns.push(int128(&*identifier, vec![rng.gen::<i128>(); num_rows])),
-            "scalar" => columns.push(scalar(
+            "int128" => columns.push(int128::<S>(&*identifier, vec![rng.gen::<i128>(); num_rows])),
+            "scalar" => {
+                let data: Vec<_> = (0..num_rows)
+                    .map(|_| S::from_limbs(generate_random_u64_array()))
+                    .collect();
+                columns.push(scalar::<S>(&*identifier, data))
+            }
+            "varchar" => columns.push(varchar::<S>(&*identifier, gen_rnd_str(num_rows))),
+            "decimal75" => {
+                let data: Vec<_> = (0..num_rows)
+                    .map(|_| S::from_limbs(generate_random_u64_array()))
+                    .collect();
+                columns.push(decimal75::<S>(&*identifier, 12, 2, data))
+            }
+            "tinyint" => columns.push(tinyint::<S>(&*identifier, vec![rng.gen::<i8>(); num_rows])),
+            "smallint" => columns.push(smallint::<S>(
                 &*identifier,
-                vec![generate_random_u64_array(); num_rows],
+                vec![rng.gen::<i16>(); num_rows],
             )),
-            "varchar" => columns.push(varchar(&*identifier, gen_rnd_str(num_rows))),
-            "decimal75" => columns.push(decimal75(
-                &*identifier,
-                12,
-                2,
-                vec![generate_random_u64_array(); num_rows],
-            )),
-            "tinyint" => columns.push(tinyint(&*identifier, vec![rng.gen::<i8>(); num_rows])),
-            "smallint" => columns.push(smallint(&*identifier, vec![rng.gen::<i16>(); num_rows])),
-            "int" => columns.push(int(&*identifier, vec![rng.gen::<i32>(); num_rows])),
-            "timestamptz" => columns.push(timestamptz(
+            "int" => columns.push(int::<S>(&*identifier, vec![rng.gen::<i32>(); num_rows])),
+            "timestamptz" => columns.push(timestamptz::<S>(
                 &*identifier,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::utc(),

--- a/crates/proof-of-sql-benches/benches/bench_append_rows.rs
+++ b/crates/proof-of-sql-benches/benches/bench_append_rows.rs
@@ -108,14 +108,14 @@ pub fn generate_random_owned_table<S: Scalar>(
                 let data: Vec<_> = (0..num_rows)
                     .map(|_| S::from_limbs(generate_random_u64_array()))
                     .collect();
-                columns.push(scalar::<S>(&*identifier, data))
+                columns.push(scalar::<S>(&*identifier, data));
             }
             "varchar" => columns.push(varchar::<S>(&*identifier, gen_rnd_str(num_rows))),
             "decimal75" => {
                 let data: Vec<_> = (0..num_rows)
                     .map(|_| S::from_limbs(generate_random_u64_array()))
                     .collect();
-                columns.push(decimal75::<S>(&*identifier, 12, 2, data))
+                columns.push(decimal75::<S>(&*identifier, 12, 2, data));
             }
             "tinyint" => columns.push(tinyint::<S>(&*identifier, vec![rng.gen::<i8>(); num_rows])),
             "smallint" => columns.push(smallint::<S>(

--- a/crates/proof-of-sql-benches/src/utils/random_util.rs
+++ b/crates/proof-of-sql-benches/src/utils/random_util.rs
@@ -99,7 +99,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         });
                         Column::VarChar((
                             strs,
-                            alloc.alloc_slice_fill_iter(strs.iter().map(|&s| Into::into(s))),
+                            alloc.alloc_slice_fill_iter(
+                                strs.iter().map(|&s| S::from_str_via_hash(s)),
+                            ),
                         ))
                     }
                     (ColumnType::Scalar, _) => {
@@ -114,7 +116,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
                             ) as &str
                         });
                         Column::Scalar(
-                            alloc.alloc_slice_fill_iter(strs.iter().map(|&s| Into::into(s))),
+                            alloc.alloc_slice_fill_iter(
+                                strs.iter().map(|&s| S::from_str_via_hash(s)),
+                            ),
                         )
                     }
                     (ColumnType::Decimal75(p, s), _) => {
@@ -131,7 +135,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::Decimal75(
                             *p,
                             *s,
-                            alloc.alloc_slice_fill_iter(strs.iter().map(|&s| Into::into(s))),
+                            alloc.alloc_slice_fill_iter(
+                                strs.iter().map(|&s| S::from_str_via_hash(s)),
+                            ),
                         )
                     }
                     (ColumnType::TimestampTZ(u, z), None) => Column::TimestampTZ(

--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -279,7 +279,9 @@ impl ArrayRefExt for ArrayRef {
                     let scals = if let Some(scals) = precomputed_scals {
                         &scals[range.start..range.end]
                     } else {
-                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S { vals[i].into() })
+                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S {
+                            S::from_str_via_hash(vals[i])
+                        })
                     };
 
                     Ok(Column::VarChar((vals, scals)))

--- a/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
@@ -14,7 +14,7 @@ const MAX_SUPPORTED_I256: i256 = i256::from_parts(
 pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
     let is_negative = val > &S::MAX_SIGNED;
     let abs_scalar = if is_negative { -*val } else { *val };
-    let limbs: [u64; 4] = abs_scalar.into();
+    let limbs: [u64; 4] = abs_scalar.to_limbs();
 
     let low = u128::from(limbs[0]) | (u128::from(limbs[1]) << 64);
     let high = i128::from(limbs[2]) | (i128::from(limbs[3]) << 64);
@@ -47,7 +47,7 @@ pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
         ];
 
         // Convert limbs to Scalar and adjust for sign
-        let scalar: S = limbs.into();
+        let scalar: S = S::from_limbs(limbs);
         Some(if value.is_negative() { -scalar } else { scalar })
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -3,7 +3,6 @@ use crate::base::{
     if_rayon,
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    ref_into::RefInto,
     scalar::{Scalar, ScalarExt},
 };
 use alloc::vec::Vec;
@@ -116,16 +115,16 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::BigInt(ints) => CommittableColumn::BigInt(ints),
             Column::Int128(ints) => CommittableColumn::Int128(ints),
             Column::Decimal75(precision, scale, decimals) => {
-                let as_limbs: Vec<_> = decimals.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = decimals.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::Decimal75(*precision, *scale, as_limbs)
             }
             Column::Scalar(scalars) => (scalars as &[_]).into(),
             Column::VarChar((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarChar(as_limbs)
             }
             Column::VarBinary((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarBinary(as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
@@ -155,7 +154,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 decimals
                     .iter()
                     .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|s| s.to_limbs())
                     .collect(),
             ),
             OwnedColumn::Scalar(scalars) => (scalars as &[_]).into(),
@@ -163,14 +162,14 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 strings
                     .iter()
                     .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|s| s.to_limbs())
                     .collect(),
             ),
             OwnedColumn::VarBinary(bytes) => CommittableColumn::VarBinary(
                 bytes
                     .iter()
                     .map(|b| S::from_byte_slice_via_hash(b))
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|s| s.to_limbs())
                     .collect(),
             ),
             OwnedColumn::TimestampTZ(tu, tz, times) => {
@@ -216,7 +215,7 @@ impl<'a, S: Scalar> From<&'a [S]> for CommittableColumn<'a> {
     fn from(value: &'a [S]) -> Self {
         CommittableColumn::Scalar(
             if_rayon!(value.par_iter(), value.iter())
-                .map(RefInto::<[u64; 4]>::ref_into)
+                .map(Scalar::to_limbs)
                 .collect(),
         )
     }

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -161,7 +161,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
             OwnedColumn::VarChar(strings) => CommittableColumn::VarChar(
                 strings
                     .iter()
-                    .map(Into::<S>::into)
+                    .map(|s| S::from_str_via_hash(s))
                     .map(|s| s.to_limbs())
                     .collect(),
             ),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -127,7 +127,7 @@ impl<'a, S: Scalar> Column<'a, S> {
                 Column::Int128(alloc.alloc_slice_fill_copy(length, *value))
             }
             LiteralValue::Scalar(value) => {
-                Column::Scalar(alloc.alloc_slice_fill_copy(length, (*value).into()))
+                Column::Scalar(alloc.alloc_slice_fill_copy(length, S::from_limbs(*value)))
             }
             LiteralValue::Decimal75(precision, scale, value) => Column::Decimal75(
                 *precision,

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -139,7 +139,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, S::from(string)),
+                alloc.alloc_slice_fill_copy(length, S::from_str_via_hash(string)),
             )),
             LiteralValue::VarBinary(bytes) => {
                 // Convert the bytes to a slice of bytes references
@@ -177,7 +177,10 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
             OwnedColumn::VarChar(col) => {
-                let scalars = col.iter().map(S::from).collect::<Vec<_>>();
+                let scalars = col
+                    .iter()
+                    .map(|s| S::from_str_via_hash(s))
+                    .collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)

--- a/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
@@ -254,7 +254,7 @@ pub trait ComparisonOp {
             (
                 OwnedColumn::Decimal75(_, _, lhs_values),
                 OwnedColumn::Decimal75(_, _, rhs_values),
-            ) => Ok(Self::decimal_op_left_upcast(
+            ) => Ok(Self::decimal_op_left_upcast::<S, S>(
                 lhs_values,
                 rhs_values,
                 lhs.column_type(),

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -85,7 +85,7 @@ impl LiteralValue {
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),
-            Self::Scalar(limbs) => (*limbs).into(),
+            Self::Scalar(limbs) => S::from_limbs(*limbs),
             Self::TimeStampTZ(_, _, time) => time.into(),
         }
     }

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -81,7 +81,7 @@ impl LiteralValue {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar(str) => str.into(),
+            Self::VarChar(str) => S::from_str_via_hash(str),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -10,7 +10,7 @@ use crate::base::{
     },
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::Scalar,
-    slice_ops::{inner_product_ref_cast, inner_product_with_bytes},
+    slice_ops::{inner_product_ref_cast, inner_product_with_bytes, inner_product_with_strings},
 };
 use alloc::{
     string::{String, ToString},
@@ -65,7 +65,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {
                 inner_product_ref_cast(col, vec)
             }
-            OwnedColumn::VarChar(col) => inner_product_ref_cast(col, vec),
+            OwnedColumn::VarChar(col) => inner_product_with_strings(col, vec),
             OwnedColumn::VarBinary(col) => inner_product_with_bytes(col, vec),
             OwnedColumn::Int128(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => {

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
     map::IndexMap,
-    scalar::ScalarExt,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
@@ -108,7 +108,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
                 let scals: &mut [_] = self
                     .alloc
-                    .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
+                    .alloc_slice_fill_iter(col.iter().map(|s| CP::Scalar::from_str_via_hash(s)));
                 Column::VarChar((col, scals))
             }
             OwnedColumn::VarBinary(col) => {

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -288,7 +288,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
         })
         .collect();
     let alloc_strings = alloc.alloc_slice_clone(&strings);
-    let scalars: Vec<S> = strings.iter().map(|s| (*s).into()).collect();
+    let scalars: Vec<S> = strings.iter().map(|s| S::from_str_via_hash(s)).collect();
     let alloc_scalars = alloc.alloc_slice_copy(&scalars);
     (name.into(), Column::VarChar((alloc_strings, alloc_scalars)))
 }

--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -1,8 +1,7 @@
 use crate::base::{
     encode::{ZigZag, U256},
-    scalar::MontScalar,
+    scalar::Scalar,
 };
-use ark_ff::MontConfig;
 use core::cmp::{max, Ordering};
 
 /// This function writes the input scalar x as a varint encoding to buf slice
@@ -14,7 +13,7 @@ use core::cmp::{max, Ordering};
 ///
 /// crash:
 /// - in case N is bigger than `buf.len()`
-pub fn write_scalar_varint<T: MontConfig<4>>(buf: &mut [u8], x: &MontScalar<T>) -> usize {
+pub fn write_scalar_varint<S: Scalar>(buf: &mut [u8], x: &S) -> usize {
     write_u256_varint(buf, x.zigzag())
 }
 
@@ -61,7 +60,7 @@ pub fn write_u256_varint(buf: &mut [u8], mut zig_x: U256) -> usize {
 ///  Since read-scalar stores the buf into a U256 type, which can only
 ///  hold up to 256 bit numbers, the non-continuation bits
 ///  257 up to 259 from buf are ignored.
-pub fn read_scalar_varint<T: MontConfig<4>>(buf: &[u8]) -> Option<(MontScalar<T>, usize)> {
+pub fn read_scalar_varint<S: Scalar>(buf: &[u8]) -> Option<(S, usize)> {
     read_u256_varint(buf).map(|(val, s)| (val.zigzag(), s))
 }
 pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
@@ -113,7 +112,7 @@ pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
 /// error:
 /// - in case buf has not enough space to hold all the scalars encoding.
 #[cfg(test)]
-pub fn write_scalar_varints<T: MontConfig<4>>(buf: &mut [u8], scals: &[MontScalar<T>]) -> usize {
+pub fn write_scalar_varints<S: Scalar>(buf: &mut [u8], scals: &[S]) -> usize {
     let mut total_bytes_written = 0;
 
     for scal in scals {
@@ -133,10 +132,7 @@ pub fn write_scalar_varints<T: MontConfig<4>>(buf: &mut [u8], scals: &[MontScala
 /// error:
 /// - in case it's not possible to read all specified scalars from `input_buf`
 #[cfg(test)]
-pub fn read_scalar_varints<T: MontConfig<4>>(
-    scals_buf: &mut [MontScalar<T>],
-    input_buf: &[u8],
-) -> Option<()> {
+pub fn read_scalar_varints<S: Scalar>(scals_buf: &mut [S], input_buf: &[u8]) -> Option<()> {
     let mut buf = input_buf;
 
     for scal_buf in scals_buf.iter_mut() {
@@ -153,7 +149,7 @@ pub fn read_scalar_varints<T: MontConfig<4>>(
 ///
 /// This function should be used to get an upper bound on the buffer size
 /// used by the `write_scalar_varint` function.
-pub fn scalar_varint_size<T: MontConfig<4>>(x: &MontScalar<T>) -> usize {
+pub fn scalar_varint_size<S: Scalar>(x: &S) -> usize {
     u256_varint_size(x.zigzag())
 }
 pub fn u256_varint_size(zig_x: U256) -> usize {
@@ -173,7 +169,7 @@ pub fn u256_varint_size(zig_x: U256) -> usize {
 /// This function should be used to get an upper bound on the buffer size
 /// used by the `write_scalar_varints` function.
 #[cfg(test)]
-pub fn scalar_varints_size<T: MontConfig<4>>(scals: &[MontScalar<T>]) -> usize {
+pub fn scalar_varints_size<S: Scalar>(scals: &[S]) -> usize {
     let mut all_size: usize = 0;
 
     for x in scals {

--- a/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
@@ -2,7 +2,10 @@ use super::scalar_varint::{
     read_scalar_varint, read_scalar_varints, scalar_varint_size, scalar_varints_size,
     write_scalar_varint, write_scalar_varints,
 };
-use crate::base::{encode::U256, scalar::test_scalar::TestScalar};
+use crate::base::{
+    encode::{u256::u256_to_scalar, U256},
+    scalar::test_scalar::TestScalar,
+};
 use alloc::vec;
 
 #[test]
@@ -32,11 +35,10 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_posi
 ) {
     // x = (p - 1) / 10 (p is the ristretto group order)
     // y = -x = (p + 1) / 10
-    let val: TestScalar = (&U256::from_words(
+    let val: TestScalar = u256_to_scalar(&U256::from_words(
         0x9baf_e5c9_76b2_5c7b_d59b_704f_6fb2_2eca,
         0x0199_9999_9999_9999_9999_9999_9999_9999,
-    ))
-        .into();
+    ));
     assert!(scalar_varint_size(&val) == 36);
 }
 
@@ -45,11 +47,10 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
 ) {
     // x = (p + 1) / 10 (p is the ristretto group order)
     // y = -x = (p - 1) / 10
-    let val: TestScalar = (&U256::from_words(
+    let val: TestScalar = u256_to_scalar(&U256::from_words(
         0x9baf_e5c9_76b2_5c7b_d59b_704f_6fb2_2ecb,
         0x0199_9999_9999_9999_9999_9999_9999_9999,
-    ))
-        .into();
+    ));
     assert!(scalar_varint_size(&val) == 36);
 }
 
@@ -58,21 +59,19 @@ fn the_maximum_positive_and_negative_encoded_scalars_consume_the_maximum_amount_
     // maximum negative encoded scalar
     // x = (p + 1) / 2 (p is the ristretto group order)
     // y = -x = (p - 1) / 2
-    let val: TestScalar = (&U256::from_words(
+    let val: TestScalar = u256_to_scalar(&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f7,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
-    ))
-        .into();
+    ));
     assert!(scalar_varint_size(&val) == 37);
 
     // maximum positive encoded scalar
     // x = (p - 1) / 2 (p is the ristretto group order)
     // y = -x = (p + 1) / 2
-    let val: TestScalar = (&U256::from_words(
+    let val: TestScalar = u256_to_scalar(&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f6,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
-    ))
-        .into();
+    ));
 
     assert!(scalar_varint_size(&val) == 37);
 }
@@ -83,11 +82,10 @@ fn scalar_slices_consumes_the_correct_amount_of_bytes() {
     let val1 = -TestScalar::from(1_u64);
 
     // x = (p + 1) / 2
-    let val2: TestScalar = (&U256::from_words(
+    let val2: TestScalar = u256_to_scalar(&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f7,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
-    ))
-        .into();
+    ));
 
     assert!(scalar_varints_size(&[TestScalar::from(1000_u64)]) == 2);
 
@@ -151,11 +149,10 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_correctly_encod
 
     // (p - 1) / 2 (p is the ristretto group order)
     // y = -x = (p + 1) / 2 (which is bigger than x)
-    let val: TestScalar = (&U256::from_words(
+    let val: TestScalar = u256_to_scalar(&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f6,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
-    ))
-        .into();
+    ));
     assert!(write_scalar_varint(&mut buf[..], &val) == 37);
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 37));
 
@@ -170,11 +167,10 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_correctly_e
 
     // x = (p + 1) / 2 (p is the group order)
     // y = -x = (p - 1) / 2 (which is smaller than x)
-    let val: TestScalar = (&U256::from_words(
+    let val: TestScalar = u256_to_scalar(&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f7,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
-    ))
-        .into();
+    ));
 
     assert!(write_scalar_varint(&mut buf[..], &val) == 37);
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 37));
@@ -195,7 +191,7 @@ fn valid_varint_encoded_input_that_map_to_test_scalars_smaller_than_the_p_field_
     // buf represents the number 2^252 - 1
     // removing the varint encoding, we would have y = ((2^252 - 1) // 2 + 1) % p
     // since we want x, we would have x = -y
-    let expected_x = -TestScalar::from(&U256::from_words(
+    let expected_x = -u256_to_scalar::<TestScalar>(&U256::from_words(
         0x0000_0000_0000_0000_0000_0000_0000_0000,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ));
@@ -216,11 +212,10 @@ fn valid_varint_encoded_input_that_map_to_test_scalars_bigger_than_the_p_field_o
     // at this point, buf represents the number 2^256 - 2,
     // which has 256 bit-length, where 255 bits are set to 1
     // also, `expected_val` is simply x = ((2^256 - 2) >> 1) % p
-    let expected_val: TestScalar = (&U256::from_words(
+    let expected_val: TestScalar = u256_to_scalar(&U256::from_words(
         0x6de7_2ae9_8b3a_b623_977f_4a47_7547_3484,
         0x0fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
-    ))
-        .into();
+    ));
     assert!(read_scalar_varint(&buf[..]).unwrap() == (expected_val, 37));
 
     // even though we are able to read varint numbers of up to 259 bits-length,

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -1,4 +1,4 @@
-use crate::base::scalar::MontScalar;
+use crate::base::scalar::{MontScalar, Scalar};
 use ark_ff::MontConfig;
 
 /// U256 represents an unsigned 256-bits integer number
@@ -21,7 +21,7 @@ impl U256 {
 /// This trait converts a dalek scalar into a U256 integer
 impl<T: MontConfig<4>> From<&MontScalar<T>> for U256 {
     fn from(val: &MontScalar<T>) -> Self {
-        let buf: [u64; 4] = val.into();
+        let buf: [u64; 4] = val.to_limbs();
         let low: u128 = u128::from(buf[0]) | (u128::from(buf[1]) << 64);
         let high: u128 = u128::from(buf[2]) | (u128::from(buf[3]) << 64);
         U256::from_words(low, high)

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -1,5 +1,4 @@
-use crate::base::scalar::{MontScalar, Scalar};
-use ark_ff::MontConfig;
+use crate::base::scalar::Scalar;
 
 /// U256 represents an unsigned 256-bits integer number
 ///
@@ -18,9 +17,13 @@ impl U256 {
     }
 }
 
-/// This trait converts a dalek scalar into a U256 integer
-impl<T: MontConfig<4>> From<&MontScalar<T>> for U256 {
-    fn from(val: &MontScalar<T>) -> Self {
+/// Convert any `Scalar` value into a `U256`, packing its canonical limbs.
+///
+/// The orphan rule lets us blanket this conversion because `U256` is local
+/// to this crate. The body only depends on the `Scalar` trait surface
+/// (`to_limbs`), so future `Scalar` impls work for free.
+impl<S: Scalar> From<&S> for U256 {
+    fn from(val: &S) -> Self {
         let buf: [u64; 4] = val.to_limbs();
         let low: u128 = u128::from(buf[0]) | (u128::from(buf[1]) << 64);
         let high: u128 = u128::from(buf[2]) | (u128::from(buf[3]) << 64);
@@ -28,10 +31,17 @@ impl<T: MontConfig<4>> From<&MontScalar<T>> for U256 {
     }
 }
 
-/// This trait converts a U256 integer into a dalek scalar
-impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
-    fn from(val: &U256) -> Self {
-        let bytes = [val.low.to_le_bytes(), val.high.to_le_bytes()].concat();
-        MontScalar::<T>::from_le_bytes_mod_order(&bytes)
-    }
+/// Convert a `U256` into a `Scalar`, reducing modulo the field's prime.
+///
+/// Unlike the `From<&S>` direction, this conversion can't be expressed as
+/// a `From` blanket impl (orphan rule: both `From` and the generic `S`
+/// would be foreign at the impl site). Use `Scalar::from_le_bytes_mod_order`
+/// directly via this helper; it preserves the previous
+/// `From<&U256> for MontScalar<T>` semantics for any `S: Scalar`.
+#[inline]
+pub fn u256_to_scalar<S: Scalar>(val: &U256) -> S {
+    let mut bytes = [0u8; 32];
+    bytes[..16].copy_from_slice(&val.low.to_le_bytes());
+    bytes[16..].copy_from_slice(&val.high.to_le_bytes());
+    S::from_le_bytes_mod_order(&bytes)
 }

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -16,10 +16,8 @@ use super::{
     },
     U256,
 };
-use crate::base::scalar::MontScalar;
 #[cfg(test)]
 use alloc::{vec, vec::Vec};
-use ark_ff::MontConfig;
 
 /// Most-significant byte, == 0x80
 pub const MSB: u8 = 0b1000_0000;
@@ -282,7 +280,15 @@ impl VarInt for i128 {
     }
 }
 
-impl<T: MontConfig<4>> VarInt for MontScalar<T> {
+/// Blanket `VarInt` implementation for any `Scalar`.
+///
+/// This replaces the previous `MontScalar<T>`-specific impl: every `Scalar`
+/// implementor now gets varint encoding for free. The body relies only on
+/// `Scalar`'s `to_limbs` / `from_le_bytes_mod_order` surface (via
+/// `ZigZag` and the helpers in `scalar_varint`), so future `Scalar`
+/// types — non-Montgomery field representations, alternative wrappers —
+/// work without any extra impl block.
+impl<S: crate::base::scalar::Scalar> VarInt for S {
     fn required_space(self) -> usize {
         scalar_varint_size(&self)
     }

--- a/crates/proof-of-sql/src/base/encode/zigzag.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag.rs
@@ -1,5 +1,7 @@
-use crate::base::{encode::U256, scalar::MontScalar};
-use ark_ff::MontConfig;
+use crate::base::{
+    encode::{u256::u256_to_scalar, U256},
+    scalar::Scalar,
+};
 
 /// A trait for enabling zig-zag encoding
 ///
@@ -10,7 +12,7 @@ pub trait ZigZag<T> {
     fn zigzag(&self) -> T;
 }
 
-/// Zigzag conversion from a dalek Scalar to a [`ZigZag`] u256 integer
+/// Zigzag conversion from a `Scalar` to a [`ZigZag`] u256 integer
 ///
 /// For this conversion, we compute:
 ///
@@ -24,12 +26,12 @@ pub trait ZigZag<T> {
 /// which represents a positive [`ZigZag`] encoding.
 /// Otherwise, we remap `y` to `2 * y + 1` u256 integer,
 /// which represents a negative [`ZigZag`] encoding (-y).
-impl<T: MontConfig<4>> ZigZag<U256> for MontScalar<T> {
+impl<S: Scalar> ZigZag<U256> for S {
     fn zigzag(&self) -> U256 {
-        // since self is a dalek scalar, we never have the last bit 255 set
+        // since self is a field scalar, we never have the last bit 255 set
         // therefore, we should never expect overflow when multiplying by 2
         let mut x: U256 = self.into();
-        let mut y: U256 = (&-self).into(); // x + y = 0 ==> y = -x
+        let mut y: U256 = (&-*self).into(); // x + y = 0 ==> y = -x
 
         // we return the smallest ZigZag number between x and y
         // in case x is bigger than y, we return -y (encoded in the ZigZag format)
@@ -61,7 +63,7 @@ impl<T: MontConfig<4>> ZigZag<U256> for MontScalar<T> {
     }
 }
 
-/// Zigzag conversion from an u256 integer to a dalek Scalar.
+/// Zigzag conversion from a u256 integer to a `Scalar`.
 ///
 /// For this conversion, we first verify if `self` is an odd or even number.
 /// In case `self` is odd, the encoded number represents a negative
@@ -72,10 +74,13 @@ impl<T: MontConfig<4>> ZigZag<U256> for MontScalar<T> {
 /// In both cases, we divide the `self` value by 2 in order
 /// to remove the [`ZigZag`] encoding (`y = self / 2` or `x = self / 2`).
 ///
-/// Finally, we return either `-1 * dalek::Scalar(y)` or `dalek::Scalar(x)`,
+/// Finally, we return either `-1 * Scalar(y)` or `Scalar(x)`,
 /// which in both cases represents the `x` scalar.
-impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
-    fn zigzag(&self) -> MontScalar<T> {
+///
+/// `u256_to_scalar` reduces modulo the field order, so this round-trip is
+/// safe even when the encoded U256 exceeds the modulus before reduction.
+impl<S: Scalar> ZigZag<S> for U256 {
+    fn zigzag(&self) -> S {
         // we need to divide self by 2 to remove the ZigZag encoding
         let mut zig_val = U256 {
             low: (self.low >> 1) | ((self.high & 1) << 127),
@@ -98,14 +103,12 @@ impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
             // even though the encoding represented a -y,
             // zig_val actually represents a `y` (we simply divided self by 2).
             // Also, since x + y = 0, we need to compute -(zig_val.into()) to return x
-            let scal: MontScalar<T> = (&zig_val).into();
+            let scal: S = u256_to_scalar(&zig_val);
 
             -scal
         } else {
-            let scal: MontScalar<T> = (&zig_val).into();
-
             // return x
-            scal
+            u256_to_scalar(&zig_val)
         }
     }
 }

--- a/crates/proof-of-sql/src/base/encode/zigzag_test.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag_test.rs
@@ -1,5 +1,5 @@
 use crate::base::{
-    encode::{ZigZag, U256},
+    encode::{u256::u256_to_scalar, ZigZag, U256},
     scalar::test_scalar::TestScalar,
 };
 
@@ -52,11 +52,10 @@ fn big_scalars_with_small_additive_inverses_are_encoded_as_negative_zigzag_value
 fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_positive_zigzag_values()
 {
     // x = (p - 1) / 2 (p is the ristretto group order)
-    let val: TestScalar = (&U256::from_words(
+    let val: TestScalar = u256_to_scalar(&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f6,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
-    ))
-        .into();
+    ));
     // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
     assert!(
         val.zigzag()
@@ -71,11 +70,10 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_posi
 fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_negative_zigzag_values(
 ) {
     // x = (p + 1) / 2 (p is the ristretto group order)
-    let val: TestScalar = (&U256::from_words(
+    let val: TestScalar = u256_to_scalar(&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f7,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
-    ))
-        .into();
+    ));
 
     // the additive inverse of x is y = -x = (p - 1) / 2
     // since we have y < x, the ZigZag encoding is 2 * y - 1 = p - 2
@@ -89,11 +87,10 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
 
     // x = - U256 { low: 0, high: 0x1_u128 }
     // since x > y, where x + y = 0, the ZigZag value is encoded as 2 * y - 1
-    let val: TestScalar = (&U256 {
+    let val: TestScalar = u256_to_scalar(&U256 {
         low: 0x0_u128,
         high: 0x1_u128,
-    })
-        .into();
+    });
     assert!(
         (-val).zigzag()
             == U256::from_words(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128, 0x1_u128)

--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -49,9 +49,9 @@ impl I256 {
     /// NOTE: this is not a particularly efficient method. Please either refactor or avoid when performance matters.
     pub fn into_scalar<S: Scalar>(self) -> S {
         if self.0[3] & 0x8000_0000_0000_0000 == 0 {
-            self.0.into()
+            S::from_limbs(self.0)
         } else {
-            (Into::<S>::into(self.neg().0)).neg()
+            S::from_limbs(self.neg().0).neg()
         }
     }
 

--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -1,8 +1,5 @@
 use super::Transcript;
-use crate::base::{
-    ref_into::RefInto,
-    scalar::{Scalar, ScalarExt},
-};
+use crate::base::scalar::{Scalar, ScalarExt};
 use bnum::types::U256;
 use zerocopy::{AsBytes, FromBytes};
 
@@ -57,7 +54,7 @@ impl<T: TranscriptCore> Transcript for T {
         &mut self,
         messages: impl IntoIterator<Item = &'a S>,
     ) {
-        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(RefInto::ref_into));
+        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(Scalar::to_limbs));
     }
     fn scalar_challenge_as_be<S: Scalar>(&mut self) -> S {
         ScalarExt::from_wrapping(

--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -11,6 +11,7 @@
 ///     ...
 /// }
 /// ```
+#[allow(dead_code)]
 pub trait RefInto<T> {
     /// Converts a reference to this type into the (usually inferred) input type.
     fn ref_into(&self) -> T;

--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -11,7 +11,7 @@
 ///     ...
 /// }
 /// ```
-#[allow(dead_code)]
+#[expect(dead_code, reason = "kept as a public reusable conversion trait")]
 pub trait RefInto<T> {
     /// Converts a reference to this type into the (usually inferred) input type.
     fn ref_into(&self) -> T;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -275,7 +275,7 @@ impl<T: MontConfig<4>> num_traits::Inv for MontScalar<T> {
 }
 impl<T: MontConfig<4>> Serialize for MontScalar<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut limbs: [u64; 4] = self.into();
+        let mut limbs: [u64; 4] = self.to_limbs();
         limbs.reverse();
         limbs.serialize(serializer)
     }
@@ -284,7 +284,7 @@ impl<'de, T: MontConfig<4>> Deserialize<'de> for MontScalar<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let mut limbs: [u64; 4] = Deserialize::deserialize(deserializer)?;
         limbs.reverse();
-        Ok(limbs.into())
+        Ok(Self::from_limbs(limbs))
     }
 }
 
@@ -403,6 +403,14 @@ where
         255 - T::MODULUS.0[3].leading_zeros() as u8
     };
     const MAX_SIGNED_U256: U256 = U256::from_digits(T::MODULUS.divide_by_2_round_down().0);
+
+    fn from_limbs(val: [u64; 4]) -> Self {
+        Self::from(val)
+    }
+
+    fn to_limbs(&self) -> [u64; 4] {
+        self.0.into_bigint().0
+    }
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool
@@ -413,9 +421,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -447,7 +455,7 @@ where
             });
         }
 
-        let abs: [u64; 4] = value.into();
+        let abs: [u64; 4] = value.to_limbs();
 
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -471,9 +479,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -495,9 +503,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -519,9 +527,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -543,9 +551,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -569,9 +577,9 @@ where
     #[expect(clippy::cast_possible_wrap)]
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -603,7 +611,7 @@ where
         } else {
             num_bigint::Sign::Plus
         };
-        let value_abs: [u64; 4] = (if is_negative { -value } else { value }).into();
+        let value_abs: [u64; 4] = (if is_negative { -value } else { value }).to_limbs();
         let bits: &[u8] = bytemuck::cast_slice(&value_abs);
         BigInt::from_bytes_le(sign, bits)
     }

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -411,6 +411,10 @@ where
     fn to_limbs(&self) -> [u64; 4] {
         self.0.into_bigint().0
     }
+
+    fn from_le_bytes_mod_order(bytes: &[u8]) -> Self {
+        Self(Fp::from_le_bytes_mod_order(bytes))
+    }
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
+use crate::base::{encode::VarInt, scalar::ScalarConversionError};
 use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
@@ -40,8 +40,6 @@ pub trait Scalar:
     + core::convert::TryInto <i32>
     + core::convert::TryInto <i64>
     + core::convert::TryInto <i128>
-    + core::convert::Into<[u64; 4]>
-    + core::convert::From<[u64; 4]>
     + core::convert::From<u8>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
@@ -51,7 +49,6 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + RefInto<[u64; 4]>
     + for<'a> core::convert::From<&'a String>
     + VarInt
     + core::convert::From<String>
@@ -85,4 +82,9 @@ pub trait Scalar:
     const MAX_BITS: u8;
     /// A U256 representation of the largest signed value in the field.
     const MAX_SIGNED_U256: U256;
+
+    /// Convert limbs to scalar
+    fn from_limbs(val: [u64; 4]) -> Self;
+    /// Convert scalar to limbs
+    fn to_limbs(&self) -> [u64; 4];
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, scalar::ScalarConversionError};
+use crate::base::scalar::ScalarConversionError;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
@@ -47,7 +47,6 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + VarInt
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>
@@ -83,6 +82,15 @@ pub trait Scalar:
     fn from_limbs(val: [u64; 4]) -> Self;
     /// Convert scalar to limbs
     fn to_limbs(&self) -> [u64; 4];
+
+    /// Build a scalar from a little-endian byte slice, reducing modulo the
+    /// field's prime modulus.
+    ///
+    /// Unlike `from_limbs`, the input is allowed to exceed the field
+    /// modulus: it is reduced modulo `p`. Used by varint decoding and other
+    /// paths that consume raw 256-bit values which may not be canonical
+    /// before reduction.
+    fn from_le_bytes_mod_order(bytes: &[u8]) -> Self;
 
     /// Converts a string to a scalar by hashing its bytes.
     #[must_use]

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,7 +1,6 @@
 #![expect(clippy::module_inception)]
 
 use crate::base::{encode::VarInt, scalar::ScalarConversionError};
-use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
@@ -13,7 +12,6 @@ pub trait Scalar:
     + core::fmt::Display
     + PartialEq
     + Default
-    + for<'a> From<&'a str>
     + Sync
     + Send
     + num_traits::One
@@ -49,9 +47,7 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + for<'a> core::convert::From<&'a String>
     + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>
@@ -87,4 +83,9 @@ pub trait Scalar:
     fn from_limbs(val: [u64; 4]) -> Self;
     /// Convert scalar to limbs
     fn to_limbs(&self) -> [u64; 4];
+
+    /// Converts a string to a scalar by hashing its bytes.
+    fn from_str_via_hash(value: &str) -> Self {
+        <Self as super::ScalarExt>::from_byte_slice_via_hash(value.as_bytes())
+    }
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -85,6 +85,7 @@ pub trait Scalar:
     fn to_limbs(&self) -> [u64; 4];
 
     /// Converts a string to a scalar by hashing its bytes.
+    #[must_use]
     fn from_str_via_hash(value: &str) -> Self {
         <Self as super::ScalarExt>::from_byte_slice_via_hash(value.as_bytes())
     }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -24,12 +24,12 @@ pub trait ScalarExt: Scalar {
     /// Converts a U256 to Scalar, wrapping as needed
     fn from_wrapping(value: U256) -> Self {
         let value_as_limbs: [u64; 4] = value.into();
-        Self::from(value_as_limbs)
+        Self::from_limbs(value_as_limbs)
     }
 
     /// Converts a Scalar to U256. Note that any values above `MAX_SIGNED` shall remain positive, even if they are representative of negative values.
     fn into_u256_wrapping(self) -> U256 {
-        U256::from(Into::<[u64; 4]>::into(self))
+        U256::from(self.to_limbs())
     }
 
     /// Converts a byte slice to a Scalar using a hash function, preventing collisions.

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -111,6 +111,14 @@ mod tests {
     }
 
     #[test]
+    fn we_can_get_scalar_from_hashed_strings() {
+        assert_eq!(
+            TestScalar::from_str_via_hash("abc"),
+            TestScalar::from_byte_slice_via_hash(b"abc")
+        );
+    }
+
+    #[test]
     fn we_can_compute_powers_of_10() {
         for i in 0..=u128::MAX.ilog10() {
             assert_eq!(

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -2,7 +2,7 @@ use crate::base::{
     if_rayon,
     scalar::{Scalar, ScalarExt},
 };
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::{iter::Sum, ops::Mul};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
@@ -38,5 +38,13 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
     if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
         .zip(b)
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
+        .sum()
+}
+
+/// Cannot use blanket impls for `String` because `Scalar` no longer requires `From<&String>`.
+pub fn inner_product_with_strings<S: Scalar>(a: &[String], b: &[S]) -> S {
+    if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
+        .zip(b)
+        .map(|(lhs_string, &rhs)| S::from_str_via_hash(lhs_string) * rhs)
         .sum()
 }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -1,4 +1,7 @@
-use super::{decode_and_convert, decode_multiple_elements, ProvableResultColumn, QueryError};
+use super::{
+    decode_and_convert, decode_multiple_elements, ProvableResultColumn, ProvableResultElement,
+    QueryError,
+};
 use crate::base::{
     database::{Column, ColumnField, ColumnType, OwnedColumn, OwnedTable, Table},
     polynomial::compute_evaluation_vector,
@@ -117,7 +120,11 @@ impl ProvableQueryResult {
                         decode_and_convert::<S, S>(&self.data[offset..])
                     }
 
-                    ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
+                    ColumnType::VarChar => {
+                        let (raw_str, used) = <&str>::decode(&self.data[offset..])?;
+                        let x = S::from_str_via_hash(raw_str);
+                        Ok((x, used))
+                    }
                     ColumnType::VarBinary => {
                         let (raw_bytes, used) =
                             decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
@@ -103,7 +103,7 @@ impl ProofExpr for ScalingCastExpr {
     ) -> Result<S, ProofError> {
         self.from_expr
             .verifier_evaluate(builder, accessor, chi_eval, params)
-            .map(|unscaled_eval| S::from(self.scaling_factor) * unscaled_eval)
+            .map(|unscaled_eval| S::from_limbs(self.scaling_factor) * unscaled_eval)
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -137,7 +137,8 @@ pub fn const_varbinary(val: &[u8]) -> DynProofExpr {
 
 /// Create a constant scalar value. Used if we don't want to specify column types.
 pub fn const_scalar<S: Scalar, T: Into<S>>(val: T) -> DynProofExpr {
-    DynProofExpr::new_literal(LiteralValue::Scalar(val.into().into()))
+    let scalar: S = val.into();
+    DynProofExpr::new_literal(LiteralValue::Scalar(scalar.to_limbs()))
 }
 
 /// # Panics

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -191,7 +191,8 @@ where
             .take(31)
             .collect();
     for (i, scalar) in column_data.iter().enumerate() {
-        let scalar_array: [u64; 4] = (*scalar).into().into();
+        let scalar_s: S = (*scalar).into();
+        let scalar_array: [u64; 4] = scalar_s.to_limbs();
         // Convert the [u64; 4] into a slice of bytes
         let scalar_bytes = &cast_slice::<u64, u8>(&scalar_array)[..31];
 


### PR DESCRIPTION
/claim #228

## What

Closes the third checkbox of #228. Drops `+ VarInt` from `Scalar`'s super-bounds and replaces the per-`MontScalar<T>` `VarInt` impl with a blanket `impl<S: Scalar> VarInt for S`. Every `Scalar` now gets varint encoding for free, mirroring the `from_limbs` / `to_limbs` / `from_str_via_hash` pattern from sub-tasks 1 and 2.

Lifted to generic-over-`S: Scalar`:

- `From<&MontScalar<T>> for U256` → `impl<S: Scalar> From<&S> for U256` (only relies on `to_limbs`).
- `ZigZag<U256> for MontScalar<T>` → `impl<S: Scalar> ZigZag<U256> for S`.
- `ZigZag<MontScalar<T>> for U256` → `impl<S: Scalar> ZigZag<S> for U256`.
- `write_scalar_varint`, `read_scalar_varint`, `scalar_varint_size` and the test-only `*_varints` helpers.

The reverse `From<&U256> for MontScalar<T>` direction can't become a blanket `From<&U256> for S` — the orphan rule rejects a foreign `From` trait when the generic `S` is uncovered ahead of the local `U256`. Replaced with:

- free helper `encode::u256::u256_to_scalar<S: Scalar>(&U256) -> S`,
- a new required `Scalar::from_le_bytes_mod_order(&[u8]) -> Self` method (`MontScalar` implements via `Fp::from_le_bytes_mod_order`, preserving the prior modular-reduction semantics — varint readers can produce U256 values ≥ the field modulus).

## Stacking

Stacks on **#1169** (sub-task 1) and **#1170** (sub-task 2). The first four commits in this PR are sub-tasks 1 + 2 + their lint fixups; only the last commit is sub-task 3. If the predecessors land first, this collapses to a single-commit PR. Happy to rebase whenever convenient.

## Pre-PR checks

- [x] `source scripts/run_ci_checks.sh` (cargo check no-default-features / all-targets / all-targets all-features / proof-of-sql no-default-features) — all clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo test --workspace --lib` — **1420 + 107 = 1527 tests pass, 0 failed.**
- [x] Conventional Commits.

## Coherence note

`impl<S: Scalar> VarInt for S` co-exists with the existing primitive impls (`u64`, `i64`, `bool`, etc.) because no primitive currently satisfies the `Scalar` super-bounds (`CanonicalSerialize + UniformRand + Into<BigInt> + ...`). If a future change adds `Scalar` for a primitive, an E0119 conflict will fire — sealing the `Scalar` trait would resolve it. Doesn't need a change today.

This completes #228 end-to-end. After this lands, the issue's three checkboxes are all done.