### PR TITLE
test: cover record batch errors

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -29,3 +29,52 @@ pub enum AppendRecordBatchTableCommitmentError {
         source: RecordBatchToColumnsError,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_record_batch_to_columns_errors() {
+        let err = RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+            source: ArrowArrayToColumnConversionError::ArrayContainsNulls,
+        };
+
+        assert_eq!(err.to_string(), "arrow array must not contain nulls");
+    }
+
+    #[test]
+    fn we_can_display_record_batch_index_errors() {
+        let err = RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+            source: ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 3 },
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "index out of bounds: the len is 2 but the index is 3"
+        );
+    }
+
+    #[test]
+    fn we_can_display_append_record_batch_errors() {
+        let err = AppendRecordBatchTableCommitmentError::ArrowBatchToColumnError {
+            source: RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                source: ArrowArrayToColumnConversionError::ArrayContainsNulls,
+            },
+        };
+
+        assert_eq!(err.to_string(), "arrow array must not contain nulls");
+    }
+
+    #[test]
+    fn we_can_display_append_record_batch_metadata_mismatches() {
+        let err = AppendRecordBatchTableCommitmentError::ColumnCommitmentsMismatch {
+            source: ColumnCommitmentsMismatch::NumColumns,
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "commitments with different column counts cannot operate with each other"
+        );
+    }
+}


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- add direct coverage for record batch conversion error display
- cover index-out-of-bounds and null-array conversion messages
- verify append-record-batch errors preserve their wrapped conversion and metadata mismatch messages

## Verification
- `rustfmt --check crates/proof-of-sql/src/base/arrow/record_batch_errors.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::arrow::record_batch_errors --no-default-features --features "test,std,arrow"