### PR TITLE
test: cover remaining filter column variants

### DIFF
--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,6 +1,7 @@
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
@@ -115,6 +116,42 @@ fn we_can_filter_columns_with_varbinary() {
         vec![
             Column::VarBinary((filtered_bytes.as_slice(), filtered_scalars.as_slice())),
             Column::BigInt(&[10, 30, 40]),
+        ]
+    );
+}
+
+#[test]
+fn we_can_filter_remaining_primitive_column_types() {
+    let selection = vec![false, true, true, false, true];
+    let timezone = PoSQLTimeZone::new(60);
+    let columns = vec![
+        Column::<TestScalar>::Boolean(&[true, false, true, false, true]),
+        Column::Uint8(&[1, 2, 3, 4, 5]),
+        Column::TinyInt(&[-1, -2, -3, -4, -5]),
+        Column::SmallInt(&[10, 20, 30, 40, 50]),
+        Column::Int(&[100, 200, 300, 400, 500]),
+        Column::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            timezone,
+            &[1_000, 2_000, 3_000, 4_000, 5_000],
+        ),
+    ];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 3);
+    assert_eq!(
+        result,
+        vec![
+            Column::Boolean(&[false, true, true]),
+            Column::Uint8(&[2, 3, 5]),
+            Column::TinyInt(&[-2, -3, -5]),
+            Column::SmallInt(&[20, 30, 50]),
+            Column::Int(&[200, 300, 500]),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                timezone,
+                &[2_000, 3_000, 5_000]
+            ),
         ]
     );
 }


### PR DESCRIPTION
## Rationale for this change

Adds focused test coverage for additional `filter_column_by_index` branches as part of #560.

The existing `filter_util` tests covered BigInt, Int128, VarChar, VarBinary, Scalar, and Decimal75. This adds coverage for Boolean, Uint8, TinyInt, SmallInt, Int, and TimestampTZ filtering.

## What changes are included in this PR?

- Adds `we_can_filter_remaining_primitive_column_types`
- Verifies selected rows are preserved for the remaining primitive column variants
- Does not change production behavior

## Are these changes tested?

I was not able to run the Rust test suite locally because `cargo` is not installed in my current Windows environment.

This PR only adds a focused unit test.

Part of #560.
