### PR TITLE
Compare varbinary rows in order util

### DIFF
--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -88,6 +88,9 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
             (Column::VarChar((left_col, _)), Column::VarChar((right_col, _))) => {
                 left_col[left_row_index].cmp(right_col[right_row_index])
             }
+            (Column::VarBinary((left_col, _)), Column::VarBinary((right_col, _))) => {
+                left_col[left_row_index].cmp(right_col[right_row_index])
+            }
             // Should never happen since we checked the column types
             _ => unreachable!(),
         };

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -117,6 +117,37 @@ fn we_can_compare_single_row_of_tables() {
 }
 
 #[test]
+fn we_can_compare_single_row_of_tables_for_varbinary_columns() {
+    let left_raw = [b"foo".as_ref(), b"bar".as_ref(), b"baz".as_ref()];
+    let right_raw = [b"bar".as_ref(), b"foo".as_ref(), b"baz".as_ref()];
+    let left_scalars: Vec<TestScalar> = left_raw
+        .iter()
+        .map(|bytes| TestScalar::from_le_bytes_mod_order(bytes))
+        .collect();
+    let right_scalars: Vec<TestScalar> = right_raw
+        .iter()
+        .map(|bytes| TestScalar::from_le_bytes_mod_order(bytes))
+        .collect();
+    let left_column = Column::VarBinary((left_raw.as_slice(), left_scalars.as_slice()));
+    let right_column = Column::VarBinary((right_raw.as_slice(), right_scalars.as_slice()));
+    let left = &[left_column];
+    let right = &[right_column];
+
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 0, 0).unwrap(),
+        Ordering::Greater
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 1, 1).unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 2, 2).unwrap(),
+        Ordering::Equal
+    );
+}
+
+#[test]
 fn we_cannot_compare_single_row_of_tables_if_type_mismatch() {
     let left_slice = &[55, 44, 66, 66, 66, 77, 66, 66, 66, 66];
     let right_slice = &[


### PR DESCRIPTION
Adds the missing `VarBinary` arm in `compare_single_row_of_tables`, matching the existing support in index-based ordering. The new test covers greater, less, and equal row comparisons for binary values.

Verification:
- `rustfmt crates/proof-of-sql/src/base/database/order_by_util.rs crates/proof-of-sql/src/base/database/order_by_util_test.rs`
- `rustfmt --check crates/proof-of-sql/src/base/database/order_by_util.rs crates/proof-of-sql/src/base/database/order_by_util_test.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database::order_by_util_test::we_can_compare_single_row_of_tables_for_varbinary_columns --no-default-features --features "test,std"`

/claim #560