### PR TITLE
test: cover proof expression wrappers

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -10,3 +10,24 @@ pub struct AliasedDynProofExpr {
     /// The alias for the expression.
     pub alias: Ident,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::LiteralValue;
+
+    #[test]
+    fn we_clone_and_round_trip_aliased_expressions_through_json() {
+        let expr = AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+            alias: "is_active".into(),
+        };
+
+        assert_eq!(expr.clone(), expr);
+
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: AliasedDynProofExpr = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, expr);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -7,3 +7,20 @@ pub struct TableExpr {
     /// The `TableRef` for the table
     pub table_ref: TableRef,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_round_trip_table_expr_through_json() {
+        let expr = TableExpr {
+            table_ref: TableRef::new("sxt", "orders"),
+        };
+
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, expr);
+    }
+}


### PR DESCRIPTION
Adds small serialization coverage for the proof expression wrapper structs: `TableExpr` JSON round-trip and `AliasedDynProofExpr` clone plus JSON round-trip with a literal expression.

Checks run locally:
- `rustfmt --check crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql sql::proof_exprs --no-default-features --features "test,std"`

/claim #560