### PR TITLE
test: add base utility coverage pack

### DIFF
--- a/crates/proof-of-sql/src/base/map.rs
+++ b/crates/proof-of-sql/src/base/map.rs
@@ -18,3 +18,34 @@ macro_rules! indexset {
 #[cfg(test)]
 pub(crate) use indexmap;
 pub(crate) use indexset;
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    #[test]
+    fn indexmap_macro_preserves_insertion_order() {
+        let map = indexmap! {
+            "alpha" => 1,
+            "beta" => 2,
+            "gamma" => 3,
+        };
+
+        assert_eq!(
+            map.iter()
+                .map(|(key, value)| (*key, *value))
+                .collect::<alloc::vec::Vec<_>>(),
+            vec![("alpha", 1), ("beta", 2), ("gamma", 3)]
+        );
+    }
+
+    #[test]
+    fn indexset_macro_preserves_insertion_order_and_removes_duplicates() {
+        let set = indexset!["alpha", "beta", "alpha", "gamma"];
+
+        assert_eq!(
+            set.iter().copied().collect::<alloc::vec::Vec<_>>(),
+            vec!["alpha", "beta", "gamma"]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/math/log.rs
+++ b/crates/proof-of-sql/src/base/math/log.rs
@@ -71,6 +71,38 @@ mod tests {
         assert_eq!(log2_up(4u32), 2);
     }
 
+    #[test]
+    fn test_log2_across_unsigned_integer_widths() {
+        assert_eq!(log2_down(255u8), 7);
+        assert_eq!(log2_up(255u8), 8);
+        assert_eq!(log2_down(256u16), 8);
+        assert_eq!(log2_up(257u16), 9);
+        assert_eq!(log2_down(1u64 << 40), 40);
+        assert_eq!(log2_up((1u64 << 40) + 1), 41);
+    }
+
+    #[test]
+    fn test_is_pow2_bytes() {
+        assert!(is_pow2_bytes(&[0, 0, 0, 0]));
+        assert!(is_pow2_bytes(&[1, 0, 0, 0]));
+        assert!(is_pow2_bytes(&[0, 1, 0, 0]));
+        assert!(is_pow2_bytes(&[0, 0, 0, 128]));
+
+        assert!(!is_pow2_bytes(&[3, 0, 0, 0]));
+        assert!(!is_pow2_bytes(&[1, 1, 0, 0]));
+        assert!(!is_pow2_bytes(&[0, 128, 1, 0]));
+    }
+
+    #[test]
+    fn test_log2_bytes_floor() {
+        assert_eq!(log2_down_bytes(&[0, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[1, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[255, 0, 0, 0]), 7);
+        assert_eq!(log2_down_bytes(&[0, 1, 0, 0]), 8);
+        assert_eq!(log2_down_bytes(&[0, 0, 0, 128]), 31);
+        assert_eq!(log2_down_bytes(&[6, 5, 3, 0]), 17);
+    }
+
     #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     #[test]
     fn test_log2_bytes_ceil() {

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,130 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_errors_display_expected_messages() {
+        assert_eq!(
+            ProofError::VerificationError {
+                error: "challenge mismatch",
+            }
+            .to_string(),
+            "Verification error: challenge mismatch"
+        );
+        assert_eq!(
+            ProofError::UnsupportedQueryPlan {
+                error: "cross join",
+            }
+            .to_string(),
+            "Unsupported query plan: cross join"
+        );
+        assert_eq!(
+            ProofError::InvalidTypeCoercion.to_string(),
+            "Result does not match query: type mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldNamesMismatch.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldCountMismatch.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_size_mismatches_display_expected_messages() {
+        let cases = [
+            (
+                ProofSizeMismatch::SumcheckProofTooSmall,
+                "Sumcheck proof is too small",
+            ),
+            (
+                ProofSizeMismatch::TooFewMLEEvaluations,
+                "Proof has too few MLE evaluations",
+            ),
+            (
+                ProofSizeMismatch::PostResultCountMismatch,
+                "Post result challenge count mismatch",
+            ),
+            (
+                ProofSizeMismatch::ConstraintCountMismatch,
+                "Constraint count mismatch",
+            ),
+            (
+                ProofSizeMismatch::TooFewBitDistributions,
+                "Proof has too few bit distributions",
+            ),
+            (
+                ProofSizeMismatch::TooFewChiLengths,
+                "Proof has too few one lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewRhoLengths,
+                "Proof has too few rho lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewSumcheckVariables,
+                "Proof has too few sumcheck variables",
+            ),
+            (
+                ProofSizeMismatch::ChiLengthNotFound,
+                "Proof doesn't have requested one length",
+            ),
+            (
+                ProofSizeMismatch::RhoLengthNotFound,
+                "Proof doesn't have requested rho length",
+            ),
+        ];
+
+        for (error, expected_message) in cases {
+            assert_eq!(error.to_string(), expected_message);
+            assert_eq!(
+                ProofError::ProofSizeMismatch { source: error }.to_string(),
+                expected_message
+            );
+        }
+    }
+
+    #[test]
+    fn placeholder_errors_display_expected_messages() {
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderIndex {
+                index: 4,
+                num_params: 3,
+            }
+            .to_string(),
+            "Invalid placeholder index: 4, number of params: 3"
+        );
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderType {
+                index: 2,
+                expected: ColumnType::BigInt,
+                actual: ColumnType::Boolean,
+            }
+            .to_string(),
+            "Invalid placeholder type: 2, expected: BIGINT, actual: BOOLEAN"
+        );
+        assert_eq!(
+            PlaceholderError::ZeroPlaceholderId.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn proof_error_transparently_wraps_placeholder_errors() {
+        let error = PlaceholderError::InvalidPlaceholderIndex {
+            index: 9,
+            num_params: 2,
+        };
+
+        assert_eq!(
+            ProofError::PlaceholderError { source: error }.to_string(),
+            "Invalid placeholder index: 9, number of params: 2"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,30 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+    use alloc::string::{String, ToString};
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct LabelLength(usize);
+
+    struct Label(String);
+
+    impl From<&Label> for LabelLength {
+        fn from(value: &Label) -> Self {
+            Self(value.0.len())
+        }
+    }
+
+    #[test]
+    fn ref_into_converts_from_reference_without_consuming_value() {
+        let label = Label("challenge".to_string());
+
+        let length: LabelLength = label.ref_into();
+
+        assert_eq!(length, LabelLength(9));
+        assert_eq!(label.0, "challenge");
+    }
+}


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- Add proof and placeholder error display coverage, including transparent wrapper cases.
- Cover IndexMap/IndexSet test macros and RefInto reference conversion behavior.
- Add log utility edge coverage for unsigned integer widths and byte-backed power-of-two/log2 helpers.

## Verification
- `rustfmt --check crates/proof-of-sql/src/base/proof/error.rs crates/proof-of-sql/src/base/map.rs crates/proof-of-sql/src/base/ref_into.rs crates/proof-of-sql/src/base/math/log.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::proof::error --no-default-features --features "test,std"`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::map --no-default-features --features "test,std"`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::ref_into --no-default-features --features "test,std"`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::math::log --no-default-features --features "test,std"`
