### PR TITLE
test: consolidate coverage improvements for issue 560

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -685,6 +685,14 @@ mod tests {
     }
 
     #[test]
+    fn we_can_convert_uint8_array_normal_range() {
+        let alloc = Bump::new();
+        let array: ArrayRef = Arc::new(UInt8Array::from(vec![1, 3, 255]));
+        let result = array.to_column::<DoryScalar>(&alloc, &(1..3), None);
+        assert_eq!(result.unwrap(), Column::Uint8(&[3, 255]));
+    }
+
+    #[test]
     fn we_can_convert_int16_array_normal_range() {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int16Array::from(vec![1, -3, 42]));
@@ -701,6 +709,14 @@ mod tests {
     }
 
     #[test]
+    fn we_can_convert_uint8_array_empty_range() {
+        let alloc = Bump::new();
+        let array: ArrayRef = Arc::new(UInt8Array::from(vec![1, 3, 255]));
+        let result = array.to_column::<TestScalar>(&alloc, &(1..1), None);
+        assert_eq!(result.unwrap(), Column::Uint8(&[]));
+    }
+
+    #[test]
     fn we_can_convert_int16_array_empty_range() {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int16Array::from(vec![1, -3, 42]));
@@ -712,6 +728,19 @@ mod tests {
     fn we_cannot_convert_int8_array_oob_range() {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int8Array::from(vec![1, -3, 42]));
+
+        let result = array.to_column::<DoryScalar>(&alloc, &(2..4), None);
+
+        assert_eq!(
+            result,
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 3, index: 4 })
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_uint8_array_oob_range() {
+        let alloc = Bump::new();
+        let array: ArrayRef = Arc::new(UInt8Array::from(vec![1, 3, 255]));
 
         let result = array.to_column::<DoryScalar>(&alloc, &(2..4), None);
 
@@ -738,6 +767,17 @@ mod tests {
     fn we_can_convert_int8_array_with_nulls() {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int8Array::from(vec![Some(1), None, Some(42)]));
+        let result = array.to_column::<TestScalar>(&alloc, &(0..3), None);
+        assert!(matches!(
+            result,
+            Err(ArrowArrayToColumnConversionError::ArrayContainsNulls)
+        ));
+    }
+
+    #[test]
+    fn we_can_convert_uint8_array_with_nulls() {
+        let alloc = Bump::new();
+        let array: ArrayRef = Arc::new(UInt8Array::from(vec![Some(1), None, Some(255)]));
         let result = array.to_column::<TestScalar>(&alloc, &(0..3), None);
         assert!(matches!(
             result,
@@ -800,6 +840,13 @@ mod tests {
     fn we_cannot_index_on_oob_range() {
         let alloc = Bump::new();
 
+        let array_uint8: ArrayRef = Arc::new(arrow::array::UInt8Array::from(vec![1, 3]));
+        let result_uint8 = array_uint8.to_column::<DoryScalar>(&alloc, &(2..3), None);
+        assert_eq!(
+            result_uint8,
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 3 })
+        );
+
         let array0: ArrayRef = Arc::new(arrow::array::Int8Array::from(vec![1, -3]));
         let result0 = array0.to_column::<DoryScalar>(&alloc, &(2..3), None);
         assert_eq!(
@@ -832,6 +879,13 @@ mod tests {
     #[test]
     fn we_cannot_index_on_empty_oob_range() {
         let alloc = Bump::new();
+
+        let array_uint8: ArrayRef = Arc::new(arrow::array::UInt8Array::from(vec![1, 3]));
+        let result_uint8 = array_uint8.to_column::<TestScalar>(&alloc, &(5..5), None);
+        assert_eq!(
+            result_uint8,
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 5 })
+        );
 
         let array0: ArrayRef = Arc::new(arrow::array::Int8Array::from(vec![1, -3]));
         let result0 = array0.to_column::<DoryScalar>(&alloc, &(5..5), None);
@@ -970,6 +1024,14 @@ mod tests {
     #[test]
     fn we_can_convert_valid_integer_array_refs_into_valid_columns() {
         let alloc = Bump::new();
+        let array: ArrayRef = Arc::new(arrow::array::UInt8Array::from(vec![1, 3]));
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(0..2), None)
+                .unwrap(),
+            Column::Uint8(&[1, 3])
+        );
+
         let array: ArrayRef = Arc::new(arrow::array::Int8Array::from(vec![1, -3]));
         assert_eq!(
             array
@@ -1083,6 +1145,14 @@ mod tests {
     fn we_can_convert_valid_integer_array_refs_into_valid_columns_using_ranges_smaller_than_arrays()
     {
         let alloc = Bump::new();
+
+        let array: ArrayRef = Arc::new(arrow::array::UInt8Array::from(vec![0, 1, 255]));
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(1..3), None)
+                .unwrap(),
+            Column::Uint8(&[1, 255])
+        );
 
         let array: ArrayRef = Arc::new(arrow::array::Int8Array::from(vec![0, 1, 127]));
         assert_eq!(

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -87,6 +87,146 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
+    #[test]
+    fn we_can_convert_supported_column_types_to_arrow_data_types() {
+        let precision = Precision::new(12).unwrap();
+        let timestamp = ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc());
+
+        assert_eq!(DataType::from(&ColumnType::Boolean), DataType::Boolean);
+        assert_eq!(DataType::from(&ColumnType::Uint8), DataType::UInt8);
+        assert_eq!(DataType::from(&ColumnType::TinyInt), DataType::Int8);
+        assert_eq!(DataType::from(&ColumnType::SmallInt), DataType::Int16);
+        assert_eq!(DataType::from(&ColumnType::Int), DataType::Int32);
+        assert_eq!(DataType::from(&ColumnType::BigInt), DataType::Int64);
+        assert_eq!(
+            DataType::from(&ColumnType::Int128),
+            DataType::Decimal128(38, 0)
+        );
+        assert_eq!(
+            DataType::from(&ColumnType::Decimal75(precision, -2)),
+            DataType::Decimal256(12, -2)
+        );
+        assert_eq!(DataType::from(&ColumnType::VarChar), DataType::Utf8);
+        assert_eq!(
+            DataType::from(&ColumnType::VarBinary),
+            DataType::LargeBinary
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::from(&timestamp)).unwrap(),
+            timestamp
+        );
+    }
+
+    #[test]
+    fn we_can_convert_supported_arrow_data_types_to_column_types() {
+        let precision = Precision::new(75).unwrap();
+
+        assert_eq!(
+            ColumnType::try_from(DataType::Boolean).unwrap(),
+            ColumnType::Boolean
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::UInt8).unwrap(),
+            ColumnType::Uint8
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Int8).unwrap(),
+            ColumnType::TinyInt
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Int16).unwrap(),
+            ColumnType::SmallInt
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Int32).unwrap(),
+            ColumnType::Int
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Int64).unwrap(),
+            ColumnType::BigInt
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Decimal128(38, 0)).unwrap(),
+            ColumnType::Int128
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Decimal256(75, 3)).unwrap(),
+            ColumnType::Decimal75(precision, 3)
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Utf8).unwrap(),
+            ColumnType::VarChar
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::LargeBinary).unwrap(),
+            ColumnType::VarBinary
+        );
+    }
+
+    #[test]
+    fn we_can_convert_arrow_timestamp_units_to_column_types() {
+        let timezone = Some(Arc::from("UTC"));
+
+        assert_eq!(
+            ColumnType::try_from(DataType::Timestamp(ArrowTimeUnit::Second, timezone.clone()))
+                .unwrap(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc())
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Timestamp(
+                ArrowTimeUnit::Millisecond,
+                timezone.clone()
+            ))
+            .unwrap(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc())
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Timestamp(
+                ArrowTimeUnit::Microsecond,
+                timezone.clone()
+            ))
+            .unwrap(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc())
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Timestamp(ArrowTimeUnit::Nanosecond, timezone)).unwrap(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc())
+        );
+    }
+
+    #[test]
+    fn we_get_errors_for_unsupported_arrow_data_types() {
+        assert_eq!(
+            ColumnType::try_from(DataType::Float32).unwrap_err(),
+            "Unsupported arrow data type Float32"
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Decimal128(38, 1)).unwrap_err(),
+            "Unsupported arrow data type Decimal128(38, 1)"
+        );
+        assert_eq!(
+            ColumnType::try_from(DataType::Decimal256(76, 0)).unwrap_err(),
+            "Unsupported arrow data type Decimal256(76, 0)"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "not implemented: Cannot convert Scalar type to arrow type")]
+    fn we_panic_when_converting_scalar_column_type_to_arrow_data_type() {
+        let _ = DataType::from(&ColumnType::Scalar);
+    }
+
+    #[test]
+    fn we_can_convert_column_field_to_arrow_field() {
+        let column_field = ColumnField::new("amount".into(), ColumnType::Int);
+
+        let field = Field::from(&column_field);
+
+        assert_eq!(field.name(), "amount");
+        assert_eq!(field.data_type(), &DataType::Int32);
+        assert!(!field.is_nullable());
+    }
+
     proptest! {
         #[test]
         fn we_can_roundtrip_arbitrary_column_type(column_type: ColumnType) {

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -148,6 +148,10 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
     /// - `Decimal256Array` when converting from `DataType::Decimal256` if precision is less than or equal to 75.
     /// - `StringArray` when converting from `DataType::Utf8`.
     fn try_from(value: &ArrayRef) -> Result<Self, Self::Error> {
+        if value.null_count() != 0 {
+            return Err(OwnedArrowConversionError::NullNotSupportedYet);
+        }
+
         match &value.data_type() {
             // Arrow uses a bit-packed representation for booleans.
             // Hence we need to unpack the bits to get the actual boolean values.
@@ -301,6 +305,39 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                 datatype: data_type.clone(),
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn assert_null_not_supported(array_ref: ArrayRef) {
+        assert!(matches!(
+            OwnedColumn::<TestScalar>::try_from(array_ref),
+            Err(OwnedArrowConversionError::NullNotSupportedYet)
+        ));
+    }
+
+    #[test]
+    fn we_reject_nulls_before_converting_arrow_arrays_to_owned_columns() {
+        assert_null_not_supported(Arc::new(BooleanArray::from(vec![Some(true), None])));
+        assert_null_not_supported(Arc::new(UInt8Array::from(vec![Some(1), None])));
+        assert_null_not_supported(Arc::new(Int8Array::from(vec![Some(1), None])));
+        assert_null_not_supported(Arc::new(Int16Array::from(vec![Some(1), None])));
+        assert_null_not_supported(Arc::new(Int32Array::from(vec![Some(1), None])));
+        assert_null_not_supported(Arc::new(Int64Array::from(vec![Some(1), None])));
+        assert_null_not_supported(Arc::new(
+            Decimal128Array::from(vec![Some(1_i128), None])
+                .with_precision_and_scale(38, 0)
+                .unwrap(),
+        ));
+        assert_null_not_supported(Arc::new(StringArray::from(vec![Some("a"), None])));
+        assert_null_not_supported(Arc::new(LargeBinaryArray::from_iter([
+            Some(b"a".as_slice()),
+            None,
+        ])));
     }
 }
 

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -7,8 +7,8 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
-        StringArray,
+        ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int16Array, Int32Array, Int64Array,
+        Int8Array, LargeBinaryArray, StringArray, UInt8Array,
     },
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
@@ -42,6 +42,30 @@ fn we_can_convert_between_boolean_owned_column_and_array_ref_impl(data: Vec<bool
         Arc::new(BooleanArray::from(data)),
     );
 }
+fn we_can_convert_between_uint8_owned_column_and_array_ref_impl(data: Vec<u8>) {
+    we_can_convert_between_owned_column_and_array_ref_impl(
+        &OwnedColumn::<TestScalar>::Uint8(data.clone()),
+        Arc::new(UInt8Array::from(data)),
+    );
+}
+fn we_can_convert_between_tinyint_owned_column_and_array_ref_impl(data: Vec<i8>) {
+    we_can_convert_between_owned_column_and_array_ref_impl(
+        &OwnedColumn::<TestScalar>::TinyInt(data.clone()),
+        Arc::new(Int8Array::from(data)),
+    );
+}
+fn we_can_convert_between_smallint_owned_column_and_array_ref_impl(data: Vec<i16>) {
+    we_can_convert_between_owned_column_and_array_ref_impl(
+        &OwnedColumn::<TestScalar>::SmallInt(data.clone()),
+        Arc::new(Int16Array::from(data)),
+    );
+}
+fn we_can_convert_between_int_owned_column_and_array_ref_impl(data: Vec<i32>) {
+    we_can_convert_between_owned_column_and_array_ref_impl(
+        &OwnedColumn::<TestScalar>::Int(data.clone()),
+        Arc::new(Int32Array::from(data)),
+    );
+}
 fn we_can_convert_between_bigint_owned_column_and_array_ref_impl(data: Vec<i64>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
         &OwnedColumn::<TestScalar>::BigInt(data.clone()),
@@ -67,11 +91,23 @@ fn we_can_convert_between_varchar_owned_column_and_array_ref_impl(data: Vec<Stri
 #[test]
 fn we_can_convert_between_owned_column_and_array_ref() {
     we_can_convert_between_boolean_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_uint8_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_tinyint_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_smallint_owned_column_and_array_ref_impl(vec![]);
+    we_can_convert_between_int_owned_column_and_array_ref_impl(vec![]);
     we_can_convert_between_bigint_owned_column_and_array_ref_impl(vec![]);
     we_can_convert_between_int128_owned_column_and_array_ref_impl(vec![]);
     we_can_convert_between_varchar_owned_column_and_array_ref_impl(vec![]);
     let data = vec![true, false, true, false, true, false, true, false, true];
     we_can_convert_between_boolean_owned_column_and_array_ref_impl(data);
+    let data = vec![0, 1, 2, 3, 4, 5, 6, u8::MIN, u8::MAX];
+    we_can_convert_between_uint8_owned_column_and_array_ref_impl(data);
+    let data = vec![0, 1, 2, 3, 4, 5, 6, i8::MIN, i8::MAX];
+    we_can_convert_between_tinyint_owned_column_and_array_ref_impl(data);
+    let data = vec![0, 1, 2, 3, 4, 5, 6, i16::MIN, i16::MAX];
+    we_can_convert_between_smallint_owned_column_and_array_ref_impl(data);
+    let data = vec![0, 1, 2, 3, 4, 5, 6, i32::MIN, i32::MAX];
+    we_can_convert_between_int_owned_column_and_array_ref_impl(data);
     let data = vec![0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX];
     we_can_convert_between_bigint_owned_column_and_array_ref_impl(data);
     let data = vec![0, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX];
@@ -119,6 +155,10 @@ fn we_can_convert_between_owned_table_and_record_batch() {
     );
 
     let schema = Arc::new(Schema::new(vec![
+        Field::new("uint8", DataType::UInt8, false),
+        Field::new("int8", DataType::Int8, false),
+        Field::new("int16", DataType::Int16, false),
+        Field::new("int32", DataType::Int32, false),
         Field::new("int64", DataType::Int64, false),
         Field::new("int128", DataType::Decimal128(38, 0), false),
         Field::new("string", DataType::Utf8, false),
@@ -128,6 +168,10 @@ fn we_can_convert_between_owned_table_and_record_batch() {
     let batch1 = RecordBatch::try_new(
         schema.clone(),
         vec![
+            Arc::new(UInt8Array::from(Vec::<u8>::new())),
+            Arc::new(Int8Array::from(Vec::<i8>::new())),
+            Arc::new(Int16Array::from(Vec::<i16>::new())),
+            Arc::new(Int32Array::from(Vec::<i32>::new())),
             Arc::new(Int64Array::from(vec![0_i64; 0])),
             Arc::new(
                 Decimal128Array::from(vec![0_i128; 0])
@@ -142,6 +186,10 @@ fn we_can_convert_between_owned_table_and_record_batch() {
 
     we_can_convert_between_owned_table_and_record_batch_impl(
         &owned_table([
+            uint8("uint8", [0_u8; 0]),
+            tinyint("int8", [0_i8; 0]),
+            smallint("int16", [0_i16; 0]),
+            int("int32", [0_i32; 0]),
             bigint("int64", [0; 0]),
             int128("int128", [0; 0]),
             varchar("string", ["0"; 0]),
@@ -153,6 +201,40 @@ fn we_can_convert_between_owned_table_and_record_batch() {
     let batch2 = RecordBatch::try_new(
         schema.clone(),
         vec![
+            Arc::new(UInt8Array::from(vec![
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                u8::MIN,
+                u8::MAX,
+            ])),
+            Arc::new(Int8Array::from(vec![0, 1, 2, 3, 4, 5, 6, i8::MIN, i8::MAX])),
+            Arc::new(Int16Array::from(vec![
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                i16::MIN,
+                i16::MAX,
+            ])),
+            Arc::new(Int32Array::from(vec![
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                i32::MIN,
+                i32::MAX,
+            ])),
             Arc::new(Int64Array::from(vec![
                 0,
                 1,
@@ -181,6 +263,10 @@ fn we_can_convert_between_owned_table_and_record_batch() {
 
     we_can_convert_between_owned_table_and_record_batch_impl(
         &owned_table([
+            uint8("uint8", [0, 1, 2, 3, 4, 5, 6, u8::MIN, u8::MAX]),
+            tinyint("int8", [0, 1, 2, 3, 4, 5, 6, i8::MIN, i8::MAX]),
+            smallint("int16", [0, 1, 2, 3, 4, 5, 6, i16::MIN, i16::MAX]),
+            int("int32", [0, 1, 2, 3, 4, 5, 6, i32::MIN, i32::MAX]),
             bigint("int64", [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]),
             int128("int128", [0, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX]),
             varchar("string", ["0", "1", "2", "3", "4", "5", "6", "7", "8"]),

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -106,11 +106,52 @@ mod tests {
         commitment::naive_commitment::NaiveCommitment, scalar::test_scalar::TestScalar,
     };
     use arrow::{
-        array::{Int64Array, StringArray},
+        array::{Int16Array, Int32Array, Int64Array, Int8Array, StringArray, UInt8Array},
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
     use std::sync::Arc;
+
+    #[test]
+    fn we_can_convert_record_batch_to_integer_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("uint8_column", DataType::UInt8, false),
+            Field::new("tinyint_column", DataType::Int8, false),
+            Field::new("smallint_column", DataType::Int16, false),
+            Field::new("int_column", DataType::Int32, false),
+            Field::new("bigint_column", DataType::Int64, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(UInt8Array::from(vec![1, 2, 255])),
+                Arc::new(Int8Array::from(vec![-128, 0, 127])),
+                Arc::new(Int16Array::from(vec![-32_768, 0, 32_767])),
+                Arc::new(Int32Array::from(vec![-2_147_483_648, 0, 2_147_483_647])),
+                Arc::new(Int64Array::from(vec![i64::MIN, 0, i64::MAX])),
+            ],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+
+        let columns = batch_to_columns::<TestScalar>(&batch, &alloc).unwrap();
+
+        assert_eq!(columns.len(), 5);
+        assert_eq!(columns[0].0.value.as_str(), "uint8_column");
+        assert_eq!(columns[0].1, Column::Uint8(&[1, 2, 255]));
+        assert_eq!(columns[1].0.value.as_str(), "tinyint_column");
+        assert_eq!(columns[1].1, Column::TinyInt(&[-128, 0, 127]));
+        assert_eq!(columns[2].0.value.as_str(), "smallint_column");
+        assert_eq!(columns[2].1, Column::SmallInt(&[-32_768, 0, 32_767]));
+        assert_eq!(columns[3].0.value.as_str(), "int_column");
+        assert_eq!(
+            columns[3].1,
+            Column::Int(&[-2_147_483_648, 0, 2_147_483_647])
+        );
+        assert_eq!(columns[4].0.value.as_str(), "bigint_column");
+        assert_eq!(columns[4].1, Column::BigInt(&[i64::MIN, 0, i64::MAX]));
+    }
 
     #[test]
     fn we_can_create_and_append_table_commitments_with_record_batches() {

--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -29,3 +29,52 @@ pub enum AppendRecordBatchTableCommitmentError {
         source: RecordBatchToColumnsError,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_record_batch_to_columns_errors() {
+        let err = RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+            source: ArrowArrayToColumnConversionError::ArrayContainsNulls,
+        };
+
+        assert_eq!(err.to_string(), "arrow array must not contain nulls");
+    }
+
+    #[test]
+    fn we_can_display_record_batch_index_errors() {
+        let err = RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+            source: ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 3 },
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "index out of bounds: the len is 2 but the index is 3"
+        );
+    }
+
+    #[test]
+    fn we_can_display_append_record_batch_errors() {
+        let err = AppendRecordBatchTableCommitmentError::ArrowBatchToColumnError {
+            source: RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                source: ArrowArrayToColumnConversionError::ArrayContainsNulls,
+            },
+        };
+
+        assert_eq!(err.to_string(), "arrow array must not contain nulls");
+    }
+
+    #[test]
+    fn we_can_display_append_record_batch_metadata_mismatches() {
+        let err = AppendRecordBatchTableCommitmentError::ColumnCommitmentsMismatch {
+            source: ColumnCommitmentsMismatch::NumColumns,
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "commitments with different column counts cannot operate with each other"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -170,3 +170,22 @@ impl BitDistribution {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::BitDistribution;
+    use alloc::{vec, vec::Vec};
+
+    #[test]
+    fn we_iterate_varying_bits_across_all_limbs() {
+        let bit_distribution = BitDistribution {
+            vary_mask: [1, 1 << 1, 1 << 2, 1 << 3],
+            leading_bit_mask: [0; 4],
+        };
+
+        assert_eq!(
+            bit_distribution.vary_mask_iter().collect::<Vec<_>>(),
+            vec![0, 65, 130, 195]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::base::{
+    proof::ProofError,
     scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
     try_standard_binary_deserialization, try_standard_binary_serialization,
 };
@@ -391,6 +392,36 @@ fn we_can_detect_invalid_bit_distributions() {
         leading_bit_mask: [1, 0, 0, 0],
     };
     assert!(!dist.is_valid());
+}
+
+#[test]
+fn we_can_iterate_vary_mask_bits_across_limbs_in_order() {
+    let dist = BitDistribution {
+        vary_mask: [1, 1 << 1, 1 << 2, 1 << 63],
+        leading_bit_mask: [0; 4],
+    };
+
+    let varying_bits: Vec<_> = dist.vary_mask_iter().collect();
+
+    assert_eq!(varying_bits, [0, 65, 130, 255]);
+}
+
+#[test]
+fn verification_bit_distribution_error_converts_to_proof_error() {
+    let proof_error = ProofError::from(BitDistributionError::Verification);
+
+    assert!(matches!(
+        proof_error,
+        ProofError::VerificationError {
+            error: "invalid bit_decomposition"
+        }
+    ));
+}
+
+#[test]
+#[should_panic(expected = "No lead bit available despite variable lead bit.")]
+fn no_lead_bit_distribution_error_panics_when_converted() {
+    let _ = ProofError::from(BitDistributionError::NoLeadBit);
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
@@ -19,3 +19,19 @@ pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
 pub fn is_bit_mask_negative_representation(bit_mask: U256) -> bool {
     bit_mask & MSB_MASK == U256::ZERO
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{is_bit_mask_negative_representation, make_bit_mask};
+    use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+
+    #[test]
+    fn we_can_classify_signed_boundary_bit_masks() {
+        assert!(!is_bit_mask_negative_representation(make_bit_mask(
+            TestScalar::MAX_SIGNED
+        )));
+        assert!(is_bit_mask_negative_representation(make_bit_mask(
+            TestScalar::MAX_SIGNED + TestScalar::ONE
+        )));
+    }
+}

--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils_test.rs
@@ -1,7 +1,7 @@
 use super::bit_mask_utils::make_bit_mask;
 use crate::base::{
     bit::bit_mask_utils::is_bit_mask_negative_representation,
-    scalar::{test_scalar::TestScalar, Scalar},
+    scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
 };
 use bnum::types::U256;
 use core::ops::Shl;
@@ -28,6 +28,25 @@ fn we_can_make_negative_bit_mask() {
 
     // ASSERT
     assert_eq!(bit_mask, (U256::ONE.shl(255)) - U256::TWO);
+}
+
+#[test]
+fn we_can_make_zero_bit_mask() {
+    let bit_mask = make_bit_mask(TestScalar::ZERO);
+
+    assert_eq!(bit_mask, U256::ONE.shl(255));
+    assert!(!is_bit_mask_negative_representation(bit_mask));
+}
+
+#[test]
+fn we_can_make_max_signed_bit_mask() {
+    let bit_mask = make_bit_mask(TestScalar::MAX_SIGNED);
+
+    assert_eq!(
+        bit_mask,
+        (U256::ONE.shl(255)) + TestScalar::MAX_SIGNED.into_u256_wrapping()
+    );
+    assert!(!is_bit_mask_negative_representation(bit_mask));
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/byte/byte_distribution.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_distribution.rs
@@ -73,7 +73,10 @@ impl ByteDistribution {
 #[cfg(test)]
 mod tests {
     use super::ByteDistribution;
-    use crate::base::scalar::{test_scalar::TestScalar, ScalarExt};
+    use crate::base::{
+        scalar::{test_scalar::TestScalar, ScalarExt},
+        try_standard_binary_deserialization, try_standard_binary_serialization,
+    };
     use bnum::types::U256;
     use core::ops::{Neg, Shl, Shr};
     use itertools::Itertools;
@@ -256,5 +259,20 @@ mod tests {
             byte_distribution.varying_byte_indices().collect_vec(),
             (0u8..32).map(|i| i * 8).collect_vec()
         );
+    }
+
+    #[test]
+    fn we_can_serialize_byte_distribution_round_trip() {
+        let byte_distribution = ByteDistribution {
+            vary_mask: 0b101,
+            constant_mask: U256::from(149u8).shl(8_u32).into(),
+        };
+
+        let serialized = try_standard_binary_serialization(byte_distribution.clone()).unwrap();
+        let deserialized: ByteDistribution =
+            try_standard_binary_deserialization(&serialized).unwrap().0;
+
+        assert_eq!(deserialized, byte_distribution);
+        assert_eq!(deserialized.varying_byte_indices().collect_vec(), [0, 16]);
     }
 }

--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -54,6 +54,32 @@ mod tests {
     }
 
     #[test]
+    fn we_can_compute_varying_byte_matrix_for_empty_scalars() {
+        let alloc = Bump::new();
+        let scalars: Vec<TestScalar> = Vec::new();
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert!(varying_columns.is_empty());
+        assert_eq!(byte_distribution, expected_byte_distribution);
+    }
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_constant_scalars() {
+        let alloc = Bump::new();
+        let scalars = vec![TestScalar::from(0x1122u64); 4];
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert!(varying_columns.is_empty());
+        assert_eq!(byte_distribution, expected_byte_distribution);
+    }
+
+    #[test]
     fn we_can_compute_varying_byte_matrix_for_large_scalars() {
         let alloc = Bump::new();
         let scalars = vec![

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -586,6 +586,35 @@ mod tests {
     }
 
     #[test]
+    fn we_can_handle_uint8_column_bounds() {
+        let empty_column = OwnedColumn::<TestScalar>::Uint8(vec![]);
+        assert_eq!(
+            ColumnBounds::from_column(&CommittableColumn::from(&empty_column)),
+            ColumnBounds::Uint8(Bounds::Empty)
+        );
+
+        let column = OwnedColumn::<TestScalar>::Uint8(vec![3, 1, 2, 1]);
+        assert_eq!(
+            ColumnBounds::from_column(&CommittableColumn::from(&column)),
+            ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 3 }))
+        );
+
+        let bounds_a = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
+        let bounds_b = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 5, max: 8 }));
+        assert_eq!(
+            bounds_a.try_union(bounds_b).unwrap(),
+            ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 8 }))
+        );
+        assert_eq!(bounds_a.try_difference(bounds_b).unwrap(), bounds_a);
+
+        let overlapping = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 2, max: 4 }));
+        assert_eq!(
+            bounds_a.try_difference(overlapping).unwrap(),
+            ColumnBounds::Uint8(Bounds::Bounded(BoundsInner { min: 1, max: 3 }))
+        );
+    }
+
+    #[test]
     fn we_can_union_column_bounds_with_matching_variant() {
         let no_order = ColumnBounds::NoOrder;
         assert_eq!(no_order.try_union(no_order).unwrap(), no_order);

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -74,6 +74,14 @@ impl ColumnCommitmentMetadata {
     #[must_use]
     pub fn from_column_type_with_max_bounds(column_type: ColumnType) -> Self {
         let bounds = match column_type {
+            ColumnType::Uint8 => ColumnBounds::Uint8(super::Bounds::Bounded(
+                BoundsInner::try_new(u8::MIN, u8::MAX)
+                    .expect("u8::MIN and u8::MAX are valid bounds for Uint8"),
+            )),
+            ColumnType::TinyInt => ColumnBounds::TinyInt(super::Bounds::Bounded(
+                BoundsInner::try_new(i8::MIN, i8::MAX)
+                    .expect("i8::MIN and i8::MAX are valid bounds for TinyInt"),
+            )),
             ColumnType::SmallInt => ColumnBounds::SmallInt(super::Bounds::Bounded(
                 BoundsInner::try_new(i16::MIN, i16::MAX)
                     .expect("i16::MIN and i16::MAX are valid bounds for SmallInt"),
@@ -196,6 +204,18 @@ mod tests {
     fn we_can_construct_metadata() {
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
+                ColumnType::Uint8,
+                ColumnBounds::Uint8(Bounds::Empty)
+            )
+            .unwrap(),
+            ColumnCommitmentMetadata {
+                column_type: ColumnType::Uint8,
+                bounds: ColumnBounds::Uint8(Bounds::Empty)
+            }
+        );
+
+        assert_eq!(
+            ColumnCommitmentMetadata::try_new(
                 ColumnType::TinyInt,
                 ColumnBounds::TinyInt(Bounds::Empty)
             )
@@ -293,7 +313,33 @@ mod tests {
     }
 
     #[test]
+    fn we_can_construct_byte_integer_metadata_with_max_bounds() {
+        let uint8_metadata =
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::Uint8);
+
+        assert_eq!(uint8_metadata.column_type(), &ColumnType::Uint8);
+        assert_eq!(
+            uint8_metadata.bounds(),
+            &ColumnBounds::Uint8(Bounds::bounded(u8::MIN, u8::MAX).unwrap())
+        );
+
+        let tinyint_metadata =
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::TinyInt);
+
+        assert_eq!(tinyint_metadata.column_type(), &ColumnType::TinyInt);
+        assert_eq!(
+            tinyint_metadata.bounds(),
+            &ColumnBounds::TinyInt(Bounds::bounded(i8::MIN, i8::MAX).unwrap())
+        );
+    }
+
+    #[test]
     fn we_cannot_construct_metadata_with_type_bounds_mismatch() {
+        assert!(matches!(
+            ColumnCommitmentMetadata::try_new(ColumnType::Uint8, ColumnBounds::NoOrder),
+            Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
+        ));
+
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
                 ColumnType::Boolean,

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -208,6 +208,34 @@ mod tests {
     }
 
     #[test]
+    fn we_can_construct_metadata_map_with_max_byte_integer_bounds() {
+        let uint8_ident: Ident = "uint8_column".into();
+        let tinyint_ident: Ident = "tinyint_column".into();
+        let column_fields = [
+            ColumnField::new(uint8_ident.clone(), ColumnType::Uint8),
+            ColumnField::new(tinyint_ident.clone(), ColumnType::TinyInt),
+        ];
+
+        let metadata_map =
+            ColumnCommitmentMetadataMap::from_column_fields_with_max_bounds(&column_fields);
+        let uint8_metadata = metadata_map.get(&uint8_ident).unwrap();
+
+        assert_eq!(uint8_metadata.column_type(), &ColumnType::Uint8);
+        assert_eq!(
+            uint8_metadata.bounds(),
+            &ColumnBounds::Uint8(Bounds::bounded(u8::MIN, u8::MAX).unwrap())
+        );
+
+        let tinyint_metadata = metadata_map.get(&tinyint_ident).unwrap();
+
+        assert_eq!(tinyint_metadata.column_type(), &ColumnType::TinyInt);
+        assert_eq!(
+            tinyint_metadata.bounds(),
+            &ColumnBounds::TinyInt(Bounds::bounded(i8::MIN, i8::MAX).unwrap())
+        );
+    }
+
+    #[test]
     fn we_can_union_matching_metadata_maps() {
         let table_a = owned_table([
             bigint("bigint_column", [1, 5]),

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -353,10 +353,77 @@ impl<C> FromIterator<(Ident, ColumnCommitmentMetadata, C)> for ColumnCommitments
 mod tests {
     use super::*;
     use crate::base::{
-        commitment::{column_bounds::Bounds, naive_commitment::NaiveCommitment, ColumnBounds},
-        database::{owned_table_utility::*, ColumnType, OwnedColumn, OwnedTable},
+        commitment::{
+            column_bounds::Bounds, naive_commitment::NaiveCommitment,
+            naive_evaluation_proof::NaiveEvaluationProof, ColumnBounds,
+        },
+        database::{
+            owned_table_utility::*, ColumnType, OwnedColumn, OwnedTable, OwnedTableTestAccessor,
+        },
         scalar::test_scalar::TestScalar,
     };
+
+    #[test]
+    fn we_can_construct_column_commitments_from_accessor_with_max_bounds() {
+        let table_ref = TableRef::new("sxt", "events");
+        let uint8_id: Ident = "uint8_column".into();
+        let bigint_id: Ident = "bigint_column".into();
+        let missing_id: Ident = "missing_column".into();
+        let owned_table: OwnedTable<TestScalar> = owned_table([
+            uint8(uint8_id.value.as_str(), [1u8, 7, 255]),
+            bigint(bigint_id.value.as_str(), [-2, 0, 3]),
+        ]);
+
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            owned_table.clone(),
+            4,
+            (),
+        );
+        let column_fields = [
+            ColumnField::new(uint8_id.clone(), ColumnType::Uint8),
+            ColumnField::new(bigint_id.clone(), ColumnType::BigInt),
+        ];
+
+        let column_commitments =
+            ColumnCommitments::<NaiveCommitment>::from_accessor_with_max_bounds(
+                &table_ref,
+                &column_fields,
+                &accessor,
+            );
+
+        let expected_commitments = Vec::<NaiveCommitment>::from_columns_with_offset(
+            [
+                owned_table.inner_table().get(&uint8_id).unwrap(),
+                owned_table.inner_table().get(&bigint_id).unwrap(),
+            ],
+            4,
+            &(),
+        );
+        assert_eq!(column_commitments.commitments(), &expected_commitments);
+        assert_eq!(
+            column_commitments.get_commitment(&uint8_id).unwrap(),
+            expected_commitments[0]
+        );
+        assert_eq!(
+            column_commitments.get_commitment(&bigint_id).unwrap(),
+            expected_commitments[1]
+        );
+        assert!(column_commitments.get_commitment(&missing_id).is_none());
+        assert!(column_commitments.get_metadata(&missing_id).is_none());
+
+        assert_eq!(
+            column_commitments.get_metadata(&uint8_id).unwrap().bounds(),
+            &ColumnBounds::Uint8(Bounds::bounded(u8::MIN, u8::MAX).unwrap())
+        );
+        assert_eq!(
+            column_commitments
+                .get_metadata(&bigint_id)
+                .unwrap()
+                .bounds(),
+            &ColumnBounds::BigInt(Bounds::bounded(i64::MIN, i64::MAX).unwrap())
+        );
+    }
 
     #[test]
     fn we_can_construct_column_commitments_from_columns_and_identifiers() {

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -223,6 +223,52 @@ fn we_can_compute_commitments_from_committable_varbinary_column_with_offset() {
     assert_eq!(commitments[0].0, expected);
 }
 
+#[test]
+fn we_can_compute_commitments_from_remaining_committable_column_variants() {
+    let decimal_values = vec![[3_u64, 0, 0, 0], [4, 0, 0, 0]];
+    let scalar_values = vec![[5_u64, 0, 0, 0], [6, 0, 0, 0]];
+    let columns = [
+        CommittableColumn::Boolean(&[true, false]),
+        CommittableColumn::Uint8(&[7, 8]),
+        CommittableColumn::TinyInt(&[-2, 3]),
+        CommittableColumn::SmallInt(&[-4, 5]),
+        CommittableColumn::Int(&[-6, 7]),
+        CommittableColumn::Int128(&[-8, 9]),
+        CommittableColumn::Decimal75(
+            crate::base::math::decimal::Precision::new(75).unwrap(),
+            0,
+            decimal_values,
+        ),
+        CommittableColumn::Scalar(scalar_values),
+        CommittableColumn::TimestampTZ(
+            crate::base::posql_time::PoSQLTimeUnit::Second,
+            crate::base::posql_time::PoSQLTimeZone::utc(),
+            &[10, 11],
+        ),
+    ];
+
+    let commitments = NaiveCommitment::compute_commitments(&columns, 0, &());
+
+    assert_eq!(
+        commitments[0].0,
+        vec![TestScalar::from(1), TestScalar::ZERO]
+    );
+    assert_eq!(commitments[1].0, vec![7.into(), 8.into()]);
+    assert_eq!(commitments[2].0, vec![(-2).into(), 3.into()]);
+    assert_eq!(commitments[3].0, vec![(-4).into(), 5.into()]);
+    assert_eq!(commitments[4].0, vec![(-6).into(), 7.into()]);
+    assert_eq!(commitments[5].0, vec![(-8).into(), 9.into()]);
+    assert_eq!(
+        commitments[6].0,
+        vec![[3, 0, 0, 0].into(), [4, 0, 0, 0].into()]
+    );
+    assert_eq!(
+        commitments[7].0,
+        vec![[5, 0, 0, 0].into(), [6, 0, 0, 0].into()]
+    );
+    assert_eq!(commitments[8].0, vec![10.into(), 11.into()]);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/proof-of-sql/src/base/commitment/naive_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_evaluation_proof.rs
@@ -103,10 +103,56 @@ impl CommitmentEvaluationProof for NaiveEvaluationProof {
 
 mod tests {
     use super::NaiveEvaluationProof;
-    use crate::base::commitment::commitment_evaluation_proof_test::{
-        test_commitment_evaluation_proof_with_length_1, test_random_commitment_evaluation_proof,
-        test_simple_commitment_evaluation_proof,
+    use crate::base::{
+        commitment::{
+            commitment_evaluation_proof_test::{
+                test_commitment_evaluation_proof_with_length_1,
+                test_random_commitment_evaluation_proof, test_simple_commitment_evaluation_proof,
+            },
+            naive_commitment::NaiveCommitment,
+            CommitmentEvaluationProof,
+        },
+        scalar::{test_scalar::TestScalar, Scalar},
     };
+    use merlin::Transcript;
+
+    #[test]
+    fn verify_proof_rejects_wrong_point_and_commitment() {
+        let a = [TestScalar::ONE, TestScalar::from(2)];
+        let b_point = [TestScalar::ZERO];
+        let product = TestScalar::ONE;
+        let commit = NaiveCommitment(a.to_vec());
+
+        let mut transcript = Transcript::new(b"evaluation_proof");
+        let proof = NaiveEvaluationProof::new(&mut transcript, &a, &b_point, 0, &());
+
+        let mut transcript = Transcript::new(b"evaluation_proof");
+        assert!(proof
+            .verify_proof(
+                &mut transcript,
+                &commit,
+                &product,
+                &[TestScalar::ONE],
+                0,
+                a.len(),
+                &(),
+            )
+            .is_err());
+
+        let wrong_commit = NaiveCommitment(vec![TestScalar::from(5), TestScalar::from(6)]);
+        let mut transcript = Transcript::new(b"evaluation_proof");
+        assert!(proof
+            .verify_proof(
+                &mut transcript,
+                &wrong_commit,
+                &product,
+                &b_point,
+                0,
+                a.len(),
+                &(),
+            )
+            .is_err());
+    }
 
     #[test]
     fn test_simple_ipa() {

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -217,6 +217,54 @@ mod tests {
     }
 
     #[test]
+    fn we_can_convert_from_committable_columns() {
+        let committable_columns = [
+            CommittableColumn::BigInt(&[12i64, 34, 56]),
+            CommittableColumn::VarChar(
+                ["Lorem", "ipsum", "dolor"]
+                    .into_iter()
+                    .map(TestScalar::from)
+                    .map(<[u64; 4]>::from)
+                    .collect(),
+            ),
+        ];
+
+        let commitments = Vec::<NaiveCommitment>::from_committable_columns_with_offset(
+            &committable_columns,
+            1,
+            &(),
+        );
+
+        let expected_commitments =
+            NaiveCommitment::compute_commitments(&committable_columns, 1, &());
+        assert_eq!(commitments, expected_commitments);
+    }
+
+    #[test]
+    fn we_can_convert_from_columns_with_non_zero_offset() {
+        let columns = vec![
+            OwnedColumn::<TestScalar>::BigInt(vec![12i64, 34, 56]),
+            OwnedColumn::VarChar(["Lorem", "ipsum", "dolor"].map(String::from).to_vec()),
+        ];
+
+        let commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 5, &());
+
+        let committable_columns = [
+            CommittableColumn::BigInt(&[12i64, 34, 56]),
+            CommittableColumn::VarChar(
+                ["Lorem", "ipsum", "dolor"]
+                    .into_iter()
+                    .map(TestScalar::from)
+                    .map(<[u64; 4]>::from)
+                    .collect(),
+            ),
+        ];
+        let expected_commitments =
+            NaiveCommitment::compute_commitments(&committable_columns, 5, &());
+        assert_eq!(commitments, expected_commitments);
+    }
+
+    #[test]
     fn we_can_append_rows() {
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
@@ -288,6 +336,16 @@ mod tests {
     }
 
     #[test]
+    fn we_can_append_zero_columns_to_empty_commitments() {
+        let empty: Vec<Column<TestScalar>> = Vec::new();
+        let mut commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&empty, 0, &());
+        commitments
+            .try_append_rows_with_offset(&empty, 10, &())
+            .unwrap();
+        assert!(commitments.is_empty());
+    }
+
+    #[test]
     fn we_can_extend_columns() {
         let column_a = [12i64, 34, 56];
         let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
@@ -340,6 +398,60 @@ mod tests {
         ];
         let expected_commitments =
             NaiveCommitment::compute_commitments(&committable_columns, 0, &());
+
+        assert_eq!(commitments, expected_commitments);
+    }
+
+    #[test]
+    fn we_can_extend_columns_with_offset() {
+        let columns = vec![
+            OwnedColumn::<TestScalar>::BigInt(vec![12i64, 34, 56]),
+            OwnedColumn::VarChar(["Lorem", "ipsum", "dolor"].map(String::from).to_vec()),
+        ];
+
+        let mut commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
+
+        let new_columns = vec![
+            OwnedColumn::<TestScalar>::VarChar(
+                ["sit", "amet", "consectetur"].map(String::from).to_vec(),
+            ),
+            OwnedColumn::BigInt(vec![78i64, 90, 1112]),
+        ];
+
+        commitments.extend_columns_with_offset(&new_columns, 2, &());
+
+        let existing_commitments = NaiveCommitment::compute_commitments(
+            &[
+                CommittableColumn::BigInt(&[12i64, 34, 56]),
+                CommittableColumn::VarChar(
+                    ["Lorem", "ipsum", "dolor"]
+                        .into_iter()
+                        .map(TestScalar::from)
+                        .map(<[u64; 4]>::from)
+                        .collect(),
+                ),
+            ],
+            0,
+            &(),
+        );
+
+        let new_commitments = NaiveCommitment::compute_commitments(
+            &[
+                CommittableColumn::VarChar(
+                    ["sit", "amet", "consectetur"]
+                        .into_iter()
+                        .map(TestScalar::from)
+                        .map(<[u64; 4]>::from)
+                        .collect(),
+                ),
+                CommittableColumn::BigInt(&[78i64, 90, 1112]),
+            ],
+            2,
+            &(),
+        );
+
+        let mut expected_commitments = existing_commitments;
+        expected_commitments.extend(new_commitments);
 
         assert_eq!(commitments, expected_commitments);
     }
@@ -498,5 +610,79 @@ mod tests {
             full_commitments.try_sub(commitments),
             Err(NumColumnsMismatch)
         ));
+    }
+
+    #[test]
+    fn we_can_append_zero_columns_to_non_empty_commitments() {
+        let column_a = [12i64, 34, 56];
+        let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
+
+        let columns = vec![
+            OwnedColumn::<TestScalar>::BigInt(column_a.to_vec()),
+            OwnedColumn::VarChar(column_b.to_vec()),
+        ];
+
+        let existing = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
+        let mut commitments = existing.clone();
+
+        let new_columns: Vec<Column<TestScalar>> = Vec::new();
+        commitments.extend_columns_with_offset(&new_columns, 3, &());
+
+        assert_eq!(commitments, existing);
+    }
+
+    #[test]
+    fn we_cannot_append_rows_with_columns_to_empty_commitments() {
+        let new_columns = vec![
+            OwnedColumn::<TestScalar>::BigInt(vec![12i64, 34]),
+            OwnedColumn::VarChar(["Lorem", "ipsum"].map(String::from).to_vec()),
+        ];
+
+        let mut commitments = Vec::<NaiveCommitment>::new();
+        assert!(matches!(
+            commitments.try_append_rows_with_offset(&new_columns, 0, &()),
+            Err(NumColumnsMismatch)
+        ));
+    }
+
+    #[test]
+    fn we_can_add_and_sub_empty_commitment_collections() {
+        let commitments_a: Vec<NaiveCommitment> = Vec::new();
+        let commitments_b: Vec<NaiveCommitment> = Vec::new();
+
+        let added = commitments_a
+            .clone()
+            .try_add(commitments_b.clone())
+            .unwrap();
+        assert_eq!(added, Vec::<NaiveCommitment>::new());
+
+        let subtracted = commitments_a.try_sub(commitments_b).unwrap();
+        assert_eq!(subtracted, Vec::<NaiveCommitment>::new());
+    }
+
+    #[test]
+    fn we_can_report_num_commitments() {
+        let empty: Vec<NaiveCommitment> = Vec::new();
+        assert_eq!(empty.num_commitments(), 0);
+
+        let column_a = [12i64, 34, 56];
+        let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
+
+        let columns = vec![
+            OwnedColumn::<TestScalar>::BigInt(column_a.to_vec()),
+            OwnedColumn::VarChar(column_b.to_vec()),
+        ];
+
+        let commitments = Vec::<NaiveCommitment>::from_columns_with_offset(&columns, 0, &());
+        assert_eq!(commitments.num_commitments(), 2);
+    }
+
+    #[test]
+    fn num_columns_mismatch_displays_expected_message() {
+        let mismatch = NumColumnsMismatch;
+        assert_eq!(
+            mismatch.to_string(),
+            "cannot update commitment collections with different column counts"
+        );
     }
 }

--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,53 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_convert_arrow_float_fields_to_posql_decimal_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("float16_col", DataType::Float16, false),
+            Field::new("float32_col", DataType::Float32, true),
+            Field::new("float64_col", DataType::Float64, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(
+            converted
+                .fields()
+                .iter()
+                .map(|field| field.data_type())
+                .collect::<Vec<_>>(),
+            vec![
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+            ]
+        );
+        assert!(!converted.field(0).is_nullable());
+        assert!(converted.field(1).is_nullable());
+        assert!(!converted.field(2).is_nullable());
+    }
+
+    #[test]
+    fn we_keep_non_float_arrow_fields_unchanged() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("payload", DataType::Utf8, true),
+            Field::new("amount", DataType::Decimal128(12, 2), false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(converted.field(0).data_type(), &DataType::Int64);
+        assert_eq!(converted.field(1).data_type(), &DataType::Utf8);
+        assert_eq!(converted.field(2).data_type(), &DataType::Decimal128(12, 2));
+        assert_eq!(converted.field(0).name(), "id");
+        assert_eq!(converted.field(1).name(), "payload");
+        assert_eq!(converted.field(2).name(), "amount");
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,27 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_field_accessors_return_constructor_values() {
+        let field = ColumnField::new("amount".into(), ColumnType::BigInt);
+
+        assert_eq!(field.name().value, "amount");
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_field_serializes_and_deserializes() {
+        let field = ColumnField::new("amount".into(), ColumnType::BigInt);
+
+        let serialized = serde_json::to_string(&field).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ColumnField>(&serialized).unwrap(),
+            field
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,101 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::math::decimal::DecimalError;
+    use alloc::string::ToString;
+
+    #[test]
+    fn column_operation_errors_display_expected_messages() {
+        assert_eq!(
+            ColumnOperationError::DifferentColumnLength { len_a: 2, len_b: 3 }.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+        assert_eq!(
+            ColumnOperationError::BinaryOperationInvalidColumnType {
+                operator: "add".to_string(),
+                left_type: ColumnType::Boolean,
+                right_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            r#""add"(lhs: Boolean, rhs: BigInt) is not supported"#
+        );
+        assert_eq!(
+            ColumnOperationError::UnaryOperationInvalidColumnType {
+                operator: "negation".to_string(),
+                operand_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            r#""negation"(operand: VarChar) is not supported"#
+        );
+        assert_eq!(
+            ColumnOperationError::IntegerOverflow {
+                error: "i64 overflow".to_string(),
+            }
+            .to_string(),
+            "Overflow in integer operation: i64 overflow"
+        );
+        assert_eq!(
+            ColumnOperationError::DivisionByZero.to_string(),
+            "Division by zero"
+        );
+        assert_eq!(
+            ColumnOperationError::UnionDifferentTypes {
+                correct_type: ColumnType::Int,
+                actual_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Cannot union columns of different types: Int and VarChar"
+        );
+        assert_eq!(
+            ColumnOperationError::IndexOutOfBounds { index: 5, len: 3 }.to_string(),
+            "Index out of bounds: 5 >= 3"
+        );
+    }
+
+    #[test]
+    fn column_operation_casting_errors_display_column_types() {
+        let expected = "Cannot fit TINYINT into UINT8 without losing data";
+
+        assert_eq!(
+            ColumnOperationError::SignedCastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            expected
+        );
+        assert_eq!(
+            ColumnOperationError::CastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            expected
+        );
+        assert_eq!(
+            ColumnOperationError::ScaleCastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            expected
+        );
+    }
+
+    #[test]
+    fn column_operation_errors_transparently_wrap_decimal_errors() {
+        assert_eq!(
+            ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidScale {
+                    scale: "76".to_string(),
+                },
+            }
+            .to_string(),
+            "Decimal scale is not valid: 76"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,33 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_ref_accessors_return_constructor_values() {
+        let table_ref = TableRef::from_names(Some("analytics"), "blocks");
+        let column_ref = ColumnRef::new(table_ref.clone(), "height".into(), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id().value, "height");
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_ref_serializes_and_deserializes() {
+        let column_ref = ColumnRef::new(
+            TableRef::from_names(Some("analytics"), "blocks"),
+            "height".into(),
+            ColumnType::BigInt,
+        );
+
+        let serialized = serde_json::to_string(&column_ref).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ColumnRef>(&serialized).unwrap(),
+            column_ref
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -153,7 +153,11 @@ impl RepetitionOp for ElementwiseRepeatOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::{
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn test_column_repetition_op() {
@@ -267,5 +271,65 @@ mod tests {
             .collect();
         let expected = Column::VarBinary((expected_bytes.as_slice(), expected_scalars.as_slice()));
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_column_repetition_op_remaining_column_types() {
+        let bump = Bump::new();
+
+        let column: Column<TestScalar> = Column::TinyInt(&[-1, 2]);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result.as_tinyint().unwrap(), &[-1, 2, -1, 2]);
+
+        let column: Column<TestScalar> = Column::SmallInt(&[-3, 4]);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result.as_smallint().unwrap(), &[-3, 4, -3, 4]);
+
+        let column: Column<TestScalar> = Column::BigInt(&[5, -6]);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result.as_bigint().unwrap(), &[5, -6, 5, -6]);
+
+        let column: Column<TestScalar> = Column::Int128(&[7, -8]);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result.as_int128().unwrap(), &[7, -8, 7, -8]);
+
+        let scalars = [TestScalar::from(9), TestScalar::from(10)];
+        let column = Column::Scalar(&scalars);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        let expected_scalars = [
+            TestScalar::from(9),
+            TestScalar::from(10),
+            TestScalar::from(9),
+            TestScalar::from(10),
+        ];
+        assert_eq!(result.as_scalar().unwrap(), expected_scalars);
+
+        let precision = Precision::new(6).unwrap();
+        let decimals = [TestScalar::from(1_200), TestScalar::from(-340)];
+        let column = Column::Decimal75(precision, 2, &decimals);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        let expected_decimals = [
+            TestScalar::from(1_200),
+            TestScalar::from(-340),
+            TestScalar::from(1_200),
+            TestScalar::from(-340),
+        ];
+        assert_eq!(result, Column::Decimal75(precision, 2, &expected_decimals));
+
+        let timezone = PoSQLTimeZone::utc();
+        let column = Column::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            timezone,
+            &[1_000, 2_000],
+        );
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(
+            result,
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                timezone,
+                &[1_000, 2_000, 1_000, 2_000],
+            )
+        );
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -54,7 +54,7 @@ pub enum ColumnType {
     #[cfg_attr(test, proptest(skip))]
     Scalar,
     /// Mapped to [u8]
-    #[serde(alias = "BINARY", alias = "BINARY")]
+    #[serde(alias = "BINARY", alias = "binary")]
     VarBinary,
 }
 
@@ -336,6 +336,10 @@ mod tests {
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""VarChar""#);
 
+        let column_type = ColumnType::VarBinary;
+        let serialized = serde_json::to_string(&column_type).unwrap();
+        assert_eq!(serialized, r#""VarBinary""#);
+
         let column_type = ColumnType::Scalar;
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""Scalar""#);
@@ -391,6 +395,10 @@ mod tests {
 
         let expected_column_type = ColumnType::VarChar;
         let deserialized: ColumnType = serde_json::from_str(r#""VarChar""#).unwrap();
+        assert_eq!(deserialized, expected_column_type);
+
+        let expected_column_type = ColumnType::VarBinary;
+        let deserialized: ColumnType = serde_json::from_str(r#""VarBinary""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
         let expected_column_type = ColumnType::Scalar;
@@ -470,6 +478,14 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""varchar""#).unwrap(),
             ColumnType::VarChar
+        );
+        assert_eq!(
+            serde_json::from_str::<ColumnType>(r#""BINARY""#).unwrap(),
+            ColumnType::VarBinary
+        );
+        assert_eq!(
+            serde_json::from_str::<ColumnType>(r#""binary""#).unwrap(),
+            ColumnType::VarBinary
         );
 
         assert_eq!(
@@ -587,6 +603,14 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<ColumnType>(&varchar_json).unwrap(),
             varchar
+        );
+
+        let varbinary = ColumnType::VarBinary;
+        let varbinary_json = serde_json::to_string(&varbinary).unwrap();
+        assert_eq!(varbinary_json, "\"VarBinary\"");
+        assert_eq!(
+            serde_json::from_str::<ColumnType>(&varbinary_json).unwrap(),
+            varbinary
         );
 
         let scalar = ColumnType::Scalar;

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -1401,4 +1401,16 @@ mod test {
             matches!(try_neg_type(ColumnType::VarChar).unwrap_err(), ColumnOperationError::UnaryOperationInvalidColumnType { operator, operand_type } if operator == "negation" && operand_type == ColumnType::VarChar)
         );
     }
+
+    #[test]
+    fn we_can_check_boolean_logical_operator_types() {
+        assert!(can_and_or_types(ColumnType::Boolean, ColumnType::Boolean));
+        assert!(!can_and_or_types(ColumnType::Boolean, ColumnType::Int));
+        assert!(!can_and_or_types(ColumnType::Int, ColumnType::Boolean));
+        assert!(!can_and_or_types(ColumnType::Int, ColumnType::Int));
+
+        assert!(can_not_type(ColumnType::Boolean));
+        assert!(!can_not_type(ColumnType::Int));
+        assert!(!can_not_type(ColumnType::VarChar));
+    }
 }

--- a/crates/proof-of-sql/src/base/database/columnar_value.rs
+++ b/crates/proof-of-sql/src/base/database/columnar_value.rs
@@ -65,7 +65,7 @@ impl<'a, S: Scalar> ColumnarValue<'a, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::scalar::{test_scalar::TestScalar, ScalarExt};
     use core::convert::Into;
 
     #[test]
@@ -97,6 +97,44 @@ mod tests {
         let columnar_value = ColumnarValue::Column(Column::<TestScalar>::SmallInt(&[]));
         let column = columnar_value.into_column(0, &bump).unwrap();
         assert_eq!(column, Column::SmallInt(&[]));
+    }
+
+    #[test]
+    fn we_can_transform_var_length_literals_into_columns() {
+        let bump = Bump::new();
+
+        let columnar_value =
+            ColumnarValue::<TestScalar>::Literal(LiteralValue::VarChar("Lorem".into()));
+        let column = columnar_value.into_column(2, &bump).unwrap();
+        let expected_strings = ["Lorem", "Lorem"];
+        let expected_scalars = [TestScalar::from("Lorem"), TestScalar::from("Lorem")];
+        assert_eq!(
+            column,
+            Column::VarChar((&expected_strings, &expected_scalars))
+        );
+
+        let bytes = vec![1, 2, 3, 4];
+        let columnar_value =
+            ColumnarValue::<TestScalar>::Literal(LiteralValue::VarBinary(bytes.clone()));
+        let column = columnar_value.into_column(3, &bump).unwrap();
+        let expected_bytes = [bytes.as_slice(), bytes.as_slice(), bytes.as_slice()];
+        let expected_scalars = [TestScalar::from_byte_slice_via_hash(&bytes); 3];
+        assert_eq!(
+            column,
+            Column::VarBinary((&expected_bytes, &expected_scalars))
+        );
+    }
+
+    #[test]
+    fn we_can_transform_scalar_literals_into_columns() {
+        let bump = Bump::new();
+        let scalar = TestScalar::from(123u64);
+        let limbs = <[u64; 4]>::from(scalar);
+
+        let columnar_value = ColumnarValue::<TestScalar>::Literal(LiteralValue::Scalar(limbs));
+        let column = columnar_value.into_column(3, &bump).unwrap();
+
+        assert_eq!(column, Column::Scalar(&[scalar; 3]));
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,20 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn parse_error_displays_invalid_table_reference() {
+        assert_eq!(
+            ParseError::InvalidTableReference {
+                table_reference: "schema.table.extra".to_string(),
+            }
+            .to_string(),
+            "Invalid table reference: schema.table.extra"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -84,3 +84,59 @@ pub fn filter_column_by_index<'a, S: Scalar>(
         ),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
+
+    #[test]
+    fn we_can_filter_remaining_column_variants_by_index() {
+        let alloc = Bump::new();
+        let indexes = [3, 0, 2];
+
+        let column = Column::<TestScalar>::Boolean(&[true, false, true, false]);
+        assert_eq!(
+            filter_column_by_index(&alloc, &column, &indexes),
+            Column::Boolean(&[false, true, true])
+        );
+
+        let column = Column::<TestScalar>::Uint8(&[10_u8, 20, 30, 40]);
+        assert_eq!(
+            filter_column_by_index(&alloc, &column, &indexes),
+            Column::Uint8(&[40_u8, 10, 30])
+        );
+
+        let column = Column::<TestScalar>::TinyInt(&[-1_i8, 2, -3, 4]);
+        assert_eq!(
+            filter_column_by_index(&alloc, &column, &indexes),
+            Column::TinyInt(&[4_i8, -1, -3])
+        );
+
+        let column = Column::<TestScalar>::SmallInt(&[-10_i16, 20, -30, 40]);
+        assert_eq!(
+            filter_column_by_index(&alloc, &column, &indexes),
+            Column::SmallInt(&[40_i16, -10, -30])
+        );
+
+        let column = Column::<TestScalar>::Int(&[-100_i32, 200, -300, 400]);
+        assert_eq!(
+            filter_column_by_index(&alloc, &column, &indexes),
+            Column::Int(&[400_i32, -100, -300])
+        );
+
+        let timezone = PoSQLTimeZone::utc();
+        let column = Column::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            timezone,
+            &[1_000, 2_000, 3_000, 4_000],
+        );
+        assert_eq!(
+            filter_column_by_index(&alloc, &column, &indexes),
+            Column::TimestampTZ(PoSQLTimeUnit::Second, timezone, &[4_000, 1_000, 3_000])
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -48,6 +48,26 @@ fn we_cannot_apply_min_to_varchar() {
 }
 
 #[test]
+#[should_panic(expected = "SUM can not be applied to non-numeric types")]
+fn we_cannot_apply_sum_to_varchar() {
+    let col: Column<'_, TestScalar> = Column::VarChar((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = sum_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+#[should_panic(expected = "SUM can not be applied to non-numeric types")]
+fn we_cannot_apply_sum_to_varbinary() {
+    let col: Column<'_, TestScalar> = Column::VarBinary((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = sum_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
 fn we_can_aggregate_empty_columns() {
     let column_a = Column::BigInt::<TestScalar>(&[]);
     let column_b = Column::VarChar((&[], &[]));
@@ -65,6 +85,55 @@ fn we_can_aggregate_empty_columns() {
     );
     assert_eq!(aggregate_result.sum_columns, vec![&[], &[]]);
     assert_eq!(aggregate_result.count_column, &[0i64; 0]);
+}
+
+#[test]
+fn we_reject_aggregate_columns_with_mismatched_lengths() {
+    let alloc = Bump::new();
+    let selection = &[true, false, true];
+    let group_by = &[Column::BigInt::<TestScalar>(&[1, 2, 3])];
+    let sums = &[Column::Int128::<TestScalar>(&[10, 20, 30])];
+    let maxes = &[Column::Scalar(&[
+        TestScalar::from(100),
+        TestScalar::from(200),
+        TestScalar::from(300),
+    ])];
+    let mins = &[Column::Uint8::<TestScalar>(&[4, 5, 6])];
+
+    let short_group_by = &[Column::BigInt::<TestScalar>(&[1, 2])];
+    assert_eq!(
+        aggregate_columns(&alloc, short_group_by, sums, maxes, mins, selection).unwrap_err(),
+        AggregateColumnsError::ColumnLengthMismatch
+    );
+
+    let short_sums = &[Column::Int128::<TestScalar>(&[10, 20])];
+    assert_eq!(
+        aggregate_columns(&alloc, group_by, short_sums, maxes, mins, selection).unwrap_err(),
+        AggregateColumnsError::ColumnLengthMismatch
+    );
+
+    let short_maxes = &[Column::Scalar(&[
+        TestScalar::from(100),
+        TestScalar::from(200),
+    ])];
+    assert_eq!(
+        aggregate_columns(&alloc, group_by, sums, short_maxes, mins, selection).unwrap_err(),
+        AggregateColumnsError::ColumnLengthMismatch
+    );
+
+    let short_mins = &[Column::Uint8::<TestScalar>(&[4, 5])];
+    assert_eq!(
+        aggregate_columns(&alloc, group_by, sums, maxes, short_mins, selection).unwrap_err(),
+        AggregateColumnsError::ColumnLengthMismatch
+    );
+}
+
+#[test]
+fn column_length_mismatch_displays_expected_message() {
+    assert_eq!(
+        AggregateColumnsError::ColumnLengthMismatch.to_string(),
+        "Column length mismatch"
+    );
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -88,6 +88,9 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
             (Column::VarChar((left_col, _)), Column::VarChar((right_col, _))) => {
                 left_col[left_row_index].cmp(right_col[right_row_index])
             }
+            (Column::VarBinary((left_col, _)), Column::VarBinary((right_col, _))) => {
+                left_col[left_row_index].cmp(right_col[right_row_index])
+            }
             // Should never happen since we checked the column types
             _ => unreachable!(),
         };

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -117,6 +117,96 @@ fn we_can_compare_single_row_of_tables() {
 }
 
 #[test]
+fn we_can_compare_single_row_of_tables_with_no_columns() {
+    let left: &[Column<TestScalar>] = &[];
+    let right: &[Column<TestScalar>] = &[];
+
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 0, 0).unwrap(),
+        Ordering::Equal
+    );
+}
+
+#[test]
+fn we_can_compare_single_row_of_tables_for_varchar_and_scalar_columns() {
+    let left_varchar = ["apple", "banana", "banana"];
+    let right_varchar = ["banana", "banana", "banana"];
+    let left_varchar_scalars: Vec<TestScalar> =
+        left_varchar.iter().map(core::convert::Into::into).collect();
+    let right_varchar_scalars: Vec<TestScalar> = right_varchar
+        .iter()
+        .map(core::convert::Into::into)
+        .collect();
+    let left_scalar = [1, 2, 4].map(TestScalar::from);
+    let right_scalar = [1, 3, 4].map(TestScalar::from);
+
+    let left = &[
+        Column::VarChar((&left_varchar, &left_varchar_scalars)),
+        Column::Scalar(&left_scalar),
+    ];
+    let right = &[
+        Column::VarChar((&right_varchar, &right_varchar_scalars)),
+        Column::Scalar(&right_scalar),
+    ];
+
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 0, 0).unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 1, 1).unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 2, 2).unwrap(),
+        Ordering::Equal
+    );
+}
+
+#[test]
+fn we_can_compare_single_row_of_tables_for_varbinary_columns() {
+    let left_raw = [b"foo".as_ref(), b"bar".as_ref(), b"baz".as_ref()];
+    let right_raw = [b"bar".as_ref(), b"foo".as_ref(), b"baz".as_ref()];
+    let left_scalars: Vec<TestScalar> = left_raw
+        .iter()
+        .map(|bytes| TestScalar::from_le_bytes_mod_order(bytes))
+        .collect();
+    let right_scalars: Vec<TestScalar> = right_raw
+        .iter()
+        .map(|bytes| TestScalar::from_le_bytes_mod_order(bytes))
+        .collect();
+    let left_column = Column::VarBinary((left_raw.as_slice(), left_scalars.as_slice()));
+    let right_column = Column::VarBinary((right_raw.as_slice(), right_scalars.as_slice()));
+    let left = &[left_column];
+    let right = &[right_column];
+
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 0, 0).unwrap(),
+        Ordering::Greater
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 1, 1).unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 2, 2).unwrap(),
+        Ordering::Equal
+    );
+}
+
+#[test]
+#[should_panic]
+fn compare_single_row_of_tables_panics_on_column_count_mismatch() {
+    let left = &[Column::BigInt::<TestScalar>(&[1, 2, 3])];
+    let right = &[
+        Column::BigInt::<TestScalar>(&[1, 2, 3]),
+        Column::BigInt::<TestScalar>(&[4, 5, 6]),
+    ];
+
+    let _ = compare_single_row_of_tables(left, right, 0, 0);
+}
+
+#[test]
 fn we_cannot_compare_single_row_of_tables_if_type_mismatch() {
     let left_slice = &[55, 44, 66, 66, 66, 77, 66, 66, 66, 66];
     let right_slice = &[

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,47 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn owned_column_errors_display_expected_messages() {
+        assert_eq!(
+            OwnedColumnError::TypeCastError {
+                from_type: ColumnType::Boolean,
+                to_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Can not perform type casting from Boolean to BigInt"
+        );
+        assert_eq!(
+            OwnedColumnError::ScalarConversionError {
+                error: "negative value".to_string(),
+            }
+            .to_string(),
+            "Error in converting scalars to a given column type: negative value"
+        );
+        assert_eq!(
+            OwnedColumnError::Unsupported {
+                error: "varchar hashes".to_string(),
+            }
+            .to_string(),
+            "Unsupported operation: varchar hashes"
+        );
+    }
+
+    #[test]
+    fn column_coercion_errors_display_expected_messages() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -821,6 +821,15 @@ mod test {
     }
 
     #[test]
+    fn we_reject_integer_column_division_by_zero() {
+        let lhs = OwnedColumn::<TestScalar>::Int(vec![10, 20, 30]);
+        let rhs = OwnedColumn::<TestScalar>::Int(vec![2, 0, 5]);
+        let result = lhs.element_wise_div(&rhs);
+
+        assert!(matches!(result, Err(ColumnOperationError::DivisionByZero)));
+    }
+
+    #[test]
     fn we_can_try_divide_decimal_columns() {
         // lhs and rhs are both decimals
         let lhs_scalars = [4, 5, 3].iter().map(TestScalar::from).collect();

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -203,6 +203,53 @@ fn we_can_access_schema_and_column_names() {
 }
 
 #[test]
+fn we_can_create_owned_table_test_accessor_from_table() {
+    let table_ref = TableRef::new("sxt", "from_table");
+    let data = owned_table([int("a", [1, 2, 3]), boolean("b", [true, false, true])]);
+
+    let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        table_ref.clone(),
+        data,
+        7,
+        (),
+    );
+
+    assert_eq!(accessor.get_length(&table_ref), 3);
+    assert_eq!(accessor.get_offset(&table_ref), 7);
+    assert_eq!(accessor.get_column_names(&table_ref), vec!["a", "b"]);
+    assert_eq!(
+        accessor.lookup_schema(&table_ref),
+        vec![
+            ("a".into(), ColumnType::Int),
+            ("b".into(), ColumnType::Boolean)
+        ]
+    );
+}
+
+#[test]
+fn cloning_owned_table_test_accessor_preserves_independent_offsets() {
+    let table_ref = TableRef::new("sxt", "clone_test");
+    let data = owned_table([bigint("a", [1, 2, 3])]);
+
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        table_ref.clone(),
+        data,
+        3,
+        (),
+    );
+    let cloned_accessor = accessor.clone();
+
+    accessor.update_offset(&table_ref, 9);
+
+    assert_eq!(accessor.get_offset(&table_ref), 9);
+    assert_eq!(cloned_accessor.get_offset(&table_ref), 3);
+    assert_eq!(
+        cloned_accessor.lookup_column(&table_ref, &"a".into()),
+        Some(ColumnType::BigInt)
+    );
+}
+
+#[test]
 fn we_can_correctly_update_offsets() {
     let mut accessor1 = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let table_ref = TableRef::new("sxt", "test1");

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -320,3 +320,61 @@ pub fn timestamptz<S: Scalar>(
         OwnedColumn::TimestampTZ(time_unit, timezone, data.into_iter().collect()),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{math::decimal::Precision, scalar::test_scalar::TestScalar};
+
+    #[test]
+    fn we_can_create_integer_owned_column_pairs() {
+        assert_eq!(
+            uint8::<TestScalar>("uint8_col", [1_u8, 2, 3]),
+            (
+                Ident::new("uint8_col"),
+                OwnedColumn::Uint8(vec![1_u8, 2, 3])
+            )
+        );
+        assert_eq!(
+            tinyint::<TestScalar>("tinyint_col", [-1_i8, 2, 3]),
+            (
+                Ident::new("tinyint_col"),
+                OwnedColumn::TinyInt(vec![-1_i8, 2, 3])
+            )
+        );
+        assert_eq!(
+            smallint::<TestScalar>("smallint_col", [-1_i16, 2, 3]),
+            (
+                Ident::new("smallint_col"),
+                OwnedColumn::SmallInt(vec![-1_i16, 2, 3])
+            )
+        );
+        assert_eq!(
+            int::<TestScalar>("int_col", [-1_i32, 2, 3]),
+            (Ident::new("int_col"), OwnedColumn::Int(vec![-1_i32, 2, 3]))
+        );
+    }
+
+    #[test]
+    fn we_can_create_varbinary_and_decimal_owned_column_pairs() {
+        assert_eq!(
+            varbinary::<TestScalar>("bytes_col", [vec![1_u8, 2], vec![3, 4, 5]]),
+            (
+                Ident::new("bytes_col"),
+                OwnedColumn::VarBinary(vec![vec![1_u8, 2], vec![3, 4, 5]])
+            )
+        );
+
+        assert_eq!(
+            decimal75::<TestScalar>("decimal_col", 6, 2, [1_200, -340]),
+            (
+                Ident::new("decimal_col"),
+                OwnedColumn::Decimal75(
+                    Precision::new(6).unwrap(),
+                    2,
+                    vec![TestScalar::from(1_200), TestScalar::from(-340)]
+                )
+            )
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
@@ -1313,4 +1313,19 @@ mod test {
         let expected = (Precision::new(9).unwrap(), 6, expected_scalars);
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn we_reject_decimal_column_division_by_zero() {
+        let lhs = [10_i16, 20, 30];
+        let rhs = [2_i16, 0, 5]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let left_column_type = ColumnType::SmallInt;
+        let right_column_type = ColumnType::Decimal75(Precision::new(4).unwrap(), 2);
+        let result: ColumnOperationResult<(Precision, i8, Vec<TestScalar>)> =
+            try_divide_decimal_columns(&lhs, &rhs, left_column_type, right_column_type);
+
+        assert!(matches!(result, Err(ColumnOperationError::DivisionByZero)));
+    }
 }

--- a/crates/proof-of-sql/src/base/database/slice_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_operation.rs
@@ -321,6 +321,19 @@ mod test {
     }
 
     #[test]
+    fn we_can_do_fallible_binary_ops_on_empty_slices() {
+        let empty: [i32; 0] = [];
+
+        let actual: ColumnOperationResult<Vec<i32>> =
+            try_slice_lit_binary_op(&empty, &1, |_, _| panic!("op should not be called"));
+        assert_eq!(actual.unwrap(), Vec::<i32>::new());
+
+        let actual: ColumnOperationResult<Vec<i32>> =
+            try_slice_binary_op(&empty, &empty, |_, _| panic!("op should not be called"));
+        assert_eq!(actual.unwrap(), Vec::<i32>::new());
+    }
+
+    #[test]
     fn we_cannot_do_fallible_binary_op_on_a_single_value_and_a_slice_if_error_anywhere() {
         // No casting
         let slice = [1, i16::MAX, 1];

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,32 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::vec;
+
+    #[test]
+    fn table_evaluation_accessors_return_constructor_values() {
+        let evaluation = TableEvaluation::new(
+            vec![TestScalar::from(3), TestScalar::from(5)],
+            (TestScalar::from(8), 4),
+        );
+
+        assert_eq!(
+            evaluation.column_evals(),
+            &[TestScalar::from(3), TestScalar::from(5)]
+        );
+        assert_eq!(evaluation.chi_eval(), TestScalar::from(8));
+        assert_eq!(evaluation.chi(), (TestScalar::from(8), 4));
+    }
+
+    #[test]
+    fn table_evaluation_clone_preserves_values() {
+        let evaluation = TableEvaluation::new(vec![TestScalar::from(1)], (TestScalar::from(2), 3));
+
+        assert_eq!(evaluation.clone(), evaluation);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,59 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn table_operation_errors_display_expected_messages() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+        assert_eq!(
+            TableOperationError::JoinWithDifferentNumberOfColumns {
+                left_num_columns: 2,
+                right_num_columns: 3,
+            }
+            .to_string(),
+            "Cannot join tables with different numbers of columns: 2 and 3"
+        );
+        assert_eq!(
+            TableOperationError::JoinIncompatibleTypes {
+                left_type: ColumnType::Boolean,
+                right_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Cannot join tables on columns with incompatible types: Boolean and BigInt"
+        );
+        assert_eq!(
+            TableOperationError::ColumnDoesNotExist {
+                column_ident: "missing_column".into(),
+            }
+            .to_string(),
+            r#"Column Ident { value: "missing_column", quote_style: None } does not exist in table"#
+        );
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+        assert_eq!(
+            TableOperationError::ColumnIndexOutOfBounds { column_index: 9 }.to_string(),
+            "Column index out of bounds: 9"
+        );
+    }
+
+    #[test]
+    fn table_operation_errors_transparently_wrap_column_operation_errors() {
+        assert_eq!(
+            TableOperationError::ColumnOperationError {
+                source: ColumnOperationError::DivisionByZero,
+            }
+            .to_string(),
+            "Division by zero"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,119 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::IndexMap;
+    use alloc::vec;
+
+    #[test]
+    fn new_treats_empty_schema_as_unqualified_table() {
+        let table_ref = TableRef::new("", "blocks");
+
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "blocks");
+        assert_eq!(table_ref.to_string(), "blocks");
+    }
+
+    #[test]
+    fn from_names_preserves_schema_and_table() {
+        let table_ref = TableRef::from_names(Some("analytics"), "blocks");
+
+        assert_eq!(table_ref.schema_id().unwrap().value, "analytics");
+        assert_eq!(table_ref.table_id().value, "blocks");
+        assert_eq!(table_ref.to_string(), "analytics.blocks");
+    }
+
+    #[test]
+    fn from_idents_preserves_identifier_values() {
+        let table_ref = TableRef::from_idents(Some("sxt".into()), "proofs".into());
+
+        assert_eq!(table_ref.schema_id().unwrap().value, "sxt");
+        assert_eq!(table_ref.table_id().value, "proofs");
+    }
+
+    #[test]
+    fn from_strs_accepts_one_or_two_components() {
+        let unqualified = TableRef::from_strs(&["blocks"]).unwrap();
+        let qualified = TableRef::from_strs(&["analytics", "blocks"]).unwrap();
+
+        assert_eq!(unqualified.to_string(), "blocks");
+        assert_eq!(qualified.to_string(), "analytics.blocks");
+    }
+
+    #[test]
+    fn from_strs_rejects_invalid_component_counts() {
+        let empty = TableRef::from_strs::<&str>(&[]).unwrap_err();
+        let too_many = TableRef::from_strs(&["a", "b", "c"]).unwrap_err();
+
+        assert_eq!(
+            empty,
+            ParseError::InvalidTableReference {
+                table_reference: "".into(),
+            }
+        );
+        assert_eq!(
+            too_many,
+            ParseError::InvalidTableReference {
+                table_reference: "a,b,c".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn try_from_dot_separated_string_matches_from_str() {
+        let expected = TableRef::from_names(Some("analytics"), "blocks");
+
+        assert_eq!(TableRef::try_from("analytics.blocks").unwrap(), expected);
+        assert_eq!("analytics.blocks".parse::<TableRef>().unwrap(), expected);
+    }
+
+    #[test]
+    fn try_from_rejects_more_than_two_dot_components() {
+        assert_eq!(
+            TableRef::try_from("a.b.c").unwrap_err(),
+            ParseError::InvalidTableReference {
+                table_reference: "a.b.c".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn table_ref_serializes_as_display_string() {
+        let table_ref = TableRef::from_names(Some("analytics"), "blocks");
+
+        assert_eq!(
+            serde_json::to_string(&table_ref).unwrap(),
+            r#""analytics.blocks""#
+        );
+        assert_eq!(
+            serde_json::from_str::<TableRef>(r#""analytics.blocks""#).unwrap(),
+            table_ref
+        );
+    }
+
+    #[test]
+    fn borrowed_table_ref_can_lookup_index_map_entries() {
+        let table_ref = TableRef::from_names(Some("analytics"), "blocks");
+        let mut map: IndexMap<TableRef, i32> = IndexMap::with_hasher(Default::default());
+        map.insert(table_ref.clone(), 7);
+
+        assert_eq!(map.get(&&table_ref), Some(&7));
+    }
+
+    #[test]
+    fn table_refs_keep_insertion_order_in_index_map() {
+        let mut map: IndexMap<TableRef, i32> = IndexMap::with_hasher(Default::default());
+        map.insert(TableRef::from_names(None, "blocks"), 1);
+        map.insert(TableRef::from_names(Some("analytics"), "proofs"), 2);
+
+        assert_eq!(
+            map.keys()
+                .map(ToString::to_string)
+                .collect::<alloc::vec::Vec<_>>(),
+            vec!["blocks", "analytics.proofs"]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -233,6 +233,50 @@ fn we_can_access_schema_and_column_names() {
 }
 
 #[test]
+fn we_can_create_table_test_accessor_from_table() {
+    let alloc = Bump::new();
+    let table_ref = TableRef::new("sxt", "from_table");
+    let data = table([
+        borrowed_int("a", [1, 2, 3], &alloc),
+        borrowed_boolean("b", [true, false, true], &alloc),
+    ]);
+
+    let accessor =
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(table_ref.clone(), data, 7, ());
+
+    assert_eq!(accessor.get_length(&table_ref), 3);
+    assert_eq!(accessor.get_offset(&table_ref), 7);
+    assert_eq!(accessor.get_column_names(&table_ref), vec!["a", "b"]);
+    assert_eq!(
+        accessor.lookup_schema(&table_ref),
+        vec![
+            ("a".into(), ColumnType::Int),
+            ("b".into(), ColumnType::Boolean)
+        ]
+    );
+}
+
+#[test]
+fn cloning_table_test_accessor_preserves_independent_offsets() {
+    let alloc = Bump::new();
+    let table_ref = TableRef::new("sxt", "clone_test");
+    let data = table([borrowed_bigint("a", [1, 2, 3], &alloc)]);
+
+    let mut accessor =
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(table_ref.clone(), data, 3, ());
+    let cloned_accessor = accessor.clone();
+
+    accessor.update_offset(&table_ref, 9);
+
+    assert_eq!(accessor.get_offset(&table_ref), 9);
+    assert_eq!(cloned_accessor.get_offset(&table_ref), 3);
+    assert_eq!(
+        cloned_accessor.lookup_column(&table_ref, &"a".into()),
+        Some(ColumnType::BigInt)
+    );
+}
+
+#[test]
 fn we_can_correctly_update_offsets() {
     let alloc = Bump::new();
     let mut accessor1 = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -245,7 +245,12 @@ pub fn table_union<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{map::IndexMap, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        map::IndexMap,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn we_can_union_no_columns() {
@@ -278,6 +283,94 @@ mod tests {
         assert_eq!(
             result,
             Column::VarChar((&doubled_strings, &doubled_scalars))
+        );
+    }
+
+    #[test]
+    fn we_can_union_fixed_width_and_timestamp_columns() {
+        let alloc = Bump::new();
+
+        let col0: Column<TestScalar> = Column::Boolean(&[true, false]);
+        let col1: Column<TestScalar> = Column::Boolean(&[false]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Boolean).unwrap();
+        assert_eq!(result, Column::Boolean(&[true, false, false]));
+
+        let col0: Column<TestScalar> = Column::Uint8(&[0, u8::MAX]);
+        let col1: Column<TestScalar> = Column::Uint8(&[7]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Uint8).unwrap();
+        assert_eq!(result, Column::Uint8(&[0, u8::MAX, 7]));
+
+        let col0: Column<TestScalar> = Column::TinyInt(&[i8::MIN]);
+        let col1: Column<TestScalar> = Column::TinyInt(&[0, i8::MAX]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::TinyInt).unwrap();
+        assert_eq!(result, Column::TinyInt(&[i8::MIN, 0, i8::MAX]));
+
+        let col0: Column<TestScalar> = Column::SmallInt(&[i16::MIN, -1]);
+        let col1: Column<TestScalar> = Column::SmallInt(&[i16::MAX]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::SmallInt).unwrap();
+        assert_eq!(result, Column::SmallInt(&[i16::MIN, -1, i16::MAX]));
+
+        let col0: Column<TestScalar> = Column::Int(&[i32::MIN]);
+        let col1: Column<TestScalar> = Column::Int(&[0, i32::MAX]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Int).unwrap();
+        assert_eq!(result, Column::Int(&[i32::MIN, 0, i32::MAX]));
+
+        let col0: Column<TestScalar> = Column::Int128(&[i128::MIN]);
+        let col1: Column<TestScalar> = Column::Int128(&[0, i128::MAX]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Int128).unwrap();
+        assert_eq!(result, Column::Int128(&[i128::MIN, 0, i128::MAX]));
+
+        let scalar0 = [TestScalar::from(1), TestScalar::from(2)];
+        let scalar1 = [TestScalar::from(3)];
+        let expected_scalars = [TestScalar::from(1), TestScalar::from(2), TestScalar::from(3)];
+        let col0 = Column::Scalar(scalar0.as_slice());
+        let col1 = Column::Scalar(scalar1.as_slice());
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Scalar).unwrap();
+        assert_eq!(result, Column::Scalar(expected_scalars.as_slice()));
+
+        let precision = Precision::new(12).unwrap();
+        let decimal0 = [TestScalar::from(100), TestScalar::from(200)];
+        let decimal1 = [TestScalar::from(300)];
+        let expected_decimals = [
+            TestScalar::from(100),
+            TestScalar::from(200),
+            TestScalar::from(300),
+        ];
+        let col0 = Column::Decimal75(precision, 2, decimal0.as_slice());
+        let col1 = Column::Decimal75(precision, 2, decimal1.as_slice());
+        let result =
+            column_union(&[&col0, &col1], &alloc, ColumnType::Decimal75(precision, 2)).unwrap();
+        assert_eq!(
+            result,
+            Column::Decimal75(precision, 2, expected_decimals.as_slice())
+        );
+
+        let timestamps0 = [1_700_000_000, 1_700_000_001];
+        let timestamps1 = [1_700_000_002];
+        let expected_timestamps = [1_700_000_000, 1_700_000_001, 1_700_000_002];
+        let col0 = Column::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            timestamps0.as_slice(),
+        );
+        let col1 = Column::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            timestamps1.as_slice(),
+        );
+        let result = column_union(
+            &[&col0, &col1],
+            &alloc,
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                expected_timestamps.as_slice()
+            )
         );
     }
 

--- a/crates/proof-of-sql/src/base/encode/zigzag_test.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag_test.rs
@@ -49,6 +49,39 @@ fn big_scalars_with_small_additive_inverses_are_encoded_as_negative_zigzag_value
 }
 
 #[test]
+fn positive_zigzag_values_decode_to_original_scalars() {
+    let test_cases = [0_u128, 1, 2, 123, u128::MAX];
+
+    for x in test_cases {
+        let encoded = TestScalar::from(x).zigzag();
+        let decoded: TestScalar = encoded.zigzag();
+
+        assert_eq!(decoded, TestScalar::from(x));
+    }
+}
+
+#[test]
+fn negative_zigzag_values_decode_to_original_scalars() {
+    let test_cases = [1_u128, 2, 3, 123];
+
+    for y in test_cases {
+        let encoded = U256::from_words(2 * y - 1, 0);
+        let decoded: TestScalar = encoded.zigzag();
+
+        assert_eq!(decoded, -TestScalar::from(y));
+    }
+}
+
+#[test]
+fn odd_zigzag_decoding_handles_low_word_carry() {
+    let encoded = U256::from_words(u128::MAX, 1);
+    let decoded: TestScalar = encoded.zigzag();
+    let expected_positive: TestScalar = (&U256::from_words(0, 1)).into();
+
+    assert_eq!(decoded, -expected_positive);
+}
+
+#[test]
 fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_positive_zigzag_values()
 {
     // x = (p - 1) / 2 (p is the ristretto group order)

--- a/crates/proof-of-sql/src/base/map.rs
+++ b/crates/proof-of-sql/src/base/map.rs
@@ -18,3 +18,34 @@ macro_rules! indexset {
 #[cfg(test)]
 pub(crate) use indexmap;
 pub(crate) use indexset;
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    #[test]
+    fn indexmap_macro_preserves_insertion_order() {
+        let map = indexmap! {
+            "alpha" => 1,
+            "beta" => 2,
+            "gamma" => 3,
+        };
+
+        assert_eq!(
+            map.iter()
+                .map(|(key, value)| (*key, *value))
+                .collect::<alloc::vec::Vec<_>>(),
+            vec![("alpha", 1), ("beta", 2), ("gamma", 3)]
+        );
+    }
+
+    #[test]
+    fn indexset_macro_preserves_insertion_order_and_removes_duplicates() {
+        let set = indexset!["alpha", "beta", "alpha", "gamma"];
+
+        assert_eq!(
+            set.iter().copied().collect::<alloc::vec::Vec<_>>(),
+            vec!["alpha", "beta", "gamma"]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -89,4 +89,26 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, IntermediateDecimalError::ConversionFailure));
     }
+
+    #[test]
+    fn we_can_convert_decimal_to_bigint_with_target_scale() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+
+        let bigint = big_decimal
+            .try_into_bigint_with_precision_and_scale(7, 4)
+            .unwrap();
+
+        assert_eq!(bigint, BigInt::from(1_234_500));
+    }
+
+    #[test]
+    fn we_can_catch_lossy_cast_when_precision_is_too_small() {
+        let big_decimal: BigDecimal = "999.99".parse::<BigDecimal>().unwrap().normalized();
+
+        let err = big_decimal
+            .try_into_bigint_with_precision_and_scale(4, 2)
+            .unwrap_err();
+
+        assert!(matches!(err, LossyCast));
+    }
 }

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -86,6 +86,110 @@ impl From<DecimalError> for String {
     }
 }
 
+#[cfg(test)]
+mod error_tests {
+    use super::*;
+    use alloc::string::{String, ToString};
+
+    #[test]
+    fn intermediate_decimal_errors_display_expected_messages() {
+        assert_eq!(
+            IntermediateDecimalError::OutOfRange.to_string(),
+            "Value out of range for target type"
+        );
+        assert_eq!(
+            IntermediateDecimalError::LossyCast.to_string(),
+            "Fractional part of decimal is non-zero"
+        );
+        assert_eq!(
+            IntermediateDecimalError::ConversionFailure.to_string(),
+            "Conversion to integer failed"
+        );
+    }
+
+    #[test]
+    fn decimal_errors_display_expected_messages() {
+        assert_eq!(
+            DecimalError::InvalidDecimal {
+                error: "not a decimal".to_string(),
+            }
+            .to_string(),
+            "Invalid decimal format or value: not a decimal"
+        );
+        assert_eq!(
+            DecimalError::InvalidPrecision {
+                error: "76".to_string(),
+            }
+            .to_string(),
+            "Decimal precision is not valid: 76"
+        );
+        assert_eq!(
+            DecimalError::InvalidScale {
+                scale: "-129".to_string(),
+            }
+            .to_string(),
+            "Decimal scale is not valid: -129"
+        );
+        assert_eq!(
+            DecimalError::RoundingError {
+                error: "lossy scale".to_string(),
+            }
+            .to_string(),
+            "Unsupported operation: cannot round decimal: lossy scale"
+        );
+    }
+
+    #[test]
+    fn decimal_errors_transparently_wrap_intermediate_decimal_errors() {
+        assert_eq!(
+            DecimalError::IntermediateDecimalConversionError {
+                source: IntermediateDecimalError::LossyCast,
+            }
+            .to_string(),
+            "Fractional part of decimal is non-zero"
+        );
+    }
+
+    #[test]
+    fn decimal_error_converts_into_string() {
+        let message: String = DecimalError::InvalidScale {
+            scale: "100".to_string(),
+        }
+        .into();
+
+        assert_eq!(message, "Decimal scale is not valid: 100");
+    }
+
+    #[test]
+    fn precision_rejects_zero_and_values_above_max() {
+        assert_eq!(
+            Precision::new(0),
+            Err(DecimalError::InvalidPrecision {
+                error: "0".to_string(),
+            })
+        );
+        assert_eq!(
+            Precision::new(MAX_SUPPORTED_PRECISION + 1),
+            Err(DecimalError::InvalidPrecision {
+                error: "76".to_string(),
+            })
+        );
+        assert_eq!(
+            Precision::try_from(u64::from(u8::MAX) + 1),
+            Err(DecimalError::InvalidPrecision {
+                error: "256".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn precision_deserializes_only_supported_values() {
+        assert_eq!(serde_json::from_str::<Precision>("10").unwrap().value(), 10);
+        assert!(serde_json::from_str::<Precision>("0").is_err());
+        assert!(serde_json::from_str::<Precision>("76").is_err());
+    }
+}
+
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Serialize, Copy)]
 /// limit-enforced precision
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]

--- a/crates/proof-of-sql/src/base/math/log.rs
+++ b/crates/proof-of-sql/src/base/math/log.rs
@@ -71,6 +71,38 @@ mod tests {
         assert_eq!(log2_up(4u32), 2);
     }
 
+    #[test]
+    fn test_log2_across_unsigned_integer_widths() {
+        assert_eq!(log2_down(255u8), 7);
+        assert_eq!(log2_up(255u8), 8);
+        assert_eq!(log2_down(256u16), 8);
+        assert_eq!(log2_up(257u16), 9);
+        assert_eq!(log2_down(1u64 << 40), 40);
+        assert_eq!(log2_up((1u64 << 40) + 1), 41);
+    }
+
+    #[test]
+    fn test_is_pow2_bytes() {
+        assert!(is_pow2_bytes(&[0, 0, 0, 0]));
+        assert!(is_pow2_bytes(&[1, 0, 0, 0]));
+        assert!(is_pow2_bytes(&[0, 1, 0, 0]));
+        assert!(is_pow2_bytes(&[0, 0, 0, 128]));
+
+        assert!(!is_pow2_bytes(&[3, 0, 0, 0]));
+        assert!(!is_pow2_bytes(&[1, 1, 0, 0]));
+        assert!(!is_pow2_bytes(&[0, 128, 1, 0]));
+    }
+
+    #[test]
+    fn test_log2_bytes_floor() {
+        assert_eq!(log2_down_bytes(&[0, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[1, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[255, 0, 0, 0]), 7);
+        assert_eq!(log2_down_bytes(&[0, 1, 0, 0]), 8);
+        assert_eq!(log2_down_bytes(&[0, 0, 0, 128]), 31);
+        assert_eq!(log2_down_bytes(&[6, 5, 3, 0]), 17);
+    }
+
     #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     #[test]
     fn test_log2_bytes_ceil() {

--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -90,6 +90,7 @@ impl Permutation {
 #[cfg(test)]
 mod test {
     use super::*;
+    use alloc::string::ToString;
     use alloc::vec;
 
     #[test]
@@ -123,6 +124,39 @@ mod test {
                 permutation_size: 3,
                 slice_length: 2
             })
+        );
+    }
+
+    #[test]
+    fn test_invalid_permutation_messages() {
+        assert_eq!(
+            Permutation::try_new(vec![1, 0, 0]).unwrap_err().to_string(),
+            "Permutation is invalid Permutation can not have duplicate elements: [1, 0, 0]"
+        );
+        assert_eq!(
+            Permutation::try_new(vec![1, 0, 3]).unwrap_err().to_string(),
+            "Permutation is invalid Permutation can not have elements out of bounds: [1, 0, 3]"
+        );
+    }
+
+    #[test]
+    fn test_unchecked_new_from_cmp_orders_indexes() {
+        let permutation = Permutation::unchecked_new_from_cmp(4, |left, right| right.cmp(left));
+
+        assert_eq!(
+            permutation.try_apply(&["a", "b", "c", "d"]).unwrap(),
+            vec!["d", "c", "b", "a"]
+        );
+    }
+
+    #[test]
+    fn test_empty_permutation_can_be_applied_to_empty_slice() {
+        let permutation = Permutation::try_new(vec![]).unwrap();
+
+        assert_eq!(permutation.size(), 0);
+        assert_eq!(
+            permutation.try_apply::<usize>(&[]).unwrap(),
+            Vec::<usize>::new()
         );
     }
 }

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -149,3 +149,30 @@ impl<S: Scalar> CompositePolynomial<S> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CompositePolynomial;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::{rc::Rc, vec};
+
+    #[test]
+    fn we_reuse_existing_mle_indices_for_shared_products() {
+        let shared = Rc::new(vec![TestScalar::from(1_u32), TestScalar::from(2_u32)]);
+        let other = Rc::new(vec![TestScalar::from(3_u32), TestScalar::from(4_u32)]);
+        let mut polynomial = CompositePolynomial::new(1);
+
+        polynomial.add_product([shared.clone()], TestScalar::from(5_u32));
+        polynomial.add_product(
+            [shared.clone(), other.clone(), shared.clone()],
+            TestScalar::from(6_u32),
+        );
+
+        assert_eq!(polynomial.max_multiplicands, 3);
+        assert_eq!(polynomial.flattened_ml_extensions.len(), 2);
+        assert!(Rc::ptr_eq(&polynomial.flattened_ml_extensions[0], &shared));
+        assert!(Rc::ptr_eq(&polynomial.flattened_ml_extensions[1], &other));
+        assert_eq!(polynomial.products[0].1, vec![0]);
+        assert_eq!(polynomial.products[1].1, vec![0, 1, 0]);
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -39,6 +39,28 @@ fn test_composite_polynomial_evaluation() {
     assert_eq!(prod11, calc11);
 }
 
+#[test]
+fn add_product_reuses_existing_multilinear_extensions() {
+    let values = Rc::new(vec![TestScalar::from(2), TestScalar::from(3)]);
+    let mut prod = CompositePolynomial::new(1);
+
+    prod.add_product([values.clone(), values.clone()], TestScalar::from(5));
+    prod.add_product([values], TestScalar::from(7));
+
+    assert_eq!(prod.max_multiplicands, 2);
+    assert_eq!(prod.flattened_ml_extensions.len(), 1);
+    assert_eq!(prod.products[0].1, vec![0, 0]);
+    assert_eq!(prod.products[1].1, vec![0]);
+}
+
+#[test]
+#[should_panic(expected = "assertion failed: !product.is_empty()")]
+fn add_product_rejects_empty_products() {
+    let mut prod = CompositePolynomial::<TestScalar>::new(1);
+
+    prod.add_product([], TestScalar::from(5));
+}
+
 #[expect(clippy::identity_op)]
 #[test]
 fn test_composite_polynomial_hypercube_sum() {

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -67,3 +67,18 @@ where
 
     log::log_memory_usage("End");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_evaluation_vector;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use num_traits::Zero;
+
+    #[test]
+    #[should_panic]
+    fn we_reject_evaluation_vectors_larger_than_the_point_domain() {
+        let mut evaluation_vector = [TestScalar::zero(); 3];
+
+        compute_evaluation_vector(&mut evaluation_vector, &[TestScalar::from(2_u32)]);
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
@@ -66,6 +66,21 @@ fn we_compute_the_evaluation_vector_for_an_empty_point() {
 }
 
 #[test]
+fn we_compute_an_empty_evaluation_vector_for_a_nonempty_point() {
+    let mut v: [TestScalar; 0] = [];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64)]);
+
+    assert!(v.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "assertion failed: v.len() <= (1 << point.len())")]
+fn we_reject_evaluation_vector_longer_than_the_point_domain() {
+    let mut v = [TestScalar::zero(); 3];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64)]);
+}
+
+#[test]
 fn we_get_the_same_result_using_evaluation_vector_as_direct_evaluation() {
     let xs = [
         TestScalar::from(3u64),

--- a/crates/proof-of-sql/src/base/polynomial/interpolate.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate.rs
@@ -127,3 +127,23 @@ where
         })
         .unwrap_or(vec![])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::interpolate_uni_poly;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_interpolate_uni_poly_at_negative_query_points() {
+        let evaluations = [
+            TestScalar::from(3_i32),
+            TestScalar::from(6_i32),
+            TestScalar::from(11_i32),
+        ];
+
+        assert_eq!(
+            interpolate_uni_poly(&evaluations, TestScalar::from(-2_i32)),
+            TestScalar::from(3_i32)
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
@@ -161,3 +161,24 @@ fn we_can_interpolate_evaluations_to_reverse_coefficients_with_degree_3_degenera
         vec![S::from(0), S::from(0), S::from(2), S::from(1)]
     );
 }
+
+#[test]
+fn interpolated_reverse_coefficients_roundtrip_degree_4_evaluations() {
+    let evals = [
+        S::from(4),
+        S::from(8),
+        S::from(14),
+        S::from(22),
+        S::from(32),
+    ];
+    let coefficients = interpolate_evaluations_to_reverse_coefficients(&evals);
+
+    assert_eq!(coefficients.len(), evals.len());
+    for (i, expected_eval) in evals.into_iter().enumerate() {
+        let x = S::from(i as i32);
+        let actual_eval = coefficients
+            .iter()
+            .fold(S::zero(), |acc, coefficient| acc * x + *coefficient);
+        assert_eq!(actual_eval, expected_eval);
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
@@ -174,3 +174,19 @@ where
         rho
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_truncated_lagrange_basis_sum;
+    use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+
+    #[test]
+    fn we_get_full_lagrange_sum_when_length_exceeds_the_point_domain() {
+        let point = [TestScalar::from(2_u32), TestScalar::from(5_u32)];
+
+        assert_eq!(
+            compute_truncated_lagrange_basis_sum(5, &point),
+            TestScalar::ONE
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -180,3 +180,41 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
         (&self).id()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::MultilinearExtension;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_use_multilinear_extension_methods_for_arrays() {
+        let values = [2_i64, 3, 4];
+        let extension = &values;
+        let evaluation_vec = vec![TestScalar::from(10_u32), 20.into(), 30.into()];
+
+        assert_eq!(
+            extension.inner_product(&evaluation_vec),
+            TestScalar::from(200_u32)
+        );
+
+        let mut result = vec![TestScalar::from(1_u32); 3];
+        extension.mul_add(&mut result, &TestScalar::from(2_u32));
+        assert_eq!(
+            result,
+            vec![
+                TestScalar::from(5_u32),
+                TestScalar::from(7_u32),
+                TestScalar::from(9_u32)
+            ]
+        );
+        assert_eq!(
+            <&[i64; 3] as MultilinearExtension<TestScalar>>::to_sumcheck_term(&extension, 2),
+            vec![
+                TestScalar::from(2_u32),
+                TestScalar::from(3_u32),
+                TestScalar::from(4_u32),
+                TestScalar::from(0_u32)
+            ]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -48,6 +48,24 @@ fn we_can_use_multilinear_extension_methods_for_i64_slice() {
 }
 
 #[test]
+fn we_can_use_multilinear_extension_methods_for_i64_array() {
+    let array = [2_i64, 3, 5, 7];
+    let point = [TestScalar::from(2), TestScalar::from(3)];
+    let evaluation = (&array).evaluate_at_point(&point);
+
+    let expected =
+        TestScalar::from(2) * (TestScalar::from(1) - point[0]) * (TestScalar::from(1) - point[1])
+            + TestScalar::from(3) * point[0] * (TestScalar::from(1) - point[1])
+            + TestScalar::from(5) * (TestScalar::from(1) - point[0]) * point[1]
+            + TestScalar::from(7) * point[0] * point[1];
+    assert_eq!(evaluation, expected);
+    assert_eq!(
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&&array, 2),
+        vec![2.into(), 3.into(), 5.into(), 7.into()]
+    );
+}
+
+#[test]
 fn we_can_use_multilinear_extension_methods_for_column() {
     let slice = Column::BigInt(&[2, 3, 4, 5, 6]);
     let evaluation_vec: Vec<TestScalar> =

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,49 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PoSQLTimestampError;
+    use alloc::string::{String, ToString};
+
+    #[test]
+    fn invalid_timezone_display_includes_original_timezone() {
+        let error = PoSQLTimestampError::InvalidTimezone {
+            timezone: "Mars/Phobos".to_string(),
+        };
+
+        assert_eq!(error.to_string(), "invalid timezone string: Mars/Phobos");
+    }
+
+    #[test]
+    fn timestamp_errors_display_expected_messages() {
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezoneOffset.to_string(),
+            "invalid timezone offset"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimeUnit {
+                error: "minute".to_string()
+            }
+            .to_string(),
+            "Invalid time unit"
+        );
+        assert_eq!(
+            PoSQLTimestampError::UnsupportedPrecision {
+                error: "12".to_string()
+            }
+            .to_string(),
+            "Unsupported precision for timestamp: 12"
+        );
+    }
+
+    #[test]
+    fn timestamp_error_converts_into_string() {
+        let message = String::from(PoSQLTimestampError::UnsupportedPrecision {
+            error: "2".to_string(),
+        });
+
+        assert_eq!(message, "Unsupported precision for timestamp: 2");
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -104,6 +104,29 @@ mod timezone_parsing_tests {
     }
 
     #[test]
+    fn we_can_parse_utc_aliases() {
+        for value in ["Z", "UTC", "utc", "00:00", "+00:00", "0:00", "+0:00"] {
+            let timezone_as_str: Option<Arc<str>> = Some(value.into());
+
+            assert_eq!(
+                PoSQLTimeZone::try_from(&timezone_as_str).unwrap(),
+                PoSQLTimeZone::utc(),
+                "failed to parse UTC alias {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn we_can_parse_positive_time_zone_offsets() {
+        let timezone_as_str: Option<Arc<str>> = Some("+05:45".into());
+
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+
+        assert_eq!(timezone, PoSQLTimeZone::new(20_700));
+        assert_eq!(format!("{timezone}"), "+05:45");
+    }
+
+    #[test]
     fn we_can_parse_none_time_zone() {
         let timezone = PoSQLTimeZone::try_from(&None).unwrap();
         let expected_time_zone = PoSQLTimeZone::utc();
@@ -118,5 +141,14 @@ mod timezone_parsing_tests {
             timezone_err,
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
         ));
+    }
+
+    #[test]
+    fn we_cannot_parse_offsets_with_invalid_digits() {
+        let timezone_as_str: Option<Arc<str>> = Some("+0A:30".into());
+
+        let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();
+
+        assert_eq!(timezone_err, PoSQLTimestampError::InvalidTimezoneOffset);
     }
 }

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -59,6 +59,7 @@ impl fmt::Display for PoSQLTimeUnit {
 mod time_unit_tests {
     use super::*;
     use crate::base::posql_time::PoSQLTimestampError;
+    use alloc::format;
 
     #[test]
     fn test_valid_precisions() {
@@ -80,5 +81,44 @@ mod time_unit_tests {
                 Err(PoSQLTimestampError::UnsupportedPrecision { .. })
             ));
         }
+    }
+
+    #[test]
+    fn we_can_convert_time_units_to_precision_values() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn we_can_display_time_units_with_precision() {
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Second),
+            "seconds (precision: 0)"
+        );
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Millisecond),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Microsecond),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Nanosecond),
+            "nanoseconds (precision: 9)"
+        );
+    }
+
+    #[test]
+    fn unsupported_precision_preserves_original_input() {
+        let err = PoSQLTimeUnit::try_from("12").unwrap_err();
+
+        assert_eq!(
+            err,
+            PoSQLTimestampError::UnsupportedPrecision { error: "12".into() }
+        );
+        assert_eq!(format!("{err}"), "Unsupported precision for timestamp: 12");
     }
 }

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,130 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_errors_display_expected_messages() {
+        assert_eq!(
+            ProofError::VerificationError {
+                error: "challenge mismatch",
+            }
+            .to_string(),
+            "Verification error: challenge mismatch"
+        );
+        assert_eq!(
+            ProofError::UnsupportedQueryPlan {
+                error: "cross join",
+            }
+            .to_string(),
+            "Unsupported query plan: cross join"
+        );
+        assert_eq!(
+            ProofError::InvalidTypeCoercion.to_string(),
+            "Result does not match query: type mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldNamesMismatch.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldCountMismatch.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_size_mismatches_display_expected_messages() {
+        let cases = [
+            (
+                ProofSizeMismatch::SumcheckProofTooSmall,
+                "Sumcheck proof is too small",
+            ),
+            (
+                ProofSizeMismatch::TooFewMLEEvaluations,
+                "Proof has too few MLE evaluations",
+            ),
+            (
+                ProofSizeMismatch::PostResultCountMismatch,
+                "Post result challenge count mismatch",
+            ),
+            (
+                ProofSizeMismatch::ConstraintCountMismatch,
+                "Constraint count mismatch",
+            ),
+            (
+                ProofSizeMismatch::TooFewBitDistributions,
+                "Proof has too few bit distributions",
+            ),
+            (
+                ProofSizeMismatch::TooFewChiLengths,
+                "Proof has too few one lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewRhoLengths,
+                "Proof has too few rho lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewSumcheckVariables,
+                "Proof has too few sumcheck variables",
+            ),
+            (
+                ProofSizeMismatch::ChiLengthNotFound,
+                "Proof doesn't have requested one length",
+            ),
+            (
+                ProofSizeMismatch::RhoLengthNotFound,
+                "Proof doesn't have requested rho length",
+            ),
+        ];
+
+        for (error, expected_message) in cases {
+            assert_eq!(error.to_string(), expected_message);
+            assert_eq!(
+                ProofError::ProofSizeMismatch { source: error }.to_string(),
+                expected_message
+            );
+        }
+    }
+
+    #[test]
+    fn placeholder_errors_display_expected_messages() {
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderIndex {
+                index: 4,
+                num_params: 3,
+            }
+            .to_string(),
+            "Invalid placeholder index: 4, number of params: 3"
+        );
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderType {
+                index: 2,
+                expected: ColumnType::BigInt,
+                actual: ColumnType::Boolean,
+            }
+            .to_string(),
+            "Invalid placeholder type: 2, expected: BIGINT, actual: BOOLEAN"
+        );
+        assert_eq!(
+            PlaceholderError::ZeroPlaceholderId.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn proof_error_transparently_wraps_placeholder_errors() {
+        let error = PlaceholderError::InvalidPlaceholderIndex {
+            index: 9,
+            num_params: 2,
+        };
+
+        assert_eq!(
+            ProofError::PlaceholderError { source: error }.to_string(),
+            "Invalid placeholder index: 9, number of params: 2"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/proof/keccak256_transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/keccak256_transcript.rs
@@ -38,7 +38,20 @@ impl TranscriptCore for Keccak256Transcript {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::transcript_core::test_util::*, Keccak256Transcript};
+    use super::{
+        super::transcript_core::{test_util::*, TranscriptCore},
+        Keccak256Transcript,
+    };
+    use tiny_keccak::{Hasher, Keccak};
+
+    fn keccak256(message: &[u8]) -> [u8; 32] {
+        let mut result = [0_u8; 32];
+        let mut hasher = Keccak::v256();
+        hasher.update(message);
+        hasher.finalize(&mut result);
+        result
+    }
+
     #[test]
     fn we_get_equivalent_challenges_with_equivalent_keccak256_transcripts() {
         we_get_equivalent_challenges_with_equivalent_transcripts::<Keccak256Transcript>();
@@ -50,5 +63,16 @@ mod tests {
     #[test]
     fn we_get_different_nontrivial_consecutive_challenges_from_keccak256_transcript() {
         we_get_different_nontrivial_consecutive_challenges_from_transcript::<Keccak256Transcript>();
+    }
+    #[test]
+    fn we_chain_keccak_challenges_through_transcript_state() {
+        let mut transcript: Keccak256Transcript = TranscriptCore::new();
+        transcript.raw_append(b"message");
+
+        let first_challenge = transcript.raw_challenge();
+        assert_eq!(first_challenge, keccak256(b"message"));
+
+        let second_challenge = transcript.raw_challenge();
+        assert_eq!(second_challenge, keccak256(&first_challenge));
     }
 }

--- a/crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs
@@ -14,7 +14,10 @@ impl super::transcript_core::TranscriptCore for merlin::Transcript {
 
 #[cfg(test)]
 mod tests {
-    use super::super::transcript_core::test_util::*;
+    use super::super::{
+        transcript_core::{test_util::*, TranscriptCore},
+        Transcript,
+    };
     #[test]
     fn we_get_equivalent_challenges_with_equivalent_merlin_transcripts() {
         we_get_equivalent_challenges_with_equivalent_transcripts::<merlin::Transcript>();
@@ -26,5 +29,30 @@ mod tests {
     #[test]
     fn we_get_different_nontrivial_consecutive_challenges_from_keccak256_transcript() {
         we_get_different_nontrivial_consecutive_challenges_from_transcript::<merlin::Transcript>();
+    }
+    #[test]
+    fn we_can_add_values_to_merlin_transcript_in_big_endian_form() {
+        let mut transcript1 = <merlin::Transcript as Transcript>::new();
+        transcript1.extend_as_be([1_u16, 1000, 2]);
+
+        let mut transcript2: merlin::Transcript = TranscriptCore::new();
+        transcript2.raw_append(&[0, 1]);
+        transcript2.raw_append(&[3, 232]);
+        transcript2.raw_append(&[0, 2]);
+
+        assert_eq!(transcript1.raw_challenge(), transcript2.raw_challenge());
+    }
+    #[test]
+    fn we_can_add_refs_to_merlin_transcript_in_little_endian_form() {
+        let values = [1_u16, 1000, 2];
+        let mut transcript1 = <merlin::Transcript as Transcript>::new();
+        transcript1.extend_as_le_from_refs(&values);
+
+        let mut transcript2: merlin::Transcript = TranscriptCore::new();
+        transcript2.raw_append(&[1, 0]);
+        transcript2.raw_append(&[232, 3]);
+        transcript2.raw_append(&[2, 0]);
+
+        assert_eq!(transcript1.raw_challenge(), transcript2.raw_challenge());
     }
 }

--- a/crates/proof-of-sql/src/base/proof/transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript.rs
@@ -141,6 +141,36 @@ mod tests {
     }
 
     #[test]
+    fn we_can_extend_transcript_with_little_endian_messages() {
+        let mut transcript1: Keccak256Transcript = Transcript::new();
+        let mut transcript2: Keccak256Transcript = Transcript::new();
+
+        let messages: Vec<u32> = vec![1, 2, 3, 4];
+        transcript1.extend_as_le(messages.clone());
+        transcript2.extend_as_le_from_refs(&messages);
+
+        assert_eq!(transcript1.challenge_as_le(), transcript2.challenge_as_le());
+
+        transcript2.extend_as_le([5_u32]);
+
+        assert_ne!(transcript1.challenge_as_le(), transcript2.challenge_as_le());
+    }
+
+    #[test]
+    fn big_endian_messages_match_their_little_endian_byte_reversal() {
+        let mut little_endian_transcript: Keccak256Transcript = Transcript::new();
+        let mut big_endian_transcript: Keccak256Transcript = Transcript::new();
+
+        little_endian_transcript.extend_as_le([0x0102_0304_u32]);
+        big_endian_transcript.extend_as_be([0x0403_0201_u32]);
+
+        assert_eq!(
+            little_endian_transcript.challenge_as_le(),
+            big_endian_transcript.challenge_as_le()
+        );
+    }
+
+    #[test]
     fn we_can_extend_transcript_with_extend_as_be_from_refs() {
         let mut transcript1: Keccak256Transcript = Transcript::new();
         let mut transcript2: Keccak256Transcript = Transcript::new();

--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,30 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+    use alloc::string::{String, ToString};
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct LabelLength(usize);
+
+    struct Label(String);
+
+    impl From<&Label> for LabelLength {
+        fn from(value: &Label) -> Self {
+            Self(value.0.len())
+        }
+    }
+
+    #[test]
+    fn ref_into_converts_from_reference_without_consuming_value() {
+        let label = Label("challenge".to_string());
+
+        let length: LabelLength = label.ref_into();
+
+        assert_eq!(length, LabelLength(9));
+        assert_eq!(label.0, "challenge");
+    }
+}

--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,18 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_scalar_conversion_overflow_errors() {
+        let err = ScalarConversionError::Overflow {
+            error: "value exceeds i64".to_string(),
+        };
+
+        assert_eq!(err.to_string(), "Overflow error: value exceeds i64");
+    }
+}

--- a/crates/proof-of-sql/src/base/serialize.rs
+++ b/crates/proof-of-sql/src/base/serialize.rs
@@ -51,3 +51,99 @@ macro_rules! impl_serde_for_ark_serde_unchecked {
 
 pub(crate) use impl_serde_for_ark_serde_checked;
 pub(crate) use impl_serde_for_ark_serde_unchecked;
+
+#[cfg(test)]
+mod tests {
+    use crate::base::{try_standard_binary_deserialization, try_standard_binary_serialization};
+    use ark_serialize::{
+        CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid,
+        Validate, Write,
+    };
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    struct CheckedSerdeByte(u8);
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    struct UncheckedSerdeByte(u8);
+
+    macro_rules! impl_canonical_byte {
+        ($t:ty) => {
+            impl CanonicalSerialize for $t {
+                fn serialize_with_mode<W: Write>(
+                    &self,
+                    writer: W,
+                    compress: Compress,
+                ) -> Result<(), SerializationError> {
+                    self.0.serialize_with_mode(writer, compress)
+                }
+
+                fn serialized_size(&self, compress: Compress) -> usize {
+                    self.0.serialized_size(compress)
+                }
+            }
+
+            impl Valid for $t {
+                fn check(&self) -> Result<(), SerializationError> {
+                    if self.0 == u8::MAX {
+                        Err(SerializationError::InvalidData)
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+
+            impl CanonicalDeserialize for $t {
+                fn deserialize_with_mode<R: Read>(
+                    reader: R,
+                    compress: Compress,
+                    validate: Validate,
+                ) -> Result<Self, SerializationError> {
+                    let value = Self(u8::deserialize_with_mode(reader, compress, Validate::No)?);
+                    if validate == Validate::Yes {
+                        value.check()?;
+                    }
+                    Ok(value)
+                }
+            }
+        };
+    }
+
+    impl_canonical_byte!(CheckedSerdeByte);
+    impl_canonical_byte!(UncheckedSerdeByte);
+    impl_serde_for_ark_serde_checked!(CheckedSerdeByte);
+    impl_serde_for_ark_serde_unchecked!(UncheckedSerdeByte);
+
+    #[test]
+    fn checked_ark_serde_helper_roundtrips_valid_values() {
+        let value = CheckedSerdeByte(42);
+
+        let serialized = try_standard_binary_serialization(value).unwrap();
+        let (deserialized, consumed): (CheckedSerdeByte, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, value);
+        assert_eq!(consumed, serialized.len());
+    }
+
+    #[test]
+    fn checked_ark_serde_helper_rejects_invalid_values() {
+        let serialized = try_standard_binary_serialization(CheckedSerdeByte(u8::MAX)).unwrap();
+
+        let result: Result<(CheckedSerdeByte, usize), _> =
+            try_standard_binary_deserialization(&serialized);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unchecked_ark_serde_helper_accepts_invalid_values() {
+        let value = UncheckedSerdeByte(u8::MAX);
+
+        let serialized = try_standard_binary_serialization(value).unwrap();
+        let (deserialized, consumed): (UncheckedSerdeByte, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, value);
+        assert_eq!(consumed, serialized.len());
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/add_const.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const.rs
@@ -17,3 +17,17 @@ where
         *res_i += to_add.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::add_const;
+
+    #[test]
+    fn we_can_add_const_to_an_empty_slice() {
+        let mut values: [i32; 0] = [];
+
+        add_const(&mut values, 10);
+
+        assert!(values.is_empty());
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
@@ -7,3 +7,17 @@ fn test_add_const() {
     let b = vec![1 + 10, 2 + 10, 3 + 10, 4 + 10];
     assert_eq!(a, b);
 }
+
+#[test]
+fn we_can_add_const_to_empty_slice() {
+    let mut values: [i64; 0] = [];
+    add_const(&mut values, 5_i64);
+    assert!(values.is_empty());
+}
+
+#[test]
+fn we_can_add_const_from_convertible_value() {
+    let mut values = vec![10_i64, -5, 0, 12];
+    add_const(&mut values, 7_i16);
+    assert_eq!(values, [17_i64, 2, 7, 19]);
+}

--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
@@ -106,3 +106,31 @@ where
         tmp = new_tmp;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::batch_inversion_and_mul;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use num_traits::{Inv, Zero};
+
+    #[test]
+    fn we_can_scale_batch_inversion_results() {
+        let input = [
+            TestScalar::from(0_u32),
+            TestScalar::from(2_u32),
+            TestScalar::from(5_u32),
+            TestScalar::zero(),
+            TestScalar::from(7_u32),
+        ];
+        let coeff = TestScalar::from(3_u32);
+        let mut actual = input;
+
+        batch_inversion_and_mul(&mut actual, coeff);
+
+        assert_eq!(actual[0], TestScalar::zero());
+        assert_eq!(actual[1], input[1].inv().unwrap() * coeff);
+        assert_eq!(actual[2], input[2].inv().unwrap() * coeff);
+        assert_eq!(actual[3], TestScalar::zero());
+        assert_eq!(actual[4], input[4].inv().unwrap() * coeff);
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
@@ -116,3 +116,35 @@ fn we_can_pseudo_invert_arrays_with_nonzero_count_smaller_than_min_chunking_size
         }
     }
 }
+
+#[test]
+fn we_can_batch_invert_and_multiply_by_a_coefficient() {
+    let input = [
+        TestScalar::from(2_u32),
+        TestScalar::from(3_u32),
+        TestScalar::zero(),
+        TestScalar::from(5_u32),
+    ];
+    let coeff = TestScalar::from(7_u32);
+    let mut res = input.to_vec();
+
+    slice_ops::batch_inversion_and_mul(&mut res, coeff);
+
+    for (input_val, res_val) in input.iter().zip(res) {
+        if *input_val == TestScalar::zero() {
+            assert_eq!(res_val, TestScalar::zero());
+        } else {
+            assert_eq!(res_val * *input_val, coeff);
+        }
+    }
+}
+
+#[test]
+fn we_leave_all_zero_values_unchanged_when_scaling_batch_inverse() {
+    let coeff = TestScalar::from(11_u32);
+    let mut res = vec![TestScalar::zero(); 4];
+
+    slice_ops::batch_inversion_and_mul(&mut res, coeff);
+
+    assert_eq!(res, vec![TestScalar::zero(); 4]);
+}

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -162,3 +162,31 @@ fn test_inner_product_testscalar_uneven() {
     ];
     assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
+
+#[test]
+fn test_inner_product_ref_cast() {
+    let a = vec![
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
+        TestScalar::from(5u64),
+    ];
+    let b = vec![
+        TestScalar::from(7u64),
+        TestScalar::from(11u64),
+        TestScalar::from(13u64),
+    ];
+
+    assert_eq!(TestScalar::from(112u64), inner_product_ref_cast(&a, &b));
+}
+
+#[test]
+fn test_inner_product_ref_cast_truncates_to_shorter_slice() {
+    let a = vec![TestScalar::from(2u64), TestScalar::from(3u64)];
+    let b = vec![
+        TestScalar::from(7u64),
+        TestScalar::from(11u64),
+        TestScalar::from(13u64),
+    ];
+
+    assert_eq!(TestScalar::from(47u64), inner_product_ref_cast(&a, &b));
+}

--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
@@ -24,3 +24,20 @@ where
         *res_i += multiplier * data_i.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::mul_add_assign;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_leave_result_unchanged_when_mul_add_input_is_empty() {
+        let mut result = [1_u32, 2, 3].map(TestScalar::from);
+        let original = result;
+        let to_mul_add: [u32; 0] = [];
+
+        mul_add_assign(&mut result, TestScalar::from(10_u32), &to_mul_add);
+
+        assert_eq!(result, original);
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
@@ -54,3 +54,35 @@ fn test_mul_add_assign_testscalar_uneven() {
     let c = [1 + 10 * 2, 2 + 10 * 3, 3].map(TestScalar::from).to_vec();
     assert_eq!(a, c);
 }
+
+#[test]
+fn test_mul_add_assign_empty_input_leaves_result_unchanged() {
+    let mut a = [1, 2, 3].map(TestScalar::from).to_vec();
+    let expected = a.clone();
+    let b: Vec<TestScalar> = Vec::new();
+
+    mul_add_assign(&mut a, TestScalar::from(10u64), &b);
+
+    assert_eq!(a, expected);
+}
+
+#[test]
+fn test_mul_add_assign_empty_result_accepts_empty_input() {
+    let mut a: Vec<TestScalar> = Vec::new();
+    let b: Vec<TestScalar> = Vec::new();
+
+    mul_add_assign(&mut a, TestScalar::from(10u64), &b);
+
+    assert!(a.is_empty());
+}
+
+#[test]
+fn test_mul_add_assign_zero_multiplier_leaves_result_unchanged() {
+    let mut a = [1, 2, 3].map(TestScalar::from).to_vec();
+    let expected = a.clone();
+    let b = [4, 5, 6].map(TestScalar::from).to_vec();
+
+    mul_add_assign(&mut a, TestScalar::from(0u64), &b);
+
+    assert_eq!(a, expected);
+}

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
@@ -53,3 +53,18 @@ where
 {
     slice_cast_mut_with(value, result, Into::into);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::slice_cast_mut_with;
+
+    #[test]
+    fn we_only_fill_available_mut_cast_slots() {
+        let input = [1_u32, 2, 3];
+        let mut result = [0_u64; 2];
+
+        slice_cast_mut_with(&input, &mut result, |&value| u64::from(value) * 10);
+
+        assert_eq!(result, [10, 20]);
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
@@ -41,6 +41,14 @@ fn test_slice_cast_random_from_integer_to_testscalar() {
     assert_eq!(a, b);
 }
 
+#[test]
+fn we_can_slice_cast_empty_input() {
+    let values: Vec<u32> = vec![];
+    let casted: Vec<u64> = slice_cast_with(&values, |&value| u64::from(value));
+
+    assert!(casted.is_empty());
+}
+
 /// Test that mut cast does the same as vec cast
 #[test]
 fn test_slice_cast_mut() {
@@ -48,6 +56,16 @@ fn test_slice_cast_mut() {
     let mut b: Vec<u64> = vec![0, 0, 0, 0];
     slice_cast_mut_with(&a, &mut b, |&x| u64::from(x));
     assert_eq!(b, slice_cast_with(&a, |&x| u64::from(x)));
+}
+
+#[test]
+fn we_can_slice_cast_mut_without_overwriting_extra_result_values() {
+    let values = vec![1_u32, 2, 3];
+    let mut result = vec![10_u64, 20, 30, 40, 50];
+
+    slice_cast_mut_with(&values, &mut result, |&value| u64::from(value) * 2);
+
+    assert_eq!(result, [2_u64, 4, 6, 40, 50]);
 }
 
 /// random test for [`slice_cast_mut_with`]

--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,34 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn serializes_in_fixed_width_big_endian_order() {
+        let serialized = try_standard_binary_serialization((0x1234u16, -2i16)).unwrap();
+
+        assert_eq!(serialized, [0x12, 0x34, 0xff, 0xfe]);
+    }
+
+    #[test]
+    fn deserialization_reports_consumed_byte_count_with_trailing_bytes() {
+        let mut serialized = try_standard_binary_serialization(0x1234_5678u32).unwrap();
+        let original_len = serialized.len();
+        serialized.extend_from_slice(&[0xaa, 0xbb]);
+
+        let (deserialized, bytes_read): (u32, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, 0x1234_5678);
+        assert_eq!(bytes_read, original_len);
+    }
+
+    #[test]
+    fn deserialization_rejects_invalid_boolean_encoding() {
+        let err = try_standard_binary_deserialization::<bool>(&[2]).unwrap_err();
+
+        assert!(matches!(
+            err,
+            bincode::error::DecodeError::InvalidBooleanValue(2)
+        ));
+    }
 }

--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,49 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct LimbsContainer {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn serialize_limbs_emits_most_significant_limb_first() {
+        let value = LimbsContainer {
+            limbs: [0x11, 0x22, 0x33, 0x44],
+        };
+
+        let serialized = serde_json::to_string(&value).unwrap();
+
+        assert_eq!(serialized, r#"{"limbs":[68,51,34,17]}"#);
+    }
+
+    #[test]
+    fn deserialize_to_limbs_restores_internal_limb_order() {
+        let deserialized: LimbsContainer =
+            serde_json::from_str(r#"{"limbs":[68,51,34,17]}"#).unwrap();
+
+        assert_eq!(
+            deserialized,
+            LimbsContainer {
+                limbs: [0x11, 0x22, 0x33, 0x44],
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_to_limbs_rejects_the_wrong_limb_count() {
+        let err = serde_json::from_str::<LimbsContainer>(r#"{"limbs":[1,2,3]}"#).unwrap_err();
+
+        assert!(err.is_data());
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/inner_product/inner_product_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/inner_product_proof.rs
@@ -52,6 +52,11 @@ impl CommitmentEvaluationProof for InnerProductProof {
         _setup: &Self::VerifierPublicSetup<'_>,
     ) -> Result<(), Self::Error> {
         assert!(table_length > 0);
+        if commit_batch.len() != batching_factors.len()
+            || evaluations.len() != batching_factors.len()
+        {
+            return Err(ProofError::VerificationError);
+        }
         let b = &mut vec![MontScalar::default(); table_length];
         if b_point.is_empty() {
             assert_eq!(b.len(), 1);
@@ -88,9 +93,15 @@ impl CommitmentEvaluationProof for InnerProductProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::commitment::commitment_evaluation_proof_test::{
-        test_commitment_evaluation_proof_with_length_1, test_random_commitment_evaluation_proof,
-        test_simple_commitment_evaluation_proof,
+    use crate::base::{
+        commitment::{
+            commitment_evaluation_proof_test::{
+                test_commitment_evaluation_proof_with_length_1,
+                test_random_commitment_evaluation_proof, test_simple_commitment_evaluation_proof,
+            },
+            VecCommitmentExt,
+        },
+        database::Column,
     };
 
     #[test]
@@ -101,6 +112,30 @@ mod tests {
     #[test]
     fn test_random_ipa_with_length_1() {
         test_commitment_evaluation_proof_with_length_1::<InnerProductProof>(&(), &());
+    }
+
+    #[test]
+    fn we_reject_mismatched_batched_proof_lengths() {
+        let a = [MontScalar::from(7_u64)];
+        let mut transcript = merlin::Transcript::new(b"evaluation_proof");
+        let proof = InnerProductProof::new(&mut transcript, &a, &[], 0, &());
+
+        let commits = Vec::from_columns_with_offset([Column::Scalar(&a)], 0, &());
+        let batching_factors = [MontScalar::ONE, MontScalar::ZERO];
+        let evaluations = [a[0], MontScalar::from(123_u64)];
+
+        let mut transcript = merlin::Transcript::new(b"evaluation_proof");
+        let result = proof.verify_batched_proof(
+            &mut transcript,
+            &commits,
+            &batching_factors,
+            &evaluations,
+            &[],
+            0,
+            1,
+            &(),
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,63 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_direct_analyze_errors() {
+        assert_eq!(
+            AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::Boolean
+            }
+            .to_string(),
+            "Expression has datatype BOOLEAN, which was not valid"
+        );
+        assert_eq!(
+            AnalyzeError::DataTypeMismatch {
+                left_type: "INT".to_string(),
+                right_type: "VARCHAR".to_string(),
+            }
+            .to_string(),
+            "Left side has 'INT' type but right side has 'VARCHAR' type"
+        );
+        assert_eq!(
+            AnalyzeError::DifferentColumnLength { len_a: 3, len_b: 5 }.to_string(),
+            "Columns have different lengths: 3 != 5"
+        );
+        assert_eq!(
+            AnalyzeError::NotEnoughInputPlans.to_string(),
+            "Not enough input plans"
+        );
+    }
+
+    #[test]
+    fn we_can_convert_analyze_errors_into_strings() {
+        let err = AnalyzeError::DataTypeMismatch {
+            left_type: "BOOLEAN".to_string(),
+            right_type: "BIGINT".to_string(),
+        };
+
+        assert_eq!(
+            String::from(err),
+            "Left side has 'BOOLEAN' type but right side has 'BIGINT' type"
+        );
+    }
+
+    #[test]
+    fn we_wrap_intermediate_decimal_errors_as_analyze_errors() {
+        let err = AnalyzeError::from(IntermediateDecimalError::LossyCast);
+
+        assert_eq!(err.to_string(), "Fractional part of decimal is non-zero");
+        assert!(matches!(
+            err,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::LossyCast
+                }
+            }
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,55 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::{String, ToString};
+
+    #[test]
+    fn we_can_display_evm_proof_plan_errors() {
+        let cases = [
+            (EVMProofPlanError::NotSupported, "plan not yet supported"),
+            (EVMProofPlanError::ColumnNotFound, "column not found"),
+            (EVMProofPlanError::TableNotFound, "table not found"),
+            (
+                EVMProofPlanError::InvalidTableName,
+                "table name can not be parsed into TableRef",
+            ),
+            (
+                EVMProofPlanError::InvalidOutputColumnName,
+                "invalid or missing output column name",
+            ),
+            (
+                EVMProofPlanError::InconsistentGroupByColumnCounts,
+                "column counts in group by plans are inconsistent",
+            ),
+            (
+                EVMProofPlanError::IncorrectScalingFactor,
+                "incorrect scaling factor",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn analyze_errors_are_transparently_wrapped() {
+        let error = EVMProofPlanError::AnalyzeError {
+            source: AnalyzeError::NotEnoughInputPlans,
+        };
+
+        assert_eq!(error.to_string(), "Not enough input plans");
+    }
+
+    #[test]
+    fn evm_proof_plan_errors_convert_into_string() {
+        let error = EVMProofPlanError::ColumnNotFound;
+        let message: String = error.to_string();
+
+        assert_eq!(message, "column not found");
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder_test.rs
@@ -2,6 +2,19 @@ use super::CompositePolynomialBuilder;
 use crate::proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar;
 use num_traits::One;
 
+fn eval_three_value_mle_at_two_var_point(
+    values: [u64; 3],
+    pt: &[Curve25519Scalar; 2],
+) -> Curve25519Scalar {
+    let m00 = (Curve25519Scalar::one() - pt[0]) * (Curve25519Scalar::one() - pt[1]);
+    let m10 = pt[0] * (Curve25519Scalar::one() - pt[1]);
+    let m01 = (Curve25519Scalar::one() - pt[0]) * pt[1];
+
+    Curve25519Scalar::from(values[0]) * m00
+        + Curve25519Scalar::from(values[1]) * m10
+        + Curve25519Scalar::from(values[2]) * m01
+}
+
 #[test]
 fn we_combine_single_degree_fr_multiplicands() {
     let fr = [Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
@@ -116,4 +129,39 @@ fn we_can_handle_empty_terms_with_other_terms() {
     let eval_fr = fr[0] * m0 + fr[1] * m1;
     let expected = eval_fr * (eval1 * eval2 + Curve25519Scalar::from(17)) - eval3 * eval4;
     assert_eq!(p.evaluate(&pt), expected);
+}
+
+#[test]
+fn we_can_build_with_padded_terms_and_single_zero_sum_multiplicand() {
+    let fr = [
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(2u64),
+        Curve25519Scalar::from(3u64),
+    ];
+    let mle = [4, 5, 6];
+    let zero_sum_mle = [7, 8, 9];
+    let mut builder = CompositePolynomialBuilder::new(2, &fr);
+    builder.produce_fr_multiplicand(&Curve25519Scalar::from(3), &[Box::new(&mle)]);
+    builder.produce_zerosum_multiplicand(&-Curve25519Scalar::from(2), &[Box::new(&zero_sum_mle)]);
+
+    let p = builder.make_composite_polynomial();
+
+    assert_eq!(p.products.len(), 2);
+    assert_eq!(p.flattened_ml_extensions.len(), 3);
+    let pt = [Curve25519Scalar::from(2u64), Curve25519Scalar::from(3u64)];
+    let eval_fr = eval_three_value_mle_at_two_var_point([1, 2, 3], &pt);
+    let eval_mle = eval_three_value_mle_at_two_var_point([4, 5, 6], &pt);
+    let eval_zero_sum_mle = eval_three_value_mle_at_two_var_point([7, 8, 9], &pt);
+    let expected = eval_fr * Curve25519Scalar::from(3) * eval_mle
+        - Curve25519Scalar::from(2) * eval_zero_sum_mle;
+    assert_eq!(p.evaluate(&pt), expected);
+}
+
+#[test]
+#[should_panic]
+fn we_reject_empty_zero_sum_multiplicands() {
+    let fr = [Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
+    let mut builder = CompositePolynomialBuilder::new(1, &fr);
+
+    builder.produce_zerosum_multiplicand(&Curve25519Scalar::one(), &[]);
 }

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
@@ -156,3 +156,27 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
         self.post_result_challenges.pop_front().unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{FinalRoundBuilder, SumcheckSubpolynomialType};
+    use crate::base::{bit::BitDistribution, scalar::test_scalar::TestScalar};
+    use alloc::{collections::VecDeque, vec};
+
+    #[test]
+    fn we_can_track_bit_distributions_and_sumcheck_subpolynomials() {
+        let mut builder = FinalRoundBuilder::<TestScalar>::new(3, VecDeque::new());
+        let bit_distribution = BitDistribution::new::<TestScalar, _>(&[1_i64, 3, 7]);
+
+        builder.produce_bit_distribution(bit_distribution.clone());
+        builder.produce_sumcheck_subpolynomial(SumcheckSubpolynomialType::Identity, vec![]);
+
+        assert_eq!(builder.num_sumcheck_variables(), 3);
+        assert_eq!(builder.bit_distributions(), &[bit_distribution]);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+        assert_eq!(
+            builder.sumcheck_subpolynomials()[0].subpolynomial_type(),
+            SumcheckSubpolynomialType::Identity
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -1,12 +1,13 @@
-use super::{FinalRoundBuilder, ProvableQueryResult};
+use super::{FinalRoundBuilder, ProvableQueryResult, SumcheckSubpolynomialType};
 use crate::{
     base::{
+        bit::BitDistribution,
         commitment::{Commitment, CommittableColumn},
         database::{Column, ColumnField, ColumnType},
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
 };
-use alloc::{collections::VecDeque, sync::Arc};
+use alloc::{boxed::Box, collections::VecDeque, sync::Arc};
 #[cfg(feature = "arrow")]
 use arrow::{
     array::Int64Array,
@@ -70,6 +71,38 @@ fn we_can_evaluate_pcs_proof_mles() {
         Curve25519Scalar::from(1200u64),
     ];
     assert_eq!(evals, expected_evals);
+}
+
+#[test]
+fn we_can_track_final_round_builder_state() {
+    let mle = [5_i64, 6];
+    let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+    assert_eq!(builder.num_sumcheck_variables(), 2);
+    assert_eq!(builder.num_sumcheck_subpolynomials(), 0);
+    assert!(builder.bit_distributions().is_empty());
+    assert!(builder.pcs_proof_mles().is_empty());
+    assert!(builder.sumcheck_subpolynomials().is_empty());
+
+    let bit_distribution = BitDistribution::new::<Curve25519Scalar, _>(&[1_u64, 2, 3]);
+    builder.produce_bit_distribution(bit_distribution.clone());
+    assert_eq!(
+        builder.bit_distributions(),
+        core::slice::from_ref(&bit_distribution)
+    );
+
+    builder.produce_anchored_mle(&mle);
+    assert_eq!(builder.pcs_proof_mles().len(), 1);
+
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![(Curve25519Scalar::from(7_u64), vec![Box::new(&mle)])],
+    );
+
+    assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+    assert_eq!(
+        builder.sumcheck_subpolynomials()[0].subpolynomial_type(),
+        SumcheckSubpolynomialType::Identity
+    );
 }
 
 #[cfg(feature = "arrow")]

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
@@ -139,3 +139,23 @@ impl<'a, S: Scalar> FirstRoundBuilder<'a, S> {
         self.num_post_result_challenges += cnt;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FirstRoundBuilder;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_track_range_and_requested_evaluation_lengths() {
+        let mut builder = FirstRoundBuilder::<TestScalar>::new(4);
+
+        builder.update_range_length(2);
+        builder.produce_chi_evaluation_length(8);
+        builder.produce_rho_evaluation_length(6);
+
+        assert_eq!(builder.range_length(), 8);
+        assert_eq!(builder.chi_evaluation_lengths(), &[8]);
+        assert_eq!(builder.rho_evaluation_lengths(), &[6]);
+        assert!(builder.pcs_proof_mles().is_empty());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder_test.rs
@@ -65,6 +65,33 @@ fn we_can_evaluate_pcs_proof_mles() {
 }
 
 #[test]
+fn we_can_track_first_round_builder_state() {
+    let mle = [3_i64, 4];
+    let mut builder = FirstRoundBuilder::<Curve25519Scalar>::new(2);
+
+    assert_eq!(builder.range_length(), 2);
+    assert!(builder.chi_evaluation_lengths().is_empty());
+    assert!(builder.rho_evaluation_lengths().is_empty());
+    assert!(builder.pcs_proof_mles().is_empty());
+
+    builder.update_range_length(1);
+    assert_eq!(builder.range_length(), 2);
+
+    builder.produce_chi_evaluation_length(5);
+    builder.produce_chi_evaluation_length(3);
+    assert_eq!(builder.chi_evaluation_lengths(), &[5, 3]);
+    assert_eq!(builder.range_length(), 5);
+
+    builder.produce_rho_evaluation_length(8);
+    builder.produce_rho_evaluation_length(13);
+    assert_eq!(builder.rho_evaluation_lengths(), &[8, 13]);
+    assert_eq!(builder.range_length(), 5);
+
+    builder.produce_intermediate_mle(&mle[..]);
+    assert_eq!(builder.pcs_proof_mles().len(), 1);
+}
+
+#[test]
 fn we_can_add_post_result_challenges() {
     let mut builder = FirstRoundBuilder::<Curve25519Scalar>::new(0);
     assert_eq!(builder.num_post_result_challenges(), 0);

--- a/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
+++ b/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
@@ -289,4 +289,28 @@ mod tests {
         assert_eq!(prover_state.num_vars, 3);
         assert_eq!(prover_state.max_multiplicands, 4);
     }
+
+    #[test]
+    fn we_do_not_add_entrywise_multipliers_for_zerosum_only_terms() {
+        let mle = &[2, 4];
+        let subpolynomials = vec![SumcheckSubpolynomial::new(
+            SumcheckSubpolynomialType::ZeroSum,
+            vec![(TestScalar::from(3), vec![Box::new(mle)])],
+        )];
+        let scalars = vec![TestScalar::from(5), TestScalar::from(99)];
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 2, 1);
+
+        let prover_state = make_sumcheck_prover_state(&subpolynomials, 1, &random_scalars);
+
+        assert_eq!(
+            prover_state.list_of_products,
+            vec![(TestScalar::from(15), vec![0])]
+        );
+        assert_eq!(
+            prover_state.flattened_ml_extensions,
+            vec![vec![TestScalar::from(2), TestScalar::from(4)]]
+        );
+        assert_eq!(prover_state.num_vars, 1);
+        assert_eq!(prover_state.max_multiplicands, 1);
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -664,4 +664,70 @@ mod tests {
             .unwrap_err();
         assert!(matches!(error, ProofSizeMismatch::TooFewBitDistributions));
     }
+
+    #[test]
+    fn we_can_collect_identity_and_zero_sum_results() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(
+                Vec::new(),
+                2,
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            );
+
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::ZERO,
+                1,
+            )
+            .unwrap();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::ONE,
+                1,
+            )
+            .unwrap();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::ZeroSum,
+                TestScalar::ONE,
+                2,
+            )
+            .unwrap();
+
+        verification_builder.increment_row_index();
+
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::ZERO,
+                1,
+            )
+            .unwrap();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::ZERO,
+                1,
+            )
+            .unwrap();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::ZeroSum,
+                -TestScalar::ONE,
+                2,
+            )
+            .unwrap();
+
+        assert_eq!(
+            verification_builder.get_identity_results(),
+            vec![vec![true, false], vec![true, true]]
+        );
+        assert_eq!(verification_builder.get_zero_sum_results(), vec![true]);
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -69,3 +69,41 @@ impl<'a, T: ProvableResultElement<'a>, const N: usize> ProvableResultColumn for 
         (&self[..]).write(out, length)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_count_and_write_result_slices() {
+        let values = [3_u8, 5, 8];
+        let column = &values[..];
+        let mut out = [0_u8; 3];
+
+        assert_eq!(column.num_bytes(3), 3);
+        assert_eq!(column.write(&mut out, 3), 3);
+        assert_eq!(out, values);
+    }
+
+    #[test]
+    fn we_count_and_write_result_arrays() {
+        let values = [13_u8, 21];
+        let mut out = [0_u8; 2];
+
+        assert_eq!(values.num_bytes(2), 2);
+        assert_eq!(values.write(&mut out, 2), 2);
+        assert_eq!(out, values);
+    }
+
+    #[test]
+    fn we_delegate_column_serialization_to_the_inner_column() {
+        let values = [34_u8, 55];
+        let column = Column::<TestScalar>::Uint8(&values);
+        let mut out = [0_u8; 2];
+
+        assert_eq!(column.num_bytes(2), (&values[..]).num_bytes(2));
+        assert_eq!(column.write(&mut out, 2), 2);
+        assert_eq!(out, values);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,61 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_display_direct_query_errors() {
+        assert_eq!(QueryError::Overflow.to_string(), "Overflow error");
+        assert_eq!(QueryError::InvalidString.to_string(), "String decode error");
+        assert_eq!(
+            QueryError::MiscellaneousDecodingError.to_string(),
+            "Miscellaneous decoding error"
+        );
+        assert_eq!(
+            QueryError::MiscellaneousEvaluationError.to_string(),
+            "Miscellaneous evaluation error"
+        );
+        assert_eq!(
+            QueryError::InvalidColumnCount.to_string(),
+            "Invalid number of columns"
+        );
+    }
+
+    #[test]
+    fn we_convert_table_coercion_overflow_to_query_overflow() {
+        let error = TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::Overflow,
+        };
+
+        let query_error = QueryError::from(error);
+
+        assert!(matches!(query_error, QueryError::Overflow));
+    }
+
+    #[test]
+    fn we_convert_table_coercion_mismatches_to_proof_errors() {
+        let query_error = QueryError::from(TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::InvalidTypeCoercion,
+        });
+        assert_eq!(
+            query_error.to_string(),
+            "Result does not match query: type mismatch"
+        );
+
+        let query_error = QueryError::from(TableCoercionError::NameMismatch);
+        assert_eq!(
+            query_error.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+
+        let query_error = QueryError::from(TableCoercionError::ColumnCountMismatch);
+        assert_eq!(
+            query_error.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -206,6 +206,18 @@ mod tests {
     }
 
     #[test]
+    fn we_can_encode_and_decode_an_owned_string() {
+        let value = String::from("owned test string");
+        let mut out = vec![0_u8; value.required_bytes()];
+        value.encode(&mut out[..]);
+
+        let (decoded_value, read_bytes) = String::decode(&out[..]).unwrap();
+
+        assert_eq!(read_bytes, out.len());
+        assert_eq!(decoded_value, value);
+    }
+
+    #[test]
     fn we_can_encode_and_decode_a_simple_array() {
         let value = &[1_u8, 3_u8, 5_u8][..];
         let mut out = vec![0_u8; value.required_bytes()];
@@ -387,6 +399,21 @@ mod tests {
         let out = encode_multiple_rows(&data);
         let (decoded_data, decoded_bytes) =
             decode_multiple_elements::<&str>(&out[..], data.len()).unwrap();
+        assert_eq!(decoded_data, data);
+        assert_eq!(decoded_bytes, out.len());
+    }
+
+    #[test]
+    fn multiple_owned_string_rows_are_correctly_encoded_and_decoded() {
+        let data = [
+            String::from("abc1"),
+            String::from("joe123"),
+            String::from("testing435t"),
+        ];
+        let out = encode_multiple_rows(&data);
+        let (decoded_data, decoded_bytes) =
+            decode_multiple_elements::<String>(&out[..], data.len()).unwrap();
+
         assert_eq!(decoded_data, data);
         assert_eq!(decoded_bytes, out.len());
     }

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations.rs
@@ -112,3 +112,65 @@ impl<'a, S: Scalar> SumcheckMleEvaluations<'a, S> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SumcheckMleEvaluations;
+    use crate::{
+        base::scalar::{test_scalar::TestScalar, Scalar},
+        sql::proof::SumcheckRandomScalars,
+    };
+
+    #[test]
+    fn we_only_compute_rho_256_when_the_point_has_enough_variables() {
+        let evaluation_point = [TestScalar::ONE; 7];
+        let random_scalars = [TestScalar::ZERO; 7];
+        let sumcheck_random_scalars =
+            SumcheckRandomScalars::new(&random_scalars, 1, evaluation_point.len());
+
+        let evaluations = SumcheckMleEvaluations::new(
+            1,
+            [],
+            [],
+            &evaluation_point,
+            &sumcheck_random_scalars,
+            &[],
+            &[],
+        );
+
+        assert_eq!(evaluations.rho_256_evaluation, None);
+    }
+
+    #[test]
+    fn we_compute_rho_256_with_padding_variables() {
+        let evaluation_point = [
+            TestScalar::ONE,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::from(3_u32),
+        ];
+        let random_scalars = [TestScalar::ZERO; 9];
+        let sumcheck_random_scalars =
+            SumcheckRandomScalars::new(&random_scalars, 1, evaluation_point.len());
+
+        let evaluations = SumcheckMleEvaluations::new(
+            1,
+            [],
+            [],
+            &evaluation_point,
+            &sumcheck_random_scalars,
+            &[],
+            &[],
+        );
+
+        assert_eq!(
+            evaluations.rho_256_evaluation,
+            Some(-TestScalar::from(2_u32))
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
@@ -3,7 +3,7 @@ use crate::{
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::SumcheckRandomScalars,
 };
-use num_traits::One;
+use num_traits::{One, Zero};
 
 #[test]
 fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
@@ -46,5 +46,63 @@ fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
     assert_eq!(
         *evals.chi_evaluations.values().next().unwrap(),
         expected_eval
+    );
+}
+
+#[test]
+fn we_track_rho_and_rho_256_evaluations_used_within_sumcheck() {
+    let evaluation_point = [
+        Curve25519Scalar::one(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+    ];
+    let random_scalars = [
+        Curve25519Scalar::from(123u64),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+        Curve25519Scalar::zero(),
+    ];
+    let sumcheck_random_scalars = SumcheckRandomScalars::new(&random_scalars, 1, 8);
+    let first_round_evaluations = [Curve25519Scalar::from(11u64)];
+    let final_round_evaluations = [Curve25519Scalar::from(22u64), Curve25519Scalar::from(33u64)];
+
+    let evals = SumcheckMleEvaluations::new(
+        1,
+        [1, 2, 2],
+        [2],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &first_round_evaluations,
+        &final_round_evaluations,
+    );
+
+    assert_eq!(evals.rho_256_evaluation, Some(Curve25519Scalar::one()));
+    assert_eq!(evals.chi_evaluations.len(), 2);
+    assert_eq!(
+        evals.chi_evaluations[&1],
+        Curve25519Scalar::zero(),
+        "the singleton basis is zero at index 1"
+    );
+    assert_eq!(evals.chi_evaluations[&2], Curve25519Scalar::one());
+    assert_eq!(evals.rho_evaluations[&2], Curve25519Scalar::one());
+    assert_eq!(evals.singleton_chi_evaluation, Curve25519Scalar::zero());
+    assert_eq!(evals.random_evaluation, Curve25519Scalar::zero());
+    assert_eq!(
+        evals.first_round_pcs_proof_evaluations,
+        &first_round_evaluations
+    );
+    assert_eq!(
+        evals.final_round_pcs_proof_evaluations,
+        &final_round_evaluations
     );
 }

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
@@ -27,3 +27,60 @@ impl<'a, S: Scalar> SumcheckRandomScalars<'a, S> {
         v
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use num_traits::One;
+
+    #[test]
+    fn we_split_sumcheck_scalars_into_multipliers_and_entrywise_point() {
+        let scalars = [
+            TestScalar::from(10u64),
+            TestScalar::from(20u64),
+            TestScalar::from(30u64),
+            TestScalar::from(3u64),
+            TestScalar::from(4u64),
+        ];
+
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 3, 2);
+
+        assert_eq!(random_scalars.subpolynomial_multipliers, &scalars[..3]);
+        assert_eq!(random_scalars.entrywise_point, &scalars[3..]);
+        assert_eq!(random_scalars.table_length, 3);
+    }
+
+    #[test]
+    fn we_compute_entrywise_multipliers_for_the_table_length() {
+        let scalars = [
+            TestScalar::from(10u64),
+            TestScalar::from(3u64),
+            TestScalar::from(4u64),
+        ];
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 3, 2);
+
+        let multipliers = random_scalars.compute_entrywise_multipliers();
+
+        assert_eq!(
+            multipliers,
+            vec![
+                (TestScalar::one() - TestScalar::from(4u64))
+                    * (TestScalar::one() - TestScalar::from(3u64)),
+                (TestScalar::one() - TestScalar::from(4u64)) * TestScalar::from(3u64),
+                TestScalar::from(4u64) * (TestScalar::one() - TestScalar::from(3u64)),
+            ]
+        );
+    }
+
+    #[test]
+    fn we_compute_empty_entrywise_multipliers_for_empty_tables() {
+        let scalars = [TestScalar::from(3u64), TestScalar::from(4u64)];
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 0, 2);
+
+        assert_eq!(
+            random_scalars.compute_entrywise_multipliers(),
+            Vec::<TestScalar>::new()
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -91,9 +91,10 @@ impl<'a, S: Scalar> SumcheckSubpolynomial<'a, S> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::CompositePolynomialBuilder;
     use super::{SumcheckSubpolynomial, SumcheckSubpolynomialTerm, SumcheckSubpolynomialType};
     use crate::base::scalar::test_scalar::TestScalar;
-    use alloc::boxed::Box;
+    use alloc::{boxed::Box, vec::Vec};
 
     #[test]
     fn test_iter_mul_by() {
@@ -118,5 +119,53 @@ mod tests {
         assert_eq!(coeff, TestScalar::from(15));
 
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_iter_mul_by_for_zerosum_terms() {
+        let mle = vec![TestScalar::from(7), TestScalar::from(11)];
+        let terms: Vec<SumcheckSubpolynomialTerm<_>> =
+            vec![(TestScalar::from(2), vec![Box::new(&mle)])];
+        let subpoly = SumcheckSubpolynomial::new(SumcheckSubpolynomialType::ZeroSum, terms);
+
+        let mut iter = subpoly.iter_mul_by(TestScalar::from(5));
+        let (subpoly_type, coeff, extensions) = iter.next().unwrap();
+
+        assert_eq!(
+            subpoly.subpolynomial_type(),
+            SumcheckSubpolynomialType::ZeroSum
+        );
+        assert_eq!(subpoly_type, SumcheckSubpolynomialType::ZeroSum);
+        assert_eq!(coeff, TestScalar::from(10));
+        assert_eq!(extensions.len(), 1);
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_compose_adds_identity_and_zerosum_terms() {
+        let fr = [TestScalar::from(7), TestScalar::from(11)];
+        let mut builder = CompositePolynomialBuilder::new(1, &fr);
+
+        let identity_terms: Vec<SumcheckSubpolynomialTerm<'_, TestScalar>> =
+            vec![(TestScalar::from(3), vec![])];
+        let identity_subpoly =
+            SumcheckSubpolynomial::new(SumcheckSubpolynomialType::Identity, identity_terms);
+        identity_subpoly.compose(&mut builder, TestScalar::from(5));
+
+        let mle = vec![TestScalar::from(2), TestScalar::from(4)];
+        let zerosum_terms: Vec<SumcheckSubpolynomialTerm<_>> =
+            vec![(TestScalar::from(6), vec![Box::new(&mle)])];
+        let zerosum_subpoly =
+            SumcheckSubpolynomial::new(SumcheckSubpolynomialType::ZeroSum, zerosum_terms);
+        zerosum_subpoly.compose(&mut builder, TestScalar::from(2));
+
+        let composite = builder.make_composite_polynomial();
+        let expected_identity = TestScalar::from(15) * (fr[0] + fr[1]);
+        let expected_zerosum = TestScalar::from(12) * (mle[0] + mle[1]);
+
+        assert_eq!(
+            composite.hypercube_sum(2),
+            expected_identity + expected_zerosum
+        );
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
@@ -141,3 +141,67 @@ impl<'a, S: Scalar + 'a> IntoIterator for &'a OptimizedSumcheckTerms<'a, S> {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SumcheckTermOptimizer;
+    use crate::{
+        base::{polynomial::MultilinearExtension, scalar::test_scalar::TestScalar},
+        sql::proof::SumcheckSubpolynomialType,
+    };
+    use alloc::{boxed::Box, vec};
+
+    #[test]
+    fn we_can_merge_constant_and_linear_terms() {
+        let linear_a = vec![
+            TestScalar::from(1_u32),
+            TestScalar::from(2_u32),
+            TestScalar::from(3_u32),
+        ];
+        let linear_b = vec![
+            TestScalar::from(10_u32),
+            TestScalar::from(20_u32),
+            TestScalar::from(30_u32),
+        ];
+        let constant_term: Vec<Box<dyn MultilinearExtension<TestScalar>>> = vec![];
+        let linear_a_term: Vec<Box<dyn MultilinearExtension<TestScalar>>> =
+            vec![Box::new(&linear_a)];
+        let linear_b_term: Vec<Box<dyn MultilinearExtension<TestScalar>>> =
+            vec![Box::new(&linear_b)];
+
+        let terms = vec![
+            (
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::from(5_u32),
+                &constant_term,
+            ),
+            (
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::from(2_u32),
+                &linear_a_term,
+            ),
+            (
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::from(3_u32),
+                &linear_b_term,
+            ),
+        ];
+        let optimizer = SumcheckTermOptimizer::new(terms.into_iter(), 3);
+        let optimized_terms = optimizer.terms();
+        let collected_terms: Vec<_> = (&optimized_terms).into_iter().collect();
+
+        assert_eq!(collected_terms.len(), 1);
+        assert_eq!(collected_terms[0].0, SumcheckSubpolynomialType::Identity);
+        assert_eq!(collected_terms[0].1, TestScalar::from(1_u32));
+        assert_eq!(collected_terms[0].2.len(), 1);
+        assert_eq!(
+            collected_terms[0].2[0].to_sumcheck_term(2),
+            vec![
+                TestScalar::from(37_u32),
+                TestScalar::from(69_u32),
+                TestScalar::from(101_u32),
+                TestScalar::from(0_u32)
+            ]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -153,3 +153,20 @@ pub fn tamper_first_row_of_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedCo
     }
     column
 }
+
+#[cfg(test)]
+mod tests {
+    use super::tamper_first_row_of_column;
+    use crate::base::{database::OwnedColumn, scalar::test_scalar::TestScalar};
+    use alloc::vec;
+
+    #[test]
+    fn we_can_tamper_varbinary_columns_without_mutating_the_original() {
+        let column = OwnedColumn::<TestScalar>::VarBinary(vec![vec![1_u8, 2]]);
+
+        let tampered = tamper_first_row_of_column(&column);
+
+        assert_eq!(column, OwnedColumn::VarBinary(vec![vec![1_u8, 2]]));
+        assert_eq!(tampered, OwnedColumn::VarBinary(vec![vec![1_u8, 2, 1]]));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -259,3 +259,60 @@ impl<S: Scalar> VerificationBuilder<S> for VerificationBuilderImpl<'_, S> {
         self.mle_evaluations.rho_256_evaluation
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{SumcheckMleEvaluations, VerificationBuilder, VerificationBuilderImpl};
+    use crate::base::{
+        bit::BitDistribution,
+        scalar::{test_scalar::TestScalar, Scalar},
+    };
+
+    #[test]
+    fn we_can_consume_recorded_evaluations_and_accessors() {
+        let first_round_evaluations = [TestScalar::from(11_u32), TestScalar::from(22_u32)];
+        let final_round_evaluations = [TestScalar::from(33_u32)];
+        let bit_distribution = BitDistribution::new::<TestScalar, _>(&[1_i64, 2, 3]);
+        let mle_evaluations = SumcheckMleEvaluations {
+            chi_evaluations: [(4, TestScalar::from(44_u32))].into_iter().collect(),
+            rho_evaluations: [(8, TestScalar::from(88_u32))].into_iter().collect(),
+            singleton_chi_evaluation: TestScalar::from(55_u32),
+            random_evaluation: TestScalar::ONE,
+            first_round_pcs_proof_evaluations: &first_round_evaluations,
+            final_round_pcs_proof_evaluations: &final_round_evaluations,
+            rho_256_evaluation: Some(TestScalar::from(66_u32)),
+        };
+        let mut builder = VerificationBuilderImpl::new(
+            mle_evaluations,
+            core::slice::from_ref(&bit_distribution),
+            &[],
+            Default::default(),
+            vec![4],
+            vec![8],
+            0,
+        );
+
+        assert_eq!(
+            builder.try_consume_chi_evaluation().unwrap(),
+            (TestScalar::from(44_u32), 4)
+        );
+        assert_eq!(
+            builder.try_consume_rho_evaluation().unwrap(),
+            TestScalar::from(88_u32)
+        );
+        assert_eq!(
+            builder.try_consume_first_round_mle_evaluations(2).unwrap(),
+            first_round_evaluations
+        );
+        assert_eq!(
+            builder.try_consume_final_round_mle_evaluation().unwrap(),
+            final_round_evaluations[0]
+        );
+        assert_eq!(
+            builder.try_consume_bit_distribution().unwrap(),
+            bit_distribution
+        );
+        assert_eq!(builder.singleton_chi_evaluation(), TestScalar::from(55_u32));
+        assert_eq!(builder.rho_256_evaluation(), Some(TestScalar::from(66_u32)));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -1,5 +1,6 @@
 use super::{SumcheckMleEvaluations, VerificationBuilderImpl};
 use crate::{
+    base::{bit::BitDistribution, map::IndexMap},
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::{SumcheckSubpolynomialType, VerificationBuilder},
 };
@@ -87,5 +88,83 @@ fn we_can_consume_post_result_challenges_in_verification_builder() {
     assert_eq!(
         Curve25519Scalar::from(789),
         builder.try_consume_post_result_challenge().unwrap()
+    );
+}
+
+#[test]
+fn we_can_consume_verification_builder_inputs() {
+    let mut chi_evaluations = IndexMap::default();
+    chi_evaluations.insert(4, Curve25519Scalar::from(40_u64));
+    chi_evaluations.insert(7, Curve25519Scalar::from(70_u64));
+
+    let mut rho_evaluations = IndexMap::default();
+    rho_evaluations.insert(8, Curve25519Scalar::from(80_u64));
+
+    let first_round = [
+        Curve25519Scalar::from(101_u64),
+        Curve25519Scalar::from(102_u64),
+    ];
+    let final_round = [
+        Curve25519Scalar::from(201_u64),
+        Curve25519Scalar::from(202_u64),
+        Curve25519Scalar::from(203_u64),
+    ];
+    let bit_distribution = BitDistribution::new::<Curve25519Scalar, _>(&[1_u64, 2, 3]);
+    let bit_distributions = [bit_distribution.clone()];
+    let mle_evaluations = SumcheckMleEvaluations {
+        chi_evaluations,
+        rho_evaluations,
+        singleton_chi_evaluation: Curve25519Scalar::from(1_u64),
+        first_round_pcs_proof_evaluations: &first_round,
+        final_round_pcs_proof_evaluations: &final_round,
+        rho_256_evaluation: Some(Curve25519Scalar::from(256_u64)),
+        ..Default::default()
+    };
+
+    let mut builder = VerificationBuilderImpl::new(
+        mle_evaluations,
+        &bit_distributions,
+        &[][..],
+        VecDeque::new(),
+        vec![4, 7],
+        vec![8],
+        0,
+    );
+
+    assert_eq!(
+        builder.try_consume_chi_evaluation().unwrap(),
+        (Curve25519Scalar::from(40_u64), 4)
+    );
+    assert_eq!(
+        builder.try_consume_chi_evaluation().unwrap(),
+        (Curve25519Scalar::from(70_u64), 7)
+    );
+    assert_eq!(
+        builder.try_consume_rho_evaluation().unwrap(),
+        Curve25519Scalar::from(80_u64)
+    );
+    assert_eq!(
+        builder.try_consume_first_round_mle_evaluations(2).unwrap(),
+        first_round
+    );
+    assert_eq!(
+        builder.try_consume_final_round_mle_evaluation().unwrap(),
+        final_round[0]
+    );
+    assert_eq!(
+        builder.try_consume_final_round_mle_evaluations(2).unwrap(),
+        &final_round[1..]
+    );
+    assert_eq!(
+        builder.try_consume_bit_distribution().unwrap(),
+        bit_distribution
+    );
+    assert_eq!(
+        builder.singleton_chi_evaluation(),
+        Curve25519Scalar::from(1_u64)
+    );
+    assert_eq!(
+        builder.rho_256_evaluation(),
+        Some(Curve25519Scalar::from(256_u64))
     );
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -10,3 +10,24 @@ pub struct AliasedDynProofExpr {
     /// The alias for the expression.
     pub alias: Ident,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::LiteralValue;
+
+    #[test]
+    fn we_clone_and_round_trip_aliased_expressions_through_json() {
+        let expr = AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+            alias: "is_active".into(),
+        };
+
+        assert_eq!(expr.clone(), expr);
+
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: AliasedDynProofExpr = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, expr);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -662,8 +662,8 @@ pub fn cast_column_with_scaling<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::{
-        cast_bool_column_to_signed_int_column, cast_column, cast_int_slice_to_int_column,
-        divide_columns, divide_integer_columns,
+        add_subtract_columns, cast_bool_column_to_signed_int_column, cast_column,
+        cast_int_slice_to_int_column, divide_columns, divide_integer_columns, multiply_columns,
     };
     use crate::{
         base::{
@@ -712,6 +712,26 @@ mod tests {
         let remainder_ba: &[i128] = modulo_integer_columns(b, a, &alloc, false);
         assert_eq!(quotient_ba.0, &[0i128, 42, 0, 0]);
         assert_eq!(remainder_ba, &[-1i128, 6, 6, 0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "lhs and rhs should have the same length")]
+    fn we_reject_add_subtract_columns_with_mismatched_lengths() {
+        let alloc = Bump::new();
+        let lhs = Column::<TestScalar>::Int(&[1, 2]);
+        let rhs = Column::<TestScalar>::Int(&[3]);
+
+        add_subtract_columns(lhs, rhs, &alloc, false);
+    }
+
+    #[test]
+    #[should_panic(expected = "lhs and rhs should have the same length")]
+    fn we_reject_multiply_columns_with_mismatched_lengths() {
+        let alloc = Bump::new();
+        let lhs = Column::<TestScalar>::Int(&[1, 2]);
+        let rhs = Column::<TestScalar>::Int(&[3]);
+
+        multiply_columns(&lhs, &rhs, &alloc);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -7,3 +7,20 @@ pub struct TableExpr {
     /// The `TableRef` for the table
     pub table_ref: TableRef,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_round_trip_table_expr_through_json() {
+        let expr = TableExpr {
+            table_ref: TableRef::new("sxt", "orders"),
+        };
+
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, expr);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -150,3 +150,66 @@ pub(crate) fn final_round_filter_constraints<'a, S: Scalar + 'a>(
         ],
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{database::Column, scalar::test_scalar::TestScalar};
+    use alloc::collections::VecDeque;
+    use num_traits::{One, Zero};
+
+    #[test]
+    fn we_build_filter_final_round_intermediate_mles_and_constraints() {
+        let alloc = Bump::new();
+        let input_column = Column::BigInt(&[1_i64, 2]);
+        let output_column = Column::BigInt(&[1_i64]);
+        let selection = [true, false];
+        let mut builder = FinalRoundBuilder::new(1, VecDeque::new());
+
+        final_round_evaluate_filter(
+            &mut builder,
+            &alloc,
+            TestScalar::from(3u64),
+            TestScalar::from(10u64),
+            &[input_column],
+            &selection,
+            &[output_column],
+            2,
+            1,
+        );
+
+        assert_eq!(builder.pcs_proof_mles().len(), 2);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 4);
+
+        let evaluations = builder.evaluate_pcs_proof_mles(&[TestScalar::one(), TestScalar::zero()]);
+        assert_eq!(evaluations.len(), 2);
+        assert_eq!(evaluations[0] * TestScalar::from(4u64), TestScalar::one());
+        assert_eq!(evaluations[1] * TestScalar::from(4u64), TestScalar::one());
+    }
+
+    #[test]
+    fn we_can_record_filter_constraints_without_intermediate_mles() {
+        let c_star = [TestScalar::one()];
+        let d_star = [TestScalar::one()];
+        let selection = [true];
+        let c_fold = [TestScalar::zero()];
+        let d_fold = [TestScalar::zero()];
+        let input_chi = [true];
+        let output_chi = [true];
+        let mut builder = FinalRoundBuilder::<TestScalar>::new(1, VecDeque::new());
+
+        final_round_filter_constraints(
+            &mut builder,
+            &c_star,
+            &d_star,
+            &selection,
+            &c_fold,
+            &d_fold,
+            &input_chi,
+            &output_chi,
+        );
+
+        assert_eq!(builder.pcs_proof_mles().len(), 0);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 4);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
@@ -83,3 +83,47 @@ impl<S: Scalar> FoldLogExpr<S> {
         self.final_round_evaluate_with_chi(builder, alloc, columns, length, chi)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::collections::VecDeque;
+    use num_traits::{One, Zero};
+
+    #[test]
+    fn we_compute_fold_log_star_and_fold_columns() {
+        let alloc = Bump::new();
+        let mut builder = FinalRoundBuilder::new(1, VecDeque::new());
+        let gadget = FoldLogExpr::new(TestScalar::from(3u64), TestScalar::from(10u64));
+        let column = Column::BigInt(&[1_i64, 2]);
+
+        let (star, fold) = gadget.final_round_evaluate(&mut builder, &alloc, &[column], 2);
+
+        assert_eq!(fold, &[TestScalar::from(3u64), TestScalar::from(6u64)]);
+        assert!(star
+            .iter()
+            .zip(fold)
+            .all(
+                |(&star_eval, &fold_eval)| star_eval * (fold_eval + TestScalar::one())
+                    == TestScalar::one()
+            ));
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+    }
+
+    #[test]
+    fn we_can_build_fold_log_constraints_with_a_supplied_chi_column() {
+        let alloc = Bump::new();
+        let mut builder = FinalRoundBuilder::new(1, VecDeque::new());
+        let gadget = FoldLogExpr::new(TestScalar::from(3u64), TestScalar::from(10u64));
+        let chi = alloc.alloc_slice_copy(&[true, false]);
+
+        let (star, fold) = gadget.final_round_evaluate_with_chi(&mut builder, &alloc, &[], 2, chi);
+
+        assert_eq!(fold, &[TestScalar::zero(), TestScalar::zero()]);
+        assert_eq!(star, &[TestScalar::one(), TestScalar::one()]);
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
@@ -132,3 +132,57 @@ pub(crate) fn verify_membership_check<S: Scalar>(
 
     Ok(multiplicity_eval)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::collections::VecDeque;
+
+    #[test]
+    fn we_compute_membership_multiplicities_in_the_first_round() {
+        let alloc = Bump::new();
+        let source_values = [1_i64, 2];
+        let candidate_values = [1_i64, 1, 2];
+        let columns = [Column::<TestScalar>::BigInt(&source_values)];
+        let candidate_subset = [Column::<TestScalar>::BigInt(&candidate_values)];
+        let mut builder = FirstRoundBuilder::new(0);
+
+        let multiplicities = first_round_evaluate_membership_check(
+            &mut builder,
+            &alloc,
+            &columns,
+            &candidate_subset,
+        );
+
+        assert_eq!(multiplicities, &[2, 1]);
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+    }
+
+    #[test]
+    fn we_build_membership_final_round_constraints() {
+        let alloc = Bump::new();
+        let source_values = [1_i64, 2];
+        let candidate_values = [1_i64, 1, 2];
+        let columns = [Column::<TestScalar>::BigInt(&source_values)];
+        let candidate_subset = [Column::<TestScalar>::BigInt(&candidate_values)];
+        let chi_n = [true, true];
+        let chi_m = [true, true, true];
+        let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+
+        let multiplicities = final_round_evaluate_membership_check(
+            &mut builder,
+            &alloc,
+            TestScalar::from(3u64),
+            TestScalar::from(10u64),
+            &chi_n,
+            &chi_m,
+            &columns,
+            &candidate_subset,
+        );
+
+        assert_eq!(multiplicities, &[2, 1]);
+        assert_eq!(builder.pcs_proof_mles().len(), 2);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 3);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -37,6 +37,25 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_negative_constant_colum
 }
 
 #[test]
+fn prover_evaluation_generates_binary_constraints_for_varying_sign_columns() {
+    let raw_data = [123_i64, -452, 0, 789, -910];
+    let dist = BitDistribution::new::<TestScalar, _>(&raw_data);
+    let alloc = Bump::new();
+    let data: Vec<TestScalar> = raw_data.into_iter().map(TestScalar::from).collect();
+    let mut builder = FinalRoundBuilder::new(3, VecDeque::new());
+
+    let sign = final_round_evaluate_sign(&mut builder, &alloc, &data);
+
+    assert_eq!(sign, [false, true, false, false, true]);
+    assert_eq!(builder.bit_distributions(), [dist.clone()]);
+    assert_eq!(builder.pcs_proof_mles().len(), dist.num_varying_bits());
+    assert_eq!(
+        builder.num_sumcheck_subpolynomials(),
+        dist.num_varying_bits()
+    );
+}
+
+#[test]
 fn we_can_verify_a_constant_decomposition() {
     let data = [123_i64, 123, 123];
 
@@ -110,6 +129,15 @@ fn we_can_compute_the_correct_sign_of_scalars_using_first_round_evaluate_sign_fo
     let res = first_round_evaluate_sign(2, &alloc, data);
     let expected_res = [true, true];
     assert_eq!(res, expected_res);
+}
+
+#[test]
+#[should_panic]
+fn we_reject_first_round_sign_length_mismatch() {
+    let data: &[TestScalar] = &[(-123).into(), 123.into()];
+    let alloc = Bump::new();
+
+    first_round_evaluate_sign(3, &alloc, data);
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
@@ -32,3 +32,25 @@ pub fn fold_vals<S: Scalar>(beta: S, vals: &[S]) -> S {
 fn powers<S: Scalar>(init: S, base: S) -> impl Iterator<Item = S> {
     core::iter::successors(Some(init), move |&m| Some(m * base))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::fold_columns;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_leave_fold_result_unchanged_when_there_are_no_columns() {
+        let mut result = [1_u32, 2, 3].map(TestScalar::from);
+        let original = result;
+        let columns: [&[TestScalar]; 0] = [];
+
+        fold_columns(
+            &mut result,
+            TestScalar::from(5_u32),
+            TestScalar::from(7_u32),
+            &columns,
+        );
+
+        assert_eq!(result, original);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -106,6 +106,17 @@ fn we_can_fold_empty_columns() {
 }
 
 #[test]
+fn fold_columns_leaves_result_unchanged_when_there_are_no_columns() {
+    let columns: Vec<Column<Curve25519Scalar>> = vec![];
+    let alloc = Bump::new();
+    let result = alloc.alloc_slice_fill_copy(3, 77.into());
+
+    fold_columns(result, 33.into(), 10.into(), &columns);
+
+    assert_eq!(result, vec![77.into(), 77.into(), 77.into()]);
+}
+
+#[test]
 fn we_can_fold_vals() {
     assert_eq!(fold_vals(Curve25519Scalar::from(10), &[]), Zero::zero());
     assert_eq!(
@@ -120,5 +131,18 @@ fn we_can_fold_vals() {
             ]
         ),
         (12345).into()
+    );
+    assert_eq!(
+        fold_vals(
+            Curve25519Scalar::zero(),
+            &[
+                Curve25519Scalar::from(1),
+                2.into(),
+                3.into(),
+                4.into(),
+                5.into()
+            ]
+        ),
+        Curve25519Scalar::from(5)
     );
 }

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,77 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn test_find_bigdecimals_ignores_non_big_decimal_columns() {
+        let sql = "CREATE TABLE PUBLIC.ACCOUNTS(
+            ID BIGINT NOT NULL,
+            EXACT_LIMIT DECIMAL(38, 10),
+            LARGE_BALANCE DECIMAL(39, 2),
+            UNBOUNDED DECIMAL,
+            HUGE_REWARD DECIMAL(78, 0),
+            DISPLAY_NAME VARCHAR
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(
+            bigdecimals.get("PUBLIC.ACCOUNTS").unwrap(),
+            &[
+                ("LARGE_BALANCE".to_string(), 39, 2),
+                ("HUGE_REWARD".to_string(), 78, 0)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_bigdecimals_ignores_non_create_table_statements() {
+        let sql = "SELECT 1;
+
+        CREATE TABLE PUBLIC.TRADES(
+            TRADE_ID BIGINT NOT NULL,
+            NOTIONAL DECIMAL(78, 4)
+        );
+
+        SELECT 2;";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("PUBLIC.TRADES").unwrap(),
+            &[("NOTIONAL".to_string(), 78, 4)]
+        );
+    }
+
+    #[test]
+    fn test_find_bigdecimals_preserves_table_and_column_order() {
+        let sql = "CREATE TABLE FIRST_TABLE(
+            FIRST_AMOUNT DECIMAL(39, 1),
+            SECOND_AMOUNT DECIMAL(40, 2)
+        );
+
+        CREATE TABLE SECOND_TABLE(
+            THIRD_AMOUNT DECIMAL(41, 3)
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+        let table_names: Vec<String> = bigdecimals.keys().cloned().collect();
+
+        assert_eq!(
+            table_names,
+            vec!["FIRST_TABLE".to_string(), "SECOND_TABLE".to_string()]
+        );
+        assert_eq!(
+            bigdecimals.get("FIRST_TABLE").unwrap(),
+            &[
+                ("FIRST_AMOUNT".to_string(), 39, 1),
+                ("SECOND_AMOUNT".to_string(), 40, 2)
+            ]
+        );
+        assert_eq!(
+            bigdecimals.get("SECOND_TABLE").unwrap(),
+            &[("THIRD_AMOUNT".to_string(), 41, 3)]
+        );
+    }
 }


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist

- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This consolidates the coverage work I previously split across many small PRs into one reviewable PR.

I want to apologize for the review noise caused by opening the individual PRs separately. That was a poor judgment call on my side. I have consolidated the non-overlapping changes here and will close the individual PRs so maintainers only need to review this PR.

# What changes are included in this PR?

- Adds focused coverage for base database conversions, table utilities, Arrow conversions, serialization helpers, time parsing, scalar/math errors, bit/byte utilities, slice ops, polynomial helpers, transcripts, proof builders, proof gadgets, proof plans, and query/result serialization.
- Keeps the small correctness guards that were part of the same coverage work, including null Arrow array rejection, byte integer commitment bounds, lowercase binary type alias handling, inner product length validation, and ordered varbinary row comparison.
- Resolves the two consolidation conflicts by retaining both sides of the added tests.
- Supersedes the individual PRs for issue #560, from #1176 through #1276, excluding unrelated or missing numbers in that range.

# Are these changes tested?

This PR primarily adds test coverage. I have not rerun `source scripts/run_ci_checks.sh` or `source scripts/check_commits.sh`, so the checklist items above remain unchecked until those commands are completed.
