### PR TITLE
Cover empty mul-add inputs

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
@@ -24,3 +24,20 @@ where
         *res_i += multiplier * data_i.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::mul_add_assign;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_leave_result_unchanged_when_mul_add_input_is_empty() {
+        let mut result = [1_u32, 2, 3].map(TestScalar::from);
+        let original = result;
+        let to_mul_add: [u32; 0] = [];
+
+        mul_add_assign(&mut result, TestScalar::from(10_u32), &to_mul_add);
+
+        assert_eq!(result, original);
+    }
+}


### PR DESCRIPTION
Adds a no-op coverage case for `mul_add_assign` when the input slice to multiply and add is empty. The test checks that the existing result values are left untouched.

Verification:
- `rustfmt crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs`
- `rustfmt --check crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::slice_ops::mul_add_assign::tests --no-default-features --features "test,std"`

/claim #560