### PR TITLE
Cover boolean column type helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -1401,4 +1401,16 @@ mod test {
             matches!(try_neg_type(ColumnType::VarChar).unwrap_err(), ColumnOperationError::UnaryOperationInvalidColumnType { operator, operand_type } if operator == "negation" && operand_type == ColumnType::VarChar)
         );
     }
+
+    #[test]
+    fn we_can_check_boolean_logical_operator_types() {
+        assert!(can_and_or_types(ColumnType::Boolean, ColumnType::Boolean));
+        assert!(!can_and_or_types(ColumnType::Boolean, ColumnType::Int));
+        assert!(!can_and_or_types(ColumnType::Int, ColumnType::Boolean));
+        assert!(!can_and_or_types(ColumnType::Int, ColumnType::Int));
+
+        assert!(can_not_type(ColumnType::Boolean));
+        assert!(!can_not_type(ColumnType::Int));
+        assert!(!can_not_type(ColumnType::VarChar));
+    }
 }


### PR DESCRIPTION
Adds direct coverage for the boolean logical type helpers used by AND, OR, and NOT planning. The test checks the accepted Boolean/Boolean case and a few representative non-boolean rejections.

Verification:
- `rustfmt crates/proof-of-sql/src/base/database/column_type_operation.rs`
- `rustfmt --check crates/proof-of-sql/src/base/database/column_type_operation.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database::column_type_operation::test::we_can_check_boolean_logical_operator_types --no-default-features --features "test,std"`

/claim #560