### PR TITLE
Cover nonnumeric group-by sums

### DIFF
--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -48,6 +48,26 @@ fn we_cannot_apply_min_to_varchar() {
 }
 
 #[test]
+#[should_panic(expected = "SUM can not be applied to non-numeric types")]
+fn we_cannot_apply_sum_to_varchar() {
+    let col: Column<'_, TestScalar> = Column::VarChar((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = sum_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+#[should_panic(expected = "SUM can not be applied to non-numeric types")]
+fn we_cannot_apply_sum_to_varbinary() {
+    let col: Column<'_, TestScalar> = Column::VarBinary((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = sum_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
 fn we_can_aggregate_empty_columns() {
     let column_a = Column::BigInt::<TestScalar>(&[]);
     let column_b = Column::VarChar((&[], &[]));


### PR DESCRIPTION
Adds direct coverage for the group-by SUM helper when it receives nonnumeric columns. MAX and MIN already had similar varchar/varbinary guard tests, and this covers the SUM branch as well.

Verification:
- `rustfmt crates/proof-of-sql/src/base/database/group_by_util_test.rs`
- `rustfmt --check crates/proof-of-sql/src/base/database/group_by_util_test.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql 'base::database::group_by_util_test::we_cannot_apply_sum_to_' --no-default-features --features "test,std"`\n\n/claim #560