### PR TITLE
test: cover column scalar and owned-column helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -302,7 +302,7 @@ impl<'a, S: Scalar> Column<'a, S> {
     ///
     /// Note that if index is out of bounds, this function will return None
     pub(crate) fn scalar_at(&self, index: usize) -> Option<S> {
-        (index < self.len()).then_some(match self {
+        (index < self.len()).then(|| match self {
             Self::Boolean(col) => S::from(col[index]),
             Self::Uint8(col) => S::from(col[index]),
             Self::TinyInt(col) => S::from(col[index]),
@@ -338,7 +338,10 @@ impl<'a, S: Scalar> Column<'a, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{base::scalar::test_scalar::TestScalar, proof_primitive::dory::DoryScalar};
+    use crate::{
+        base::{math::i256::I256, scalar::test_scalar::TestScalar},
+        proof_primitive::dory::DoryScalar,
+    };
     use alloc::{string::String, vec};
 
     #[test]
@@ -577,5 +580,286 @@ mod tests {
 
         let round_trip_owned: OwnedColumn<TestScalar> = (&column).into();
         assert_eq!(owned_varbinary, round_trip_owned);
+    }
+
+    #[test]
+    fn we_can_create_columns_from_literals_with_repeated_values() {
+        let alloc = Bump::new();
+        let precision = Precision::new(18).unwrap();
+        let decimal_value = I256::from(42_i32);
+        let scalar_limbs = [1, 2, 3, 4];
+        let binary_value = vec![9_u8, 8, 7];
+
+        let cases = [
+            (
+                LiteralValue::Boolean(true),
+                ColumnType::Boolean,
+                vec![TestScalar::from(true); 3],
+            ),
+            (
+                LiteralValue::Uint8(2),
+                ColumnType::Uint8,
+                vec![TestScalar::from(2_u8); 3],
+            ),
+            (
+                LiteralValue::TinyInt(-3),
+                ColumnType::TinyInt,
+                vec![TestScalar::from(-3_i8); 3],
+            ),
+            (
+                LiteralValue::SmallInt(4),
+                ColumnType::SmallInt,
+                vec![TestScalar::from(4_i16); 3],
+            ),
+            (
+                LiteralValue::Int(-5),
+                ColumnType::Int,
+                vec![TestScalar::from(-5_i32); 3],
+            ),
+            (
+                LiteralValue::BigInt(6),
+                ColumnType::BigInt,
+                vec![TestScalar::from(6_i64); 3],
+            ),
+            (
+                LiteralValue::Int128(-7),
+                ColumnType::Int128,
+                vec![TestScalar::from(-7_i128); 3],
+            ),
+            (
+                LiteralValue::Scalar(scalar_limbs),
+                ColumnType::Scalar,
+                vec![TestScalar::from(scalar_limbs); 3],
+            ),
+            (
+                LiteralValue::Decimal75(precision, 2, decimal_value),
+                ColumnType::Decimal75(precision, 2),
+                vec![decimal_value.into_scalar(); 3],
+            ),
+            (
+                LiteralValue::TimeStampTZ(
+                    PoSQLTimeUnit::Nanosecond,
+                    PoSQLTimeZone::new(-3600),
+                    1_700_000_000,
+                ),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::new(-3600)),
+                vec![TestScalar::from(1_700_000_000_i64); 3],
+            ),
+            (
+                LiteralValue::VarChar(String::from("alpha")),
+                ColumnType::VarChar,
+                vec![TestScalar::from("alpha"); 3],
+            ),
+            (
+                LiteralValue::VarBinary(binary_value.clone()),
+                ColumnType::VarBinary,
+                vec![TestScalar::from_byte_slice_via_hash(&binary_value); 3],
+            ),
+        ];
+
+        for (literal, expected_type, expected_scalars) in cases {
+            let column = Column::<TestScalar>::from_literal_with_length(&literal, 3, &alloc);
+            assert_eq!(column.len(), 3);
+            assert_eq!(column.column_type(), expected_type);
+            assert_eq!(column.to_scalar(), expected_scalars);
+        }
+    }
+
+    #[test]
+    fn we_can_use_typed_column_accessors() {
+        let bools = [true, false];
+        let uint8s = [1_u8, 2];
+        let tinyints = [-1_i8, 2];
+        let smallints = [-2_i16, 3];
+        let ints = [-3_i32, 4];
+        let bigints = [-4_i64, 5];
+        let int128s = [-5_i128, 6];
+        let scalars = [TestScalar::from(7), TestScalar::from(8)];
+        let strings = ["alpha", "beta"];
+        let string_scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let bytes: &[&[u8]] = &[b"abc", b"xyz"];
+        let byte_scalars = bytes
+            .iter()
+            .map(|value| TestScalar::from_byte_slice_via_hash(value))
+            .collect::<Vec<_>>();
+        let timestamps = [1_625_072_400_i64, 1_625_076_000];
+        let precision = Precision::new(12).unwrap();
+
+        assert_eq!(
+            Column::<TestScalar>::Boolean(&bools).as_boolean(),
+            Some(bools.as_slice())
+        );
+        assert_eq!(
+            Column::<TestScalar>::Uint8(&uint8s).as_uint8(),
+            Some(uint8s.as_slice())
+        );
+        assert_eq!(
+            Column::<TestScalar>::TinyInt(&tinyints).as_tinyint(),
+            Some(tinyints.as_slice())
+        );
+        assert_eq!(
+            Column::<TestScalar>::SmallInt(&smallints).as_smallint(),
+            Some(smallints.as_slice())
+        );
+        assert_eq!(
+            Column::<TestScalar>::Int(&ints).as_int(),
+            Some(ints.as_slice())
+        );
+        assert_eq!(
+            Column::<TestScalar>::BigInt(&bigints).as_bigint(),
+            Some(bigints.as_slice())
+        );
+        assert_eq!(
+            Column::<TestScalar>::Int128(&int128s).as_int128(),
+            Some(int128s.as_slice())
+        );
+        assert_eq!(
+            Column::Scalar(&scalars).as_scalar(),
+            Some(scalars.as_slice())
+        );
+        assert_eq!(
+            Column::Decimal75(precision, 2, &scalars).as_decimal75(),
+            Some(scalars.as_slice())
+        );
+        assert_eq!(
+            Column::VarChar((&strings, string_scalars.as_slice())).as_varchar(),
+            Some((strings.as_slice(), string_scalars.as_slice()))
+        );
+        assert_eq!(
+            Column::VarBinary((bytes, byte_scalars.as_slice())).as_varbinary(),
+            Some((bytes, byte_scalars.as_slice()))
+        );
+        assert_eq!(
+            Column::<TestScalar>::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                &timestamps
+            )
+            .as_timestamptz(),
+            Some(timestamps.as_slice())
+        );
+        assert_eq!(Column::<TestScalar>::BigInt(&bigints).as_boolean(), None);
+    }
+
+    #[test]
+    fn typed_column_accessors_return_none_for_other_variants() {
+        let booleans = [true, false];
+        let uint8s = [1_u8, 2];
+        let tinyints = [-1_i8, 2];
+        let smallints = [-2_i16, 3];
+        let ints = [-3_i32, 4];
+        let bigints = [-4_i64, 5];
+        let int128s = [-5_i128, 6];
+        let scalars = [TestScalar::from(7), TestScalar::from(8)];
+        let precision = Precision::new(20).unwrap();
+        let strings = ["alpha", "beta"];
+        let string_scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let bytes: &[&[u8]] = &[b"abc", b"xyz"];
+        let byte_scalars = bytes
+            .iter()
+            .map(|value| TestScalar::from_byte_slice_via_hash(value))
+            .collect::<Vec<_>>();
+        let timestamps = [-6_i64, 7];
+
+        assert_eq!(Column::<TestScalar>::Boolean(&booleans).as_uint8(), None);
+        assert_eq!(Column::<TestScalar>::Uint8(&uint8s).as_tinyint(), None);
+        assert_eq!(Column::<TestScalar>::TinyInt(&tinyints).as_smallint(), None);
+        assert_eq!(Column::<TestScalar>::SmallInt(&smallints).as_int(), None);
+        assert_eq!(Column::<TestScalar>::Int(&ints).as_bigint(), None);
+        assert_eq!(Column::<TestScalar>::BigInt(&bigints).as_int128(), None);
+        assert_eq!(Column::<TestScalar>::Int128(&int128s).as_scalar(), None);
+        assert_eq!(Column::<TestScalar>::Scalar(&scalars).as_decimal75(), None);
+        assert_eq!(
+            Column::<TestScalar>::Decimal75(precision, 2, &scalars).as_varchar(),
+            None
+        );
+        assert_eq!(
+            Column::<TestScalar>::VarChar((&strings, string_scalars.as_slice())).as_varbinary(),
+            None
+        );
+        assert_eq!(
+            Column::<TestScalar>::VarBinary((bytes, byte_scalars.as_slice())).as_timestamptz(),
+            None
+        );
+        assert_eq!(
+            Column::<TestScalar>::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                &timestamps
+            )
+            .as_boolean(),
+            None
+        );
+    }
+
+    #[test]
+    fn we_can_convert_column_values_to_scalars() {
+        let strings = ["alpha", "beta"];
+        let string_scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let bytes: &[&[u8]] = &[b"abc", b"xyz"];
+        let byte_scalars = bytes
+            .iter()
+            .map(|value| TestScalar::from_byte_slice_via_hash(value))
+            .collect::<Vec<_>>();
+        let scalar_values = [TestScalar::from(17), TestScalar::from(19)];
+        let precision = Precision::new(20).unwrap();
+
+        let cases = [
+            (
+                Column::Boolean(&[true, false]),
+                vec![TestScalar::from(true), TestScalar::from(false)],
+            ),
+            (
+                Column::Uint8(&[1_u8, 2]),
+                vec![TestScalar::from(1_u8), TestScalar::from(2_u8)],
+            ),
+            (
+                Column::TinyInt(&[-1_i8, 2]),
+                vec![TestScalar::from(-1_i8), TestScalar::from(2_i8)],
+            ),
+            (
+                Column::SmallInt(&[-2_i16, 3]),
+                vec![TestScalar::from(-2_i16), TestScalar::from(3_i16)],
+            ),
+            (
+                Column::Int(&[-3_i32, 4]),
+                vec![TestScalar::from(-3_i32), TestScalar::from(4_i32)],
+            ),
+            (
+                Column::BigInt(&[-4_i64, 5]),
+                vec![TestScalar::from(-4_i64), TestScalar::from(5_i64)],
+            ),
+            (
+                Column::Int128(&[-5_i128, 6]),
+                vec![TestScalar::from(-5_i128), TestScalar::from(6_i128)],
+            ),
+            (Column::Scalar(&scalar_values), scalar_values.to_vec()),
+            (
+                Column::Decimal75(precision, 4, &scalar_values),
+                scalar_values.to_vec(),
+            ),
+            (
+                Column::VarChar((&strings, string_scalars.as_slice())),
+                string_scalars.clone(),
+            ),
+            (
+                Column::VarBinary((bytes, byte_scalars.as_slice())),
+                byte_scalars.clone(),
+            ),
+            (
+                Column::TimestampTZ(
+                    PoSQLTimeUnit::Microsecond,
+                    PoSQLTimeZone::new(3600),
+                    &[-6_i64, 7],
+                ),
+                vec![TestScalar::from(-6_i64), TestScalar::from(7_i64)],
+            ),
+        ];
+
+        for (column, expected_scalars) in cases {
+            assert_eq!(column.scalar_at(0), Some(expected_scalars[0]));
+            assert_eq!(column.scalar_at(expected_scalars.len()), None);
+            assert_eq!(column.to_scalar(), expected_scalars);
+        }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -907,4 +907,435 @@ mod test {
 
         assert_eq!(product, expected);
     }
+
+    #[test]
+    fn we_can_compute_inner_product_for_remaining_owned_column_variants() {
+        let precision = Precision::new(12).unwrap();
+        let timezone = PoSQLTimeZone::utc();
+        let weights = vec![TestScalar::from(2), TestScalar::from(3)];
+        let decimal_values = vec![TestScalar::from(17), TestScalar::from(19)];
+        let scalar_values = vec![TestScalar::from(23), TestScalar::from(29)];
+        let text_values = vec!["a".to_string(), "b".to_string()];
+
+        let cases = vec![
+            (
+                OwnedColumn::Boolean(vec![true, false]),
+                TestScalar::from(true) * weights[0] + TestScalar::from(false) * weights[1],
+            ),
+            (
+                OwnedColumn::Uint8(vec![5, 7]),
+                TestScalar::from(5_u8) * weights[0] + TestScalar::from(7_u8) * weights[1],
+            ),
+            (
+                OwnedColumn::TinyInt(vec![-5, 7]),
+                TestScalar::from(-5_i8) * weights[0] + TestScalar::from(7_i8) * weights[1],
+            ),
+            (
+                OwnedColumn::SmallInt(vec![-50, 70]),
+                TestScalar::from(-50_i16) * weights[0] + TestScalar::from(70_i16) * weights[1],
+            ),
+            (
+                OwnedColumn::Int(vec![-500, 700]),
+                TestScalar::from(-500_i32) * weights[0] + TestScalar::from(700_i32) * weights[1],
+            ),
+            (
+                OwnedColumn::BigInt(vec![-5_000, 7_000]),
+                TestScalar::from(-5_000_i64) * weights[0]
+                    + TestScalar::from(7_000_i64) * weights[1],
+            ),
+            (
+                OwnedColumn::Int128(vec![-50_000, 70_000]),
+                TestScalar::from(-50_000_i128) * weights[0]
+                    + TestScalar::from(70_000_i128) * weights[1],
+            ),
+            (
+                OwnedColumn::VarChar(text_values.clone()),
+                TestScalar::from(text_values[0].as_str()) * weights[0]
+                    + TestScalar::from(text_values[1].as_str()) * weights[1],
+            ),
+            (
+                OwnedColumn::Decimal75(precision, 2, decimal_values.clone()),
+                decimal_values[0] * weights[0] + decimal_values[1] * weights[1],
+            ),
+            (
+                OwnedColumn::Scalar(scalar_values.clone()),
+                scalar_values[0] * weights[0] + scalar_values[1] * weights[1],
+            ),
+            (
+                OwnedColumn::TimestampTZ(PoSQLTimeUnit::Second, timezone, vec![11, 13]),
+                TestScalar::from(11_i64) * weights[0] + TestScalar::from(13_i64) * weights[1],
+            ),
+        ];
+
+        for (column, expected) in cases {
+            assert_eq!(column.inner_product(weights.as_slice()), expected);
+        }
+    }
+
+    #[test]
+    fn we_can_slice_all_owned_column_variants() {
+        let precision = Precision::new(12).unwrap();
+        let timezone = PoSQLTimeZone::utc();
+        let scalar_values = vec![
+            TestScalar::from(10),
+            TestScalar::from(20),
+            TestScalar::from(30),
+        ];
+
+        let cases = vec![
+            (
+                OwnedColumn::Boolean(vec![true, false, true]),
+                ColumnType::Boolean,
+                OwnedColumn::Boolean(vec![false, true]),
+            ),
+            (
+                OwnedColumn::Uint8(vec![1, 2, 3]),
+                ColumnType::Uint8,
+                OwnedColumn::Uint8(vec![2, 3]),
+            ),
+            (
+                OwnedColumn::TinyInt(vec![-1, 2, 3]),
+                ColumnType::TinyInt,
+                OwnedColumn::TinyInt(vec![2, 3]),
+            ),
+            (
+                OwnedColumn::SmallInt(vec![-10, 20, 30]),
+                ColumnType::SmallInt,
+                OwnedColumn::SmallInt(vec![20, 30]),
+            ),
+            (
+                OwnedColumn::Int(vec![-100, 200, 300]),
+                ColumnType::Int,
+                OwnedColumn::Int(vec![200, 300]),
+            ),
+            (
+                OwnedColumn::BigInt(vec![-1000, 2000, 3000]),
+                ColumnType::BigInt,
+                OwnedColumn::BigInt(vec![2000, 3000]),
+            ),
+            (
+                OwnedColumn::Int128(vec![-10_000, 20_000, 30_000]),
+                ColumnType::Int128,
+                OwnedColumn::Int128(vec![20_000, 30_000]),
+            ),
+            (
+                OwnedColumn::VarChar(vec!["a".to_string(), "b".to_string(), "c".to_string()]),
+                ColumnType::VarChar,
+                OwnedColumn::VarChar(vec!["b".to_string(), "c".to_string()]),
+            ),
+            (
+                OwnedColumn::VarBinary(vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]),
+                ColumnType::VarBinary,
+                OwnedColumn::VarBinary(vec![b"b".to_vec(), b"c".to_vec()]),
+            ),
+            (
+                OwnedColumn::Decimal75(precision, 2, scalar_values.clone()),
+                ColumnType::Decimal75(precision, 2),
+                OwnedColumn::Decimal75(precision, 2, scalar_values[1..].to_vec()),
+            ),
+            (
+                OwnedColumn::Scalar(scalar_values.clone()),
+                ColumnType::Scalar,
+                OwnedColumn::Scalar(scalar_values[1..].to_vec()),
+            ),
+            (
+                OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Millisecond,
+                    timezone,
+                    vec![1_000, 2_000, 3_000],
+                ),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, timezone),
+                OwnedColumn::TimestampTZ(PoSQLTimeUnit::Millisecond, timezone, vec![2_000, 3_000]),
+            ),
+        ];
+
+        for (column, column_type, expected_slice) in cases {
+            assert_eq!(column.len(), 3);
+            assert!(!column.is_empty());
+            assert_eq!(column.column_type(), column_type);
+            assert_eq!(column.slice(1, 3), expected_slice);
+        }
+
+        assert!(OwnedColumn::<TestScalar>::Uint8(vec![]).is_empty());
+    }
+
+    #[test]
+    fn we_can_permute_all_owned_column_variants() {
+        let precision = Precision::new(9).unwrap();
+        let timezone = PoSQLTimeZone::utc();
+        let scalar_values = vec![
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+        ];
+        let permutation = Permutation::try_new(vec![2, 0, 1]).unwrap();
+
+        let cases = vec![
+            (
+                OwnedColumn::Boolean(vec![true, false, true]),
+                OwnedColumn::Boolean(vec![true, true, false]),
+            ),
+            (
+                OwnedColumn::Uint8(vec![1, 2, 3]),
+                OwnedColumn::Uint8(vec![3, 1, 2]),
+            ),
+            (
+                OwnedColumn::TinyInt(vec![-1, 2, 3]),
+                OwnedColumn::TinyInt(vec![3, -1, 2]),
+            ),
+            (
+                OwnedColumn::SmallInt(vec![-10, 20, 30]),
+                OwnedColumn::SmallInt(vec![30, -10, 20]),
+            ),
+            (
+                OwnedColumn::Int(vec![-100, 200, 300]),
+                OwnedColumn::Int(vec![300, -100, 200]),
+            ),
+            (
+                OwnedColumn::BigInt(vec![-1000, 2000, 3000]),
+                OwnedColumn::BigInt(vec![3000, -1000, 2000]),
+            ),
+            (
+                OwnedColumn::Int128(vec![-10_000, 20_000, 30_000]),
+                OwnedColumn::Int128(vec![30_000, -10_000, 20_000]),
+            ),
+            (
+                OwnedColumn::VarChar(vec!["a".to_string(), "b".to_string(), "c".to_string()]),
+                OwnedColumn::VarChar(vec!["c".to_string(), "a".to_string(), "b".to_string()]),
+            ),
+            (
+                OwnedColumn::VarBinary(vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]),
+                OwnedColumn::VarBinary(vec![b"c".to_vec(), b"a".to_vec(), b"b".to_vec()]),
+            ),
+            (
+                OwnedColumn::Decimal75(precision, -2, scalar_values.clone()),
+                OwnedColumn::Decimal75(
+                    precision,
+                    -2,
+                    vec![scalar_values[2], scalar_values[0], scalar_values[1]],
+                ),
+            ),
+            (
+                OwnedColumn::Scalar(scalar_values.clone()),
+                OwnedColumn::Scalar(vec![scalar_values[2], scalar_values[0], scalar_values[1]]),
+            ),
+            (
+                OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Second,
+                    timezone,
+                    vec![1_000, 2_000, 3_000],
+                ),
+                OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Second,
+                    timezone,
+                    vec![3_000, 1_000, 2_000],
+                ),
+            ),
+        ];
+
+        for (column, expected) in cases {
+            assert_eq!(column.try_permute(&permutation).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn we_can_convert_remaining_column_variants_to_owned_columns_round_trip() {
+        let alloc = Bump::new();
+        let timezone = PoSQLTimeZone::utc();
+        let scalars = vec![
+            TestScalar::from(7),
+            TestScalar::from(8),
+            TestScalar::from(9),
+        ];
+
+        let cases = vec![
+            Column::Uint8(&[7, 8, 9]),
+            Column::TinyInt(&[-7, 8, 9]),
+            Column::SmallInt(&[-70, 80, 90]),
+            Column::Int(&[-700, 800, 900]),
+            Column::BigInt(&[-7_000, 8_000, 9_000]),
+            Column::Scalar(scalars.as_slice()),
+            Column::TimestampTZ(PoSQLTimeUnit::Second, timezone, &[1_000, 2_000, 3_000]),
+        ];
+
+        for column in cases {
+            let owned_column: OwnedColumn<TestScalar> = (&column).into();
+            let round_trip = Column::<TestScalar>::from_owned_column(&owned_column, &alloc);
+            assert_eq!(round_trip, column);
+        }
+    }
+
+    #[test]
+    fn we_can_convert_scalars_to_remaining_owned_column_types() {
+        let scalars = vec![
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+        ];
+        let timezone = PoSQLTimeZone::utc();
+
+        let cases = vec![
+            (ColumnType::Uint8, OwnedColumn::Uint8(vec![1, 2, 3])),
+            (ColumnType::TinyInt, OwnedColumn::TinyInt(vec![1, 2, 3])),
+            (ColumnType::SmallInt, OwnedColumn::SmallInt(vec![1, 2, 3])),
+            (ColumnType::Int, OwnedColumn::Int(vec![1, 2, 3])),
+            (ColumnType::BigInt, OwnedColumn::BigInt(vec![1, 2, 3])),
+            (
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, timezone),
+                OwnedColumn::TimestampTZ(PoSQLTimeUnit::Second, timezone, vec![1, 2, 3]),
+            ),
+            (ColumnType::Scalar, OwnedColumn::Scalar(scalars.clone())),
+        ];
+
+        for (column_type, expected) in cases {
+            assert_eq!(
+                OwnedColumn::try_from_scalars(scalars.as_slice(), column_type).unwrap(),
+                expected
+            );
+        }
+
+        assert!(matches!(
+            OwnedColumn::try_from_scalars(scalars.as_slice(), ColumnType::VarBinary),
+            Err(OwnedColumnError::TypeCastError { .. })
+        ));
+    }
+
+    #[test]
+    fn we_reject_overflow_when_converting_scalars_to_remaining_numeric_types() {
+        let too_large_for_i64 = vec![TestScalar::from(i128::MAX)];
+        let too_large_for_i128 = vec![-TestScalar::from(i128::MIN)];
+        let timezone = PoSQLTimeZone::utc();
+
+        for column_type in [
+            ColumnType::Uint8,
+            ColumnType::TinyInt,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, timezone),
+        ] {
+            assert!(matches!(
+                OwnedColumn::try_from_scalars(too_large_for_i64.as_slice(), column_type),
+                Err(OwnedColumnError::ScalarConversionError { .. })
+            ));
+        }
+
+        assert!(matches!(
+            OwnedColumn::try_from_scalars(too_large_for_i128.as_slice(), ColumnType::Int128),
+            Err(OwnedColumnError::ScalarConversionError { .. })
+        ));
+    }
+
+    #[test]
+    fn we_can_coerce_scalar_to_uint8_and_keep_matching_type_unchanged() {
+        let scalars = vec![
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+        ];
+        let scalar_col = OwnedColumn::Scalar(scalars);
+
+        assert_eq!(
+            scalar_col
+                .try_coerce_scalar_to_numeric(ColumnType::Uint8)
+                .unwrap(),
+            OwnedColumn::Uint8(vec![1, 2, 3])
+        );
+
+        let uint8_col = OwnedColumn::<TestScalar>::Uint8(vec![4, 5, 6]);
+        assert_eq!(
+            uint8_col
+                .clone()
+                .try_coerce_scalar_to_numeric(ColumnType::Uint8),
+            Ok(uint8_col)
+        );
+    }
+
+    #[test]
+    fn we_can_iterate_typed_owned_column_values() {
+        let precision = Precision::new(9).unwrap();
+        let decimal_values = vec![TestScalar::from(17), TestScalar::from(19)];
+        let scalar_values = vec![TestScalar::from(23), TestScalar::from(29)];
+
+        assert_eq!(
+            OwnedColumn::<TestScalar>::Uint8(vec![1, 2])
+                .u8_iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::TinyInt(vec![-1, 2])
+                .i8_iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![-1, 2]
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::SmallInt(vec![-2, 3])
+                .i16_iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![-2, 3]
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::Int(vec![-3, 4])
+                .i32_iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![-3, 4]
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::BigInt(vec![-4, 5])
+                .i64_iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![-4, 5]
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![6, 7]
+            )
+            .i64_iter()
+            .copied()
+            .collect::<Vec<_>>(),
+            vec![6, 7]
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::Int128(vec![-8, 9])
+                .i128_iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![-8, 9]
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false])
+                .bool_iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![true, false]
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::Scalar(scalar_values.clone())
+                .scalar_iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            scalar_values
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::Decimal75(precision, 2, decimal_values.clone())
+                .scalar_iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            decimal_values
+        );
+        assert_eq!(
+            OwnedColumn::<TestScalar>::VarChar(vec!["alpha".to_string(), "beta".to_string()])
+                .string_iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["alpha".to_string(), "beta".to_string()]
+        );
+    }
 }


### PR DESCRIPTION
This PR keeps issue #560 to a narrow `Column` and `OwnedColumn` coverage slice. While adding the tests, it exposed one observable behavior bug: `Column::scalar_at` eagerly indexed before returning `Option`, so an out-of-bounds lookup could panic instead of returning `None`. The production change is limited to that bounds check; the rest of the patch is coverage for the two touched files.

/claim #560

## Scope And Evidence

| Area | What changed | Evidence |
| --- | --- | --- |
| `crates/proof-of-sql/src/base/database/column.rs` | `scalar_at` now handles out-of-bounds indexes lazily and the in-file tests cover typed accessors, literal expansion, scalar conversion, and missing scalar lookups. | `base::database::column::tests` passed locally with `9 passed`; filtered coverage reported `644` lines with `1` missed line, or `99.84%` line coverage. |
| `crates/proof-of-sql/src/base/database/owned_column.rs` | Existing helper behavior is covered across inner products, slicing, permutation, scalar conversion, scalar coercion, typed iteration, and overflow errors. | `base::database::owned_column::test` passed locally with `24 passed`; filtered coverage reported `982` lines with `9` missed lines, or `99.08%` line coverage. |
| `base::database` module | The slice was checked against the broader database module after the focused tests passed. | `cargo test -p proof-of-sql --no-default-features --features=test base::database --lib` passed locally with `241 passed`. |

## Validation

```text
cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
git diff --check
cargo test -p proof-of-sql --no-default-features --features=test base::database::column::tests --lib
cargo test -p proof-of-sql --no-default-features --features=test base::database::owned_column::test --lib
cargo test -p proof-of-sql --no-default-features --features=test base::database --lib
cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lib --summary-only -- base::database
```

## Boundaries

I removed broader database coverage from this branch after checking the active #560 field. This PR does not cover table refs, column refs, literal values, column types, table utilities, accessor construction, operation dispatch, arithmetic helpers, or comparison helpers; those areas are already represented by other active or prior attempts. The only production behavior change here is the `Column::scalar_at` out-of-bounds fix.