### PR TITLE
Cover evaluation vector domain bound

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -67,3 +67,18 @@ where
 
     log::log_memory_usage("End");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_evaluation_vector;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use num_traits::Zero;
+
+    #[test]
+    #[should_panic]
+    fn we_reject_evaluation_vectors_larger_than_the_point_domain() {
+        let mut evaluation_vector = [TestScalar::zero(); 3];
+
+        compute_evaluation_vector(&mut evaluation_vector, &[TestScalar::from(2_u32)]);
+    }
+}


### PR DESCRIPTION
Adds a small assertion-boundary test for `compute_evaluation_vector` when the output vector is larger than the domain implied by the evaluation point. This covers the existing guard against overlong evaluation vectors.

Verification:
- `rustfmt crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs`
- `rustfmt --check crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::polynomial::evaluation_vector::tests --no-default-features --features "test,std"`

/claim #560