### PR TITLE
test: cover scale and error helper paths

### DIFF
--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,113 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_error_formats_top_level_variants() {
+        assert_eq!(
+            ProofError::VerificationError {
+                error: "bad evaluation"
+            }
+            .to_string(),
+            "Verification error: bad evaluation"
+        );
+        assert_eq!(
+            ProofError::UnsupportedQueryPlan {
+                error: "unsupported node"
+            }
+            .to_string(),
+            "Unsupported query plan: unsupported node"
+        );
+        assert_eq!(
+            ProofError::InvalidTypeCoercion.to_string(),
+            "Result does not match query: type mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldNamesMismatch.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldCountMismatch.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_size_mismatch_formats_all_variants() {
+        let cases = [
+            (
+                ProofSizeMismatch::SumcheckProofTooSmall,
+                "Sumcheck proof is too small",
+            ),
+            (
+                ProofSizeMismatch::TooFewMLEEvaluations,
+                "Proof has too few MLE evaluations",
+            ),
+            (
+                ProofSizeMismatch::PostResultCountMismatch,
+                "Post result challenge count mismatch",
+            ),
+            (
+                ProofSizeMismatch::ConstraintCountMismatch,
+                "Constraint count mismatch",
+            ),
+            (
+                ProofSizeMismatch::TooFewBitDistributions,
+                "Proof has too few bit distributions",
+            ),
+            (
+                ProofSizeMismatch::TooFewChiLengths,
+                "Proof has too few one lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewRhoLengths,
+                "Proof has too few rho lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewSumcheckVariables,
+                "Proof has too few sumcheck variables",
+            ),
+            (
+                ProofSizeMismatch::ChiLengthNotFound,
+                "Proof doesn't have requested one length",
+            ),
+            (
+                ProofSizeMismatch::RhoLengthNotFound,
+                "Proof doesn't have requested rho length",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn placeholder_error_formats_context() {
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderIndex {
+                index: 4,
+                num_params: 2
+            }
+            .to_string(),
+            "Invalid placeholder index: 4, number of params: 2"
+        );
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderType {
+                index: 1,
+                expected: ColumnType::Int,
+                actual: ColumnType::Boolean,
+            }
+            .to_string(),
+            "Invalid placeholder type: 1, expected: INT, actual: BOOLEAN"
+        );
+        assert_eq!(
+            PlaceholderError::ZeroPlaceholderId.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
@@ -29,6 +29,13 @@ fn test_dalek_interop_1() {
 }
 
 #[test]
+fn test_dalek_interop_borrowed_scalar() {
+    let x = curve25519_dalek::scalar::Scalar::from(7u64);
+    let xp = Curve25519Scalar::from(7u64);
+    assert_eq!(curve25519_dalek::scalar::Scalar::from(&xp), x);
+}
+
+#[test]
 fn test_dalek_interop_m1() {
     let x = curve25519_dalek::scalar::Scalar::from(123u64);
     let mx = -x;
@@ -36,6 +43,20 @@ fn test_dalek_interop_m1() {
     let mxp = -xp;
     assert_eq!(mxp, Curve25519Scalar::from(-123i64));
     assert_eq!(curve25519_dalek::scalar::Scalar::from(mxp), mx);
+}
+
+#[test]
+fn test_curve25519_scalar_point_multiplication_forms_match() {
+    use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
+
+    let scalar = Curve25519Scalar::from(9u64);
+    let point = RISTRETTO_BASEPOINT_POINT;
+    let expected = curve25519_dalek::scalar::Scalar::from(9u64) * point;
+
+    assert_eq!(scalar * point, expected);
+    assert_eq!(scalar * &point, expected);
+    assert_eq!(point * scalar, expected);
+    assert_eq!((&point) * scalar, expected);
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,57 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn analyze_error_converts_to_string_using_display_text() {
+        let error = AnalyzeError::DataTypeMismatch {
+            left_type: "INT".to_string(),
+            right_type: "BOOLEAN".to_string(),
+        };
+
+        let message: String = error.into();
+
+        assert_eq!(
+            message,
+            "Left side has 'INT' type but right side has 'BOOLEAN' type"
+        );
+    }
+
+    #[test]
+    fn analyze_error_formats_structural_variants() {
+        assert_eq!(
+            AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::Boolean
+            }
+            .to_string(),
+            "Expression has datatype BOOLEAN, which was not valid"
+        );
+        assert_eq!(
+            AnalyzeError::DifferentColumnLength { len_a: 2, len_b: 3 }.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+        assert_eq!(
+            AnalyzeError::NotEnoughInputPlans.to_string(),
+            "Not enough input plans"
+        );
+    }
+
+    #[test]
+    fn intermediate_decimal_error_converts_to_analyze_error() {
+        let error = AnalyzeError::from(IntermediateDecimalError::LossyCast);
+
+        assert!(matches!(
+            error,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::LossyCast
+                }
+            }
+        ));
+        assert_eq!(error.to_string(), "Fractional part of decimal is non-zero");
+    }
+}

--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -73,7 +73,10 @@ pub fn scale_cast_binary_op(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::{ColumnRef, TableRef};
+    use crate::base::{
+        database::{ColumnRef, TableRef},
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    };
 
     #[expect(non_snake_case)]
     fn COLUMN1_BOOLEAN() -> DynProofExpr {
@@ -138,6 +141,15 @@ mod tests {
                 Precision::new(25).expect("Precision is definitely valid"),
                 5,
             ),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn TIMESTAMP_COLUMN(time_unit: PoSQLTimeUnit) -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "timestamp_column".into(),
+            ColumnType::TimestampTZ(time_unit, PoSQLTimeZone::utc()),
         ))
     }
 
@@ -234,5 +246,39 @@ mod tests {
         let right = COLUMN2_DECIMAL_25_5();
         let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
         assert_eq!(proof_exprs, (left, right));
+    }
+
+    #[test]
+    fn we_can_convert_scale_cast_binary_op_upcasting_left_timestamp() {
+        let left = TIMESTAMP_COLUMN(PoSQLTimeUnit::Second);
+        let right = TIMESTAMP_COLUMN(PoSQLTimeUnit::Millisecond);
+        let right_type = right.data_type();
+
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+
+        assert_eq!(
+            proof_exprs,
+            (
+                DynProofExpr::try_new_scaling_cast(left, right_type).unwrap(),
+                right
+            )
+        );
+    }
+
+    #[test]
+    fn we_can_convert_scale_cast_binary_op_upcasting_right_timestamp() {
+        let left = TIMESTAMP_COLUMN(PoSQLTimeUnit::Nanosecond);
+        let right = TIMESTAMP_COLUMN(PoSQLTimeUnit::Microsecond);
+        let left_type = left.data_type();
+
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+
+        assert_eq!(
+            proof_exprs,
+            (
+                left,
+                DynProofExpr::try_new_scaling_cast(right, left_type).unwrap()
+            )
+        );
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add timestamp scale-cast coverage for left/right upcast branches in `scale_cast_binary_op`
- cover SQL analyze error display/conversion behavior and intermediate decimal conversion wrapping
- cover proof/placeholder error display variants
- add Curve25519/Ristretto interop tests for borrowed scalar conversion and scalar/point multiplication forms

## Verification
- `cargo +stable check -p proof-of-sql --no-default-features --features="arrow rayon"`
- `cargo +stable test -p proof-of-sql --no-default-features --features="arrow rayon test"`
- `rustfmt +stable --edition 2021 --check crates\proof-of-sql\src\sql\scale.rs crates\proof-of-sql\src\sql\error.rs crates\proof-of-sql\src\base\proof\error.rs crates\proof-of-sql\src\proof_primitive\inner_product\curve_25519_tests.rs`

Note: the full `cargo +stable fmt --check` command currently reports an unrelated pre-existing import ordering diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`, which this PR leaves untouched.
