### PR TITLE
test: cover table helpers and query result errors

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -99,8 +99,109 @@ impl<C: Commitment> TableCommitment<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::base::{
+        commitment::naive_commitment::NaiveCommitment, database::ColumnType,
+        scalar::test_scalar::TestScalar,
+    };
+    use arrow::{
+        array::{Int64Array, StringArray},
+        datatypes::{DataType, Field, Schema},
+        record_batch::RecordBatch,
+    };
+    use std::sync::Arc;
+
+    fn make_batch(a: Vec<i64>, b: Vec<&str>) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("a", DataType::Int64, false),
+                Field::new("b", DataType::Utf8, false),
+            ])),
+            vec![
+                Arc::new(Int64Array::from(a)),
+                Arc::new(StringArray::from(b)),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn batch_to_columns_converts_record_batch_fields() {
+        let batch = make_batch(vec![1, 2, 3], vec!["one", "two", "three"]);
+        let alloc = Bump::new();
+
+        let columns = batch_to_columns::<TestScalar>(&batch, &alloc).unwrap();
+
+        assert_eq!(columns.len(), 2);
+        assert_eq!(columns[0].0, "a".into());
+        assert!(matches!(columns[0].1, Column::BigInt([1, 2, 3])));
+
+        assert_eq!(columns[1].0, "b".into());
+        let Column::VarChar((values, scalars)) = columns[1].1 else {
+            panic!("expected varchar column");
+        };
+        assert_eq!(values, ["one", "two", "three"]);
+        assert_eq!(scalars.len(), values.len());
+    }
+
+    #[test]
+    fn batch_to_columns_returns_conversion_errors() {
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, true)])),
+            vec![Arc::new(Int64Array::from(vec![Some(1), None]))],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+
+        assert!(batch_to_columns::<TestScalar>(&batch, &alloc).is_err());
+    }
+
+    #[test]
+    fn record_batches_create_and_append_table_commitments() {
+        let first_batch = make_batch(vec![1, 2, 3], vec!["1", "2", "3"]);
+        let second_batch = make_batch(vec![4, 5], vec!["4", "5"]);
+
+        let mut commitment = TableCommitment::<NaiveCommitment>::try_from_record_batch_with_offset(
+            &first_batch,
+            2,
+            &(),
+        )
+        .unwrap();
+        assert_eq!(commitment.range(), &(2..5));
+        assert_eq!(commitment.num_rows(), 3);
+
+        commitment
+            .try_append_record_batch(&second_batch, &())
+            .unwrap();
+        assert_eq!(commitment.range(), &(2..7));
+        assert_eq!(commitment.num_rows(), 5);
+        let a_id: Ident = "a".into();
+        let b_id: Ident = "b".into();
+        assert_eq!(
+            commitment
+                .column_commitments()
+                .column_metadata()
+                .get(&a_id)
+                .unwrap()
+                .column_type(),
+            &ColumnType::BigInt
+        );
+        assert_eq!(
+            commitment
+                .column_commitments()
+                .column_metadata()
+                .get(&b_id)
+                .unwrap()
+                .column_type(),
+            &ColumnType::VarChar
+        );
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod dory_tests {
     use super::*;
     use crate::base::{
         commitment::naive_commitment::NaiveCommitment, scalar::test_scalar::TestScalar,

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -122,8 +122,147 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::base::{
+        commitment::{
+            naive_commitment::NaiveCommitment, naive_evaluation_proof::NaiveEvaluationProof,
+        },
+        database::{
+            owned_table_utility::*, ColumnType, OwnedTable, OwnedTableTestAccessor, TableRef,
+            TestAccessor,
+        },
+        scalar::test_scalar::TestScalar,
+    };
+
+    #[test]
+    fn query_commitments_expose_metadata_schema_and_commitments() {
+        let column_a_id: Ident = "column_a".into();
+        let column_b_id: Ident = "column_b".into();
+
+        let table_a: OwnedTable<TestScalar> = owned_table([
+            bigint(column_a_id.value.as_str(), [1, 2, 3, 4]),
+            varchar(
+                column_b_id.value.as_str(),
+                ["Lorem", "ipsum", "dolor", "sit"],
+            ),
+        ]);
+        let table_b: OwnedTable<TestScalar> =
+            owned_table([scalar(column_a_id.value.as_str(), [1, 2])]);
+
+        let table_a_commitment =
+            TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_a, 2, &());
+        let table_a_id = TableRef::new("table", "a");
+        let table_b_commitment =
+            TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_b, 0, &());
+        let table_b_id = TableRef::new("table", "b");
+
+        let query_commitments = QueryCommitments::from_iter([
+            (table_a_id.clone(), table_a_commitment.clone()),
+            (table_b_id.clone(), table_b_commitment.clone()),
+        ]);
+
+        assert_eq!(query_commitments.get_offset(&table_a_id), 2);
+        assert_eq!(query_commitments.get_length(&table_a_id), 4);
+        assert_eq!(query_commitments.get_offset(&table_b_id), 0);
+        assert_eq!(query_commitments.get_length(&table_b_id), 2);
+
+        assert_eq!(
+            query_commitments.lookup_column(&table_a_id, &column_a_id),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            query_commitments.lookup_column(&table_a_id, &column_b_id),
+            Some(ColumnType::VarChar)
+        );
+        assert_eq!(
+            query_commitments.lookup_column(&table_b_id, &column_a_id),
+            Some(ColumnType::Scalar)
+        );
+        assert_eq!(
+            query_commitments.lookup_column(&table_b_id, &column_b_id),
+            None
+        );
+        assert_eq!(
+            query_commitments.lookup_schema(&table_a_id),
+            vec![
+                (column_a_id.clone(), ColumnType::BigInt),
+                (column_b_id.clone(), ColumnType::VarChar),
+            ]
+        );
+
+        assert_eq!(
+            query_commitments.get_commitment(&table_a_id, &column_a_id),
+            table_a_commitment.column_commitments().commitments()[0]
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_a_id, &column_b_id),
+            table_a_commitment.column_commitments().commitments()[1]
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_b_id, &column_a_id),
+            table_b_commitment.column_commitments().commitments()[0]
+        );
+    }
+
+    #[test]
+    fn query_commitments_from_accessor_groups_columns_by_table() {
+        let column_a_id: Ident = "column_a".into();
+        let column_b_id: Ident = "column_b".into();
+
+        let table_a: OwnedTable<TestScalar> = owned_table([
+            bigint(column_a_id.value.as_str(), [1, 2, 3]),
+            varchar(column_b_id.value.as_str(), ["a", "b", "c"]),
+        ]);
+        let table_b: OwnedTable<TestScalar> = owned_table([
+            scalar(column_a_id.value.as_str(), [10, 20]),
+            int128(column_b_id.value.as_str(), [100, 200]),
+        ]);
+
+        let table_a_id = TableRef::new("table", "a");
+        let table_b_id = TableRef::new("table", "b");
+        let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+        accessor.add_table(table_a_id.clone(), table_a, 1);
+        accessor.add_table(table_b_id.clone(), table_b, 4);
+
+        let query_commitments = QueryCommitments::<NaiveCommitment>::from_accessor_with_max_bounds(
+            [
+                ColumnRef::new(table_b_id.clone(), column_b_id.clone(), ColumnType::Int128),
+                ColumnRef::new(table_a_id.clone(), column_b_id.clone(), ColumnType::VarChar),
+                ColumnRef::new(table_a_id.clone(), column_a_id.clone(), ColumnType::BigInt),
+            ],
+            &accessor,
+        );
+
+        assert_eq!(query_commitments.get_offset(&table_a_id), 1);
+        assert_eq!(query_commitments.get_length(&table_a_id), 3);
+        assert_eq!(query_commitments.get_offset(&table_b_id), 4);
+        assert_eq!(query_commitments.get_length(&table_b_id), 2);
+        assert_eq!(
+            query_commitments.lookup_schema(&table_a_id),
+            vec![
+                (column_a_id.clone(), ColumnType::BigInt),
+                (column_b_id.clone(), ColumnType::VarChar),
+            ]
+        );
+        assert_eq!(
+            query_commitments.lookup_schema(&table_b_id),
+            vec![(column_b_id.clone(), ColumnType::Int128)]
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_a_id, &column_a_id),
+            accessor.get_commitment(&table_a_id, &column_a_id)
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_b_id, &column_b_id),
+            accessor.get_commitment(&table_b_id, &column_b_id)
+        );
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod dory_tests {
     use super::*;
     use crate::{
         base::{

--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,39 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn posql_compatible_schema_converts_float_fields_and_preserves_others() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("float16", DataType::Float16, false),
+            Field::new("float32", DataType::Float32, true),
+            Field::new("float64", DataType::Float64, false),
+            Field::new("int64", DataType::Int64, true),
+            Field::new("text", DataType::Utf8, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(
+            converted
+                .fields()
+                .iter()
+                .map(|field| field.data_type())
+                .collect::<Vec<_>>(),
+            vec![
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+                &DataType::Int64,
+                &DataType::Utf8,
+            ]
+        );
+        assert_eq!(converted.field(1).name(), "float32");
+        assert!(converted.field(1).is_nullable());
+        assert!(!converted.field(4).is_nullable());
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -212,3 +212,191 @@ impl<'a, CP: CommitmentEvaluationProof> OwnedTableTestAccessor<'a, CP> {
         res
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        commitment::{
+            naive_commitment::NaiveCommitment, naive_evaluation_proof::NaiveEvaluationProof,
+            Commitment, CommittableColumn,
+        },
+        database::owned_table_utility::*,
+        map::indexset,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
+
+    type OwnedAccessor = OwnedTableTestAccessor<'static, NaiveEvaluationProof>;
+
+    fn sample_table() -> OwnedTable<TestScalar> {
+        owned_table([
+            boolean("bool", [true, false]),
+            uint8("u8", [1_u8, 2]),
+            tinyint("i8", [-1_i8, 2]),
+            smallint("i16", [-3_i16, 4]),
+            int("i32", [-5_i32, 6]),
+            bigint("i64", [-7_i64, 8]),
+            int128("i128", [-9_i128, 10]),
+            decimal75("decimal", 10, 2, [11, 12]),
+            scalar("scalar", [13, 14]),
+            varchar("text", ["a", "bc"]),
+            varbinary("bytes", [vec![1_u8, 2], vec![3, 4, 5]]),
+            timestamptz(
+                "time",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                [100, 200],
+            ),
+        ])
+    }
+
+    #[test]
+    fn owned_table_test_accessor_exposes_metadata_and_schema() {
+        let table_ref = TableRef::new("sxt", "owned");
+        let accessor = OwnedAccessor::new_from_table(table_ref.clone(), sample_table(), 7, ());
+
+        assert_eq!(accessor.get_length(&table_ref), 2);
+        assert_eq!(accessor.get_offset(&table_ref), 7);
+        assert_eq!(
+            accessor.get_column_names(&table_ref),
+            vec![
+                "bool", "u8", "i8", "i16", "i32", "i64", "i128", "decimal", "scalar", "text",
+                "bytes", "time"
+            ]
+        );
+        assert_eq!(
+            accessor.lookup_column(&table_ref, &"decimal".into()),
+            Some(ColumnType::Decimal75(Precision::new(10).unwrap(), 2))
+        );
+        assert_eq!(accessor.lookup_column(&table_ref, &"missing".into()), None);
+        assert_eq!(
+            accessor.lookup_schema(&table_ref)[..3],
+            [
+                ("bool".into(), ColumnType::Boolean),
+                ("u8".into(), ColumnType::Uint8),
+                ("i8".into(), ColumnType::TinyInt),
+            ]
+        );
+    }
+
+    #[test]
+    fn owned_table_test_accessor_returns_borrowed_columns_for_each_type() {
+        let table_ref = TableRef::new("sxt", "owned");
+        let accessor = OwnedAccessor::new_from_table(table_ref.clone(), sample_table(), 0, ());
+
+        match accessor.get_column(&table_ref, &"bool".into()) {
+            Column::Boolean(col) => assert_eq!(col, &[true, false]),
+            _ => panic!("expected boolean column"),
+        }
+        match accessor.get_column(&table_ref, &"u8".into()) {
+            Column::Uint8(col) => assert_eq!(col, &[1, 2]),
+            _ => panic!("expected uint8 column"),
+        }
+        match accessor.get_column(&table_ref, &"i8".into()) {
+            Column::TinyInt(col) => assert_eq!(col, &[-1, 2]),
+            _ => panic!("expected tinyint column"),
+        }
+        match accessor.get_column(&table_ref, &"i16".into()) {
+            Column::SmallInt(col) => assert_eq!(col, &[-3, 4]),
+            _ => panic!("expected smallint column"),
+        }
+        match accessor.get_column(&table_ref, &"i32".into()) {
+            Column::Int(col) => assert_eq!(col, &[-5, 6]),
+            _ => panic!("expected int column"),
+        }
+        match accessor.get_column(&table_ref, &"i64".into()) {
+            Column::BigInt(col) => assert_eq!(col, &[-7, 8]),
+            _ => panic!("expected bigint column"),
+        }
+        match accessor.get_column(&table_ref, &"i128".into()) {
+            Column::Int128(col) => assert_eq!(col, &[-9, 10]),
+            _ => panic!("expected int128 column"),
+        }
+        match accessor.get_column(&table_ref, &"decimal".into()) {
+            Column::Decimal75(precision, scale, col) => {
+                assert_eq!(precision.value(), 10);
+                assert_eq!(scale, 2);
+                assert_eq!(col, &[TestScalar::from(11), TestScalar::from(12)]);
+            }
+            _ => panic!("expected decimal column"),
+        }
+        match accessor.get_column(&table_ref, &"scalar".into()) {
+            Column::Scalar(col) => assert_eq!(col, &[TestScalar::from(13), TestScalar::from(14)]),
+            _ => panic!("expected scalar column"),
+        }
+        match accessor.get_column(&table_ref, &"text".into()) {
+            Column::VarChar((strings, scalars)) => {
+                assert_eq!(strings, &["a", "bc"]);
+                assert_eq!(scalars, &[TestScalar::from("a"), TestScalar::from("bc")]);
+            }
+            _ => panic!("expected varchar column"),
+        }
+        match accessor.get_column(&table_ref, &"bytes".into()) {
+            Column::VarBinary((bytes, scalars)) => {
+                assert_eq!(bytes, &[&[1_u8, 2][..], &[3_u8, 4, 5][..]]);
+                assert_eq!(scalars.len(), 2);
+            }
+            _ => panic!("expected varbinary column"),
+        }
+        match accessor.get_column(&table_ref, &"time".into()) {
+            Column::TimestampTZ(unit, zone, col) => {
+                assert_eq!(unit, PoSQLTimeUnit::Second);
+                assert_eq!(zone, PoSQLTimeZone::utc());
+                assert_eq!(col, &[100, 200]);
+            }
+            _ => panic!("expected timestamp column"),
+        }
+    }
+
+    #[test]
+    fn owned_table_test_accessor_builds_tables_and_updates_offsets() {
+        let table_ref = TableRef::new("sxt", "owned");
+        let mut accessor = OwnedAccessor::new_from_table(table_ref.clone(), sample_table(), 0, ());
+
+        let selected = indexset! {"i64".into(), "text".into()};
+        let table = accessor.get_table(&table_ref, &selected);
+        assert_eq!(table.num_columns(), 2);
+        assert_eq!(table.num_rows(), 2);
+
+        let empty = accessor.get_table(&table_ref, &indexset! {});
+        assert_eq!(empty.num_columns(), 0);
+        assert_eq!(empty.num_rows(), 2);
+
+        let original_commitment = accessor.get_commitment(&table_ref, &"i64".into());
+        accessor.update_offset(&table_ref, 5);
+        assert_eq!(accessor.get_offset(&table_ref), 5);
+        assert_ne!(
+            original_commitment,
+            accessor.get_commitment(&table_ref, &"i64".into())
+        );
+
+        assert_eq!(
+            accessor.get_commitment(&table_ref, &"i64".into()),
+            NaiveCommitment::compute_commitments(
+                &[CommittableColumn::from(&[-7_i64, 8][..])],
+                5,
+                &()
+            )[0]
+        );
+    }
+
+    #[test]
+    fn cloned_owned_table_test_accessor_keeps_tables_and_setup() {
+        let table_ref = TableRef::new("sxt", "owned");
+        let accessor = OwnedAccessor::new_from_table(table_ref.clone(), sample_table(), 3, ());
+        let clone = accessor.clone();
+
+        assert_eq!(clone.get_length(&table_ref), 2);
+        assert_eq!(clone.get_offset(&table_ref), 3);
+        assert_eq!(
+            clone.get_commitment(&table_ref, &"u8".into()),
+            NaiveCommitment::compute_commitments(
+                &[CommittableColumn::from(&[1_u8, 2][..])],
+                3,
+                &()
+            )[0]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,21 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn table_evaluation_returns_column_and_chi_evaluations() {
+        let column_evals = vec![TestScalar::from(7u8), TestScalar::from(11u8)];
+        let chi = (TestScalar::from(13u8), 5);
+
+        let table_evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+        assert_eq!(table_evaluation.column_evals(), column_evals.as_slice());
+        assert_eq!(table_evaluation.chi_eval(), chi.0);
+        assert_eq!(table_evaluation.chi(), chi);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,78 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableRef;
+    use crate::base::database::ParseError;
+    use indexmap::Equivalent;
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn table_ref_constructors_and_display_cover_schema_variants() {
+        let table_ref = TableRef::new("sxt", "blocks");
+        assert_eq!(table_ref.schema_id().unwrap().value, "sxt");
+        assert_eq!(table_ref.table_id().value, "blocks");
+        assert_eq!(table_ref.to_string(), "sxt.blocks");
+
+        let table_ref = TableRef::new("", "transactions");
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "transactions");
+        assert_eq!(table_ref.to_string(), "transactions");
+
+        let from_names = TableRef::from_names(Some("public"), "balances");
+        let from_idents = TableRef::from_idents(Some(Ident::new("public")), Ident::new("balances"));
+        assert_eq!(from_names, from_idents);
+        assert!((&from_names).equivalent(&from_idents));
+    }
+
+    #[test]
+    fn table_ref_parsing_accepts_one_or_two_components() {
+        assert_eq!(
+            TableRef::from_strs(&["orders"]).unwrap(),
+            TableRef::from_names(None, "orders")
+        );
+        assert_eq!(
+            TableRef::from_strs(&["sales", "orders"]).unwrap(),
+            TableRef::from_names(Some("sales"), "orders")
+        );
+        assert_eq!(
+            TableRef::try_from("sales.orders").unwrap(),
+            TableRef::from_names(Some("sales"), "orders")
+        );
+        assert_eq!(
+            "orders".parse::<TableRef>().unwrap(),
+            TableRef::from_names(None, "orders")
+        );
+    }
+
+    #[test]
+    fn table_ref_parsing_rejects_more_than_two_components() {
+        assert!(matches!(
+            TableRef::from_strs(&["too", "many", "parts"]),
+            Err(ParseError::InvalidTableReference { table_reference })
+                if table_reference == "too,many,parts"
+        ));
+
+        assert!(matches!(
+            TableRef::try_from("too.many.parts"),
+            Err(ParseError::InvalidTableReference { table_reference })
+                if table_reference == "too.many.parts"
+        ));
+    }
+
+    #[test]
+    fn table_ref_serializes_as_its_display_form() {
+        let table_ref = TableRef::from_names(Some("sxt"), "blocks");
+
+        let serialized = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(serialized, r#""sxt.blocks""#);
+
+        let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, table_ref);
+
+        let error = serde_json::from_str::<TableRef>(r#""too.many.parts""#).unwrap_err();
+        assert!(error.to_string().contains("Invalid table reference"));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -1,6 +1,9 @@
 use crate::base::{
-    database::{table_utility::*, Column, Table, TableError, TableOptions},
+    database::{
+        table_utility::*, Column, ColumnField, ColumnType, Table, TableError, TableOptions,
+    },
     map::{indexmap, IndexMap},
+    math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
 };
@@ -192,6 +195,62 @@ fn we_can_create_a_table_with_data() {
     expected_table.insert(Ident::new("boolean"), Column::Boolean(boolean_data));
 
     assert_eq!(borrowed_table.into_inner(), expected_table);
+}
+
+#[test]
+fn we_can_create_and_inspect_a_table_with_numeric_helper_columns() {
+    let alloc = Bump::new();
+    let table = table::<TestScalar>([
+        borrowed_uint8("uint8", [0_u8, u8::MAX], &alloc),
+        borrowed_tinyint("tinyint", [i8::MIN, i8::MAX], &alloc),
+        borrowed_smallint("smallint", [i16::MIN, i16::MAX], &alloc),
+        borrowed_int("int", [i32::MIN, i32::MAX], &alloc),
+        borrowed_decimal75("decimal", 12, -2, [100_i64, -50], &alloc),
+    ]);
+
+    assert!(!table.is_empty());
+    assert_eq!(table.num_columns(), 5);
+    assert_eq!(table.num_rows(), 2);
+    assert_eq!(
+        table
+            .column_names()
+            .map(|ident| ident.value.as_str())
+            .collect::<Vec<_>>(),
+        vec!["uint8", "tinyint", "smallint", "int", "decimal"]
+    );
+    assert_eq!(
+        table.schema(),
+        vec![
+            ColumnField::new("uint8".into(), ColumnType::Uint8),
+            ColumnField::new("tinyint".into(), ColumnType::TinyInt),
+            ColumnField::new("smallint".into(), ColumnType::SmallInt),
+            ColumnField::new("int".into(), ColumnType::Int),
+            ColumnField::new(
+                "decimal".into(),
+                ColumnType::Decimal75(Precision::new(12).unwrap(), -2)
+            ),
+        ]
+    );
+    assert_eq!(table.column(0), Some(&Column::Uint8(&[0, u8::MAX])));
+    assert_eq!(table["tinyint"], Column::TinyInt(&[i8::MIN, i8::MAX]));
+    assert_eq!(
+        table.inner_table().get(&Ident::new("smallint")),
+        Some(&Column::SmallInt(&[i16::MIN, i16::MAX]))
+    );
+    assert_eq!(
+        table.columns().copied().collect::<Vec<_>>(),
+        vec![
+            Column::Uint8(&[0, u8::MAX]),
+            Column::TinyInt(&[i8::MIN, i8::MAX]),
+            Column::SmallInt(&[i16::MIN, i16::MAX]),
+            Column::Int(&[i32::MIN, i32::MAX]),
+            Column::Decimal75(
+                Precision::new(12).unwrap(),
+                -2,
+                &[TestScalar::from(100_i64), TestScalar::from(-50_i64)]
+            ),
+        ]
+    );
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/database/table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor.rs
@@ -168,3 +168,212 @@ impl<'a, CP: CommitmentEvaluationProof> TableTestAccessor<'a, CP> {
         res
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        commitment::{
+            naive_commitment::NaiveCommitment, naive_evaluation_proof::NaiveEvaluationProof,
+            Commitment, CommittableColumn,
+        },
+        database::table_utility::*,
+        map::indexset,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::{test_scalar::TestScalar, ScalarExt},
+    };
+    use bumpalo::Bump;
+
+    type Accessor<'a> = TableTestAccessor<'a, NaiveEvaluationProof>;
+
+    fn sample_table<'a>(alloc: &'a Bump) -> Table<'a, TestScalar> {
+        let raw_bytes = [
+            alloc.alloc_slice_copy(&[1_u8, 2][..]) as &[u8],
+            alloc.alloc_slice_copy(&[3_u8, 4, 5][..]) as &[u8],
+        ];
+        let byte_scalars = [
+            TestScalar::from_byte_slice_via_hash(raw_bytes[0]),
+            TestScalar::from_byte_slice_via_hash(raw_bytes[1]),
+        ];
+        table([
+            borrowed_boolean("bool", [true, false], alloc),
+            borrowed_uint8("u8", [1_u8, 2], alloc),
+            borrowed_tinyint("i8", [-1_i8, 2], alloc),
+            borrowed_smallint("i16", [-3_i16, 4], alloc),
+            borrowed_int("i32", [-5_i32, 6], alloc),
+            borrowed_bigint("i64", [-7_i64, 8], alloc),
+            borrowed_int128("i128", [-9_i128, 10], alloc),
+            borrowed_decimal75("decimal", 10, 2, [11, 12], alloc),
+            borrowed_scalar("scalar", [13, 14], alloc),
+            borrowed_varchar("text", ["a", "bc"], alloc),
+            (
+                "bytes".into(),
+                Column::VarBinary((
+                    alloc.alloc_slice_copy(&raw_bytes),
+                    alloc.alloc_slice_copy(&byte_scalars),
+                )),
+            ),
+            borrowed_timestamptz(
+                "time",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                [100, 200],
+                alloc,
+            ),
+        ])
+    }
+
+    #[test]
+    fn table_test_accessor_exposes_metadata_and_schema() {
+        let alloc = Bump::new();
+        let table_ref = TableRef::new("sxt", "borrowed");
+        let accessor = Accessor::new_from_table(table_ref.clone(), sample_table(&alloc), 7, ());
+
+        assert_eq!(accessor.get_length(&table_ref), 2);
+        assert_eq!(accessor.get_offset(&table_ref), 7);
+        assert_eq!(
+            accessor.get_column_names(&table_ref),
+            vec![
+                "bool", "u8", "i8", "i16", "i32", "i64", "i128", "decimal", "scalar", "text",
+                "bytes", "time"
+            ]
+        );
+        assert_eq!(
+            accessor.lookup_column(&table_ref, &"decimal".into()),
+            Some(ColumnType::Decimal75(Precision::new(10).unwrap(), 2))
+        );
+        assert_eq!(accessor.lookup_column(&table_ref, &"missing".into()), None);
+        assert_eq!(
+            accessor.lookup_schema(&table_ref)[..3],
+            [
+                ("bool".into(), ColumnType::Boolean),
+                ("u8".into(), ColumnType::Uint8),
+                ("i8".into(), ColumnType::TinyInt),
+            ]
+        );
+    }
+
+    #[test]
+    fn table_test_accessor_returns_borrowed_columns_for_each_type() {
+        let alloc = Bump::new();
+        let table_ref = TableRef::new("sxt", "borrowed");
+        let accessor = Accessor::new_from_table(table_ref.clone(), sample_table(&alloc), 0, ());
+
+        match accessor.get_column(&table_ref, &"bool".into()) {
+            Column::Boolean(col) => assert_eq!(col, &[true, false]),
+            _ => panic!("expected boolean column"),
+        }
+        match accessor.get_column(&table_ref, &"u8".into()) {
+            Column::Uint8(col) => assert_eq!(col, &[1, 2]),
+            _ => panic!("expected uint8 column"),
+        }
+        match accessor.get_column(&table_ref, &"i8".into()) {
+            Column::TinyInt(col) => assert_eq!(col, &[-1, 2]),
+            _ => panic!("expected tinyint column"),
+        }
+        match accessor.get_column(&table_ref, &"i16".into()) {
+            Column::SmallInt(col) => assert_eq!(col, &[-3, 4]),
+            _ => panic!("expected smallint column"),
+        }
+        match accessor.get_column(&table_ref, &"i32".into()) {
+            Column::Int(col) => assert_eq!(col, &[-5, 6]),
+            _ => panic!("expected int column"),
+        }
+        match accessor.get_column(&table_ref, &"i64".into()) {
+            Column::BigInt(col) => assert_eq!(col, &[-7, 8]),
+            _ => panic!("expected bigint column"),
+        }
+        match accessor.get_column(&table_ref, &"i128".into()) {
+            Column::Int128(col) => assert_eq!(col, &[-9, 10]),
+            _ => panic!("expected int128 column"),
+        }
+        match accessor.get_column(&table_ref, &"decimal".into()) {
+            Column::Decimal75(precision, scale, col) => {
+                assert_eq!(precision.value(), 10);
+                assert_eq!(scale, 2);
+                assert_eq!(col, &[TestScalar::from(11), TestScalar::from(12)]);
+            }
+            _ => panic!("expected decimal column"),
+        }
+        match accessor.get_column(&table_ref, &"scalar".into()) {
+            Column::Scalar(col) => assert_eq!(col, &[TestScalar::from(13), TestScalar::from(14)]),
+            _ => panic!("expected scalar column"),
+        }
+        match accessor.get_column(&table_ref, &"text".into()) {
+            Column::VarChar((strings, scalars)) => {
+                assert_eq!(strings, &["a", "bc"]);
+                assert_eq!(scalars, &[TestScalar::from("a"), TestScalar::from("bc")]);
+            }
+            _ => panic!("expected varchar column"),
+        }
+        match accessor.get_column(&table_ref, &"bytes".into()) {
+            Column::VarBinary((bytes, scalars)) => {
+                assert_eq!(bytes[0], &[1_u8, 2]);
+                assert_eq!(bytes[1], &[3_u8, 4, 5]);
+                assert_eq!(scalars.len(), 2);
+            }
+            _ => panic!("expected varbinary column"),
+        }
+        match accessor.get_column(&table_ref, &"time".into()) {
+            Column::TimestampTZ(unit, zone, col) => {
+                assert_eq!(unit, PoSQLTimeUnit::Second);
+                assert_eq!(zone, PoSQLTimeZone::utc());
+                assert_eq!(col, &[100, 200]);
+            }
+            _ => panic!("expected timestamp column"),
+        }
+    }
+
+    #[test]
+    fn table_test_accessor_builds_tables_and_updates_offsets() {
+        let alloc = Bump::new();
+        let table_ref = TableRef::new("sxt", "borrowed");
+        let mut accessor = Accessor::new_from_table(table_ref.clone(), sample_table(&alloc), 0, ());
+
+        let selected = indexset! {"i64".into(), "text".into()};
+        let table = accessor.get_table(&table_ref, &selected);
+        assert_eq!(table.num_columns(), 2);
+        assert_eq!(table.num_rows(), 2);
+
+        let empty = accessor.get_table(&table_ref, &indexset! {});
+        assert_eq!(empty.num_columns(), 0);
+        assert_eq!(empty.num_rows(), 2);
+
+        let original_commitment = accessor.get_commitment(&table_ref, &"i64".into());
+        accessor.update_offset(&table_ref, 5);
+        assert_eq!(accessor.get_offset(&table_ref), 5);
+        assert_ne!(
+            original_commitment,
+            accessor.get_commitment(&table_ref, &"i64".into())
+        );
+
+        assert_eq!(
+            accessor.get_commitment(&table_ref, &"i64".into()),
+            NaiveCommitment::compute_commitments(
+                &[CommittableColumn::from(&[-7_i64, 8][..])],
+                5,
+                &()
+            )[0]
+        );
+    }
+
+    #[test]
+    fn cloned_table_test_accessor_keeps_tables_and_setup() {
+        let alloc = Bump::new();
+        let table_ref = TableRef::new("sxt", "borrowed");
+        let accessor = Accessor::new_from_table(table_ref.clone(), sample_table(&alloc), 3, ());
+        let clone = accessor.clone();
+
+        assert_eq!(clone.get_length(&table_ref), 2);
+        assert_eq!(clone.get_offset(&table_ref), 3);
+        assert_eq!(
+            clone.get_commitment(&table_ref, &"u8".into()),
+            NaiveCommitment::compute_commitments(
+                &[CommittableColumn::from(&[1_u8, 2][..])],
+                3,
+                &()
+            )[0]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -2,10 +2,11 @@ use super::{ProvableQueryResult, QueryError};
 use crate::base::scalar::test_scalar::TestScalar;
 use crate::{
     base::{
-        database::{Column, ColumnField, ColumnType},
+        database::{Column, ColumnField, ColumnType, OwnedColumn},
         math::decimal::Precision,
         polynomial::compute_evaluation_vector,
-        scalar::Scalar,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::{Scalar, ScalarExt},
     },
     // proof_primitive::inner_product::TestScalar,
 };
@@ -149,6 +150,77 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
         TestScalar::from(5u64) * evaluation_vec[0] + TestScalar::from(9u64) * evaluation_vec[1],
     ];
     assert_eq!(evals, expected_evals);
+}
+
+#[expect(clippy::too_many_lines)]
+#[test]
+fn we_can_evaluate_additional_result_column_types_as_mles() {
+    let booleans = [true, false];
+    let uints = [1_u8, 2];
+    let tinyints = [-1_i8, 2];
+    let smallints = [-10_i16, 20];
+    let ints = [-100_i32, 200];
+    let timestamps = [1_000_i64, 2_000];
+    let scalars = [TestScalar::from(11), TestScalar::from(22)];
+    let strings = ["alpha", "beta"];
+    let string_scalars = strings
+        .iter()
+        .map(|value| TestScalar::from(*value))
+        .collect::<Vec<_>>();
+    let bytes = [b"foo".as_slice(), b"bar".as_slice()];
+    let byte_scalars = bytes
+        .iter()
+        .map(|value| TestScalar::from_le_bytes_mod_order(value))
+        .collect::<Vec<_>>();
+    let timezone = PoSQLTimeZone::new(3_600);
+
+    let cols = [
+        Column::Boolean(&booleans),
+        Column::Uint8(&uints),
+        Column::TinyInt(&tinyints),
+        Column::SmallInt(&smallints),
+        Column::Int(&ints),
+        Column::TimestampTZ(PoSQLTimeUnit::Millisecond, timezone, &timestamps),
+        Column::Decimal75(Precision::new(75).unwrap(), 0, &scalars),
+        Column::VarChar((&strings, &string_scalars)),
+        Column::VarBinary((&bytes, &byte_scalars)),
+    ];
+    let column_fields = [
+        ColumnField::new("bool_col".into(), ColumnType::Boolean),
+        ColumnField::new("uint_col".into(), ColumnType::Uint8),
+        ColumnField::new("tiny_col".into(), ColumnType::TinyInt),
+        ColumnField::new("small_col".into(), ColumnType::SmallInt),
+        ColumnField::new("int_col".into(), ColumnType::Int),
+        ColumnField::new(
+            "timestamp_col".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, timezone),
+        ),
+        ColumnField::new(
+            "decimal_col".into(),
+            ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
+        ),
+        ColumnField::new("varchar_col".into(), ColumnType::VarChar),
+        ColumnField::new("varbinary_col".into(), ColumnType::VarBinary),
+    ];
+
+    let res = ProvableQueryResult::new(2, &cols);
+    let evaluation_point = [TestScalar::ONE];
+    let evals = res.evaluate(&evaluation_point, 2, &column_fields).unwrap();
+
+    assert_eq!(
+        evals,
+        [
+            TestScalar::ZERO,
+            TestScalar::from(2_u64),
+            TestScalar::from(2_u64),
+            TestScalar::from(20_u64),
+            TestScalar::from(200_u64),
+            TestScalar::from(2_000_u64),
+            TestScalar::from(22_u64),
+            TestScalar::from("beta"),
+            TestScalar::from_byte_slice_via_hash(b"bar"),
+        ]
+    );
 }
 
 #[test]
@@ -334,6 +406,75 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_mixed_data_types() {
     )
     .unwrap();
     assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_convert_additional_result_column_types_to_owned_table() {
+    let booleans = [true, false];
+    let uints = [1_u8, 2];
+    let tinyints = [-1_i8, 2];
+    let smallints = [-10_i16, 20];
+    let ints = [-100_i32, 200];
+    let timestamps = [1_000_i64, 2_000];
+    let scalars = [TestScalar::from(11), TestScalar::from(22)];
+    let timezone = PoSQLTimeZone::new(3_600);
+    let cols = [
+        Column::Boolean(&booleans),
+        Column::Uint8(&uints),
+        Column::TinyInt(&tinyints),
+        Column::SmallInt(&smallints),
+        Column::Int(&ints),
+        Column::TimestampTZ(PoSQLTimeUnit::Millisecond, timezone, &timestamps),
+        Column::Scalar(&scalars),
+    ];
+    let column_fields = [
+        ColumnField::new("bool_col".into(), ColumnType::Boolean),
+        ColumnField::new("uint_col".into(), ColumnType::Uint8),
+        ColumnField::new("tiny_col".into(), ColumnType::TinyInt),
+        ColumnField::new("small_col".into(), ColumnType::SmallInt),
+        ColumnField::new("int_col".into(), ColumnType::Int),
+        ColumnField::new(
+            "timestamp_col".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, timezone),
+        ),
+        ColumnField::new("scalar_col".into(), ColumnType::Scalar),
+    ];
+
+    let res = ProvableQueryResult::new(2, &cols);
+    let owned_table = res.to_owned_table::<TestScalar>(&column_fields).unwrap();
+
+    assert_eq!(
+        owned_table["bool_col"],
+        OwnedColumn::<TestScalar>::Boolean(vec![true, false])
+    );
+    assert_eq!(
+        owned_table["uint_col"],
+        OwnedColumn::<TestScalar>::Uint8(vec![1, 2])
+    );
+    assert_eq!(
+        owned_table["tiny_col"],
+        OwnedColumn::<TestScalar>::TinyInt(vec![-1, 2])
+    );
+    assert_eq!(
+        owned_table["small_col"],
+        OwnedColumn::<TestScalar>::SmallInt(vec![-10, 20])
+    );
+    assert_eq!(
+        owned_table["int_col"],
+        OwnedColumn::<TestScalar>::Int(vec![-100, 200])
+    );
+    assert_eq!(
+        owned_table["timestamp_col"],
+        OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            timezone,
+            vec![1_000, 2_000],
+        )
+    );
+    assert_eq!(
+        owned_table["scalar_col"],
+        OwnedColumn::Scalar(vec![TestScalar::from(11), TestScalar::from(22)])
+    );
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -69,3 +69,94 @@ impl<'a, T: ProvableResultElement<'a>, const N: usize> ProvableResultColumn for 
         (&self[..]).write(out, length)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProvableResultColumn;
+    use crate::base::{
+        database::Column,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
+    use alloc::vec::Vec;
+
+    fn assert_column_encodes_like_slice<'a, T>(column: Column<'a, TestScalar>, expected: &'a [T])
+    where
+        T: crate::sql::proof::ProvableResultElement<'a>,
+    {
+        let length = expected.len() as u64;
+        let expected_len = expected.num_bytes(length);
+        assert_eq!(column.num_bytes(length), expected_len);
+
+        let mut column_bytes = vec![0; expected_len];
+        let mut expected_bytes = vec![0; expected_len];
+
+        assert_eq!(column.write(&mut column_bytes, length), expected_len);
+        assert_eq!(expected.write(&mut expected_bytes, length), expected_len);
+        assert_eq!(column_bytes, expected_bytes);
+    }
+
+    #[test]
+    fn columns_delegate_result_serialization_to_their_values() {
+        let booleans = [true, false];
+        assert_column_encodes_like_slice(Column::Boolean(&booleans), &booleans);
+
+        let uints = [1_u8, 2];
+        assert_column_encodes_like_slice(Column::Uint8(&uints), &uints);
+
+        let tinyints = [-1_i8, 2];
+        assert_column_encodes_like_slice(Column::TinyInt(&tinyints), &tinyints);
+
+        let smallints = [-10_i16, 20];
+        assert_column_encodes_like_slice(Column::SmallInt(&smallints), &smallints);
+
+        let ints = [-100_i32, 200];
+        assert_column_encodes_like_slice(Column::Int(&ints), &ints);
+
+        let bigints = [-1_000_i64, 2_000];
+        assert_column_encodes_like_slice(Column::BigInt(&bigints), &bigints);
+        assert_column_encodes_like_slice(
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &bigints),
+            &bigints,
+        );
+
+        let int128s = [-10_000_i128, 20_000];
+        assert_column_encodes_like_slice(Column::Int128(&int128s), &int128s);
+
+        let scalars = [TestScalar::from(11), TestScalar::from(22)];
+        assert_column_encodes_like_slice(Column::Scalar(&scalars), &scalars);
+        assert_column_encodes_like_slice(
+            Column::Decimal75(Precision::new(75).unwrap(), 0, &scalars),
+            &scalars,
+        );
+
+        let strings = ["alpha", "beta"];
+        let string_scalars = strings
+            .iter()
+            .map(|value| TestScalar::from(*value))
+            .collect::<Vec<_>>();
+        assert_column_encodes_like_slice(Column::VarChar((&strings, &string_scalars)), &strings);
+
+        let bytes = [b"alpha".as_slice(), b"beta".as_slice()];
+        let byte_scalars = bytes
+            .iter()
+            .map(|value| TestScalar::from_le_bytes_mod_order(value))
+            .collect::<Vec<_>>();
+        assert_column_encodes_like_slice(Column::VarBinary((&bytes, &byte_scalars)), &bytes);
+    }
+
+    #[test]
+    fn arrays_delegate_result_serialization_to_their_slices() {
+        let values = [1_i32, 2, 3];
+        let length = values.len() as u64;
+        let expected_len = (&values[..]).num_bytes(length);
+        let mut array_bytes = vec![0; expected_len];
+        let mut slice_bytes = vec![0; expected_len];
+
+        assert_eq!(values.num_bytes(length), expected_len);
+        assert_eq!(values.write(&mut array_bytes, length), expected_len);
+        assert_eq!((&values[..]).write(&mut slice_bytes, length), expected_len);
+        assert_eq!(array_bytes, slice_bytes);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,60 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        database::{ColumnCoercionError, TableCoercionError},
+        proof::ProofError,
+        scalar::test_scalar::TestScalar,
+    };
+
+    #[test]
+    fn table_coercion_errors_map_to_query_errors() {
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCoercionError {
+                source: ColumnCoercionError::Overflow,
+            }),
+            QueryError::Overflow
+        ));
+
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCoercionError {
+                source: ColumnCoercionError::InvalidTypeCoercion,
+            }),
+            QueryError::ProofError {
+                source: ProofError::InvalidTypeCoercion,
+            }
+        ));
+
+        assert!(matches!(
+            QueryError::from(TableCoercionError::NameMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldNamesMismatch,
+            }
+        ));
+
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCountMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldCountMismatch,
+            }
+        ));
+    }
+
+    #[test]
+    fn query_data_can_hold_verified_table_metadata() {
+        let table = OwnedTable::<TestScalar>::try_from_iter([]).unwrap();
+        let query_data = QueryData {
+            table: table.clone(),
+            verification_hash: [7; 32],
+        };
+        let query_result: QueryResult<TestScalar> = Ok(query_data);
+
+        let query_data = query_result.unwrap();
+        assert_eq!(query_data.table, table);
+        assert_eq!(query_data.verification_hash, [7; 32]);
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for table numeric helper columns and table inspection methods
- add coverage for `TableRef` construction, parsing, display, equality lookup, and serde round-tripping
- add coverage for provable result column serialization across column variants and array delegation
- add coverage for provable query result type dispatch in evaluation and owned-table conversion
- add coverage for query-result coercion error mapping and query data metadata
- add coverage for `OwnedTableTestAccessor` metadata, schema lookup, table extraction, offset updates, cloning, commitments, and owned-column conversion paths
- add coverage for `TableTestAccessor` under the `arrow,test` feature set, including borrowed-column access, schema/metadata, table extraction, offset updates, cloning, and commitments
- add coverage for Arrow schema compatibility conversion of float fields to Decimal256
- add coverage for Arrow record-batch conversion and table commitment creation/append paths without requiring `blitzar`
- add coverage for `TableEvaluation` accessors
- add coverage for `QueryCommitments` metadata, schema, commitments, and accessor grouping without requiring `blitzar`

## Testing
- `cargo fmt --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" base::database::table_test::we_can_create_and_inspect_a_table_with_numeric_helper_columns`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" base::database::table_ref::tests`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" sql::proof::query_result::tests`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" sql::proof::provable_result_column::tests`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" sql::proof::provable_query_result_test`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" base::database::owned_table_test_accessor`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" base::database::table_test_accessor`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" base::database::arrow_schema_utility`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" base::arrow::record_batch_conversion`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" base::database::table_evaluation`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" base::commitment::query_commitments`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test"`
- `PATH="$HOME/.cargo/bin:$PATH" LLVM_COV=/opt/homebrew/opt/llvm/bin/llvm-cov LLVM_PROFDATA=/opt/homebrew/opt/llvm/bin/llvm-profdata cargo llvm-cov --package proof-of-sql --lib --no-default-features --features "arrow,test" --summary-only`
- `git diff --check`

Local coverage moved `table.rs`, `table_utility.rs`, `table_ref.rs`, `provable_result_column.rs`, `query_result.rs`, `arrow_schema_utility.rs`, `accessor.rs`, `table_evaluation.rs`, and `query_commitments.rs` to 100% line coverage; `owned_table_test_accessor.rs` to 95.22%; `table_test_accessor.rs` to 95.00%; `provable_query_result.rs` to 91.95%; and `record_batch_conversion.rs` to 88.98% under the macOS-safe feature set above.

The local coverage summary improved from 6700 missed lines before this PR to 5973 missed lines now, for a net +727 covered lines. The full coverage run passed with 1079 tests, 0 failures.

/claim #560
