### PR TITLE
Cover owned column integer division by zero

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -821,6 +821,15 @@ mod test {
     }
 
     #[test]
+    fn we_reject_integer_column_division_by_zero() {
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![10, 20, 30]);
+        let rhs = OwnedColumn::<TestScalar>::Int(vec![2, 0, 5]);
+        let result = lhs.element_wise_div(&rhs);
+
+        assert!(matches!(result, Err(ColumnOperationError::DivisionByZero)));
+    }
+
+    #[test]
     fn we_can_try_divide_decimal_columns() {
         // lhs and rhs are both decimals
         let lhs_scalars = [4, 5, 3].iter().map(TestScalar::from).collect();


### PR DESCRIPTION
Adds a focused test for the public `OwnedColumn::element_wise_div` path when an integer divisor column contains zero. The assertion checks that the public operation preserves the expected `DivisionByZero` error.

Verification:
- `rustfmt crates/proof-of-sql/src/base/database/owned_column_operation.rs`
- `rustfmt --check crates/proof-of-sql/src/base/database/owned_column_operation.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database::owned_column_operation::test::we_reject_integer_column_division_by_zero --no-default-features --features "test,std"`

/claim #560