### PR TITLE
refactor: make scalar string hashing explicit

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -3,7 +3,7 @@ use crate::base::{
     database::Column,
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError},
-    scalar::{Scalar, ScalarExt},
+    scalar::Scalar,
 };
 use arrow::{
     array::{
@@ -279,7 +279,7 @@ impl ArrayRefExt for ArrayRef {
                     let scals = if let Some(scals) = precomputed_scals {
                         &scals[range.start..range.end]
                     } else {
-                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S { vals[i].into() })
+                        alloc.alloc_slice_fill_with(vals.len(), |i| S::from_str_via_hash(vals[i]))
                     };
 
                     Ok(Column::VarChar((vals, scals)))

--- a/crates/proof-of-sql/src/base/byte/byte_distribution.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_distribution.rs
@@ -73,7 +73,7 @@ impl ByteDistribution {
 #[cfg(test)]
 mod tests {
     use super::ByteDistribution;
-    use crate::base::scalar::{test_scalar::TestScalar, ScalarExt};
+    use crate::base::scalar::{test_scalar::TestScalar, Scalar};
     use bnum::types::U256;
     use core::ops::{Neg, Shl, Shr};
     use itertools::Itertools;

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -4,7 +4,7 @@ use crate::base::{
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     ref_into::RefInto,
-    scalar::{Scalar, ScalarExt},
+    scalar::Scalar,
 };
 use alloc::vec::Vec;
 #[cfg(feature = "blitzar")]
@@ -162,7 +162,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
             OwnedColumn::VarChar(strings) => CommittableColumn::VarChar(
                 strings
                     .iter()
-                    .map(Into::<S>::into)
+                    .map(|s| S::from_str_via_hash(s))
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -2,7 +2,7 @@ use super::{ColumnType, LiteralValue, OwnedColumn};
 use crate::base::{
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::{Scalar, ScalarExt},
+    scalar::Scalar,
     slice_ops::slice_cast_with,
 };
 use alloc::vec::Vec;
@@ -139,7 +139,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, S::from(string)),
+                alloc.alloc_slice_fill_copy(length, S::from_str_via_hash(string)),
             )),
             LiteralValue::VarBinary(bytes) => {
                 // Convert the bytes to a slice of bytes references
@@ -177,7 +177,10 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
             OwnedColumn::VarChar(col) => {
-                let scalars = col.iter().map(S::from).collect::<Vec<_>>();
+                let scalars = col
+                    .iter()
+                    .map(|s| S::from_str_via_hash(s))
+                    .collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -2,7 +2,7 @@ use crate::base::{
     database::ColumnType,
     math::{decimal::Precision, i256::I256},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::{Scalar, ScalarExt},
+    scalar::Scalar,
     standard_serializations::limbs::{deserialize_to_limbs, serialize_limbs},
 };
 use alloc::{string::String, vec::Vec};
@@ -81,7 +81,7 @@ impl LiteralValue {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar(str) => str.into(),
+            Self::VarChar(str) => S::from_str_via_hash(str),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -10,7 +10,7 @@ use crate::base::{
     },
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::Scalar,
-    slice_ops::{inner_product_ref_cast, inner_product_with_bytes},
+    slice_ops::{inner_product_ref_cast, inner_product_with_bytes, inner_product_with_str},
 };
 use alloc::{
     string::{String, ToString},
@@ -65,7 +65,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {
                 inner_product_ref_cast(col, vec)
             }
-            OwnedColumn::VarChar(col) => inner_product_ref_cast(col, vec),
+            OwnedColumn::VarChar(col) => inner_product_with_str(col, vec),
             OwnedColumn::VarBinary(col) => inner_product_with_bytes(col, vec),
             OwnedColumn::Int128(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => {

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
     map::IndexMap,
-    scalar::ScalarExt,
+    scalar::Scalar,
 };
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
@@ -108,7 +108,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
                 let scals: &mut [_] = self
                     .alloc
-                    .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
+                    .alloc_slice_fill_iter(col.iter().map(|s| CP::Scalar::from_str_via_hash(s)));
                 Column::VarChar((col, scals))
             }
             OwnedColumn::VarBinary(col) => {

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -288,7 +288,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
         })
         .collect();
     let alloc_strings = alloc.alloc_slice_clone(&strings);
-    let scalars: Vec<S> = strings.iter().map(|s| (*s).into()).collect();
+    let scalars: Vec<S> = strings.iter().map(|s| S::from_str_via_hash(s)).collect();
     let alloc_scalars = alloc.alloc_slice_copy(&scalars);
     (name.into(), Column::VarChar((alloc_strings, alloc_scalars)))
 }

--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -1,8 +1,5 @@
 use super::Transcript;
-use crate::base::{
-    ref_into::RefInto,
-    scalar::{Scalar, ScalarExt},
-};
+use crate::base::{ref_into::RefInto, scalar::Scalar};
 use bnum::types::U256;
 use zerocopy::{AsBytes, FromBytes};
 
@@ -60,9 +57,7 @@ impl<T: TranscriptCore> Transcript for T {
         self.extend_as_be::<[u64; 4]>(messages.into_iter().map(RefInto::ref_into));
     }
     fn scalar_challenge_as_be<S: Scalar>(&mut self) -> S {
-        ScalarExt::from_wrapping(
-            U256::from(receive_challenge_as_be::<[u64; 4]>(self)) & S::CHALLENGE_MASK,
-        )
+        S::from_wrapping(U256::from(receive_challenge_as_be::<[u64; 4]>(self)) & S::CHALLENGE_MASK)
     }
     fn challenge_as_le(&mut self) -> [u8; 32] {
         self.raw_challenge()

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -1,4 +1,4 @@
-use crate::base::scalar::{Scalar, ScalarConversionError, ScalarExt};
+use crate::base::scalar::{Scalar, ScalarConversionError};
 use alloc::{
     format,
     string::{String, ToString},
@@ -134,7 +134,7 @@ macro_rules! impl_from_for_mont_scalar_for_type_supported_by_from {
 /// Implement `From<&[u8]>` for `MontScalar`
 impl<T: MontConfig<4>> From<&[u8]> for MontScalar<T> {
     fn from(x: &[u8]) -> Self {
-        ScalarExt::from_byte_slice_via_hash(x)
+        Self::from_byte_slice_via_hash(x)
     }
 }
 

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,10 +1,10 @@
 #![expect(clippy::module_inception)]
 
 use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
-use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
+use tiny_keccak::Hasher;
 
 /// A trait for the scalar field used in Proof of SQL.
 pub trait Scalar:
@@ -13,7 +13,6 @@ pub trait Scalar:
     + core::fmt::Display
     + PartialEq
     + Default
-    + for<'a> From<&'a str>
     + Sync
     + Send
     + num_traits::One
@@ -52,9 +51,7 @@ pub trait Scalar:
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
-    + for<'a> core::convert::From<&'a String>
     + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>
@@ -85,4 +82,35 @@ pub trait Scalar:
     const MAX_BITS: u8;
     /// A U256 representation of the largest signed value in the field.
     const MAX_SIGNED_U256: U256;
+    /// Converts a string to a scalar by hashing it into the scalar field.
+    #[must_use]
+    fn from_str_via_hash(val: &str) -> Self {
+        Self::from_byte_slice_via_hash(val.as_bytes())
+    }
+
+    /// Converts an arbitrary-length byte slice to a scalar using a hash function.
+    /// Hashing makes collisions computationally unlikely, but does not eliminate them.
+    /// `PoSQL` cryptographic objects support 248-bit scalar embeddings, so this masks
+    /// the hash to the largest power-of-two range below the field modulus.
+    #[must_use]
+    fn from_byte_slice_via_hash(bytes: &[u8]) -> Self {
+        if bytes.is_empty() {
+            return Self::zero();
+        }
+
+        let mut hasher = tiny_keccak::Keccak::v256();
+        hasher.update(bytes);
+        let mut hashed_bytes = [0u8; 32];
+        hasher.finalize(&mut hashed_bytes);
+        let hashed_val =
+            U256::from_le_slice(&hashed_bytes).expect("32 bytes => guaranteed to parse as U256");
+        let masked_val = hashed_val & Self::CHALLENGE_MASK;
+        Self::from_wrapping(masked_val)
+    }
+
+    /// Converts a U256 to Scalar, wrapping as needed.
+    #[must_use]
+    fn from_wrapping(value: U256) -> Self {
+        Self::from(<[u64; 4]>::from(value))
+    }
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -1,7 +1,6 @@
 use super::Scalar;
 use bnum::types::U256;
 use core::cmp::Ordering;
-use tiny_keccak::Hasher;
 
 /// Extension trait for blanket implementations for `Scalar` types.
 /// This trait is primarily to avoid cluttering the core `Scalar` implementation with default implementations
@@ -20,36 +19,9 @@ pub trait ScalarExt: Scalar {
         }
     }
 
-    #[must_use]
-    /// Converts a U256 to Scalar, wrapping as needed
-    fn from_wrapping(value: U256) -> Self {
-        let value_as_limbs: [u64; 4] = value.into();
-        Self::from(value_as_limbs)
-    }
-
     /// Converts a Scalar to U256. Note that any values above `MAX_SIGNED` shall remain positive, even if they are representative of negative values.
     fn into_u256_wrapping(self) -> U256 {
         U256::from(Into::<[u64; 4]>::into(self))
-    }
-
-    /// Converts a byte slice to a Scalar using a hash function, preventing collisions.
-    /// WARNING: Only up to 31 bytes (2^248 bits) are supported by `PoSQL` cryptographic
-    /// objects. This function masks off the last byte of the hash to ensure the result
-    /// fits in this range.
-    #[must_use]
-    fn from_byte_slice_via_hash(bytes: &[u8]) -> Self {
-        if bytes.is_empty() {
-            return Self::zero();
-        }
-
-        let mut hasher = tiny_keccak::Keccak::v256();
-        hasher.update(bytes);
-        let mut hashed_bytes = [0u8; 32];
-        hasher.finalize(&mut hashed_bytes);
-        let hashed_val =
-            U256::from_le_slice(&hashed_bytes).expect("32 bytes => guaranteed to parse as U256");
-        let masked_val = hashed_val & Self::CHALLENGE_MASK;
-        Self::from_wrapping(masked_val)
     }
 }
 

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -1,8 +1,5 @@
-use crate::base::{
-    if_rayon,
-    scalar::{Scalar, ScalarExt},
-};
-use alloc::vec::Vec;
+use crate::base::{if_rayon, scalar::Scalar};
+use alloc::{string::String, vec::Vec};
 use core::{iter::Sum, ops::Mul};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
@@ -38,5 +35,13 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
     if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
         .zip(b)
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
+        .sum()
+}
+
+/// Cannot use blanket impls for strings because they are hashed into scalars rather than parsed.
+pub fn inner_product_with_str<S: Scalar>(a: &[String], b: &[S]) -> S {
+    if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
+        .zip(b)
+        .map(|(lhs_str, &rhs)| S::from_str_via_hash(lhs_str) * rhs)
         .sum()
 }

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::base::scalar::{test_scalar::TestScalar, ScalarExt};
+use crate::base::scalar::{test_scalar::TestScalar, Scalar};
 
 #[test]
 fn test_inner_product_with_bytes_basic() {
@@ -105,6 +105,42 @@ fn test_inner_product_with_bytes_some_edge_cases() {
         .zip(rhs.iter())
         .map(|(bts, &sc)| TestScalar::from_byte_slice_via_hash(bts) * sc)
         .sum::<TestScalar>();
+    assert_eq!(product, expected);
+}
+
+#[test]
+fn test_inner_product_with_str_basic() {
+    let lhs = vec!["abc".to_string(), "xyz".to_string(), "foo".to_string()];
+    let rhs = vec![
+        TestScalar::from(10),
+        TestScalar::from(20),
+        TestScalar::from(30),
+    ];
+    let product = inner_product_with_str(&lhs, &rhs);
+    let expected = lhs
+        .iter()
+        .zip(rhs.iter())
+        .map(|(value, &scalar)| TestScalar::from_str_via_hash(value) * scalar)
+        .sum::<TestScalar>();
+
+    assert_eq!(product, expected);
+}
+
+#[test]
+fn test_inner_product_with_str_uneven() {
+    let lhs = vec!["foo".to_string(), "bar".to_string()];
+    let rhs = vec![
+        TestScalar::from(5),
+        TestScalar::from(6),
+        TestScalar::from(7),
+    ];
+    let product = inner_product_with_str(&lhs, &rhs);
+    let expected = lhs
+        .iter()
+        .zip(rhs.iter())
+        .map(|(value, &scalar)| TestScalar::from_str_via_hash(value) * scalar)
+        .sum::<TestScalar>();
+
     assert_eq!(product, expected);
 }
 

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -2,7 +2,7 @@ use super::{decode_and_convert, decode_multiple_elements, ProvableResultColumn, 
 use crate::base::{
     database::{Column, ColumnField, ColumnType, OwnedColumn, OwnedTable, Table},
     polynomial::compute_evaluation_vector,
-    scalar::{Scalar, ScalarExt},
+    scalar::Scalar,
 };
 use alloc::{vec, vec::Vec};
 use num_traits::Zero;
@@ -117,7 +117,11 @@ impl ProvableQueryResult {
                         decode_and_convert::<S, S>(&self.data[offset..])
                     }
 
-                    ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
+                    ColumnType::VarChar => {
+                        let (raw_str, used) =
+                            decode_and_convert::<&str, &str>(&self.data[offset..])?;
+                        Ok((S::from_str_via_hash(raw_str), used))
+                    }
                     ColumnType::VarBinary => {
                         let (raw_bytes, used) =
                             decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Part of #228. This PR addresses the scalar string conversion slice by making hashed string embedding explicit instead of requiring blanket string conversion bounds on `Scalar`.

/claim #228

# What changes are included in this PR?

- Remove string `From` bounds from the `Scalar` trait.
- Add explicit `Scalar::from_str_via_hash` / `from_byte_slice_via_hash` defaults for hash-based embedding.
- Update generic varchar/result/commitment paths to call the explicit API instead of relying on `From<&str>` / `From<String>`.
- Add direct `inner_product_with_str` tests and clarify hash/masking docs after review.
- Rewrote the branch history into a single conventional commit: `refactor: make scalar string hashing explicit`.

# Are these changes tested?

Yes.

```sh
source scripts/check_commits.sh
cargo check -p proof-of-sql --no-default-features --features arrow
cargo test -p proof-of-sql --no-default-features --features arrow --lib
cargo fmt --check
cargo test -p proof-of-sql --no-default-features --features arrow --lib base::slice_ops::inner_product_test
```

Notes:
- `source scripts/check_commits.sh` now passes: 1 commit checked, 0 failures.
- `base::slice_ops::inner_product_test` passed 14 tests.
- Default `cargo check -p proof-of-sql` / full `run_ci_checks.sh` is not fully runnable on this Apple Silicon machine because the default `perf` feature enables `halo2curves/asm`, which errors with `Currently feature asm can only be enabled on x86_64 arch.`
- GitHub Actions for the repo workflows still require maintainer approval on this fork PR before full CI/coverage evidence is available.
