### PR TITLE
test: cover targeted proof plan verifier slices

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -184,3 +184,40 @@ impl DynProofPlan {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DynProofPlan;
+    use crate::{
+        base::database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+        sql::proof_exprs::{AliasedDynProofExpr, DynProofExpr, TableExpr},
+    };
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn new_legacy_filter_builds_legacy_filter_variant() {
+        let table_ref = TableRef::new("sxt", "t");
+        let column_ref = ColumnRef::new(table_ref.clone(), Ident::from("c"), ColumnType::BigInt);
+        let aliased_result = AliasedDynProofExpr {
+            expr: DynProofExpr::new_column(column_ref),
+            alias: Ident::from("result"),
+        };
+        let input = TableExpr { table_ref };
+        let filter_expr = DynProofExpr::new_literal(LiteralValue::Boolean(true));
+
+        let plan = DynProofPlan::new_legacy_filter(
+            vec![aliased_result.clone()],
+            input.clone(),
+            filter_expr.clone(),
+        );
+
+        match plan {
+            DynProofPlan::LegacyFilter(filter) => {
+                assert_eq!(filter.aliased_results(), &[aliased_result]);
+                assert_eq!(filter.table(), &input);
+                assert_eq!(filter.where_clause(), &filter_expr);
+            }
+            other => panic!("expected legacy filter plan, got {other:?}"),
+        }
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -7,11 +7,14 @@ use crate::{
         },
         map::{indexmap, IndexMap},
         math::decimal::Precision,
+        proof::ProofError,
+        scalar::{test_scalar::TestScalar, Scalar},
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
-            exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
+            exercise_verification, mock_verification_builder::MockVerificationBuilder,
+            FirstRoundBuilder, ProofPlan, ProvableQueryResult, ProverEvaluate,
             VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, DynProofExpr},
@@ -19,6 +22,86 @@ use crate::{
 };
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
+use sqlparser::ast::Ident;
+
+#[test]
+fn we_can_verify_slice_exec_verifier_lengths() {
+    let t = TableRef::new("sxt", "t");
+    let plan = slice_exec(
+        table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
+        1,
+        Some(2),
+    );
+    let accessor = indexmap! {
+        t.clone() => indexmap! { Ident::from("a") => TestScalar::ONE }
+    };
+    let chi_eval_map = indexmap! { t => (TestScalar::ONE, 5) };
+    let mut verification_builder = MockVerificationBuilder::new(
+        Vec::new(),
+        3,
+        vec![vec![TestScalar::ONE]],
+        vec![vec![TestScalar::ZERO, TestScalar::ZERO]],
+        vec![TestScalar::ZERO, TestScalar::ZERO],
+        vec![2, 1, 3],
+        Vec::new(),
+    );
+
+    let result = plan
+        .verifier_evaluate(&mut verification_builder, &accessor, &chi_eval_map, &[])
+        .unwrap();
+
+    assert_eq!(result.column_evals(), &[TestScalar::ONE]);
+    assert_eq!(result.chi(), (TestScalar::ONE, 2));
+}
+
+#[test]
+fn we_reject_slice_exec_verifier_lengths() {
+    let verify_with_chi_lengths = |chi_evaluation_length_queue| {
+        let t = TableRef::new("sxt", "t");
+        let plan = slice_exec(
+            table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
+            1,
+            Some(2),
+        );
+        let accessor = indexmap! {
+            t.clone() => indexmap! { Ident::from("a") => TestScalar::ONE }
+        };
+        let chi_eval_map = indexmap! { t => (TestScalar::ONE, 5) };
+        let mut verification_builder = MockVerificationBuilder::<TestScalar>::new(
+            Vec::new(),
+            2,
+            vec![vec![TestScalar::ONE]],
+            vec![vec![TestScalar::ZERO, TestScalar::ZERO]],
+            vec![TestScalar::ZERO, TestScalar::ZERO],
+            chi_evaluation_length_queue,
+            Vec::new(),
+        );
+
+        plan.verifier_evaluate(&mut verification_builder, &accessor, &chi_eval_map, &[])
+    };
+
+    let invalid_lengths = [
+        (
+            vec![1, 1, 3],
+            "output length does not match selection length",
+        ),
+        (vec![3, 0, 3], "offset length does not match plan value"),
+        (vec![3, 1, 4], "max length does not match expected value"),
+    ];
+
+    for (chi_lengths, expected_error) in invalid_lengths {
+        if let Err(ProofError::VerificationError { error }) = verify_with_chi_lengths(chi_lengths) {
+            assert_eq!(error, expected_error);
+        } else {
+            panic!("expected slice verifier length error");
+        }
+    }
+
+    assert!(matches!(
+        verify_with_chi_lengths(vec![2, 1, 3]),
+        Err(ProofError::ProofSizeMismatch { .. })
+    ));
+}
 
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -1,23 +1,175 @@
 use super::test_utility::*;
 use crate::{
     base::{
+        bit::BitDistribution,
         database::{
             owned_table_utility::*, table_utility::*, ColumnType, OwnedTable,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         map::indexmap,
+        proof::{ProofError, ProofSizeMismatch},
+        scalar::{test_scalar::TestScalar, Scalar},
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
-            exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
-            VerifiableQueryResult,
+            exercise_verification, mock_verification_builder::MockVerificationBuilder,
+            FirstRoundBuilder, ProofPlan, ProvableQueryResult, ProverEvaluate,
+            SumcheckSubpolynomialType, VerifiableQueryResult, VerificationBuilder,
         },
         proof_exprs::test_utility::*,
     },
 };
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
+use sqlparser::ast::Ident;
+
+struct RejectZeroSumBuilder<S: Scalar> {
+    inner: MockVerificationBuilder<S>,
+}
+
+impl<S: Scalar> VerificationBuilder<S> for RejectZeroSumBuilder<S> {
+    fn try_consume_chi_evaluation(&mut self) -> Result<(S, usize), ProofSizeMismatch> {
+        self.inner.try_consume_chi_evaluation()
+    }
+
+    fn try_consume_rho_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        self.inner.try_consume_rho_evaluation()
+    }
+
+    fn try_consume_first_round_mle_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        self.inner.try_consume_first_round_mle_evaluation()
+    }
+
+    fn try_consume_first_round_mle_evaluations(
+        &mut self,
+        count: usize,
+    ) -> Result<Vec<S>, ProofSizeMismatch> {
+        self.inner.try_consume_first_round_mle_evaluations(count)
+    }
+
+    fn try_consume_final_round_mle_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        self.inner.try_consume_final_round_mle_evaluation()
+    }
+
+    fn try_consume_final_round_mle_evaluations(
+        &mut self,
+        count: usize,
+    ) -> Result<Vec<S>, ProofSizeMismatch> {
+        self.inner.try_consume_final_round_mle_evaluations(count)
+    }
+
+    fn try_consume_bit_distribution(&mut self) -> Result<BitDistribution, ProofSizeMismatch> {
+        self.inner.try_consume_bit_distribution()
+    }
+
+    fn try_produce_sumcheck_subpolynomial_evaluation(
+        &mut self,
+        subpolynomial_type: SumcheckSubpolynomialType,
+        eval: S,
+        degree: usize,
+    ) -> Result<(), ProofSizeMismatch> {
+        if subpolynomial_type == SumcheckSubpolynomialType::ZeroSum {
+            Err(ProofSizeMismatch::SumcheckProofTooSmall)
+        } else {
+            self.inner.try_produce_sumcheck_subpolynomial_evaluation(
+                subpolynomial_type,
+                eval,
+                degree,
+            )
+        }
+    }
+
+    fn try_consume_post_result_challenge(&mut self) -> Result<S, ProofSizeMismatch> {
+        self.inner.try_consume_post_result_challenge()
+    }
+
+    fn singleton_chi_evaluation(&self) -> S {
+        self.inner.singleton_chi_evaluation()
+    }
+
+    fn rho_256_evaluation(&self) -> Option<S> {
+        self.inner.rho_256_evaluation()
+    }
+}
+
+#[test]
+fn we_reject_union_exec_verifier_missing_output_mle() {
+    let t0 = TableRef::new("sxt", "t0");
+    let t1 = TableRef::new("sxt", "t1");
+    let plan = union_exec(vec![
+        table_exec(t0.clone(), vec![column_field("a", ColumnType::BigInt)]),
+        table_exec(t1.clone(), vec![column_field("a", ColumnType::BigInt)]),
+    ]);
+    let accessor = indexmap! {
+        t0.clone() => indexmap! { Ident::from("a") => TestScalar::ONE },
+        t1.clone() => indexmap! { Ident::from("a") => TestScalar::TWO },
+    };
+    let chi_eval_map = indexmap! {
+        t0 => (TestScalar::ONE, 1),
+        t1 => (TestScalar::ONE, 1),
+    };
+    let mut verification_builder = MockVerificationBuilder::<TestScalar>::new(
+        Vec::new(),
+        3,
+        vec![vec![]],
+        vec![vec![TestScalar::ZERO, TestScalar::ZERO]],
+        vec![TestScalar::ZERO, TestScalar::ZERO],
+        Vec::new(),
+        Vec::new(),
+    );
+
+    let err = plan
+        .verifier_evaluate(&mut verification_builder, &accessor, &chi_eval_map, &[])
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ProofError::ProofSizeMismatch {
+            source: ProofSizeMismatch::TooFewMLEEvaluations
+        }
+    ));
+}
+
+#[test]
+fn we_reject_union_exec_verifier_zero_sum() {
+    let t0 = TableRef::new("sxt", "t0");
+    let t1 = TableRef::new("sxt", "t1");
+    let plan = union_exec(vec![
+        table_exec(t0.clone(), vec![column_field("a", ColumnType::BigInt)]),
+        table_exec(t1.clone(), vec![column_field("a", ColumnType::BigInt)]),
+    ]);
+    let accessor = indexmap! {
+        t0.clone() => indexmap! { Ident::from("a") => TestScalar::ONE },
+        t1.clone() => indexmap! { Ident::from("a") => TestScalar::TWO },
+    };
+    let chi_eval_map = indexmap! {
+        t0 => (TestScalar::ONE, 1),
+        t1 => (TestScalar::ONE, 1),
+    };
+    let mut verification_builder = RejectZeroSumBuilder {
+        inner: MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            vec![vec![TestScalar::ONE]],
+            vec![vec![TestScalar::ZERO, TestScalar::ZERO, TestScalar::ZERO]],
+            vec![TestScalar::ZERO, TestScalar::ZERO],
+            vec![2],
+            Vec::new(),
+        ),
+    };
+
+    let err = plan
+        .verifier_evaluate(&mut verification_builder, &accessor, &chi_eval_map, &[])
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ProofError::ProofSizeMismatch {
+            source: ProofSizeMismatch::SumcheckProofTooSmall
+        }
+    ));
+}
 
 #[test]
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: NotEnoughInputPlans")]


### PR DESCRIPTION
/claim #560

## Summary
- keep the existing `DynProofPlan::new_legacy_filter` coverage slice
- add focused verifier coverage for `SliceExec` length validation and filter proof propagation
- add focused verifier coverage for `UnionExec` proof-size error propagation

## Coverage
- Codecov main identified `dyn_proof_plan.rs` lines 114-120 as uncovered for the existing slice
- Codecov main identified `slice_exec.rs` lines 94-96, 99-101, 108-110, and 130 as uncovered
- Codecov main identified `union_exec.rs` lines 85 and 100 as uncovered
- targeted `cargo llvm-cov` runs in the Codespace show the new `slice_exec` and `union_exec` verifier tests execute those targeted lines

## Tests
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --all-features --lib slice_exec_verifier_lengths -- --nocapture`
- `cargo test -p proof-of-sql --all-features --lib union_exec_verifier -- --nocapture`
- `cargo llvm-cov test -p proof-of-sql --all-features --lib --no-clean --show-missing-lines --text slice_exec_verifier_lengths`
- `cargo llvm-cov test -p proof-of-sql --all-features --lib --no-clean --show-missing-lines --text union_exec_verifier`
- `cargo clippy -p proof-of-sql --all-features --lib --tests -- -D warnings`
- `bash scripts/check_commits.sh`

## Notes
- `source scripts/run_ci_checks.sh` was not run; this PR is a narrow test-only coverage slice, so I ran targeted all-features tests plus clippy on the touched crate instead.