### PR TITLE
test: cover proof builder and result serialization paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
@@ -156,3 +156,44 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
         self.post_result_challenges.pop_front().unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FinalRoundBuilder;
+    use crate::{
+        base::{bit::BitDistribution, scalar::test_scalar::TestScalar},
+        sql::proof::SumcheckSubpolynomialType,
+    };
+    use alloc::{boxed::Box, collections::VecDeque};
+
+    #[test]
+    fn we_can_track_final_round_components() {
+        let bit_distribution = BitDistribution {
+            leading_bit_mask: [1, 0, 0, 0],
+            vary_mask: [0, 1, 0, 0],
+        };
+        let mle = [TestScalar::from(3), TestScalar::from(5)];
+        let mut builder = FinalRoundBuilder::<TestScalar>::new(1, VecDeque::new());
+
+        assert_eq!(builder.num_sumcheck_variables(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 0);
+        assert!(builder.bit_distributions().is_empty());
+        assert!(builder.pcs_proof_mles().is_empty());
+        assert!(builder.sumcheck_subpolynomials().is_empty());
+
+        builder.produce_bit_distribution(bit_distribution.clone());
+        builder.produce_anchored_mle(&mle);
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![(TestScalar::from(7), vec![Box::new(&mle as &[_])])],
+        );
+
+        assert_eq!(builder.bit_distributions(), [bit_distribution]);
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+        assert_eq!(
+            builder.sumcheck_subpolynomials()[0].subpolynomial_type(),
+            SumcheckSubpolynomialType::Identity
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
@@ -139,3 +139,31 @@ impl<'a, S: Scalar> FirstRoundBuilder<'a, S> {
         self.num_post_result_challenges += cnt;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FirstRoundBuilder;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_track_first_round_lengths_and_mles() {
+        let mle = [7, 11];
+        let mut builder = FirstRoundBuilder::<TestScalar>::new(2);
+        assert_eq!(builder.range_length(), 2);
+        assert!(builder.pcs_proof_mles().is_empty());
+        assert!(builder.chi_evaluation_lengths().is_empty());
+        assert!(builder.rho_evaluation_lengths().is_empty());
+
+        builder.update_range_length(1);
+        assert_eq!(builder.range_length(), 2);
+
+        builder.produce_chi_evaluation_length(5);
+        builder.produce_rho_evaluation_length(3);
+        assert_eq!(builder.range_length(), 5);
+        assert_eq!(builder.chi_evaluation_lengths(), [5]);
+        assert_eq!(builder.rho_evaluation_lengths(), [3]);
+
+        builder.produce_intermediate_mle(&mle[..]);
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -69,3 +69,37 @@ impl<'a, T: ProvableResultElement<'a>, const N: usize> ProvableResultColumn for 
         (&self[..]).write(out, length)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProvableResultColumn;
+    use crate::base::{database::Column, scalar::test_scalar::TestScalar};
+    use alloc::vec;
+
+    #[test]
+    fn arrays_delegate_result_column_serialization_to_slices() {
+        let values = [7_i16, -11_i16];
+        let slice = &values[..];
+        assert_eq!(values.num_bytes(2), slice.num_bytes(2));
+
+        let mut array_output = vec![0; values.num_bytes(2)];
+        let mut slice_output = vec![0; slice.num_bytes(2)];
+        assert_eq!(values.write(&mut array_output, 2), array_output.len());
+        assert_eq!(slice.write(&mut slice_output, 2), slice_output.len());
+        assert_eq!(array_output, slice_output);
+    }
+
+    #[test]
+    fn columns_delegate_result_column_serialization_to_backing_values() {
+        let values = [7_i64, -11_i64];
+        let column = Column::<TestScalar>::BigInt(&values);
+        let slice = &values[..];
+        assert_eq!(column.num_bytes(2), slice.num_bytes(2));
+
+        let mut column_output = vec![0; column.num_bytes(2)];
+        let mut slice_output = vec![0; slice.num_bytes(2)];
+        assert_eq!(column.write(&mut column_output, 2), column_output.len());
+        assert_eq!(slice.write(&mut slice_output, 2), slice_output.len());
+        assert_eq!(column_output, slice_output);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -553,3 +553,49 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::get_index_range;
+    use crate::base::database::{MetadataAccessor, TableRef};
+    use alloc::vec::Vec;
+
+    struct TestMetadataAccessor {
+        spans: Vec<(TableRef, usize, usize)>,
+    }
+
+    impl MetadataAccessor for TestMetadataAccessor {
+        fn get_length(&self, table_ref: &TableRef) -> usize {
+            self.spans
+                .iter()
+                .find(|(stored_ref, _, _)| stored_ref == table_ref)
+                .map(|(_, length, _)| *length)
+                .unwrap()
+        }
+
+        fn get_offset(&self, table_ref: &TableRef) -> usize {
+            self.spans
+                .iter()
+                .find(|(stored_ref, _, _)| stored_ref == table_ref)
+                .map(|(_, _, offset)| *offset)
+                .unwrap()
+        }
+    }
+
+    #[test]
+    fn index_range_defaults_for_queries_without_tables() {
+        let accessor = TestMetadataAccessor { spans: Vec::new() };
+        assert_eq!(get_index_range(&accessor, Vec::<&TableRef>::new()), (0, 1));
+    }
+
+    #[test]
+    fn index_range_spans_all_referenced_tables() {
+        let table_a = TableRef::new("", "a");
+        let table_b = TableRef::new("schema", "b");
+        let accessor = TestMetadataAccessor {
+            spans: vec![(table_a.clone(), 4, 5), (table_b.clone(), 7, 1)],
+        };
+
+        assert_eq!(get_index_range(&accessor, [&table_a, &table_b]), (1, 9));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,42 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::QueryError;
+    use crate::base::{
+        database::{ColumnCoercionError, TableCoercionError},
+        proof::ProofError,
+    };
+
+    #[test]
+    fn table_coercion_errors_map_to_query_errors() {
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCoercionError {
+                source: ColumnCoercionError::Overflow
+            }),
+            QueryError::Overflow
+        ));
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCoercionError {
+                source: ColumnCoercionError::InvalidTypeCoercion
+            }),
+            QueryError::ProofError {
+                source: ProofError::InvalidTypeCoercion
+            }
+        ));
+        assert!(matches!(
+            QueryError::from(TableCoercionError::NameMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldNamesMismatch
+            }
+        ));
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCountMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldCountMismatch
+            }
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -93,6 +93,7 @@ impl<'a, S: Scalar> SumcheckSubpolynomial<'a, S> {
 mod tests {
     use super::{SumcheckSubpolynomial, SumcheckSubpolynomialTerm, SumcheckSubpolynomialType};
     use crate::base::scalar::test_scalar::TestScalar;
+    use crate::sql::proof::CompositePolynomialBuilder;
     use alloc::boxed::Box;
 
     #[test]
@@ -118,5 +119,45 @@ mod tests {
         assert_eq!(coeff, TestScalar::from(15));
 
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_compose_identity_and_zero_sum_terms() {
+        let fr = vec![TestScalar::from(2), TestScalar::from(5)];
+        let identity_mle = vec![TestScalar::from(3), TestScalar::from(7)];
+        let zerosum_mle = vec![TestScalar::from(11), TestScalar::from(13)];
+
+        let identity_subpoly = SumcheckSubpolynomial::new(
+            SumcheckSubpolynomialType::Identity,
+            vec![(TestScalar::from(3), vec![Box::new(&identity_mle)])],
+        );
+        let zerosum_subpoly = SumcheckSubpolynomial::new(
+            SumcheckSubpolynomialType::ZeroSum,
+            vec![(TestScalar::from(5), vec![Box::new(&zerosum_mle)])],
+        );
+
+        assert_eq!(
+            zerosum_subpoly.subpolynomial_type(),
+            SumcheckSubpolynomialType::ZeroSum
+        );
+
+        let mut builder = CompositePolynomialBuilder::new(1, &fr);
+        let group_multiplier = TestScalar::from(2);
+        identity_subpoly.compose(&mut builder, group_multiplier);
+        zerosum_subpoly.compose(&mut builder, group_multiplier);
+
+        let point = [TestScalar::from(17)];
+        let m0 = TestScalar::from(1) - point[0];
+        let m1 = point[0];
+        let eval_fr = fr[0] * m0 + fr[1] * m1;
+        let eval_identity = identity_mle[0] * m0 + identity_mle[1] * m1;
+        let eval_zerosum = zerosum_mle[0] * m0 + zerosum_mle[1] * m1;
+
+        let expected =
+            eval_fr * TestScalar::from(6) * eval_identity + TestScalar::from(10) * eval_zerosum;
+        assert_eq!(
+            builder.make_composite_polynomial().evaluate(&point),
+            expected
+        );
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add focused tests for proof round-builder bookkeeping
- cover result-column serialization delegation and query result coercion error mapping
- cover query proof index range handling and sumcheck subpolynomial composition

## Tests
- cargo fmt --check
- git diff --check
- cargo test -p proof-of-sql --no-default-features --features std
- cargo test -p proof-of-sql --no-default-features --features "std,arrow" sql::proof

Note: cargo test --all-features cannot run on Windows because blitzar-sys exits during build with Unsupported OS. Only Linux is supported.