### PR TITLE
ci: cache coverage workflow builds

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -23,6 +23,10 @@ jobs:
     - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get install -y clang lld
     - uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Setup Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: coverage
     - name: Clean Previous Coverage Artifacts
       run: cargo llvm-cov clean --workspace
     - name: Run Tests to Generate Coverage Data (All Features)

--- a/scripts/run_ci_checks.sh
+++ b/scripts/run_ci_checks.sh
@@ -38,7 +38,7 @@ cargo_commands=$(
     | grep -v 'test' \
     | grep -v 'rustup' \
     | grep -v 'udeps' \
-    | sed -E 's/^\s*run:\s*//'
+    | sed -E 's/^[[:space:]]*run:[[:space:]]*//'
 )
 
 if [ -z "$cargo_commands" ]; then


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Issue #557 calls out slow CI runtime and was later clarified to include broader CI runtime improvements. In the issue thread, Jay noted that CI rebuilds dependencies from scratch and that the build cache appears not to be used effectively.

The `CI-Lint-And-Test` workflow already restores `Swatinem/rust-cache` before Cargo-heavy jobs, but `CI-Code-Coverage` currently installs `cargo-llvm-cov` and then builds/tests the full workspace without restoring Rust build/cache state. This PR adds the same Rust cache action to the coverage workflow with a coverage-specific key.

This does not change which tests run, coverage thresholds, Codecov upload behavior, or `cargo llvm-cov` arguments. It only gives the coverage job access to the same Cargo registry/git and target-cache mechanism already used elsewhere in CI.

/claim #557

# What changes are included in this PR?

- Add `Swatinem/rust-cache@v2` to `.github/workflows/code-coverage.yml`.
- Use a `coverage` cache key so coverage cache entries are isolated from the existing lint/test matrix keys.
- Fix `scripts/run_ci_checks.sh` command extraction so indented workflow lines like `run: cargo check --no-default-features` are converted to executable commands instead of being run literally as `run: cargo ...`.

# Are these changes tested?

Local workflow validation:

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/code-coverage.yml"); puts "yaml ok"'
git diff --check origin/main...HEAD
source scripts/check_commits.sh
source scripts/run_ci_checks.sh
```

Results:

- Workflow YAML parsed successfully (`yaml ok`).
- `git diff --check origin/main...HEAD` passed with no whitespace errors.
- `source scripts/check_commits.sh` passes: 2 commits checked, 0 failures.
- `source scripts/run_ci_checks.sh` now extracts executable commands correctly, then reaches the local Apple Silicon build limitation: the default `perf` feature enables `halo2curves/asm`, which errors with `Currently feature asm can only be enabled on x86_64 arch.`
- Orca PR checks are passing on this branch.

I did not produce full CI timing evidence locally because the behavioral surface is a GitHub Actions cache restore/save change; the relevant runtime evidence will come from GitHub Actions coverage-job timings after maintainers approve the fork workflow run.
