### PR TITLE
Cover scaled batch inversion

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
@@ -106,3 +106,31 @@ where
         tmp = new_tmp;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::batch_inversion_and_mul;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use num_traits::{Inv, Zero};
+
+    #[test]
+    fn we_can_scale_batch_inversion_results() {
+        let input = [
+            TestScalar::from(0_u32),
+            TestScalar::from(2_u32),
+            TestScalar::from(5_u32),
+            TestScalar::zero(),
+            TestScalar::from(7_u32),
+        ];
+        let coeff = TestScalar::from(3_u32);
+        let mut actual = input;
+
+        batch_inversion_and_mul(&mut actual, coeff);
+
+        assert_eq!(actual[0], TestScalar::zero());
+        assert_eq!(actual[1], input[1].inv().unwrap() * coeff);
+        assert_eq!(actual[2], input[2].inv().unwrap() * coeff);
+        assert_eq!(actual[3], TestScalar::zero());
+        assert_eq!(actual[4], input[4].inv().unwrap() * coeff);
+    }
+}


### PR DESCRIPTION
Adds a focused unit test for `batch_inversion_and_mul` that checks scaled inverses while preserving zero entries. This covers the coefficient path separately from plain batch inversion.

Verification:
- `rustfmt crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs`
- `rustfmt --check crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::slice_ops::batch_inverse::tests --no-default-features --features "test,std"`

/claim #560