### PR TITLE
Cover bit mask signed boundary

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
@@ -19,3 +19,19 @@ pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
 pub fn is_bit_mask_negative_representation(bit_mask: U256) -> bool {
     bit_mask & MSB_MASK == U256::ZERO
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{is_bit_mask_negative_representation, make_bit_mask};
+    use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+
+    #[test]
+    fn we_can_classify_signed_boundary_bit_masks() {
+        assert!(!is_bit_mask_negative_representation(make_bit_mask(
+            TestScalar::MAX_SIGNED
+        )));
+        assert!(is_bit_mask_negative_representation(make_bit_mask(
+            TestScalar::MAX_SIGNED + TestScalar::ONE
+        )));
+    }
+}


### PR DESCRIPTION
Adds a small boundary test for bit-mask classification at the signed scalar split: `MAX_SIGNED` remains positive-representation, while the next scalar is classified as negative-representation.

Verification:
- `rustfmt crates/proof-of-sql/src/base/bit/bit_mask_utils.rs`
- `rustfmt --check crates/proof-of-sql/src/base/bit/bit_mask_utils.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::bit::bit_mask_utils::tests --no-default-features --features "test,std"`

/claim #560