### PR TITLE
Add Merlin transcript encoding coverage

### DIFF
--- a/crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs
@@ -14,7 +14,10 @@ impl super::transcript_core::TranscriptCore for merlin::Transcript {
 
 #[cfg(test)]
 mod tests {
-    use super::super::transcript_core::test_util::*;
+    use super::super::{
+        transcript_core::{test_util::*, TranscriptCore},
+        Transcript,
+    };
     #[test]
     fn we_get_equivalent_challenges_with_equivalent_merlin_transcripts() {
         we_get_equivalent_challenges_with_equivalent_transcripts::<merlin::Transcript>();
@@ -26,5 +29,30 @@ mod tests {
     #[test]
     fn we_get_different_nontrivial_consecutive_challenges_from_keccak256_transcript() {
         we_get_different_nontrivial_consecutive_challenges_from_transcript::<merlin::Transcript>();
+    }
+    #[test]
+    fn we_can_add_values_to_merlin_transcript_in_big_endian_form() {
+        let mut transcript1 = <merlin::Transcript as Transcript>::new();
+        transcript1.extend_as_be([1_u16, 1000, 2]);
+
+        let mut transcript2: merlin::Transcript = TranscriptCore::new();
+        transcript2.raw_append(&[0, 1]);
+        transcript2.raw_append(&[3, 232]);
+        transcript2.raw_append(&[0, 2]);
+
+        assert_eq!(transcript1.raw_challenge(), transcript2.raw_challenge());
+    }
+    #[test]
+    fn we_can_add_refs_to_merlin_transcript_in_little_endian_form() {
+        let values = [1_u16, 1000, 2];
+        let mut transcript1 = <merlin::Transcript as Transcript>::new();
+        transcript1.extend_as_le_from_refs(&values);
+
+        let mut transcript2: merlin::Transcript = TranscriptCore::new();
+        transcript2.raw_append(&[1, 0]);
+        transcript2.raw_append(&[232, 3]);
+        transcript2.raw_append(&[2, 0]);
+
+        assert_eq!(transcript1.raw_challenge(), transcript2.raw_challenge());
     }
 }


### PR DESCRIPTION
Adds focused checks that the Merlin transcript implementation uses the shared `Transcript` encoding helpers consistently for big-endian values and little-endian references.

This sits next to the existing Merlin raw challenge tests and mirrors the byte-level expectations used by the core transcript tests.

Verification:
- `rustfmt crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs`
- `rustfmt --check crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::proof::merlin_transcript_core --no-default-features --features "test,std"`

/claim #560