### PR TITLE
Cover negative interpolate queries

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/interpolate.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate.rs
@@ -127,3 +127,23 @@ where
         })
         .unwrap_or(vec![])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::interpolate_uni_poly;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_interpolate_uni_poly_at_negative_query_points() {
+        let evaluations = [
+            TestScalar::from(3_i32),
+            TestScalar::from(6_i32),
+            TestScalar::from(11_i32),
+        ];
+
+        assert_eq!(
+            interpolate_uni_poly(&evaluations, TestScalar::from(-2_i32)),
+            TestScalar::from(3_i32)
+        );
+    }
+}


### PR DESCRIPTION
Adds a focused `interpolate_uni_poly` test for a negative query point using evaluations from a small quadratic. This exercises interpolation away from the sampled domain on the other side of zero.

Verification:
- `rustfmt crates/proof-of-sql/src/base/polynomial/interpolate.rs`
- `rustfmt --check crates/proof-of-sql/src/base/polynomial/interpolate.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::polynomial::interpolate::tests --no-default-features --features "test,std"`

/claim #560