### PR TITLE
refactor: blanket implement VarInt for Scalar

### DIFF
--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -1,8 +1,7 @@
 use crate::base::{
     encode::{ZigZag, U256},
-    scalar::MontScalar,
+    scalar::Scalar,
 };
-use ark_ff::MontConfig;
 use core::cmp::{max, Ordering};
 
 /// This function writes the input scalar x as a varint encoding to buf slice
@@ -14,7 +13,7 @@ use core::cmp::{max, Ordering};
 ///
 /// crash:
 /// - in case N is bigger than `buf.len()`
-pub fn write_scalar_varint<T: MontConfig<4>>(buf: &mut [u8], x: &MontScalar<T>) -> usize {
+pub fn write_scalar_varint<S: Scalar>(buf: &mut [u8], x: &S) -> usize {
     write_u256_varint(buf, x.zigzag())
 }
 
@@ -61,7 +60,7 @@ pub fn write_u256_varint(buf: &mut [u8], mut zig_x: U256) -> usize {
 ///  Since read-scalar stores the buf into a U256 type, which can only
 ///  hold up to 256 bit numbers, the non-continuation bits
 ///  257 up to 259 from buf are ignored.
-pub fn read_scalar_varint<T: MontConfig<4>>(buf: &[u8]) -> Option<(MontScalar<T>, usize)> {
+pub fn read_scalar_varint<S: Scalar>(buf: &[u8]) -> Option<(S, usize)> {
     read_u256_varint(buf).map(|(val, s)| (val.zigzag(), s))
 }
 pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
@@ -113,7 +112,7 @@ pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
 /// error:
 /// - in case buf has not enough space to hold all the scalars encoding.
 #[cfg(test)]
-pub fn write_scalar_varints<T: MontConfig<4>>(buf: &mut [u8], scals: &[MontScalar<T>]) -> usize {
+pub fn write_scalar_varints<S: Scalar>(buf: &mut [u8], scals: &[S]) -> usize {
     let mut total_bytes_written = 0;
 
     for scal in scals {
@@ -133,10 +132,7 @@ pub fn write_scalar_varints<T: MontConfig<4>>(buf: &mut [u8], scals: &[MontScala
 /// error:
 /// - in case it's not possible to read all specified scalars from `input_buf`
 #[cfg(test)]
-pub fn read_scalar_varints<T: MontConfig<4>>(
-    scals_buf: &mut [MontScalar<T>],
-    input_buf: &[u8],
-) -> Option<()> {
+pub fn read_scalar_varints<S: Scalar>(scals_buf: &mut [S], input_buf: &[u8]) -> Option<()> {
     let mut buf = input_buf;
 
     for scal_buf in scals_buf.iter_mut() {
@@ -153,7 +149,7 @@ pub fn read_scalar_varints<T: MontConfig<4>>(
 ///
 /// This function should be used to get an upper bound on the buffer size
 /// used by the `write_scalar_varint` function.
-pub fn scalar_varint_size<T: MontConfig<4>>(x: &MontScalar<T>) -> usize {
+pub fn scalar_varint_size<S: Scalar>(x: &S) -> usize {
     u256_varint_size(x.zigzag())
 }
 pub fn u256_varint_size(zig_x: U256) -> usize {
@@ -173,7 +169,7 @@ pub fn u256_varint_size(zig_x: U256) -> usize {
 /// This function should be used to get an upper bound on the buffer size
 /// used by the `write_scalar_varints` function.
 #[cfg(test)]
-pub fn scalar_varints_size<T: MontConfig<4>>(scals: &[MontScalar<T>]) -> usize {
+pub fn scalar_varints_size<S: Scalar>(scals: &[S]) -> usize {
     let mut all_size: usize = 0;
 
     for x in scals {

--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -48,7 +48,7 @@ pub fn write_u256_varint(buf: &mut [u8], mut zig_x: U256) -> usize {
 /// besides MSB 1-bit to represent in which byte the encoding ends.
 ///
 /// return `Some((value, read_bytes))`:
-/// - `value` = the dalek scalar generated out of the consumed bytes
+/// - `value` = the scalar generated out of the consumed bytes
 /// - `read_bytes` = the total number of bytes N consumed
 ///
 /// return None:
@@ -124,8 +124,8 @@ pub fn write_scalar_varints<S: Scalar>(buf: &mut [u8], scals: &[S]) -> usize {
     total_bytes_written
 }
 
-/// This function read all the specified scalars from `input_buf` to `scals_buf`.
-/// For that, it converts the input buffer from a Varint and [`ZigZag`] encoding to a Dalek Scalar
+/// This function reads all the specified scalars from `input_buf` to `scals_buf`.
+/// For that, it converts the input buffer from a Varint and [`ZigZag`] encoding to `S`.
 ///
 /// See `<https://developers.google.com/protocol-buffers/docs/encoding#varints>` as reference.
 ///

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -18,20 +18,30 @@ impl U256 {
     }
 }
 
-/// This trait converts a dalek scalar into a U256 integer
-impl<T: MontConfig<4>> From<&MontScalar<T>> for U256 {
-    fn from(val: &MontScalar<T>) -> Self {
-        let buf: [u64; 4] = val.into();
-        let low: u128 = u128::from(buf[0]) | (u128::from(buf[1]) << 64);
-        let high: u128 = u128::from(buf[2]) | (u128::from(buf[3]) << 64);
+impl From<[u64; 4]> for U256 {
+    fn from(buf: [u64; 4]) -> Self {
+        let low = u128::from(buf[0]) | (u128::from(buf[1]) << 64);
+        let high = u128::from(buf[2]) | (u128::from(buf[3]) << 64);
         U256::from_words(low, high)
     }
 }
 
-/// This trait converts a U256 integer into a dalek scalar
-impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
-    fn from(val: &U256) -> Self {
-        let bytes = [val.low.to_le_bytes(), val.high.to_le_bytes()].concat();
+impl From<U256> for [u64; 4] {
+    fn from(val: U256) -> Self {
+        [
+            val.low as u64,
+            (val.low >> 64) as u64,
+            val.high as u64,
+            (val.high >> 64) as u64,
+        ]
+    }
+}
+
+impl<T: MontConfig<4>> From<U256> for MontScalar<T> {
+    fn from(val: U256) -> Self {
+        let mut bytes = [0_u8; 32];
+        bytes[..16].copy_from_slice(&val.low.to_le_bytes());
+        bytes[16..].copy_from_slice(&val.high.to_le_bytes());
         MontScalar::<T>::from_le_bytes_mod_order(&bytes)
     }
 }

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -16,10 +16,9 @@ use super::{
     },
     U256,
 };
-use crate::base::scalar::MontScalar;
+use crate::base::scalar::Scalar;
 #[cfg(test)]
 use alloc::{vec, vec::Vec};
-use ark_ff::MontConfig;
 
 /// Most-significant byte, == 0x80
 pub const MSB: u8 = 0b1000_0000;
@@ -282,7 +281,7 @@ impl VarInt for i128 {
     }
 }
 
-impl<T: MontConfig<4>> VarInt for MontScalar<T> {
+impl<S: Scalar> VarInt for S {
     fn required_space(self) -> usize {
         scalar_varint_size(&self)
     }

--- a/crates/proof-of-sql/src/base/encode/zigzag.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag.rs
@@ -1,5 +1,4 @@
-use crate::base::{encode::U256, scalar::MontScalar};
-use ark_ff::MontConfig;
+use crate::base::{encode::U256, scalar::Scalar};
 
 /// A trait for enabling zig-zag encoding
 ///
@@ -24,12 +23,12 @@ pub trait ZigZag<T> {
 /// which represents a positive [`ZigZag`] encoding.
 /// Otherwise, we remap `y` to `2 * y + 1` u256 integer,
 /// which represents a negative [`ZigZag`] encoding (-y).
-impl<T: MontConfig<4>> ZigZag<U256> for MontScalar<T> {
+impl<S: Scalar> ZigZag<U256> for S {
     fn zigzag(&self) -> U256 {
         // since self is a dalek scalar, we never have the last bit 255 set
         // therefore, we should never expect overflow when multiplying by 2
-        let mut x: U256 = self.into();
-        let mut y: U256 = (&-self).into(); // x + y = 0 ==> y = -x
+        let mut x = U256::from(Into::<[u64; 4]>::into(*self));
+        let mut y = U256::from(Into::<[u64; 4]>::into(-*self)); // x + y = 0 ==> y = -x
 
         // we return the smallest ZigZag number between x and y
         // in case x is bigger than y, we return -y (encoded in the ZigZag format)
@@ -74,8 +73,8 @@ impl<T: MontConfig<4>> ZigZag<U256> for MontScalar<T> {
 ///
 /// Finally, we return either `-1 * dalek::Scalar(y)` or `dalek::Scalar(x)`,
 /// which in both cases represents the `x` scalar.
-impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
-    fn zigzag(&self) -> MontScalar<T> {
+impl<S: Scalar> ZigZag<S> for U256 {
+    fn zigzag(&self) -> S {
         // we need to divide self by 2 to remove the ZigZag encoding
         let mut zig_val = U256 {
             low: (self.low >> 1) | ((self.high & 1) << 127),
@@ -98,14 +97,12 @@ impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
             // even though the encoding represented a -y,
             // zig_val actually represents a `y` (we simply divided self by 2).
             // Also, since x + y = 0, we need to compute -(zig_val.into()) to return x
-            let scal: MontScalar<T> = (&zig_val).into();
+            let scal = S::from(<[u64; 4]>::from(zig_val));
 
             -scal
         } else {
-            let scal: MontScalar<T> = (&zig_val).into();
-
             // return x
-            scal
+            S::from(<[u64; 4]>::from(zig_val))
         }
     }
 }

--- a/crates/proof-of-sql/src/base/encode/zigzag.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag.rs
@@ -9,7 +9,10 @@ pub trait ZigZag<T> {
     fn zigzag(&self) -> T;
 }
 
-/// Zigzag conversion from a dalek Scalar to a [`ZigZag`] u256 integer
+/// Zigzag conversion from a [`Scalar`] to a [`ZigZag`] u256 integer.
+///
+/// This encoding assumes the scalar limb representation never sets bit 255,
+/// which holds for the supported scalar fields where `S::MAX_BITS <= 254`.
 ///
 /// For this conversion, we compute:
 ///
@@ -25,8 +28,13 @@ pub trait ZigZag<T> {
 /// which represents a negative [`ZigZag`] encoding (-y).
 impl<S: Scalar> ZigZag<U256> for S {
     fn zigzag(&self) -> U256 {
-        // since self is a dalek scalar, we never have the last bit 255 set
-        // therefore, we should never expect overflow when multiplying by 2
+        assert!(
+            S::MAX_BITS <= 254,
+            "zigzag encoding requires scalar limbs to leave bit 255 clear"
+        );
+
+        // Since bit 255 is not set for supported scalars, multiplying by 2
+        // cannot overflow the U256 representation.
         let mut x = U256::from(Into::<[u64; 4]>::into(*self));
         let mut y = U256::from(Into::<[u64; 4]>::into(-*self)); // x + y = 0 ==> y = -x
 
@@ -60,7 +68,7 @@ impl<S: Scalar> ZigZag<U256> for S {
     }
 }
 
-/// Zigzag conversion from an u256 integer to a dalek Scalar.
+/// Zigzag conversion from a u256 integer to a [`Scalar`].
 ///
 /// For this conversion, we first verify if `self` is an odd or even number.
 /// In case `self` is odd, the encoded number represents a negative
@@ -71,8 +79,8 @@ impl<S: Scalar> ZigZag<U256> for S {
 /// In both cases, we divide the `self` value by 2 in order
 /// to remove the [`ZigZag`] encoding (`y = self / 2` or `x = self / 2`).
 ///
-/// Finally, we return either `-1 * dalek::Scalar(y)` or `dalek::Scalar(x)`,
-/// which in both cases represents the `x` scalar.
+/// Finally, we return either `-S::from(y)` or `S::from(x)`,
+/// which in both cases represents the original scalar.
 impl<S: Scalar> ZigZag<S> for U256 {
     fn zigzag(&self) -> S {
         // we need to divide self by 2 to remove the ZigZag encoding

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
+use crate::base::{ref_into::RefInto, scalar::ScalarConversionError};
 use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
@@ -53,7 +53,6 @@ pub trait Scalar:
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
     + for<'a> core::convert::From<&'a String>
-    + VarInt
     + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>


### PR DESCRIPTION
## Summary

- remove the direct `VarInt` supertrait bound from `Scalar`
- generalize scalar varint helpers and zig-zag conversion over any `S: Scalar`
- add a blanket `impl<S: Scalar> VarInt for S`, leaving the concrete `MontScalar` behavior covered through the generic implementation

This addresses the third checkbox in #228:

> Remove the `VarInt` bound and replace it with a blanket `impl<S: Scalar> VarInt for S` implementation.

/claim #228

## Verification

- `cargo fmt --check`
- `cargo check -p proof-of-sql --lib --no-default-features`
- `cargo test -p proof-of-sql --no-default-features --features std,test base::encode --lib`

Note: I also tried the default-feature check on Apple Silicon, but it fails before reaching this patch because the repo enables `halo2curves/asm`, whose build script reports `Currently feature asm can only be enabled on x86_64 arch.`
