### PR TITLE
Cover decimal division by zero

### DIFF
--- a/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
@@ -1313,4 +1313,19 @@ mod test {
         let expected = (Precision::new(9).unwrap(), 6, expected_scalars);
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn we_reject_decimal_column_division_by_zero() {
+        let lhs = [10_i16, 20, 30];
+        let rhs = [2_i16, 0, 5]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let left_column_type = ColumnType::SmallInt;
+        let right_column_type = ColumnType::Decimal75(Precision::new(4).unwrap(), 2);
+        let result: ColumnOperationResult<(Precision, i8, Vec<TestScalar>)> =
+            try_divide_decimal_columns(&lhs, &rhs, left_column_type, right_column_type);
+
+        assert!(matches!(result, Err(ColumnOperationError::DivisionByZero)));
+    }
 }


### PR DESCRIPTION
Adds a direct test for `try_divide_decimal_columns` when a decimal divisor is zero. This checks that the decimal path returns the same `DivisionByZero` error expected by the integer division path.

Verification:
- `rustfmt crates/proof-of-sql/src/base/database/slice_decimal_operation.rs`
- `rustfmt --check crates/proof-of-sql/src/base/database/slice_decimal_operation.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database::slice_decimal_operation::test::we_reject_decimal_column_division_by_zero --no-default-features --features "test,std"`

/claim #560