### PR TITLE
test: add database type coverage pack

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,27 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_field_accessors_return_constructor_values() {
+        let field = ColumnField::new("amount".into(), ColumnType::BigInt);
+
+        assert_eq!(field.name().value, "amount");
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_field_serializes_and_deserializes() {
+        let field = ColumnField::new("amount".into(), ColumnType::BigInt);
+
+        let serialized = serde_json::to_string(&field).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ColumnField>(&serialized).unwrap(),
+            field
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,33 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_ref_accessors_return_constructor_values() {
+        let table_ref = TableRef::from_names(Some("analytics"), "blocks");
+        let column_ref = ColumnRef::new(table_ref.clone(), "height".into(), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id().value, "height");
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_ref_serializes_and_deserializes() {
+        let column_ref = ColumnRef::new(
+            TableRef::from_names(Some("analytics"), "blocks"),
+            "height".into(),
+            ColumnType::BigInt,
+        );
+
+        let serialized = serde_json::to_string(&column_ref).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ColumnRef>(&serialized).unwrap(),
+            column_ref
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,20 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn parse_error_displays_invalid_table_reference() {
+        assert_eq!(
+            ParseError::InvalidTableReference {
+                table_reference: "schema.table.extra".to_string(),
+            }
+            .to_string(),
+            "Invalid table reference: schema.table.extra"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,32 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::vec;
+
+    #[test]
+    fn table_evaluation_accessors_return_constructor_values() {
+        let evaluation = TableEvaluation::new(
+            vec![TestScalar::from(3), TestScalar::from(5)],
+            (TestScalar::from(8), 4),
+        );
+
+        assert_eq!(
+            evaluation.column_evals(),
+            &[TestScalar::from(3), TestScalar::from(5)]
+        );
+        assert_eq!(evaluation.chi_eval(), TestScalar::from(8));
+        assert_eq!(evaluation.chi(), (TestScalar::from(8), 4));
+    }
+
+    #[test]
+    fn table_evaluation_clone_preserves_values() {
+        let evaluation = TableEvaluation::new(vec![TestScalar::from(1)], (TestScalar::from(2), 3));
+
+        assert_eq!(evaluation.clone(), evaluation);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,119 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::IndexMap;
+    use alloc::vec;
+
+    #[test]
+    fn new_treats_empty_schema_as_unqualified_table() {
+        let table_ref = TableRef::new("", "blocks");
+
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "blocks");
+        assert_eq!(table_ref.to_string(), "blocks");
+    }
+
+    #[test]
+    fn from_names_preserves_schema_and_table() {
+        let table_ref = TableRef::from_names(Some("analytics"), "blocks");
+
+        assert_eq!(table_ref.schema_id().unwrap().value, "analytics");
+        assert_eq!(table_ref.table_id().value, "blocks");
+        assert_eq!(table_ref.to_string(), "analytics.blocks");
+    }
+
+    #[test]
+    fn from_idents_preserves_identifier_values() {
+        let table_ref = TableRef::from_idents(Some("sxt".into()), "proofs".into());
+
+        assert_eq!(table_ref.schema_id().unwrap().value, "sxt");
+        assert_eq!(table_ref.table_id().value, "proofs");
+    }
+
+    #[test]
+    fn from_strs_accepts_one_or_two_components() {
+        let unqualified = TableRef::from_strs(&["blocks"]).unwrap();
+        let qualified = TableRef::from_strs(&["analytics", "blocks"]).unwrap();
+
+        assert_eq!(unqualified.to_string(), "blocks");
+        assert_eq!(qualified.to_string(), "analytics.blocks");
+    }
+
+    #[test]
+    fn from_strs_rejects_invalid_component_counts() {
+        let empty = TableRef::from_strs::<&str>(&[]).unwrap_err();
+        let too_many = TableRef::from_strs(&["a", "b", "c"]).unwrap_err();
+
+        assert_eq!(
+            empty,
+            ParseError::InvalidTableReference {
+                table_reference: "".into(),
+            }
+        );
+        assert_eq!(
+            too_many,
+            ParseError::InvalidTableReference {
+                table_reference: "a,b,c".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn try_from_dot_separated_string_matches_from_str() {
+        let expected = TableRef::from_names(Some("analytics"), "blocks");
+
+        assert_eq!(TableRef::try_from("analytics.blocks").unwrap(), expected);
+        assert_eq!("analytics.blocks".parse::<TableRef>().unwrap(), expected);
+    }
+
+    #[test]
+    fn try_from_rejects_more_than_two_dot_components() {
+        assert_eq!(
+            TableRef::try_from("a.b.c").unwrap_err(),
+            ParseError::InvalidTableReference {
+                table_reference: "a.b.c".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn table_ref_serializes_as_display_string() {
+        let table_ref = TableRef::from_names(Some("analytics"), "blocks");
+
+        assert_eq!(
+            serde_json::to_string(&table_ref).unwrap(),
+            r#""analytics.blocks""#
+        );
+        assert_eq!(
+            serde_json::from_str::<TableRef>(r#""analytics.blocks""#).unwrap(),
+            table_ref
+        );
+    }
+
+    #[test]
+    fn borrowed_table_ref_can_lookup_index_map_entries() {
+        let table_ref = TableRef::from_names(Some("analytics"), "blocks");
+        let mut map: IndexMap<TableRef, i32> = IndexMap::with_hasher(Default::default());
+        map.insert(table_ref.clone(), 7);
+
+        assert_eq!(map.get(&&table_ref), Some(&7));
+    }
+
+    #[test]
+    fn table_refs_keep_insertion_order_in_index_map() {
+        let mut map: IndexMap<TableRef, i32> = IndexMap::with_hasher(Default::default());
+        map.insert(TableRef::from_names(None, "blocks"), 1);
+        map.insert(TableRef::from_names(Some("analytics"), "proofs"), 2);
+
+        assert_eq!(
+            map.keys()
+                .map(ToString::to_string)
+                .collect::<alloc::vec::Vec<_>>(),
+            vec!["blocks", "analytics.proofs"]
+        );
+    }
+}


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- Add focused tests for `TableRef` parsing, serialization, display output, and borrowed `IndexMap` lookup.
- Cover `ColumnField`, `ColumnRef`, and `TableEvaluation` constructor/accessor behavior.
- Add display coverage for invalid table-reference parse errors.

## Verification
- `rustfmt --check crates/proof-of-sql/src/base/database/column_field.rs crates/proof-of-sql/src/base/database/column_ref.rs crates/proof-of-sql/src/base/database/error.rs crates/proof-of-sql/src/base/database/table_evaluation.rs crates/proof-of-sql/src/base/database/table_ref.rs`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database --no-default-features --features "test,std"`
- `git diff --check`