### PR TITLE
Cover empty add-const slices

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/add_const.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const.rs
@@ -17,3 +17,17 @@ where
         *res_i += to_add.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::add_const;
+
+    #[test]
+    fn we_can_add_const_to_an_empty_slice() {
+        let mut values: [i32; 0] = [];
+
+        add_const(&mut values, 10);
+
+        assert!(values.is_empty());
+    }
+}


### PR DESCRIPTION
Adds a small no-op coverage case for `add_const` with an empty result slice. This checks the iterator path handles empty inputs without changing behavior.

Verification:
- `rustfmt crates/proof-of-sql/src/base/slice_ops/add_const.rs`
- `rustfmt --check crates/proof-of-sql/src/base/slice_ops/add_const.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::slice_ops::add_const::tests --no-default-features --features "test,std"`

/claim #560