### PR TITLE
test: add binary serialization coverage

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,34 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn serializes_in_fixed_width_big_endian_order() {
+        let serialized = try_standard_binary_serialization((0x1234u16, -2i16)).unwrap();
+
+        assert_eq!(serialized, [0x12, 0x34, 0xff, 0xfe]);
+    }
+
+    #[test]
+    fn deserialization_reports_consumed_byte_count_with_trailing_bytes() {
+        let mut serialized = try_standard_binary_serialization(0x1234_5678u32).unwrap();
+        let original_len = serialized.len();
+        serialized.extend_from_slice(&[0xaa, 0xbb]);
+
+        let (deserialized, bytes_read): (u32, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, 0x1234_5678);
+        assert_eq!(bytes_read, original_len);
+    }
+
+    #[test]
+    fn deserialization_rejects_invalid_boolean_encoding() {
+        let err = try_standard_binary_deserialization::<bool>(&[2]).unwrap_err();
+
+        assert!(matches!(
+            err,
+            bincode::error::DecodeError::InvalidBooleanValue(2)
+        ));
+    }
 }


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- Add coverage for fixed-width big-endian integer serialization.
- Verify deserialization returns the consumed byte count when extra bytes follow a value.
- Cover invalid boolean decoding through the standard binary config.

## Verification
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql standard_serializations::binary --no-default-features --features "test,std"`
- `rustfmt --check crates/proof-of-sql/src/base/standard_serializations/binary.rs`
- `git diff --check`