### PR TITLE
test: cover dory packed commit helpers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -300,6 +300,72 @@ mod tests {
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     };
+    use ark_ec::{AffineRepr, CurveGroup};
+    use ark_ff::MontFp;
+    use core::ops::Mul;
+
+    fn g1_multiple(multiplier: u64) -> G1Affine {
+        G1Affine::generator().mul(F::from(multiplier)).into_affine()
+    }
+
+    fn signed_commit(first: G1Affine, second: G1Affine, column_type: ColumnType) -> G1Affine {
+        (first + second.mul(min_as_f(column_type))).into_affine()
+    }
+
+    #[test]
+    fn we_can_get_minimum_field_offsets_by_column_type() {
+        assert_eq!(min_as_f(ColumnType::TinyInt), MontFp!("-128"));
+        assert_eq!(min_as_f(ColumnType::SmallInt), MontFp!("-32768"));
+        assert_eq!(min_as_f(ColumnType::Int), MontFp!("-2147483648"));
+        assert_eq!(
+            min_as_f(ColumnType::BigInt),
+            MontFp!("-9223372036854775808")
+        );
+        assert_eq!(
+            min_as_f(ColumnType::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc()
+            )),
+            MontFp!("-9223372036854775808")
+        );
+        assert_eq!(
+            min_as_f(ColumnType::Int128),
+            MontFp!("-170141183460469231731687303715884105728")
+        );
+
+        for column_type in [
+            ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
+            ColumnType::Uint8,
+            ColumnType::Scalar,
+            ColumnType::VarChar,
+            ColumnType::VarBinary,
+            ColumnType::Boolean,
+        ] {
+            assert_eq!(min_as_f(column_type), F::from(0_u64));
+        }
+    }
+
+    #[test]
+    fn we_can_offset_signed_commits_by_column_type_minimums() {
+        let all_sub_commits = (1..=8).map(g1_multiple).collect::<Vec<_>>();
+        let committable_columns = [
+            CommittableColumn::TinyInt(&[1, 2]),
+            CommittableColumn::Uint8(&[3, 4]),
+        ];
+
+        let signed = signed_commits(&all_sub_commits, &committable_columns);
+
+        assert_eq!(
+            signed,
+            vec![
+                signed_commit(all_sub_commits[0], all_sub_commits[2], ColumnType::TinyInt),
+                signed_commit(all_sub_commits[1], all_sub_commits[3], ColumnType::Uint8),
+                signed_commit(all_sub_commits[4], all_sub_commits[6], ColumnType::TinyInt),
+                signed_commit(all_sub_commits[5], all_sub_commits[7], ColumnType::Uint8),
+            ]
+        );
+        assert!(signed_commits(&all_sub_commits, &[]).is_empty());
+    }
 
     fn assert_blitzar_metadata(
         committable_columns: &[CommittableColumn],

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -468,11 +468,91 @@ pub fn bit_table_and_scalars_for_packed_msm(
 
 #[cfg(test)]
 mod tests {
+    use super::super::F;
     use super::*;
     use crate::base::{
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     };
+    use ark_ec::{AffineRepr, CurveGroup};
+    use core::ops::Mul;
+
+    fn g1_multiple(multiplier: u64) -> G1Affine {
+        G1Affine::generator().mul(F::from(multiplier)).into_affine()
+    }
+
+    fn offset_commit(first: G1Affine, offset: G1Affine, column: &CommittableColumn) -> G1Affine {
+        (first + offset.mul(min_as_f(column.column_type()))).into_affine()
+    }
+
+    #[test]
+    fn we_can_modify_commits_for_signed_unsigned_and_empty_columns() {
+        let committable_columns = [
+            CommittableColumn::TinyInt(&[1, 2, 3]),
+            CommittableColumn::SmallInt(&[4, 5]),
+            CommittableColumn::BigInt(&[6]),
+            CommittableColumn::Uint8(&[7, 8]),
+            CommittableColumn::Int(&[]),
+        ];
+        let offset = 0;
+        let num_matrix_commitment_columns = 1;
+        let (bit_table, _) = bit_table_and_scalars_for_packed_msm(
+            &committable_columns,
+            offset,
+            num_matrix_commitment_columns,
+        );
+        let sub_commits = (1..=bit_table.len())
+            .map(|n| g1_multiple(n as u64))
+            .collect::<Vec<_>>();
+
+        let modified_commits = modify_commits(
+            &sub_commits,
+            &bit_table,
+            &committable_columns,
+            offset,
+            num_matrix_commitment_columns,
+        );
+
+        let signed_sub_commits = &sub_commits[..8];
+        let offset_sub_commits = &sub_commits[8..];
+        assert_eq!(
+            modified_commits,
+            vec![
+                offset_commit(
+                    signed_sub_commits[0],
+                    offset_sub_commits[0],
+                    &committable_columns[0]
+                ),
+                offset_commit(
+                    signed_sub_commits[1],
+                    offset_sub_commits[1],
+                    &committable_columns[0]
+                ),
+                offset_commit(
+                    signed_sub_commits[2],
+                    offset_sub_commits[2],
+                    &committable_columns[0]
+                ),
+                offset_commit(
+                    signed_sub_commits[3],
+                    offset_sub_commits[0],
+                    &committable_columns[1]
+                ),
+                offset_commit(
+                    signed_sub_commits[4],
+                    offset_sub_commits[3],
+                    &committable_columns[1]
+                ),
+                offset_commit(
+                    signed_sub_commits[5],
+                    offset_sub_commits[4],
+                    &committable_columns[2]
+                ),
+                signed_sub_commits[6],
+                signed_sub_commits[7],
+            ]
+        );
+    }
 
     #[test]
     fn we_can_get_a_bit_table() {


### PR DESCRIPTION
/claim #560

## Summary
- add direct coverage for `min_as_f` across signed, timestamp, and zero-offset column types
- cover `signed_commits` for signed and unsigned column minimum adjustments, including the empty-column guard
- cover `pack_scalars::modify_commits` across signed columns with 3, 2, 1, and 0 sub-commit cases plus unsigned passthrough

## Tests
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::dory::blitzar_metadata_table::tests::we_can -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::dory::pack_scalars::tests::we_can_modify_commits_for_signed_unsigned_and_empty_columns -- --exact --nocapture`

Note: the repo coverage workflow uses Linux/x86-only feature paths (`blitzar-sys` and `halo2curves/asm`), so I validated locally with non-default `test` features and left the full all-features coverage matrix to CI.