### PR TITLE
Add slice add-const edge case coverage

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
@@ -7,3 +7,17 @@ fn test_add_const() {
     let b = vec![1 + 10, 2 + 10, 3 + 10, 4 + 10];
     assert_eq!(a, b);
 }
+
+#[test]
+fn we_can_add_const_to_empty_slice() {
+    let mut values: [i64; 0] = [];
+    add_const(&mut values, 5_i64);
+    assert!(values.is_empty());
+}
+
+#[test]
+fn we_can_add_const_from_convertible_value() {
+    let mut values = vec![10_i64, -5, 0, 12];
+    add_const(&mut values, 7_i16);
+    assert_eq!(values, [17_i64, 2, 7, 19]);
+}


### PR DESCRIPTION
Adds a couple of focused cases around `add_const`: an empty slice and a convertible input type where the added value is converted into the result element type.

Verification:
- `rustfmt crates/proof-of-sql/src/base/slice_ops/add_const_test.rs`
- `rustfmt --check crates/proof-of-sql/src/base/slice_ops/add_const_test.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::slice_ops::add_const_test --no-default-features --features "test,std"`

/claim #560