### PR TITLE
test: cover union column variants

### DIFF
--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -245,7 +245,12 @@ pub fn table_union<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{map::IndexMap, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        map::IndexMap,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn we_can_union_no_columns() {
@@ -278,6 +283,94 @@ mod tests {
         assert_eq!(
             result,
             Column::VarChar((&doubled_strings, &doubled_scalars))
+        );
+    }
+
+    #[test]
+    fn we_can_union_fixed_width_and_timestamp_columns() {
+        let alloc = Bump::new();
+
+        let col0: Column<TestScalar> = Column::Boolean(&[true, false]);
+        let col1: Column<TestScalar> = Column::Boolean(&[false]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Boolean).unwrap();
+        assert_eq!(result, Column::Boolean(&[true, false, false]));
+
+        let col0: Column<TestScalar> = Column::Uint8(&[0, u8::MAX]);
+        let col1: Column<TestScalar> = Column::Uint8(&[7]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Uint8).unwrap();
+        assert_eq!(result, Column::Uint8(&[0, u8::MAX, 7]));
+
+        let col0: Column<TestScalar> = Column::TinyInt(&[i8::MIN]);
+        let col1: Column<TestScalar> = Column::TinyInt(&[0, i8::MAX]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::TinyInt).unwrap();
+        assert_eq!(result, Column::TinyInt(&[i8::MIN, 0, i8::MAX]));
+
+        let col0: Column<TestScalar> = Column::SmallInt(&[i16::MIN, -1]);
+        let col1: Column<TestScalar> = Column::SmallInt(&[i16::MAX]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::SmallInt).unwrap();
+        assert_eq!(result, Column::SmallInt(&[i16::MIN, -1, i16::MAX]));
+
+        let col0: Column<TestScalar> = Column::Int(&[i32::MIN]);
+        let col1: Column<TestScalar> = Column::Int(&[0, i32::MAX]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Int).unwrap();
+        assert_eq!(result, Column::Int(&[i32::MIN, 0, i32::MAX]));
+
+        let col0: Column<TestScalar> = Column::Int128(&[i128::MIN]);
+        let col1: Column<TestScalar> = Column::Int128(&[0, i128::MAX]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Int128).unwrap();
+        assert_eq!(result, Column::Int128(&[i128::MIN, 0, i128::MAX]));
+
+        let scalar0 = [TestScalar::from(1), TestScalar::from(2)];
+        let scalar1 = [TestScalar::from(3)];
+        let expected_scalars = [TestScalar::from(1), TestScalar::from(2), TestScalar::from(3)];
+        let col0 = Column::Scalar(scalar0.as_slice());
+        let col1 = Column::Scalar(scalar1.as_slice());
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Scalar).unwrap();
+        assert_eq!(result, Column::Scalar(expected_scalars.as_slice()));
+
+        let precision = Precision::new(12).unwrap();
+        let decimal0 = [TestScalar::from(100), TestScalar::from(200)];
+        let decimal1 = [TestScalar::from(300)];
+        let expected_decimals = [
+            TestScalar::from(100),
+            TestScalar::from(200),
+            TestScalar::from(300),
+        ];
+        let col0 = Column::Decimal75(precision, 2, decimal0.as_slice());
+        let col1 = Column::Decimal75(precision, 2, decimal1.as_slice());
+        let result =
+            column_union(&[&col0, &col1], &alloc, ColumnType::Decimal75(precision, 2)).unwrap();
+        assert_eq!(
+            result,
+            Column::Decimal75(precision, 2, expected_decimals.as_slice())
+        );
+
+        let timestamps0 = [1_700_000_000, 1_700_000_001];
+        let timestamps1 = [1_700_000_002];
+        let expected_timestamps = [1_700_000_000, 1_700_000_001, 1_700_000_002];
+        let col0 = Column::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            timestamps0.as_slice(),
+        );
+        let col1 = Column::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            timestamps1.as_slice(),
+        );
+        let result = column_union(
+            &[&col0, &col1],
+            &alloc,
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                expected_timestamps.as_slice()
+            )
         );
     }
 


### PR DESCRIPTION
Closes part of #560.

/claim #560

## Summary
- add focused column_union coverage for boolean and fixed-width integer columns
- cover scalar, Decimal75, and TimestampTZ union branches
- keep the patch test-only and isolated from existing table union behavior

## Testing
- Not run (not requested).