### PR TITLE
test: cover sumcheck MLE evaluations

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
@@ -3,7 +3,7 @@ use crate::{
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::SumcheckRandomScalars,
 };
-use num_traits::One;
+use num_traits::{One, Zero};
 
 #[test]
 fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
@@ -46,5 +46,63 @@ fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
     assert_eq!(
         *evals.chi_evaluations.values().next().unwrap(),
         expected_eval
+    );
+}
+
+#[test]
+fn we_track_rho_and_rho_256_evaluations_used_within_sumcheck() {
+    let evaluation_point = [
+        Curve25519Scalar::one(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+    ];
+    let random_scalars = [
+        Curve25519Scalar::from(123u64),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+    ];
+    let sumcheck_random_scalars = SumcheckRandomScalars::new(&random_scalars, 1, 8);
+    let first_round_evaluations = [Curve25519Scalar::from(11u64)];
+    let final_round_evaluations = [Curve25519Scalar::from(22u64), Curve25519Scalar::from(33u64)];
+
+    let evals = SumcheckMleEvaluations::new(
+        1,
+        [1, 2, 2],
+        [2],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &first_round_evaluations,
+        &final_round_evaluations,
+    );
+
+    assert_eq!(evals.rho_256_evaluation, Some(Curve25519Scalar::one()));
+    assert_eq!(evals.chi_evaluations.len(), 2);
+    assert_eq!(
+        evals.chi_evaluations[&1],
+        Curve25519Scalar::zero(),
+        "the singleton basis is zero at index 1"
+    );
+    assert_eq!(evals.chi_evaluations[&2], Curve25519Scalar::one());
+    assert_eq!(evals.rho_evaluations[&2], Curve25519Scalar::one());
+    assert_eq!(evals.singleton_chi_evaluation, Curve25519Scalar::zero());
+    assert_eq!(evals.random_evaluation, Curve25519Scalar::zero());
+    assert_eq!(
+        evals.first_round_pcs_proof_evaluations,
+        &first_round_evaluations
+    );
+    assert_eq!(
+        evals.final_round_pcs_proof_evaluations,
+        &final_round_evaluations
     );
 }


### PR DESCRIPTION
Adds coverage for additional `SumcheckMleEvaluations` fields: `rho_256_evaluation`, rho evaluations, singleton chi evaluation, deduplicated chi lengths, random evaluation, and the stored first/final round proof evaluation slices.

Checks run locally:
- `rustfmt --check crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql sql::proof::sumcheck_mle_evaluations_test --no-default-features --features "test,std"`

/claim #560