### PR TITLE
test: cover EVM proof plan errors

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,55 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::{String, ToString};
+
+    #[test]
+    fn we_can_display_evm_proof_plan_errors() {
+        let cases = [
+            (EVMProofPlanError::NotSupported, "plan not yet supported"),
+            (EVMProofPlanError::ColumnNotFound, "column not found"),
+            (EVMProofPlanError::TableNotFound, "table not found"),
+            (
+                EVMProofPlanError::InvalidTableName,
+                "table name can not be parsed into TableRef",
+            ),
+            (
+                EVMProofPlanError::InvalidOutputColumnName,
+                "invalid or missing output column name",
+            ),
+            (
+                EVMProofPlanError::InconsistentGroupByColumnCounts,
+                "column counts in group by plans are inconsistent",
+            ),
+            (
+                EVMProofPlanError::IncorrectScalingFactor,
+                "incorrect scaling factor",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn analyze_errors_are_transparently_wrapped() {
+        let error = EVMProofPlanError::AnalyzeError {
+            source: AnalyzeError::NotEnoughInputPlans,
+        };
+
+        assert_eq!(error.to_string(), "Not enough input plans");
+    }
+
+    #[test]
+    fn evm_proof_plan_errors_convert_into_string() {
+        let error = EVMProofPlanError::ColumnNotFound;
+        let message: String = error.to_string();
+
+        assert_eq!(message, "column not found");
+    }
+}


### PR DESCRIPTION
Contributes to #560
/claim #560

## Screening
- #560 is open and explicitly supports multiple contributors working in parallel.
- No maintainer rule or recent maintainer action found rejecting AI PRs.
- This touches only `sql/evm_proof_plan/error.rs`, avoiding recent competing PR areas.

## Summary
- Add display coverage for all direct `EVMProofPlanError` variants.
- Cover transparent wrapping of `AnalyzeError`.
- Cover conversion of an EVM proof plan error message into `String`.

## Verification
- `rustfmt --check crates/proof-of-sql/src/sql/evm_proof_plan/error.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql sql::evm_proof_plan::error --no-default-features --features "test,std"`
