### PR TITLE
test: cover posql time and limb serialization

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -37,7 +37,8 @@ impl TryFrom<&Option<Arc<str>>> for PoSQLTimeZone {
                 match tz.as_str() {
                     "Z" | "UTC" | "00:00" | "+00:00" | "0:00" | "+0:00" => Ok(PoSQLTimeZone::utc()),
                     tz if tz.chars().count() == 6
-                        && (tz.starts_with('+') || tz.starts_with('-')) =>
+                        && (tz.starts_with('+') || tz.starts_with('-'))
+                        && tz.get(3..4) == Some(":") =>
                     {
                         let sign = if tz.starts_with('-') { -1 } else { 1 };
                         let hours = tz[1..3]
@@ -96,11 +97,30 @@ mod timezone_parsing_tests {
     }
 
     #[test]
-    fn we_can_parse_time_zone() {
+    fn we_can_parse_negative_time_zone() {
         let timezone_as_str: Option<Arc<str>> = Some("-01:03".into());
         let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
         let expected_time_zone = PoSQLTimeZone::new(-3780);
         assert_eq!(timezone, expected_time_zone);
+    }
+
+    #[test]
+    fn we_can_parse_positive_time_zone() {
+        let timezone_as_str: Option<Arc<str>> = Some("+05:45".into());
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+        let expected_time_zone = PoSQLTimeZone::new(20_700);
+        assert_eq!(timezone, expected_time_zone);
+    }
+
+    #[test]
+    fn we_can_parse_utc_time_zone_aliases() {
+        let utc_aliases = ["Z", "utc", "UTC", "00:00", "+00:00", "0:00", "+0:00"];
+
+        for alias in utc_aliases {
+            let timezone_as_str: Option<Arc<str>> = Some(alias.into());
+            let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+            assert_eq!(timezone, PoSQLTimeZone::utc());
+        }
     }
 
     #[test]
@@ -118,5 +138,33 @@ mod timezone_parsing_tests {
             timezone_err,
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
         ));
+    }
+
+    #[test]
+    fn we_cannot_parse_malformed_time_zone_offsets() {
+        let invalid_timezones = ["+0130", "+01x30", "-01 30"];
+
+        for invalid_timezone in invalid_timezones {
+            let timezone_as_str: Option<Arc<str>> = Some(invalid_timezone.into());
+            let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();
+            assert!(matches!(
+                timezone_err,
+                PoSQLTimestampError::InvalidTimezone { timezone: _ }
+            ));
+        }
+    }
+
+    #[test]
+    fn we_cannot_parse_offsets_with_invalid_parts() {
+        let invalid_timezones = ["+aa:30", "+01:bb"];
+
+        for invalid_timezone in invalid_timezones {
+            let timezone_as_str: Option<Arc<str>> = Some(invalid_timezone.into());
+            let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();
+            assert_eq!(
+                timezone_err,
+                PoSQLTimestampError::InvalidTimezoneOffset
+            );
+        }
     }
 }

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -81,4 +81,29 @@ mod time_unit_tests {
             ));
         }
     }
+
+    #[test]
+    fn we_can_convert_time_units_to_precision() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn we_can_display_time_units() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
 }

--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,52 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "super::serialize_limbs",
+            deserialize_with = "super::deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn we_serialize_limbs_in_big_endian_order() {
+        let wrapper = LimbWrapper {
+            limbs: [1, 2, 3, 4],
+        };
+
+        let serialized = serde_json::to_string(&wrapper).unwrap();
+
+        assert_eq!(serialized, r#"{"limbs":[4,3,2,1]}"#);
+    }
+
+    #[test]
+    fn we_deserialize_limbs_from_big_endian_order() {
+        let wrapper: LimbWrapper = serde_json::from_str(r#"{"limbs":[4,3,2,1]}"#).unwrap();
+
+        assert_eq!(
+            wrapper,
+            LimbWrapper {
+                limbs: [1, 2, 3, 4]
+            }
+        );
+    }
+
+    #[test]
+    fn we_can_round_trip_limbs_without_changing_internal_order() {
+        let wrapper = LimbWrapper {
+            limbs: [0, u64::MAX, 42, 17],
+        };
+
+        let serialized = serde_json::to_string(&wrapper).unwrap();
+        let deserialized: LimbWrapper = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, wrapper);
+    }
+}


### PR DESCRIPTION
/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This adds focused coverage for small PoSQL time and standard serialization paths that were missing direct tests. It also tightens timezone parsing so signed offsets must use the expected `:` separator.

# What changes are included in this PR?

- Add coverage for PoSQL time unit precision conversion and display formatting.
- Add timezone parsing coverage for UTC aliases, signed offsets, malformed separators, and invalid offset parts.
- Reject signed timezone offsets that do not use `:` as the separator.
- Add limb serialization tests covering big-endian wire order and round-trip preservation.

# Are these changes tested?

Yes.

- Added unit coverage for PoSQL time unit conversion and display formatting.
- Added timezone parsing coverage for UTC aliases, signed offsets, malformed separators, and invalid offset parts.
- Added limb serialization tests for big-endian wire order and round-trip preservation.
- Tested locally in a separate Rust sandbox.
- Ran `git diff --check` in this checkout.


