### PR TITLE
test: cover decimal bigint conversion

### DIFF
--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -89,4 +89,26 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, IntermediateDecimalError::ConversionFailure));
     }
+
+    #[test]
+    fn we_can_convert_decimal_to_bigint_with_target_scale() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+
+        let bigint = big_decimal
+            .try_into_bigint_with_precision_and_scale(7, 4)
+            .unwrap();
+
+        assert_eq!(bigint, BigInt::from(1_234_500));
+    }
+
+    #[test]
+    fn we_can_catch_lossy_cast_when_precision_is_too_small() {
+        let big_decimal: BigDecimal = "999.99".parse::<BigDecimal>().unwrap().normalized();
+
+        let err = big_decimal
+            .try_into_bigint_with_precision_and_scale(4, 2)
+            .unwrap_err();
+
+        assert!(matches!(err, LossyCast));
+    }
 }


### PR DESCRIPTION
Adds a couple of direct checks for `BigDecimalExt::try_into_bigint_with_precision_and_scale`: one successful conversion with a larger target scale and one precision-too-small error case.

Checks run locally:
- `rustfmt --check crates/proof-of-sql/src/base/math/big_decimal_ext.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::math::big_decimal_ext --no-default-features --features "test,std"`

/claim #560