### PR TITLE
test: add byte matrix edge coverage

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -54,6 +54,32 @@ mod tests {
     }
 
     #[test]
+    fn we_can_compute_varying_byte_matrix_for_empty_scalars() {
+        let alloc = Bump::new();
+        let scalars: Vec<TestScalar> = Vec::new();
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert!(varying_columns.is_empty());
+        assert_eq!(byte_distribution, expected_byte_distribution);
+    }
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_constant_scalars() {
+        let alloc = Bump::new();
+        let scalars = vec![TestScalar::from(0x1122u64); 4];
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert!(varying_columns.is_empty());
+        assert_eq!(byte_distribution, expected_byte_distribution);
+    }
+
+    #[test]
     fn we_can_compute_varying_byte_matrix_for_large_scalars() {
         let alloc = Bump::new();
         let scalars = vec![


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- Add `compute_varying_byte_matrix` coverage for empty scalar columns.
- Cover constant scalar columns returning no varying byte columns while preserving the computed distribution.

## Verification
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql byte_matrix_utils --no-default-features --features "test,std"`
- `rustfmt --check crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs`
- `git diff --check`