### PR TITLE
Cover overfull lagrange basis sum

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
@@ -174,3 +174,19 @@ where
         rho
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_truncated_lagrange_basis_sum;
+    use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+
+    #[test]
+    fn we_get_full_lagrange_sum_when_length_exceeds_the_point_domain() {
+        let point = [TestScalar::from(2_u32), TestScalar::from(5_u32)];
+
+        assert_eq!(
+            compute_truncated_lagrange_basis_sum(5, &point),
+            TestScalar::ONE
+        );
+    }
+}


### PR DESCRIPTION
Adds a small boundary test for `compute_truncated_lagrange_basis_sum` when the requested length exceeds the full domain for the evaluation point. This exercises the path that returns the full Lagrange basis sum.

Verification:
- `rustfmt crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs`
- `rustfmt --check crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::polynomial::lagrange_basis_evaluation::tests --no-default-features --features "test,std"`

/claim #560