### PR TITLE
test: cover Arrow schema compatibility

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,53 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_convert_arrow_float_fields_to_posql_decimal_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("float16_col", DataType::Float16, false),
+            Field::new("float32_col", DataType::Float32, true),
+            Field::new("float64_col", DataType::Float64, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(
+            converted
+                .fields()
+                .iter()
+                .map(|field| field.data_type())
+                .collect::<Vec<_>>(),
+            vec![
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+            ]
+        );
+        assert!(!converted.field(0).is_nullable());
+        assert!(converted.field(1).is_nullable());
+        assert!(!converted.field(2).is_nullable());
+    }
+
+    #[test]
+    fn we_keep_non_float_arrow_fields_unchanged() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("payload", DataType::Utf8, true),
+            Field::new("amount", DataType::Decimal128(12, 2), false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(converted.field(0).data_type(), &DataType::Int64);
+        assert_eq!(converted.field(1).data_type(), &DataType::Utf8);
+        assert_eq!(converted.field(2).data_type(), &DataType::Decimal128(12, 2));
+        assert_eq!(converted.field(0).name(), "id");
+        assert_eq!(converted.field(1).name(), "payload");
+        assert_eq!(converted.field(2).name(), "amount");
+    }
+}


### PR DESCRIPTION
Adds focused tests for `get_posql_compatible_schema`: Float16/Float32/Float64 fields are converted to `Decimal256(20, 10)`, while non-float field types, names, and nullability are preserved.

Checks run locally:
- `rustfmt --check crates/proof-of-sql/src/base/database/arrow_schema_utility.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database::arrow_schema_utility --no-default-features --features "test,std,arrow"`

/claim #560