### PR TITLE
test: cache Dory test setups

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    cached_prover_setup, cached_verifier_setup, test_rng, DoryEvaluationProof,
+    DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup, ProverSetup, PublicParameters,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -8,45 +8,41 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(4);
+    let verifier_setup = cached_verifier_setup(4);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(prover_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(prover_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(6);
+    let verifier_setup = cached_verifier_setup(6);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(prover_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(4);
+    let verifier_setup = cached_verifier_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(prover_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(prover_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(6);
+    let verifier_setup = cached_verifier_setup(6);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(prover_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
@@ -55,15 +51,14 @@ fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
     let setup_setup = [(4, 4), (4, 3), (6, 2)];
     for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let prover_setup = cached_prover_setup(setup_p.0);
+        let verifier_setup = cached_verifier_setup(setup_p.0);
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
-                &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &DoryProverPublicSetup::new(prover_setup, setup_p.1),
+                &DoryVerifierPublicSetup::new(verifier_setup, setup_p.1),
             );
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -5,26 +5,26 @@ use crate::{
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
     proof_primitive::dory::{
-        compute_dory_commitments, DoryProverPublicSetup, ProverSetup, PublicParameters, F, GT,
+        cached_prover_setup, cached_public_parameters, compute_dory_commitments,
+        DoryProverPublicSetup, F, GT,
     },
 };
 use ark_ec::pairing::Pairing;
-use ark_std::test_rng;
 use num_traits::Zero;
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_varbinary_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
 
     let data = [[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]];
     let col = CommittableColumn::VarBinary(data.to_vec());
 
     let res = compute_dory_commitments(&[col], 0, &setup);
 
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(1u64)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(2u64)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(3u64);
@@ -34,12 +34,12 @@ fn we_can_compute_a_dory_commitment_with_varbinary_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_int128_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::Int128(&[0, -1, 2])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0_i128)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(-1_i128)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2_i128);
@@ -48,16 +48,16 @@ fn we_can_compute_a_dory_commitment_with_int128_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_boolean_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::Boolean(&[true, false, true])],
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(true)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(false)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(true);
@@ -66,12 +66,12 @@ fn we_can_compute_a_dory_commitment_with_boolean_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2);
@@ -80,12 +80,12 @@ fn we_can_compute_a_dory_commitment_with_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -95,12 +95,12 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[2, 3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(3);
     assert_eq!(res[0].0, expected);
@@ -108,12 +108,12 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with_signed_data() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(-3);
     assert_eq!(res[0].0, expected);
@@ -121,16 +121,16 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -146,9 +146,9 @@ fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -156,8 +156,8 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -182,12 +182,12 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1])], 5, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -195,16 +195,16 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -220,9 +220,9 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns()
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -230,8 +230,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -256,9 +256,9 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
 
 #[test]
 fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[
@@ -274,8 +274,8 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -342,9 +342,8 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
 
 #[test]
 fn we_can_compute_an_empty_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
     assert_eq!(res[0].0, GT::zero());
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 5, &setup);
@@ -385,12 +384,12 @@ fn we_can_compute_an_empty_dory_commitment() {
 
 #[test]
 fn test_compute_dory_commitment_when_sigma_is_zero() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 0);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(2)
@@ -401,12 +400,12 @@ fn test_compute_dory_commitment_when_sigma_is_zero() {
 
 #[test]
 fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 0);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 5, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[5]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[6]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[7]) * F::from(2)
@@ -417,9 +416,9 @@ fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[0, 1]),
@@ -444,8 +443,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -494,9 +493,9 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_fewer_rows_than_columns(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[0, 1]),
@@ -521,8 +520,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
         2,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -570,9 +569,9 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[-2, -1, 0, 1, 2]),
@@ -597,8 +596,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(0)
@@ -659,9 +658,9 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let public_parameters = cached_public_parameters(5);
+    let prover_setup = cached_prover_setup(5);
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[-2, -1, 0, 1, 2]),
@@ -686,8 +685,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
         4,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[1]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(0)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_inner_product_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_inner_product_test.rs
@@ -1,6 +1,7 @@
 use super::{
-    dory_inner_product_prove, dory_inner_product_verify, rand_G_vecs, test_rng, DoryMessages,
-    G1Affine, ProverState, PublicParameters, GT,
+    cached_prover_setup, cached_verifier_setup, dory_inner_product_prove,
+    dory_inner_product_verify, rand_G_vecs, test_rng, DoryMessages, G1Affine, ProverState,
+    PublicParameters, GT,
 };
 use ark_std::UniformRand;
 use merlin::Transcript;
@@ -9,9 +10,8 @@ use merlin::Transcript;
 fn we_can_prove_and_verify_a_dory_inner_product() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ProverState::new(v1, v2, nu);
     let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
@@ -33,9 +33,8 @@ fn we_can_prove_and_verify_a_dory_inner_product() {
 fn we_can_prove_and_verify_a_dory_inner_product_for_multiple_nu_values() {
     let mut rng = test_rng();
     let max_nu = 5;
-    let pp = PublicParameters::test_rand(max_nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(max_nu);
+    let verifier_setup = cached_verifier_setup(max_nu);
 
     for nu in 0..max_nu {
         let (v1, v2) = rand_G_vecs(nu, &mut rng);
@@ -60,9 +59,8 @@ fn we_can_prove_and_verify_a_dory_inner_product_for_multiple_nu_values() {
 fn we_fail_to_verify_a_dory_inner_product_when_a_message_is_modified() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ProverState::new(v1, v2, nu);
     let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
@@ -86,9 +84,8 @@ fn we_fail_to_verify_a_dory_inner_product_when_a_message_is_modified() {
 fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_few_GT_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ProverState::new(v1, v2, nu);
     let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
@@ -112,9 +109,8 @@ fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_few_GT_messages() {
 fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_many_GT_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ProverState::new(v1, v2, nu);
     let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
@@ -138,9 +134,8 @@ fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_many_GT_messages() 
 fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_few_G1_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ProverState::new(v1, v2, nu);
     let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
@@ -164,9 +159,8 @@ fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_few_G1_messages() {
 fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_many_G1_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ProverState::new(v1, v2, nu);
     let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
@@ -190,9 +184,8 @@ fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_many_G1_messages() 
 fn we_fail_to_verify_a_dory_inner_product_when_the_transcripts_differ() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ProverState::new(v1, v2, nu);
     let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
@@ -214,8 +207,7 @@ fn we_fail_to_verify_a_dory_inner_product_when_the_transcripts_differ() {
 fn we_fail_to_verify_a_dory_inner_product_when_the_setups_differ() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
     let pp_wrong = PublicParameters::test_rand(nu, &mut rng);
     let verifier_setup = (&pp_wrong).into();
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
@@ -241,9 +233,8 @@ fn we_fail_to_verify_a_dory_inner_product_when_the_setups_differ() {
 fn we_fail_to_verify_a_dory_inner_product_when_the_commitment_is_wrong() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ProverState::new(v1, v2, nu);
     let mut verifier_state = prover_state.calculate_verifier_state(&prover_setup);

--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    eval_vmv_re_prove, eval_vmv_re_verify, test_rng, DoryMessages, PublicParameters, F, GT, VMV,
+    cached_prover_setup, cached_verifier_setup, eval_vmv_re_prove, eval_vmv_re_verify, test_rng,
+    DoryMessages, PublicParameters, F, GT, VMV,
 };
 use ark_std::UniformRand;
 use merlin::Transcript;
@@ -8,9 +9,8 @@ use merlin::Transcript;
 fn we_can_prove_and_verify_an_eval_vmv_re() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let vmv = VMV::rand(nu, &mut rng);
     let prover_state = vmv.calculate_prover_state(&prover_setup);
     let verifier_state = vmv.calculate_verifier_state(&prover_setup);
@@ -36,9 +36,8 @@ fn we_can_prove_and_verify_an_eval_vmv_re() {
 fn we_can_prove_and_verify_an_eval_vmv_re_for_multiple_nu_values() {
     let mut rng = test_rng();
     let max_nu = 5;
-    let pp = PublicParameters::test_rand(max_nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(max_nu);
+    let verifier_setup = cached_verifier_setup(max_nu);
 
     for nu in 0..max_nu {
         let vmv = VMV::rand(nu, &mut rng);
@@ -67,9 +66,8 @@ fn we_can_prove_and_verify_an_eval_vmv_re_for_multiple_nu_values() {
 fn we_fail_to_verify_an_eval_vmv_re_when_a_message_is_modified() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let vmv = VMV::rand(nu, &mut rng);
     let prover_state = vmv.calculate_prover_state(&prover_setup);
     let verifier_state = vmv.calculate_verifier_state(&prover_setup);
@@ -98,9 +96,8 @@ fn we_fail_to_verify_an_eval_vmv_re_when_a_message_is_modified() {
 fn we_fail_to_verify_an_eval_vmv_re_when_there_are_too_few_GT_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let vmv = VMV::rand(nu, &mut rng);
     let prover_state = vmv.calculate_prover_state(&prover_setup);
     let verifier_state = vmv.calculate_verifier_state(&prover_setup);
@@ -127,9 +124,8 @@ fn we_fail_to_verify_an_eval_vmv_re_when_there_are_too_few_GT_messages() {
 fn we_fail_to_verify_an_eval_vmv_re_when_there_are_too_few_G1_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let vmv = VMV::rand(nu, &mut rng);
     let prover_state = vmv.calculate_prover_state(&prover_setup);
     let verifier_state = vmv.calculate_verifier_state(&prover_setup);
@@ -156,8 +152,7 @@ fn we_fail_to_verify_an_eval_vmv_re_when_there_are_too_few_G1_messages() {
 fn we_fail_to_verify_an_eval_vmv_re_when_the_setups_differ() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
     let pp_wrong = PublicParameters::test_rand(nu, &mut rng);
     let verifier_setup = (&pp_wrong).into();
     let vmv = VMV::rand(nu, &mut rng);
@@ -189,9 +184,8 @@ fn we_fail_to_verify_an_eval_vmv_re_when_the_setups_differ() {
 fn we_fail_to_verify_an_eval_vmv_re_when_the_commitment_is_wrong() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let vmv = VMV::rand(nu, &mut rng);
     let prover_state = vmv.calculate_prover_state(&prover_setup);
     let mut verifier_state = vmv.calculate_verifier_state(&prover_setup);
@@ -221,9 +215,8 @@ fn we_fail_to_verify_an_eval_vmv_re_when_the_commitment_is_wrong() {
 fn we_fail_to_verify_an_eval_vmv_re_when_the_evaluation_value_is_wrong() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let vmv = VMV::rand(nu, &mut rng);
     let prover_state = vmv.calculate_prover_state(&prover_setup);
     let mut verifier_state = vmv.calculate_verifier_state(&prover_setup);

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    extended_dory_inner_product_prove, extended_dory_inner_product_verify,
+    cached_prover_setup, cached_verifier_setup, extended_dory_inner_product_prove,
+    extended_dory_inner_product_verify,
     extended_dory_reduce_helper::extended_dory_reduce_verify_fold_s_vecs, rand_F_tensors,
     rand_G_vecs, test_rng, DoryMessages, ExtendedProverState, G1Affine, PublicParameters, GT,
 };
@@ -10,9 +11,8 @@ use merlin::Transcript;
 fn we_can_prove_and_verify_an_extended_dory_inner_product() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
@@ -36,9 +36,8 @@ fn we_can_prove_and_verify_an_extended_dory_inner_product() {
 fn we_can_prove_and_verify_an_extended_dory_inner_product_for_multiple_nu_values() {
     let mut rng = test_rng();
     let max_nu = 5;
-    let pp = PublicParameters::test_rand(max_nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(max_nu);
+    let verifier_setup = cached_verifier_setup(max_nu);
 
     for nu in 0..max_nu {
         let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
@@ -70,9 +69,8 @@ fn we_can_prove_and_verify_an_extended_dory_inner_product_for_multiple_nu_values
 fn we_fail_to_verify_an_extended_dory_inner_product_when_a_message_is_modified() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
@@ -98,9 +96,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_a_message_is_modified()
 fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_few_GT_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
@@ -126,9 +123,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_few_GT_me
 fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_many_GT_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
@@ -154,9 +150,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_many_GT_m
 fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_few_G1_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
@@ -182,9 +177,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_few_G1_me
 fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_many_G1_messages() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
@@ -210,9 +204,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_many_G1_m
 fn we_fail_to_verify_an_extended_dory_inner_product_when_the_transcripts_differ() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
@@ -236,8 +229,7 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_the_transcripts_differ(
 fn we_fail_to_verify_an_extended_dory_inner_product_when_the_setups_differ() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
     let pp_wrong = PublicParameters::test_rand(nu, &mut rng);
     let verifier_setup = (&pp_wrong).into();
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
@@ -265,9 +257,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_the_setups_differ() {
 fn we_fail_to_verify_an_extended_dory_inner_product_when_the_base_commitment_is_wrong() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
@@ -293,9 +284,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_the_base_commitment_is_
 fn we_fail_to_verify_an_extended_dory_inner_product_when_a_scalar_commitment_is_wrong() {
     let mut rng = test_rng();
     let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(nu);
+    let verifier_setup = cached_verifier_setup(nu);
     let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
     let (v1, v2) = rand_G_vecs(nu, &mut rng);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -39,6 +39,12 @@ mod setup;
 pub use setup::{ProverSetup, VerifierSetup};
 #[cfg(test)]
 mod setup_test;
+#[cfg(test)]
+mod test_setup_cache;
+#[cfg(test)]
+pub(crate) use test_setup_cache::{
+    cached_prover_setup, cached_public_parameters, cached_verifier_setup,
+};
 
 mod state;
 pub(crate) use state::{ProverState, VerifierState};

--- a/crates/proof-of-sql/src/proof_primitive/dory/test_setup_cache.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/test_setup_cache.rs
@@ -1,0 +1,72 @@
+use super::{test_rng, ProverSetup, PublicParameters, VerifierSetup};
+use std::sync::OnceLock;
+
+// Dory tests repeatedly rebuild the same deterministic setup values. Cache them
+// once per test binary to avoid repeating public-parameter generation, verifier
+// pairings, and prover setup initialization.
+macro_rules! cached_setups {
+    ($max_nu:literal, $public_parameters:ident, $prover_setup:ident, $verifier_setup:ident) => {
+        static $public_parameters: OnceLock<PublicParameters> = OnceLock::new();
+        static $prover_setup: OnceLock<ProverSetup<'static>> = OnceLock::new();
+        static $verifier_setup: OnceLock<VerifierSetup> = OnceLock::new();
+
+        impl CachedSetup<$max_nu> {
+            fn public_parameters() -> &'static PublicParameters {
+                $public_parameters
+                    .get_or_init(|| PublicParameters::test_rand($max_nu, &mut test_rng()))
+            }
+
+            fn prover_setup() -> &'static ProverSetup<'static> {
+                $prover_setup.get_or_init(|| ProverSetup::from(Self::public_parameters()))
+            }
+
+            fn verifier_setup() -> &'static VerifierSetup {
+                $verifier_setup.get_or_init(|| VerifierSetup::from(Self::public_parameters()))
+            }
+        }
+    };
+}
+
+struct CachedSetup<const MAX_NU: usize>;
+
+cached_setups!(4, PUBLIC_PARAMETERS_4, PROVER_SETUP_4, VERIFIER_SETUP_4);
+cached_setups!(5, PUBLIC_PARAMETERS_5, PROVER_SETUP_5, VERIFIER_SETUP_5);
+cached_setups!(6, PUBLIC_PARAMETERS_6, PROVER_SETUP_6, VERIFIER_SETUP_6);
+cached_setups!(2, PUBLIC_PARAMETERS_2, PROVER_SETUP_2, VERIFIER_SETUP_2);
+cached_setups!(3, PUBLIC_PARAMETERS_3, PROVER_SETUP_3, VERIFIER_SETUP_3);
+
+#[must_use]
+pub(crate) fn cached_public_parameters(max_nu: usize) -> &'static PublicParameters {
+    match max_nu {
+        2 => CachedSetup::<2>::public_parameters(),
+        3 => CachedSetup::<3>::public_parameters(),
+        4 => CachedSetup::<4>::public_parameters(),
+        5 => CachedSetup::<5>::public_parameters(),
+        6 => CachedSetup::<6>::public_parameters(),
+        _ => panic!("unsupported cached Dory test setup size: {max_nu}"),
+    }
+}
+
+#[must_use]
+pub(crate) fn cached_prover_setup(max_nu: usize) -> &'static ProverSetup<'static> {
+    match max_nu {
+        2 => CachedSetup::<2>::prover_setup(),
+        3 => CachedSetup::<3>::prover_setup(),
+        4 => CachedSetup::<4>::prover_setup(),
+        5 => CachedSetup::<5>::prover_setup(),
+        6 => CachedSetup::<6>::prover_setup(),
+        _ => panic!("unsupported cached Dory test setup size: {max_nu}"),
+    }
+}
+
+#[must_use]
+pub(crate) fn cached_verifier_setup(max_nu: usize) -> &'static VerifierSetup {
+    match max_nu {
+        2 => CachedSetup::<2>::verifier_setup(),
+        3 => CachedSetup::<3>::verifier_setup(),
+        4 => CachedSetup::<4>::verifier_setup(),
+        5 => CachedSetup::<5>::verifier_setup(),
+        6 => CachedSetup::<6>::verifier_setup(),
+        _ => panic!("unsupported cached Dory test setup size: {max_nu}"),
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/dory/vmv_state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/vmv_state_test.rs
@@ -1,12 +1,11 @@
-use super::{test_rng, PublicParameters, F, VMV};
+use super::{cached_prover_setup, cached_public_parameters, test_rng, F, VMV};
 use ark_ec::pairing::Pairing;
 
 #[test]
 fn we_can_create_correct_vmv_states_from_a_small_fixed_vmv() {
-    let mut rng = test_rng();
     let nu = 2;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
+    let pp = cached_public_parameters(nu);
+    let prover_setup = cached_prover_setup(nu);
     let Gamma_1 = pp.Gamma_1.clone();
     let Gamma_2 = pp.Gamma_2.clone();
     let L = vec![100.into(), 101.into(), 102.into(), 103.into()];
@@ -100,8 +99,7 @@ fn we_can_create_correct_vmv_states_from_a_small_fixed_vmv() {
 fn we_can_create_vmv_states_from_random_vmv_and_get_correct_sizes() {
     let mut rng = test_rng();
     let max_nu = 5;
-    let pp = PublicParameters::test_rand(max_nu, &mut rng);
-    let prover_setup = (&pp).into();
+    let prover_setup = cached_prover_setup(max_nu);
     for nu in 0..max_nu {
         let vmv = VMV::rand(nu, &mut rng);
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The Dory tests rebuild identical deterministic setup values many times. `PublicParameters::test_rand`, `ProverSetup::from`, and especially `VerifierSetup::from` are not what these tests are trying to exercise repeatedly; they are shared setup cost before the actual commitment/proof behavior under test.

This PR caches the common Dory test setups once per test binary with `OnceLock`. It keeps the setup values deterministic, avoids weakening the assertions, and avoids the `Box::leak` pattern from an earlier attempt.

/claim #557

# What changes are included in this PR?

- Add a test-only Dory setup cache for max nu values used by the updated tests.
- Reuse cached prover/verifier setups in Dory commitment evaluation, inner-product, extended inner-product, eval-VMV, and VMV state tests.
- Reuse cached public parameters and prover setup in the Dory commitment compute tests.
- Keep intentionally different verifier setups fresh in setup-mismatch tests.

# Are these changes tested?

Yes.

Local before/after timings were measured on the same checkout by stashing this patch for the `main` baseline, with `BLITZAR_BACKEND=cpu`.

- `cargo test -p proof-of-sql proof_primitive::dory --all-features`
  - main: 171 passed, test runtime 54.18s, elapsed 58.872s
  - patched: 171 passed, test runtime 41.09s, elapsed 41.247s
- `cargo test -p proof-of-sql proof_primitive::dory::dory_commitment_evaluation_proof_test --all-features -- --nocapture`
  - main: 4 passed, test runtime 36.13s
  - patched: 4 passed, test runtime 28.72s
- `cargo test -p proof-of-sql proof_primitive::dory::dory_compute_commitments_test --all-features -- --nocapture`
  - main: 20 passed, test runtime 5.29s
  - patched: 20 passed, test runtime 3.80s

Additional checks run:

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql proof_primitive::dory --all-features`
- `source scripts/check_commits.sh`
- `source scripts/run_ci_checks.sh`
