### PR TITLE
Cover varbinary result tampering

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -153,3 +153,20 @@ pub fn tamper_first_row_of_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedCo
     }
     column
 }
+
+#[cfg(test)]
+mod tests {
+    use super::tamper_first_row_of_column;
+    use crate::base::{database::OwnedColumn, scalar::test_scalar::TestScalar};
+    use alloc::vec;
+
+    #[test]
+    fn we_can_tamper_varbinary_columns_without_mutating_the_original() {
+        let column = OwnedColumn::<TestScalar>::VarBinary(vec![vec![1_u8, 2]]);
+
+        let tampered = tamper_first_row_of_column(&column);
+
+        assert_eq!(column, OwnedColumn::VarBinary(vec![vec![1_u8, 2]]));
+        assert_eq!(tampered, OwnedColumn::VarBinary(vec![vec![1_u8, 2, 1]]));
+    }
+}


### PR DESCRIPTION
Adds a focused unit test for the verifiable-result tampering helper on `VarBinary` columns. It checks that the helper returns a tampered clone while leaving the original column unchanged.

Verification:
- `rustfmt crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs`
- `rustfmt --check crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql sql::proof::verifiable_query_result_test_utility::tests --no-default-features --features "test,std,blitzar"`

/claim #560