### PR TITLE
test: cover planner error branches

### DIFF
--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -165,6 +165,15 @@ AND s.salary > (
     }
 
     #[test]
+    fn we_cannot_get_table_references_with_catalog_qualified_table() {
+        let statement = Parser::parse_sql(&GenericDialect {}, "SELECT * FROM catalog.schema.table")
+            .unwrap()[0]
+            .clone();
+
+        assert!(get_table_refs_from_statement(&statement).is_err());
+    }
+
+    #[test]
     fn we_can_use_abs() {
         let statements = Parser::parse_sql(&GenericDialect {}, "SELECT ABS(-1-1);").unwrap();
         sql_to_posql_plans(

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -579,6 +579,73 @@ mod tests {
     }
 
     #[test]
+    fn we_cannot_convert_binary_expr_with_invalid_operand_types() {
+        let varchar_schema = vec![
+            ("column1".into(), ColumnType::VarChar),
+            ("column2".into(), ColumnType::VarChar),
+        ];
+        for op in [Operator::Lt, Operator::Gt, Operator::LtEq, Operator::GtEq] {
+            let expr = Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(df_column("namespace.table_name", "column1")),
+                right: Box::new(df_column("namespace.table_name", "column2")),
+                op,
+            });
+            assert!(
+                expr_to_proof_expr(&expr, &varchar_schema).is_err(),
+                "{op:?} should reject varchar operands"
+            );
+        }
+
+        let mismatched_schema = vec![
+            ("column1".into(), ColumnType::VarChar),
+            ("column2".into(), ColumnType::Boolean),
+        ];
+        for op in [Operator::Eq, Operator::NotEq] {
+            let expr = Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(df_column("namespace.table_name", "column1")),
+                right: Box::new(df_column("namespace.table_name", "column2")),
+                op,
+            });
+            assert!(
+                expr_to_proof_expr(&expr, &mismatched_schema).is_err(),
+                "{op:?} should reject mismatched operand types"
+            );
+        }
+
+        let boolean_schema = vec![
+            ("column1".into(), ColumnType::Boolean),
+            ("column2".into(), ColumnType::Boolean),
+        ];
+        for op in [Operator::Plus, Operator::Minus, Operator::Multiply] {
+            let expr = Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(df_column("namespace.table_name", "column1")),
+                right: Box::new(df_column("namespace.table_name", "column2")),
+                op,
+            });
+            assert!(
+                expr_to_proof_expr(&expr, &boolean_schema).is_err(),
+                "{op:?} should reject boolean operands"
+            );
+        }
+
+        let integer_schema = vec![
+            ("column1".into(), ColumnType::Int),
+            ("column2".into(), ColumnType::Int),
+        ];
+        for op in [Operator::And, Operator::Or] {
+            let expr = Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(df_column("namespace.table_name", "column1")),
+                right: Box::new(df_column("namespace.table_name", "column2")),
+                op,
+            });
+            assert!(
+                expr_to_proof_expr(&expr, &integer_schema).is_err(),
+                "{op:?} should reject integer operands"
+            );
+        }
+    }
+
+    #[test]
     fn we_can_convert_logical_not_eq_to_proof_expr() {
         let schema = vec![
             ("column1".into(), ColumnType::BigInt),

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -236,6 +236,18 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn we_cannot_convert_placeholder_with_unsupported_type() {
+        let placeholder = Placeholder {
+            id: "$1".to_string(),
+            data_type: Some(DataType::Float32),
+        };
+        assert!(matches!(
+            placeholder_to_placeholder_expr(&placeholder),
+            Err(PlannerError::UnsupportedDataType { .. })
+        ));
+    }
+
     // TableReference to TableRef
     #[test]
     fn we_can_convert_table_reference_to_table_ref() {


### PR DESCRIPTION
/claim #560

## Summary
- Add coverage for catalog-qualified table reference extraction errors.
- Add planner expression coverage for invalid operand type branches across comparison, equality, arithmetic, and boolean operators.
- Add unsupported placeholder DataFusion type coverage.

## Validation
- cargo test -p proof-of-sql-planner --lib
- cargo fmt --all --check
- git diff --check
- scripts/check_commits.sh
- BLITZAR_BACKEND=cpu cargo llvm-cov -p proof-of-sql-planner --lib --text --show-missing-lines --ignore-filename-regex ".*(_test|evm_tests).*" --output-path /tmp/proof-of-sql-planner-cov-final.txt
