### PR TITLE
Cover empty fallible slice ops

### DIFF
--- a/crates/proof-of-sql/src/base/database/slice_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_operation.rs
@@ -321,6 +321,19 @@ mod test {
     }
 
     #[test]
+    fn we_can_do_fallible_binary_ops_on_empty_slices() {
+        let empty: [i32; 0] = [];
+
+        let actual: ColumnOperationResult<Vec<i32>> =
+            try_slice_lit_binary_op(&empty, &1, |_, _| panic!("op should not be called"));
+        assert_eq!(actual.unwrap(), Vec::<i32>::new());
+
+        let actual: ColumnOperationResult<Vec<i32>> =
+            try_slice_binary_op(&empty, &empty, |_, _| panic!("op should not be called"));
+        assert_eq!(actual.unwrap(), Vec::<i32>::new());
+    }
+
+    #[test]
     fn we_cannot_do_fallible_binary_op_on_a_single_value_and_a_slice_if_error_anywhere() {
         // No casting
         let slice = [1, i16::MAX, 1];


### PR DESCRIPTION
Adds a focused test for the fallible slice helpers on empty inputs. The test uses callbacks that would panic if invoked, so it verifies the helpers return an empty result without touching the operation.

Verification:
- `rustfmt crates/proof-of-sql/src/base/database/slice_operation.rs`
- `rustfmt --check crates/proof-of-sql/src/base/database/slice_operation.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql base::database::slice_operation::test::we_can_do_fallible_binary_ops_on_empty_slices --no-default-features --features "test,std"`

/claim #560