### PR TITLE
Cover short mutable slice casts

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
@@ -53,3 +53,18 @@ where
 {
     slice_cast_mut_with(value, result, Into::into);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::slice_cast_mut_with;
+
+    #[test]
+    fn we_only_fill_available_mut_cast_slots() {
+        let input = [1_u32, 2, 3];
+        let mut result = [0_u64; 2];
+
+        slice_cast_mut_with(&input, &mut result, |&value| u64::from(value) * 10);
+
+        assert_eq!(result, [10, 20]);
+    }
+}


### PR DESCRIPTION
Adds a focused test for `slice_cast_mut_with` when the output buffer is shorter than the input slice. This locks in the current zip-based behavior: only available output slots are filled.

Verification:
- `rustfmt crates/proof-of-sql/src/base/slice_ops/slice_cast.rs`
- `rustfmt --check crates/proof-of-sql/src/base/slice_ops/slice_cast.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::slice_ops::slice_cast::tests --no-default-features --features "test,std"`

/claim #560