### PR TITLE
test: cover bool varint and bit distribution error

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -55,6 +55,12 @@ fn we_can_get_u256_version_of_vary_mask_for_large_number() {
 
 // vary_mask function end
 
+#[test]
+#[should_panic(expected = "No lead bit available despite variable lead bit.")]
+fn converting_no_lead_bit_error_panics() {
+    let _ = crate::base::proof::ProofError::from(BitDistributionError::NoLeadBit);
+}
+
 // leading_bit_mask function start
 
 #[test]

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -238,6 +238,13 @@ fn we_can_encode_and_decode_small_u64_values() {
 }
 
 #[test]
+fn we_can_encode_and_decode_bool_values() {
+    test_encode_decode(false, [0]);
+    test_encode_decode(true, [1]);
+    assert_eq!(bool::decode_var(&[2]), None);
+}
+
+#[test]
 fn we_can_encode_and_decode_large_u64_values() {
     test_encode_decode(
         u64::MAX,


### PR DESCRIPTION
## Summary
- add direct coverage for bool `VarInt` encode/decode behavior, including invalid encoded values
- cover the `BitDistributionError::NoLeadBit` conversion panic path

/claim #560

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features="arrow test" we_can_encode_and_decode_bool_values`
- `cargo test -p proof-of-sql --lib --no-default-features --features="arrow test" converting_no_lead_bit_error_panics`
- `cargo test -p proof-of-sql --lib --no-default-features --features="arrow test" base::encode::varint_trait_test`
- `cargo test -p proof-of-sql --lib --no-default-features --features="arrow test" base::bit::bit_distribution_test`
- `cargo fmt --check`
- `cargo llvm-cov --package proof-of-sql --lib --no-default-features --features="arrow test" --summary-only` (1055 passed; local ARM-safe coverage improved `bit_distribution.rs` to 100% line coverage and `varint_trait.rs` to 100% line coverage)
- `cargo check -p proof-of-sql --no-default-features --features="arrow test"`
- `git diff --check`