### PR TITLE
test: cover ref-cast inner products

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -162,3 +162,31 @@ fn test_inner_product_testscalar_uneven() {
     ];
     assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
+
+#[test]
+fn test_inner_product_ref_cast() {
+    let a = vec![
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
+        TestScalar::from(5u64),
+    ];
+    let b = vec![
+        TestScalar::from(7u64),
+        TestScalar::from(11u64),
+        TestScalar::from(13u64),
+    ];
+
+    assert_eq!(TestScalar::from(112u64), inner_product_ref_cast(&a, &b));
+}
+
+#[test]
+fn test_inner_product_ref_cast_truncates_to_shorter_slice() {
+    let a = vec![TestScalar::from(2u64), TestScalar::from(3u64)];
+    let b = vec![
+        TestScalar::from(7u64),
+        TestScalar::from(11u64),
+        TestScalar::from(13u64),
+    ];
+
+    assert_eq!(TestScalar::from(47u64), inner_product_ref_cast(&a, &b));
+}


### PR DESCRIPTION
Adds coverage for `inner_product_ref_cast`, including the normal same-length path and the existing truncation behavior when the right-hand slice is longer.

Checks run locally:
- `rustfmt --check crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::slice_ops::inner_product_test --no-default-features --features "test,std"`

/claim #560