### PR TITLE
test: cover BigDecimalExt conversions

### DIFF
--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -89,4 +89,31 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, IntermediateDecimalError::ConversionFailure));
     }
+
+    #[test]
+    fn we_can_convert_decimal_to_bigint_with_exact_scale() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+        let bigint = big_decimal
+            .try_into_bigint_with_precision_and_scale(5, 2)
+            .unwrap();
+        assert_eq!(bigint.to_string(), "12345");
+    }
+
+    #[test]
+    fn we_can_convert_decimal_to_bigint_with_padded_scale() {
+        let big_decimal: BigDecimal = "123.4".parse::<BigDecimal>().unwrap().normalized();
+        let bigint = big_decimal
+            .try_into_bigint_with_precision_and_scale(5, 2)
+            .unwrap();
+        assert_eq!(bigint.to_string(), "12340");
+    }
+
+    #[test]
+    fn we_can_catch_lossy_cast_when_scaled_decimal_exceeds_precision() {
+        let big_decimal: BigDecimal = "12345".parse::<BigDecimal>().unwrap().normalized();
+        let err = big_decimal
+            .try_into_bigint_with_precision_and_scale(4, 0)
+            .unwrap_err();
+        assert!(matches!(err, IntermediateDecimalError::LossyCast));
+    }
 }


### PR DESCRIPTION
﻿## Summary
- Add focused BigDecimalExt tests for successful exact-scale and padded-scale BigInt conversions.
- Cover the precision overflow branch returning IntermediateDecimalError::LossyCast.
- No production code changes.

## Verification
- cargo fmt --check
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS="" cargo test -p proof-of-sql big_decimal_ext (WSL/Linux)

/claim #560
