### PR TITLE
Cover bit distribution iterator limbs

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -170,3 +170,22 @@ impl BitDistribution {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::BitDistribution;
+    use alloc::{vec, vec::Vec};
+
+    #[test]
+    fn we_iterate_varying_bits_across_all_limbs() {
+        let bit_distribution = BitDistribution {
+            vary_mask: [1, 1 << 1, 1 << 2, 1 << 3],
+            leading_bit_mask: [0; 4],
+        };
+
+        assert_eq!(
+            bit_distribution.vary_mask_iter().collect::<Vec<_>>(),
+            vec![0, 65, 130, 195]
+        );
+    }
+}


### PR DESCRIPTION
Adds a focused unit test for `BitDistribution::vary_mask_iter` across all four internal limbs. The test checks the emitted bit positions and ordering for bits set in each limb.

Verification:
- `rustfmt crates/proof-of-sql/src/base/bit/bit_distribution.rs`
- `rustfmt --check crates/proof-of-sql/src/base/bit/bit_distribution.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::bit::bit_distribution::tests --no-default-features --features "test,std"`

/claim #560