### PR TITLE
test: cover scalar and error helper paths

### DIFF
--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -35,3 +35,49 @@ impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
         MontScalar::<T>::from_le_bytes_mod_order(&bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn from_words_keeps_low_and_high_halves() {
+        let value = U256::from_words(123, 456);
+
+        assert_eq!(value.low, 123);
+        assert_eq!(value.high, 456);
+    }
+
+    #[test]
+    fn mont_scalar_to_u256_uses_little_endian_word_layout() {
+        let scalar = TestScalar::from([1, 2, 3, 4]);
+
+        let value = U256::from(&scalar);
+
+        assert_eq!(value.low, u128::from(1_u64) | (u128::from(2_u64) << 64));
+        assert_eq!(value.high, u128::from(3_u64) | (u128::from(4_u64) << 64));
+    }
+
+    #[test]
+    fn u256_to_mont_scalar_uses_little_endian_word_layout() {
+        let value = U256::from_words(
+            u128::from(11_u64) | (u128::from(22_u64) << 64),
+            u128::from(33_u64) | (u128::from(44_u64) << 64),
+        );
+
+        let scalar: TestScalar = (&value).into();
+
+        assert_eq!(scalar, TestScalar::from([11, 22, 33, 44]));
+    }
+
+    #[test]
+    fn u256_roundtrips_back_into_the_same_scalar() {
+        let original = TestScalar::from([9, 8, 7, 6]);
+
+        let value = U256::from(&original);
+        let recovered: TestScalar = (&value).into();
+
+        assert_eq!(recovered, original);
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,50 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_errors_render_human_readable_messages() {
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezone {
+                timezone: "MARS".into(),
+            }
+            .to_string(),
+            "invalid timezone string: MARS"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezoneOffset.to_string(),
+            "invalid timezone offset"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimeUnit {
+                error: "fortnight".into(),
+            }
+            .to_string(),
+            "Invalid time unit"
+        );
+        assert_eq!(
+            PoSQLTimestampError::UnsupportedPrecision { error: "12".into() }.to_string(),
+            "Unsupported precision for timestamp: 12"
+        );
+    }
+
+    #[test]
+    fn timestamp_errors_convert_into_strings_without_losing_context() {
+        let invalid_timezone: String = PoSQLTimestampError::InvalidTimezone {
+            timezone: "UTC+25".into(),
+        }
+        .into();
+        let unsupported_precision: String =
+            PoSQLTimestampError::UnsupportedPrecision { error: "2".into() }.into();
+
+        assert_eq!(invalid_timezone, "invalid timezone string: UTC+25");
+        assert_eq!(
+            unsupported_precision,
+            "Unsupported precision for timestamp: 2"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,137 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn proof_error_display_covers_top_level_variants() {
+        assert_eq!(
+            ProofError::VerificationError {
+                error: "bad transcript",
+            }
+            .to_string(),
+            "Verification error: bad transcript"
+        );
+        assert_eq!(
+            ProofError::UnsupportedQueryPlan {
+                error: "recursive CTE",
+            }
+            .to_string(),
+            "Unsupported query plan: recursive CTE"
+        );
+        assert_eq!(
+            ProofError::InvalidTypeCoercion.to_string(),
+            "Result does not match query: type mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldNamesMismatch.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldCountMismatch.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_error_transparent_variants_preserve_source_messages() {
+        let proof_size_error = ProofError::ProofSizeMismatch {
+            source: ProofSizeMismatch::TooFewMLEEvaluations,
+        };
+        let placeholder_error = ProofError::PlaceholderError {
+            source: PlaceholderError::InvalidPlaceholderType {
+                index: 2,
+                expected: ColumnType::BigInt,
+                actual: ColumnType::Boolean,
+            },
+        };
+
+        assert_eq!(
+            proof_size_error.to_string(),
+            "Proof has too few MLE evaluations"
+        );
+        assert_eq!(
+            placeholder_error.to_string(),
+            "Invalid placeholder type: 2, expected: BIGINT, actual: BOOLEAN"
+        );
+    }
+
+    #[test]
+    fn proof_size_mismatch_display_covers_each_variant() {
+        let cases = [
+            (
+                ProofSizeMismatch::SumcheckProofTooSmall,
+                "Sumcheck proof is too small",
+            ),
+            (
+                ProofSizeMismatch::TooFewMLEEvaluations,
+                "Proof has too few MLE evaluations",
+            ),
+            (
+                ProofSizeMismatch::PostResultCountMismatch,
+                "Post result challenge count mismatch",
+            ),
+            (
+                ProofSizeMismatch::ConstraintCountMismatch,
+                "Constraint count mismatch",
+            ),
+            (
+                ProofSizeMismatch::TooFewBitDistributions,
+                "Proof has too few bit distributions",
+            ),
+            (
+                ProofSizeMismatch::TooFewChiLengths,
+                "Proof has too few one lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewRhoLengths,
+                "Proof has too few rho lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewSumcheckVariables,
+                "Proof has too few sumcheck variables",
+            ),
+            (
+                ProofSizeMismatch::ChiLengthNotFound,
+                "Proof doesn't have requested one length",
+            ),
+            (
+                ProofSizeMismatch::RhoLengthNotFound,
+                "Proof doesn't have requested rho length",
+            ),
+        ];
+
+        for (err, expected) in cases {
+            assert_eq!(err.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn placeholder_error_display_covers_each_validation_failure() {
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderIndex {
+                index: 3,
+                num_params: 1,
+            }
+            .to_string(),
+            "Invalid placeholder index: 3, number of params: 1"
+        );
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderType {
+                index: 0,
+                expected: ColumnType::VarChar,
+                actual: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Invalid placeholder type: 0, expected: VARCHAR, actual: BIGINT"
+        );
+        assert_eq!(
+            PlaceholderError::ZeroPlaceholderId.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,47 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn limbs_are_serialized_in_reverse_word_order() {
+        let wrapper = LimbWrapper {
+            limbs: [1, 2, 3, 4],
+        };
+
+        let serialized = serde_json::to_string(&wrapper).unwrap();
+
+        assert_eq!(serialized, r#"{"limbs":[4,3,2,1]}"#);
+    }
+
+    #[test]
+    fn limbs_roundtrip_back_to_the_original_layout() {
+        let wrapper = LimbWrapper {
+            limbs: [11, 22, 33, 44],
+        };
+
+        let serialized = serde_json::to_string(&wrapper).unwrap();
+        let deserialized: LimbWrapper = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, wrapper);
+    }
+
+    #[test]
+    fn deserializing_the_wrong_number_of_limbs_fails() {
+        assert!(serde_json::from_str::<LimbWrapper>(r#"{"limbs":[1,2,3]}"#).is_err());
+        assert!(serde_json::from_str::<LimbWrapper>(r#"{"limbs":[1,2,3,4,5]}"#).is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,79 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        database::ColumnType,
+        math::decimal::{DecimalError, IntermediateDecimalError},
+        proof::PlaceholderError,
+    };
+
+    #[test]
+    fn analyze_error_display_covers_direct_variants() {
+        assert_eq!(
+            AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::Boolean,
+            }
+            .to_string(),
+            "Expression has datatype BOOLEAN, which was not valid"
+        );
+        assert_eq!(
+            AnalyzeError::DataTypeMismatch {
+                left_type: "BIGINT".into(),
+                right_type: "VARCHAR".into(),
+            }
+            .to_string(),
+            "Left side has 'BIGINT' type but right side has 'VARCHAR' type"
+        );
+        assert_eq!(
+            AnalyzeError::DifferentColumnLength { len_a: 2, len_b: 5 }.to_string(),
+            "Columns have different lengths: 2 != 5"
+        );
+        assert_eq!(
+            AnalyzeError::NotEnoughInputPlans.to_string(),
+            "Not enough input plans"
+        );
+    }
+
+    #[test]
+    fn analyze_error_transparent_variants_preserve_source_messages() {
+        let decimal_error: AnalyzeError = IntermediateDecimalError::LossyCast.into();
+        let placeholder_error = AnalyzeError::PlaceholderError {
+            source: PlaceholderError::ZeroPlaceholderId,
+        };
+
+        assert_eq!(
+            decimal_error,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::LossyCast,
+                },
+            }
+        );
+        assert_eq!(
+            decimal_error.to_string(),
+            "Fractional part of decimal is non-zero"
+        );
+        assert_eq!(
+            placeholder_error.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn analyze_error_converts_into_string_via_display() {
+        let message: String = AnalyzeError::DataTypeMismatch {
+            left_type: "SCALAR".into(),
+            right_type: "BOOLEAN".into(),
+        }
+        .into();
+
+        assert_eq!(
+            message,
+            "Left side has 'SCALAR' type but right side has 'BOOLEAN' type"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,50 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::AnalyzeError;
+
+    #[test]
+    fn evm_proof_plan_errors_render_expected_messages() {
+        assert_eq!(
+            EVMProofPlanError::NotSupported.to_string(),
+            "plan not yet supported"
+        );
+        assert_eq!(
+            EVMProofPlanError::ColumnNotFound.to_string(),
+            "column not found"
+        );
+        assert_eq!(
+            EVMProofPlanError::TableNotFound.to_string(),
+            "table not found"
+        );
+        assert_eq!(
+            EVMProofPlanError::InvalidTableName.to_string(),
+            "table name can not be parsed into TableRef"
+        );
+        assert_eq!(
+            EVMProofPlanError::InvalidOutputColumnName.to_string(),
+            "invalid or missing output column name"
+        );
+        assert_eq!(
+            EVMProofPlanError::InconsistentGroupByColumnCounts.to_string(),
+            "column counts in group by plans are inconsistent"
+        );
+        assert_eq!(
+            EVMProofPlanError::IncorrectScalingFactor.to_string(),
+            "incorrect scaling factor"
+        );
+    }
+
+    #[test]
+    fn evm_proof_plan_error_wraps_analyze_error_transparently() {
+        let err = EVMProofPlanError::AnalyzeError {
+            source: AnalyzeError::NotEnoughInputPlans,
+        };
+
+        assert_eq!(err.to_string(), "Not enough input plans");
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused unit coverage for `U256` word layout and scalar round-tripping
- cover timestamp, proof, analysis, and EVM proof-plan error display/transparent wrapping paths
- add serialization round-trip and invalid-length coverage for limb serialization helpers

## Tests
- `/opt/homebrew/bin/rustfmt --check crates/proof-of-sql/src/base/encode/u256.rs crates/proof-of-sql/src/base/posql_time/error.rs crates/proof-of-sql/src/base/proof/error.rs crates/proof-of-sql/src/base/standard_serializations/limbs.rs crates/proof-of-sql/src/sql/error.rs crates/proof-of-sql/src/sql/evm_proof_plan/error.rs`
- `git diff --check -- crates/proof-of-sql/src/base/encode/u256.rs crates/proof-of-sql/src/base/posql_time/error.rs crates/proof-of-sql/src/base/proof/error.rs crates/proof-of-sql/src/base/standard_serializations/limbs.rs crates/proof-of-sql/src/sql/error.rs crates/proof-of-sql/src/sql/evm_proof_plan/error.rs`
- `CARGO_HOME=/Users/liuhechuandemac/Documents/Codex/2026-05-11/5/sxt-proof-of-sql/.cargo-home CARGO_TARGET_DIR=/Users/liuhechuandemac/Documents/Codex/2026-05-11/5/sxt-proof-of-sql/target-codex /opt/homebrew/bin/cargo test -p proof-of-sql --lib --no-default-features --features test,std u256::tests`
- `CARGO_HOME=/Users/liuhechuandemac/Documents/Codex/2026-05-11/5/sxt-proof-of-sql/.cargo-home CARGO_TARGET_DIR=/Users/liuhechuandemac/Documents/Codex/2026-05-11/5/sxt-proof-of-sql/target-codex /opt/homebrew/bin/cargo test -p proof-of-sql --lib --no-default-features --features test,std error::tests`
- `CARGO_HOME=/Users/liuhechuandemac/Documents/Codex/2026-05-11/5/sxt-proof-of-sql/.cargo-home CARGO_TARGET_DIR=/Users/liuhechuandemac/Documents/Codex/2026-05-11/5/sxt-proof-of-sql/target-codex /opt/homebrew/bin/cargo test -p proof-of-sql --lib --no-default-features --features test,std standard_serializations::limbs`