### PR TITLE
test: cover subtract mismatched types

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -1,4 +1,4 @@
-use super::AddExpr;
+use super::{AddExpr, SubtractExpr};
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -287,7 +287,7 @@ fn we_cannot_add_subtract_mismatching_types() {
             right_type: _
         }
     ));
-    let sub_err = AddExpr::try_new(lhs, rhs).unwrap_err();
+    let sub_err = SubtractExpr::try_new(lhs, rhs).unwrap_err();
     assert!(matches!(
         sub_err,
         AnalyzeError::DataTypeMismatch {


### PR DESCRIPTION
## Summary
- Update the mismatched-type test to exercise `SubtractExpr::try_new` for the subtraction path
- Keep the existing add mismatch assertion intact

/claim #560

## Test plan
- `cargo fmt --all -- --check`
- `BLITZAR_BACKEND=cpu CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS="" cargo test -p proof-of-sql --lib --features test we_cannot_add_subtract_mismatching_types -- --nocapture`
- `git diff --check origin/main..HEAD`
