### PR TITLE
fix: add byte integer commitment max bounds

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -74,6 +74,14 @@ impl ColumnCommitmentMetadata {
     #[must_use]
     pub fn from_column_type_with_max_bounds(column_type: ColumnType) -> Self {
         let bounds = match column_type {
+            ColumnType::Uint8 => ColumnBounds::Uint8(super::Bounds::Bounded(
+                BoundsInner::try_new(u8::MIN, u8::MAX)
+                    .expect("u8::MIN and u8::MAX are valid bounds for Uint8"),
+            )),
+            ColumnType::TinyInt => ColumnBounds::TinyInt(super::Bounds::Bounded(
+                BoundsInner::try_new(i8::MIN, i8::MAX)
+                    .expect("i8::MIN and i8::MAX are valid bounds for TinyInt"),
+            )),
             ColumnType::SmallInt => ColumnBounds::SmallInt(super::Bounds::Bounded(
                 BoundsInner::try_new(i16::MIN, i16::MAX)
                     .expect("i16::MIN and i16::MAX are valid bounds for SmallInt"),
@@ -196,6 +204,18 @@ mod tests {
     fn we_can_construct_metadata() {
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
+                ColumnType::Uint8,
+                ColumnBounds::Uint8(Bounds::Empty)
+            )
+            .unwrap(),
+            ColumnCommitmentMetadata {
+                column_type: ColumnType::Uint8,
+                bounds: ColumnBounds::Uint8(Bounds::Empty)
+            }
+        );
+
+        assert_eq!(
+            ColumnCommitmentMetadata::try_new(
                 ColumnType::TinyInt,
                 ColumnBounds::TinyInt(Bounds::Empty)
             )
@@ -293,7 +313,33 @@ mod tests {
     }
 
     #[test]
+    fn we_can_construct_byte_integer_metadata_with_max_bounds() {
+        let uint8_metadata =
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::Uint8);
+
+        assert_eq!(uint8_metadata.column_type(), &ColumnType::Uint8);
+        assert_eq!(
+            uint8_metadata.bounds(),
+            &ColumnBounds::Uint8(Bounds::bounded(u8::MIN, u8::MAX).unwrap())
+        );
+
+        let tinyint_metadata =
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::TinyInt);
+
+        assert_eq!(tinyint_metadata.column_type(), &ColumnType::TinyInt);
+        assert_eq!(
+            tinyint_metadata.bounds(),
+            &ColumnBounds::TinyInt(Bounds::bounded(i8::MIN, i8::MAX).unwrap())
+        );
+    }
+
+    #[test]
     fn we_cannot_construct_metadata_with_type_bounds_mismatch() {
+        assert!(matches!(
+            ColumnCommitmentMetadata::try_new(ColumnType::Uint8, ColumnBounds::NoOrder),
+            Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
+        ));
+
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
                 ColumnType::Boolean,

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -208,6 +208,34 @@ mod tests {
     }
 
     #[test]
+    fn we_can_construct_metadata_map_with_max_byte_integer_bounds() {
+        let uint8_ident: Ident = "uint8_column".into();
+        let tinyint_ident: Ident = "tinyint_column".into();
+        let column_fields = [
+            ColumnField::new(uint8_ident.clone(), ColumnType::Uint8),
+            ColumnField::new(tinyint_ident.clone(), ColumnType::TinyInt),
+        ];
+
+        let metadata_map =
+            ColumnCommitmentMetadataMap::from_column_fields_with_max_bounds(&column_fields);
+        let uint8_metadata = metadata_map.get(&uint8_ident).unwrap();
+
+        assert_eq!(uint8_metadata.column_type(), &ColumnType::Uint8);
+        assert_eq!(
+            uint8_metadata.bounds(),
+            &ColumnBounds::Uint8(Bounds::bounded(u8::MIN, u8::MAX).unwrap())
+        );
+
+        let tinyint_metadata = metadata_map.get(&tinyint_ident).unwrap();
+
+        assert_eq!(tinyint_metadata.column_type(), &ColumnType::TinyInt);
+        assert_eq!(
+            tinyint_metadata.bounds(),
+            &ColumnBounds::TinyInt(Bounds::bounded(i8::MIN, i8::MAX).unwrap())
+        );
+    }
+
+    #[test]
     fn we_can_union_matching_metadata_maps() {
         let table_a = owned_table([
             bigint("bigint_column", [1, 5]),

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -353,10 +353,77 @@ impl<C> FromIterator<(Ident, ColumnCommitmentMetadata, C)> for ColumnCommitments
 mod tests {
     use super::*;
     use crate::base::{
-        commitment::{column_bounds::Bounds, naive_commitment::NaiveCommitment, ColumnBounds},
-        database::{owned_table_utility::*, ColumnType, OwnedColumn, OwnedTable},
+        commitment::{
+            column_bounds::Bounds, naive_commitment::NaiveCommitment,
+            naive_evaluation_proof::NaiveEvaluationProof, ColumnBounds,
+        },
+        database::{
+            owned_table_utility::*, ColumnType, OwnedColumn, OwnedTable, OwnedTableTestAccessor,
+        },
         scalar::test_scalar::TestScalar,
     };
+
+    #[test]
+    fn we_can_construct_column_commitments_from_accessor_with_max_bounds() {
+        let table_ref = TableRef::new("sxt", "events");
+        let uint8_id: Ident = "uint8_column".into();
+        let bigint_id: Ident = "bigint_column".into();
+        let missing_id: Ident = "missing_column".into();
+        let owned_table: OwnedTable<TestScalar> = owned_table([
+            uint8(uint8_id.value.as_str(), [1u8, 7, 255]),
+            bigint(bigint_id.value.as_str(), [-2, 0, 3]),
+        ]);
+
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            owned_table.clone(),
+            4,
+            (),
+        );
+        let column_fields = [
+            ColumnField::new(uint8_id.clone(), ColumnType::Uint8),
+            ColumnField::new(bigint_id.clone(), ColumnType::BigInt),
+        ];
+
+        let column_commitments =
+            ColumnCommitments::<NaiveCommitment>::from_accessor_with_max_bounds(
+                &table_ref,
+                &column_fields,
+                &accessor,
+            );
+
+        let expected_commitments = Vec::<NaiveCommitment>::from_columns_with_offset(
+            [
+                owned_table.inner_table().get(&uint8_id).unwrap(),
+                owned_table.inner_table().get(&bigint_id).unwrap(),
+            ],
+            4,
+            &(),
+        );
+        assert_eq!(column_commitments.commitments(), &expected_commitments);
+        assert_eq!(
+            column_commitments.get_commitment(&uint8_id).unwrap(),
+            expected_commitments[0]
+        );
+        assert_eq!(
+            column_commitments.get_commitment(&bigint_id).unwrap(),
+            expected_commitments[1]
+        );
+        assert!(column_commitments.get_commitment(&missing_id).is_none());
+        assert!(column_commitments.get_metadata(&missing_id).is_none());
+
+        assert_eq!(
+            column_commitments.get_metadata(&uint8_id).unwrap().bounds(),
+            &ColumnBounds::Uint8(Bounds::bounded(u8::MIN, u8::MAX).unwrap())
+        );
+        assert_eq!(
+            column_commitments
+                .get_metadata(&bigint_id)
+                .unwrap()
+                .bounds(),
+            &ColumnBounds::BigInt(Bounds::bounded(i64::MIN, i64::MAX).unwrap())
+        );
+    }
 
     #[test]
     fn we_can_construct_column_commitments_from_columns_and_identifiers() {


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- Add the missing `Uint8` and `TinyInt` branches when constructing commitment metadata with max bounds.
- Cover direct byte-integer metadata construction and the `ColumnField` metadata-map path.
- Cover the `ColumnCommitments::from_accessor_with_max_bounds` public path for byte-integer max bounds.

## Verification
- `rustfmt --check crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs crates/proof-of-sql/src/base/commitment/column_commitments.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::commitment::column_commitment_metadata --no-default-features --features "test,std"`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::commitment::column_commitments::tests::we_can_construct_column_commitments_from_accessor_with_max_bounds --no-default-features --features "test,std,blitzar"`
