### PR TITLE
test: cover scalar conversion errors

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,18 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_scalar_conversion_overflow_errors() {
+        let err = ScalarConversionError::Overflow {
+            error: "value exceeds i64".to_string(),
+        };
+
+        assert_eq!(err.to_string(), "Overflow error: value exceeds i64");
+    }
+}


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- add direct coverage for `ScalarConversionError::Overflow` display output
- verify the original overflow detail is preserved in the rendered error message

## Verification
- `rustfmt --check crates/proof-of-sql/src/base/scalar/error.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::scalar::error --no-default-features --features "test,std"