### PR TITLE
test: cover hyperkzg commitment helpers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -218,6 +218,8 @@ mod tests {
     use super::*;
     #[cfg(feature = "hyperkzg_proof")]
     use crate::base::database::OwnedColumn;
+    use crate::base::math::decimal::Precision;
+    use crate::base::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
     use crate::base::{try_standard_binary_deserialization, try_standard_binary_serialization};
     #[cfg(feature = "hyperkzg_proof")]
     use crate::proof_primitive::hyperkzg::nova_commitment_key_to_hyperkzg_public_setup;
@@ -242,6 +244,108 @@ mod tests {
         let commitment: HyperKZGCommitment = (&G1Affine::generator()).into();
         let expected: HyperKZGCommitment = HyperKZGCommitment::from(&G1Affine::generator());
         assert_eq!(commitment.commitment, expected.commitment);
+    }
+
+    #[test]
+    fn we_can_compute_a_hyperkzg_commitment_with_an_offset() {
+        let generator = G1Affine::generator();
+        let setup = vec![
+            generator,
+            (generator * BNScalar::from(2_u64).0).into(),
+            (generator * BNScalar::from(3_u64).0).into(),
+            (generator * BNScalar::from(5_u64).0).into(),
+        ];
+        let scalars = [7_u8, 11_u8];
+
+        let commitment = compute_commitment_generic_impl(&setup, 1, &scalars);
+
+        let expected = setup[1] * BNScalar::from(7_u8).0 + setup[2] * BNScalar::from(11_u8).0;
+        assert_eq!(commitment.commitment, expected);
+    }
+
+    #[test]
+    fn we_can_dispatch_all_committable_column_types_to_hyperkzg_commitments() {
+        let generator = G1Affine::generator();
+        let setup = vec![generator, (generator * BNScalar::from(2_u64).0).into()];
+        let bools = [true, false];
+        let uint8s = [1_u8, 2_u8];
+        let tinyints = [-1_i8, 2_i8];
+        let smallints = [-3_i16, 4_i16];
+        let ints = [-5_i32, 6_i32];
+        let bigints = [-7_i64, 8_i64];
+        let int128s = [-9_i128, 10_i128];
+        let limbs = vec![[11, 0, 0, 0], [12, 0, 0, 0]];
+        let timestamps = [13_i64, 14_i64];
+        let columns = [
+            CommittableColumn::Boolean(&bools),
+            CommittableColumn::Uint8(&uint8s),
+            CommittableColumn::TinyInt(&tinyints),
+            CommittableColumn::SmallInt(&smallints),
+            CommittableColumn::Int(&ints),
+            CommittableColumn::BigInt(&bigints),
+            CommittableColumn::Int128(&int128s),
+            CommittableColumn::Decimal75(Precision::new(75).unwrap(), 0, limbs.clone()),
+            CommittableColumn::Scalar(limbs.clone()),
+            CommittableColumn::VarChar(limbs.clone()),
+            CommittableColumn::VarBinary(limbs.clone()),
+            CommittableColumn::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                &timestamps,
+            ),
+        ];
+
+        let commitments = compute_commitments_impl(&columns, 0, &&setup[..]);
+
+        assert_eq!(commitments.len(), columns.len());
+        assert_eq!(
+            commitments[0],
+            compute_commitment_generic_impl(&setup, 0, &bools)
+        );
+        assert_eq!(
+            commitments[1],
+            compute_commitment_generic_impl(&setup, 0, &uint8s)
+        );
+        assert_eq!(
+            commitments[2],
+            compute_commitment_generic_impl(&setup, 0, &tinyints)
+        );
+        assert_eq!(
+            commitments[3],
+            compute_commitment_generic_impl(&setup, 0, &smallints)
+        );
+        assert_eq!(
+            commitments[4],
+            compute_commitment_generic_impl(&setup, 0, &ints)
+        );
+        assert_eq!(
+            commitments[5],
+            compute_commitment_generic_impl(&setup, 0, &bigints)
+        );
+        assert_eq!(
+            commitments[6],
+            compute_commitment_generic_impl(&setup, 0, &int128s)
+        );
+        assert_eq!(
+            commitments[7],
+            compute_commitment_generic_impl(&setup, 0, &limbs)
+        );
+        assert_eq!(
+            commitments[8],
+            compute_commitment_generic_impl(&setup, 0, &limbs)
+        );
+        assert_eq!(
+            commitments[9],
+            compute_commitment_generic_impl(&setup, 0, &limbs)
+        );
+        assert_eq!(
+            commitments[10],
+            compute_commitment_generic_impl(&setup, 0, &limbs)
+        );
+        assert_eq!(
+            commitments[11],
+            compute_commitment_generic_impl(&setup, 0, &timestamps)
+        );
     }
 
     #[cfg(feature = "hyperkzg_proof")]


### PR DESCRIPTION
Adds a focused coverage slice for HyperKZG commitment helper paths.

/claim #560

## Coverage

Targeted command used before and after this branch:

```sh
cargo llvm-cov test -p proof-of-sql --lib --summary-only --json --output-path /tmp/sxt-hyperkzg-commitment-*.json proof_primitive::hyperkzg::commitment::tests::we_can_
```

For `crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs` under that filtered test run:

- Parent `main`: 69/159 lines, 8/22 functions, 139/274 regions
- This branch: 192/240 lines, 14/24 functions, 348/411 regions

The line count includes added tests, but the production delta is that the generic CPU commitment helper and every `CommittableColumn` dispatch arm now have direct tests.

## Validation

```sh
cargo test -p proof-of-sql proof_primitive::hyperkzg::commitment::tests::we_can_compute_a_hyperkzg_commitment_with_an_offset
cargo test -p proof-of-sql proof_primitive::hyperkzg::commitment::tests::we_can_dispatch_all_committable_column_types_to_hyperkzg_commitments
cargo fmt --check
cargo llvm-cov test -p proof-of-sql --lib --summary-only --json --output-path /tmp/sxt-hyperkzg-commitment-after.json proof_primitive::hyperkzg::commitment::tests::we_can_
```

Note: a full unfiltered `cargo llvm-cov test -p proof-of-sql --lib` is not usable in this environment because the existing Blitzar tests abort during GPU initialization (`Update GPU drivers. The maximum supported version is 0 but blitzar requires 12060`). The targeted coverage command above avoids that GPU-dependent path.