### PR TITLE
Cover owned string result element decoding

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -206,6 +206,18 @@ mod tests {
     }
 
     #[test]
+    fn we_can_encode_and_decode_an_owned_string() {
+        let value = String::from("owned test string");
+        let mut out = vec![0_u8; value.required_bytes()];
+        value.encode(&mut out[..]);
+
+        let (decoded_value, read_bytes) = String::decode(&out[..]).unwrap();
+
+        assert_eq!(read_bytes, out.len());
+        assert_eq!(decoded_value, value);
+    }
+
+    #[test]
     fn we_can_encode_and_decode_a_simple_array() {
         let value = &[1_u8, 3_u8, 5_u8][..];
         let mut out = vec![0_u8; value.required_bytes()];
@@ -387,6 +399,21 @@ mod tests {
         let out = encode_multiple_rows(&data);
         let (decoded_data, decoded_bytes) =
             decode_multiple_elements::<&str>(&out[..], data.len()).unwrap();
+        assert_eq!(decoded_data, data);
+        assert_eq!(decoded_bytes, out.len());
+    }
+
+    #[test]
+    fn multiple_owned_string_rows_are_correctly_encoded_and_decoded() {
+        let data = [
+            String::from("abc1"),
+            String::from("joe123"),
+            String::from("testing435t"),
+        ];
+        let out = encode_multiple_rows(&data);
+        let (decoded_data, decoded_bytes) =
+            decode_multiple_elements::<String>(&out[..], data.len()).unwrap();
+
         assert_eq!(decoded_data, data);
         assert_eq!(decoded_bytes, out.len());
     }


### PR DESCRIPTION
Adds direct coverage for the owned `String` implementation of `ProvableResultElement`, both for a single encoded value and for `decode_multiple_elements`. Existing tests covered borrowed `str` paths, but not the owned conversion path itself.

Verification:
- `rustfmt crates/proof-of-sql/src/sql/proof/result_element_serialization.rs`
- `rustfmt --check crates/proof-of-sql/src/sql/proof/result_element_serialization.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql sql::proof::result_element_serialization::tests --no-default-features --features "test,std"`

/claim #560