### PR TITLE
test: cover ark serde helper macros

### DIFF
--- a/crates/proof-of-sql/src/base/serialize.rs
+++ b/crates/proof-of-sql/src/base/serialize.rs
@@ -51,3 +51,99 @@ macro_rules! impl_serde_for_ark_serde_unchecked {
 
 pub(crate) use impl_serde_for_ark_serde_checked;
 pub(crate) use impl_serde_for_ark_serde_unchecked;
+
+#[cfg(test)]
+mod tests {
+    use crate::base::{try_standard_binary_deserialization, try_standard_binary_serialization};
+    use ark_serialize::{
+        CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid,
+        Validate, Write,
+    };
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    struct CheckedSerdeByte(u8);
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    struct UncheckedSerdeByte(u8);
+
+    macro_rules! impl_canonical_byte {
+        ($t:ty) => {
+            impl CanonicalSerialize for $t {
+                fn serialize_with_mode<W: Write>(
+                    &self,
+                    writer: W,
+                    compress: Compress,
+                ) -> Result<(), SerializationError> {
+                    self.0.serialize_with_mode(writer, compress)
+                }
+
+                fn serialized_size(&self, compress: Compress) -> usize {
+                    self.0.serialized_size(compress)
+                }
+            }
+
+            impl Valid for $t {
+                fn check(&self) -> Result<(), SerializationError> {
+                    if self.0 == u8::MAX {
+                        Err(SerializationError::InvalidData)
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+
+            impl CanonicalDeserialize for $t {
+                fn deserialize_with_mode<R: Read>(
+                    reader: R,
+                    compress: Compress,
+                    validate: Validate,
+                ) -> Result<Self, SerializationError> {
+                    let value = Self(u8::deserialize_with_mode(reader, compress, Validate::No)?);
+                    if validate == Validate::Yes {
+                        value.check()?;
+                    }
+                    Ok(value)
+                }
+            }
+        };
+    }
+
+    impl_canonical_byte!(CheckedSerdeByte);
+    impl_canonical_byte!(UncheckedSerdeByte);
+    impl_serde_for_ark_serde_checked!(CheckedSerdeByte);
+    impl_serde_for_ark_serde_unchecked!(UncheckedSerdeByte);
+
+    #[test]
+    fn checked_ark_serde_helper_roundtrips_valid_values() {
+        let value = CheckedSerdeByte(42);
+
+        let serialized = try_standard_binary_serialization(value).unwrap();
+        let (deserialized, consumed): (CheckedSerdeByte, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, value);
+        assert_eq!(consumed, serialized.len());
+    }
+
+    #[test]
+    fn checked_ark_serde_helper_rejects_invalid_values() {
+        let serialized = try_standard_binary_serialization(CheckedSerdeByte(u8::MAX)).unwrap();
+
+        let result: Result<(CheckedSerdeByte, usize), _> =
+            try_standard_binary_deserialization(&serialized);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unchecked_ark_serde_helper_accepts_invalid_values() {
+        let value = UncheckedSerdeByte(u8::MAX);
+
+        let serialized = try_standard_binary_serialization(value).unwrap();
+        let (deserialized, consumed): (UncheckedSerdeByte, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, value);
+        assert_eq!(consumed, serialized.len());
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused tests for checked and unchecked ark serde helper macros
- verify checked deserialization rejects invalid canonical data
- verify unchecked deserialization accepts the same invalid value when validation is skipped

## Testing
- BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::serialize::tests --no-default-features --features "test,std"
- rustfmt --check crates/proof-of-sql/src/base/serialize.rs
- git diff --check