### PR TITLE
test: add database error coverage

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,101 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::math::decimal::DecimalError;
+    use alloc::string::ToString;
+
+    #[test]
+    fn column_operation_errors_display_expected_messages() {
+        assert_eq!(
+            ColumnOperationError::DifferentColumnLength { len_a: 2, len_b: 3 }.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+        assert_eq!(
+            ColumnOperationError::BinaryOperationInvalidColumnType {
+                operator: "add".to_string(),
+                left_type: ColumnType::Boolean,
+                right_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            r#""add"(lhs: Boolean, rhs: BigInt) is not supported"#
+        );
+        assert_eq!(
+            ColumnOperationError::UnaryOperationInvalidColumnType {
+                operator: "negation".to_string(),
+                operand_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            r#""negation"(operand: VarChar) is not supported"#
+        );
+        assert_eq!(
+            ColumnOperationError::IntegerOverflow {
+                error: "i64 overflow".to_string(),
+            }
+            .to_string(),
+            "Overflow in integer operation: i64 overflow"
+        );
+        assert_eq!(
+            ColumnOperationError::DivisionByZero.to_string(),
+            "Division by zero"
+        );
+        assert_eq!(
+            ColumnOperationError::UnionDifferentTypes {
+                correct_type: ColumnType::Int,
+                actual_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Cannot union columns of different types: Int and VarChar"
+        );
+        assert_eq!(
+            ColumnOperationError::IndexOutOfBounds { index: 5, len: 3 }.to_string(),
+            "Index out of bounds: 5 >= 3"
+        );
+    }
+
+    #[test]
+    fn column_operation_casting_errors_display_column_types() {
+        let expected = "Cannot fit TINYINT into UINT8 without losing data";
+
+        assert_eq!(
+            ColumnOperationError::SignedCastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            expected
+        );
+        assert_eq!(
+            ColumnOperationError::CastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            expected
+        );
+        assert_eq!(
+            ColumnOperationError::ScaleCastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            expected
+        );
+    }
+
+    #[test]
+    fn column_operation_errors_transparently_wrap_decimal_errors() {
+        assert_eq!(
+            ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidScale {
+                    scale: "76".to_string(),
+                },
+            }
+            .to_string(),
+            "Decimal scale is not valid: 76"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,47 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn owned_column_errors_display_expected_messages() {
+        assert_eq!(
+            OwnedColumnError::TypeCastError {
+                from_type: ColumnType::Boolean,
+                to_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Can not perform type casting from Boolean to BigInt"
+        );
+        assert_eq!(
+            OwnedColumnError::ScalarConversionError {
+                error: "negative value".to_string(),
+            }
+            .to_string(),
+            "Error in converting scalars to a given column type: negative value"
+        );
+        assert_eq!(
+            OwnedColumnError::Unsupported {
+                error: "varchar hashes".to_string(),
+            }
+            .to_string(),
+            "Unsupported operation: varchar hashes"
+        );
+    }
+
+    #[test]
+    fn column_coercion_errors_display_expected_messages() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,59 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn table_operation_errors_display_expected_messages() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+        assert_eq!(
+            TableOperationError::JoinWithDifferentNumberOfColumns {
+                left_num_columns: 2,
+                right_num_columns: 3,
+            }
+            .to_string(),
+            "Cannot join tables with different numbers of columns: 2 and 3"
+        );
+        assert_eq!(
+            TableOperationError::JoinIncompatibleTypes {
+                left_type: ColumnType::Boolean,
+                right_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Cannot join tables on columns with incompatible types: Boolean and BigInt"
+        );
+        assert_eq!(
+            TableOperationError::ColumnDoesNotExist {
+                column_ident: "missing_column".into(),
+            }
+            .to_string(),
+            r#"Column Ident { value: "missing_column", quote_style: None } does not exist in table"#
+        );
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+        assert_eq!(
+            TableOperationError::ColumnIndexOutOfBounds { column_index: 9 }.to_string(),
+            "Column index out of bounds: 9"
+        );
+    }
+
+    #[test]
+    fn table_operation_errors_transparently_wrap_column_operation_errors() {
+        assert_eq!(
+            TableOperationError::ColumnOperationError {
+                source: ColumnOperationError::DivisionByZero,
+            }
+            .to_string(),
+            "Division by zero"
+        );
+    }
+}


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- Add Display coverage for `ColumnOperationError`, including casting and transparent decimal error wrapping.
- Cover `OwnedColumnError` and `ColumnCoercionError` display messages.
- Cover `TableOperationError` display messages and transparent column-operation wrapping.

## Verification
- `rustfmt --check crates/proof-of-sql/src/base/database/owned_column_error.rs crates/proof-of-sql/src/base/database/column_operation_error.rs crates/proof-of-sql/src/base/database/table_operation_error.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database::column_operation_error --no-default-features --features "test,std"`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database::owned_column_error --no-default-features --features "test,std"`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database::table_operation_error --no-default-features --features "test,std"`
