### PR TITLE
test: cover hyperkzg commitment arithmetic and transcript bytes

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -224,6 +224,7 @@ mod tests {
     #[cfg(feature = "hyperkzg_proof")]
     use crate::proof_primitive::hyperkzg::HyperKZGEngine;
     use ark_ec::AffineRepr;
+    use ark_serialize::CanonicalSerialize;
     #[cfg(feature = "hyperkzg_proof")]
     use nova_snark::provider::hyperkzg::{CommitmentEngine, CommitmentKey};
     #[cfg(feature = "hyperkzg_proof")]
@@ -242,6 +243,55 @@ mod tests {
         let commitment: HyperKZGCommitment = (&G1Affine::generator()).into();
         let expected: HyperKZGCommitment = HyperKZGCommitment::from(&G1Affine::generator());
         assert_eq!(commitment.commitment, expected.commitment);
+    }
+
+    #[test]
+    fn we_can_apply_hyperkzg_commitment_arithmetic() {
+        let generator: HyperKZGCommitment = (&G1Affine::generator()).into();
+        let doubled = BNScalar::from(2_u64) * generator;
+        let tripled = BNScalar::from(3_u64) * &generator;
+
+        assert_eq!(
+            doubled.commitment,
+            generator.commitment + generator.commitment
+        );
+        assert_eq!(
+            tripled.commitment,
+            generator.commitment + generator.commitment + generator.commitment
+        );
+
+        let mut sum = generator;
+        sum += doubled;
+        assert_eq!(sum.commitment, tripled.commitment);
+
+        let negated = -generator;
+        assert_eq!(negated.commitment, -generator.commitment);
+
+        let mut difference = sum;
+        difference -= generator;
+        assert_eq!(difference.commitment, doubled.commitment);
+        assert_eq!((sum - doubled).commitment, generator.commitment);
+    }
+
+    #[test]
+    fn we_can_serialize_hyperkzg_commitment_to_transcript_bytes() {
+        let commitment: HyperKZGCommitment = (&G1Affine::generator()).into();
+
+        let mut expected = Vec::with_capacity(commitment.commitment.compressed_size());
+        commitment
+            .commitment
+            .serialize_compressed(&mut expected)
+            .unwrap();
+
+        assert_eq!(commitment.to_transcript_bytes(), expected);
+    }
+
+    #[test]
+    fn we_can_compute_empty_hyperkzg_commitments() {
+        let setup: [G1Affine; 0] = [];
+        let commitments = HyperKZGCommitment::compute_commitments(&[], 0, &&setup[..]);
+
+        assert!(commitments.is_empty());
     }
 
     #[cfg(feature = "hyperkzg_proof")]


### PR DESCRIPTION
/claim #560

## Summary
- Adds focused HyperKZG commitment coverage for arithmetic helpers: `+=`, scalar multiplication by value and by reference, negation, `-=`, and subtraction.
- Verifies `to_transcript_bytes` against Ark's compressed serialization.
- Covers the empty-column `compute_commitments` edge case.

## Coverage
- Local macOS coverage workaround before: `commitment.rs` LF 146 / LH 69.
- Local macOS coverage workaround after: `commitment.rs` LF 178 / LH 143.
- Pre-existing `commitment.rs` lines newly covered under that local run: 42. This is not a payout estimate; the Linux/all-features coverage job is authoritative.

Note: the repository's authoritative coverage job runs Linux/all-features with `BLITZAR_BACKEND=cpu`. I could not run that exact mode locally because `blitzar-sys` is Linux-only and the default `cpu-perf` feature pulls x86-only `halo2curves/asm` on macOS.

## Verification
- `cargo test -p proof-of-sql --no-default-features --features=arrow,rayon,ark-ec/parallel,ark-poly/parallel,ark-ff/asm --lib` (1056 passed)
- `cargo test -p proof-of-sql --no-default-features --features=arrow,rayon,ark-ec/parallel,ark-poly/parallel,ark-ff/asm proof_primitive::hyperkzg::commitment`
- `cargo test -p proof-of-sql --no-default-features --features=arrow,rayon,hyperkzg_proof,ark-ec/parallel,ark-poly/parallel proof_primitive::hyperkzg::commitment`
- `cargo llvm-cov test -p proof-of-sql --no-default-features --features=arrow,rayon,ark-ec/parallel,ark-poly/parallel,ark-ff/asm --lib --lcov --output-path /tmp/sxt-hyperkzg-after.lcov proof_primitive::hyperkzg::commitment`
- `cargo check -p proof-of-sql --no-default-features --features=arrow,rayon,ark-ec/parallel,ark-poly/parallel,ark-ff/asm`
- `cargo fmt --check`
- `git diff --check`
