### PR TITLE
Cover sign length guard

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -113,6 +113,15 @@ fn we_can_compute_the_correct_sign_of_scalars_using_first_round_evaluate_sign_fo
 }
 
 #[test]
+#[should_panic]
+fn we_reject_first_round_sign_length_mismatch() {
+    let data: &[TestScalar] = &[(-123).into(), 123.into()];
+    let alloc = Bump::new();
+
+    first_round_evaluate_sign(3, &alloc, data);
+}
+
+#[test]
 fn we_can_compute_the_correct_sign_of_scalars_using_first_round_evaluate_sign_with_varying_bits_and_fixed_sign(
 ) {
     let data: &[TestScalar] = &[123.into(), 452.into(), 0.into(), 789.into(), 910.into()];


### PR DESCRIPTION
Adds a focused test for the length assertion in `first_round_evaluate_sign`. The new case passes a table length that does not match the expression slice and expects the documented panic.

Verification:
- `rustfmt crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs`
- `rustfmt --check crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql sql::proof_gadgets::sign_expr_test::we_reject_first_round_sign_length_mismatch --no-default-features --features "test,std,blitzar"`

/claim #560