### PR TITLE
test: cover permutation comparator constructor

### DIFF
--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -29,7 +29,7 @@ pub struct Permutation {
 
 impl Permutation {
     /// Create a new permutation from a comparison function with the given length
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn unchecked_new_from_cmp<F>(length: usize, cmp: F) -> Self
     where
         F: Fn(&usize, &usize) -> Ordering + Sync,
@@ -99,6 +99,30 @@ mod test {
         assert_eq!(
             permutation.try_apply(&["and", "Space", "Time"]).unwrap(),
             vec!["Space", "and", "Time"]
+        );
+    }
+
+    #[test]
+    fn test_unchecked_new_from_cmp_builds_sorted_permutation() {
+        let values = [30, 10, 20];
+        let permutation =
+            Permutation::unchecked_new_from_cmp(values.len(), |a, b| values[*a].cmp(&values[*b]));
+
+        assert_eq!(permutation.size(), 3);
+        assert_eq!(
+            permutation.try_apply(&["thirty", "ten", "twenty"]).unwrap(),
+            vec!["ten", "twenty", "thirty"]
+        );
+    }
+
+    #[test]
+    fn test_unchecked_new_from_cmp_handles_empty_permutation() {
+        let permutation = Permutation::unchecked_new_from_cmp(0, |_, _| Ordering::Equal);
+
+        assert_eq!(permutation.size(), 0);
+        assert_eq!(
+            permutation.try_apply::<i64>(&[]).unwrap(),
+            Vec::<i64>::new()
         );
     }
 


### PR DESCRIPTION
Fixes #560.
/claim #560

## Summary
- Adds focused coverage for `Permutation::unchecked_new_from_cmp` using a comparator over an external value array.
- Covers the empty-permutation edge case and narrows the existing dead-code expectation to non-test builds.

## Verification
- `cargo fmt --all --check`
- `cargo test -p proof-of-sql base::math::permutation`
- `cargo llvm-cov test -p proof-of-sql base::math::permutation --summary-only`

Targeted llvm-cov result for `base/math/permutation.rs`: 74/74 lines, 12/12 functions, 115/117 regions covered.