### PR TITLE
test: cache Dory test setup

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,6 +1,7 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    cached_test_public_parameters, cached_test_verifier_setup, test_rng, DoryEvaluationProof,
+    DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup, ProverSetup, PublicParameters,
+    VerifierSetup,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -8,45 +9,45 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let public_parameters = cached_test_public_parameters(4);
+    let prover_setup = ProverSetup::from(public_parameters);
+    let verifier_setup = cached_test_verifier_setup(4);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let public_parameters = cached_test_public_parameters(6);
+    let prover_setup = ProverSetup::from(public_parameters);
+    let verifier_setup = cached_test_verifier_setup(6);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let public_parameters = cached_test_public_parameters(4);
+    let prover_setup = ProverSetup::from(public_parameters);
+    let verifier_setup = cached_test_verifier_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let public_parameters = cached_test_public_parameters(6);
+    let prover_setup = ProverSetup::from(public_parameters);
+    let verifier_setup = cached_test_verifier_setup(6);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
@@ -55,15 +56,15 @@ fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
     let setup_setup = [(4, 4), (4, 3), (6, 2)];
     for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let public_parameters = cached_test_public_parameters(setup_p.0);
+        let prover_setup = ProverSetup::from(public_parameters);
+        let verifier_setup = cached_test_verifier_setup(setup_p.0);
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
                 &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &DoryVerifierPublicSetup::new(verifier_setup, setup_p.1),
             );
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
+    cached_test_public_parameters, cached_test_verifier_setup, test_rng, DoryScalar,
+    DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -7,23 +8,23 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let public_parameters = cached_test_public_parameters(4);
+    let prover_setup = ProverSetup::from(public_parameters);
+    let verifier_setup = cached_test_verifier_setup(4);
     test_simple_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
         &&prover_setup,
-        &&verifier_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let public_parameters = cached_test_public_parameters(4);
+    let prover_setup = ProverSetup::from(public_parameters);
+    let verifier_setup = cached_test_verifier_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DynamicDoryEvaluationProof>(
         &&prover_setup,
-        &&verifier_setup,
+        &verifier_setup,
     );
 }
 
@@ -45,15 +46,15 @@ fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let public_parameters = cached_test_public_parameters(6);
+    let prover_setup = ProverSetup::from(public_parameters);
+    let verifier_setup = cached_test_verifier_setup(6);
     for length in lengths {
         test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
             length,
             0,
             &&prover_setup,
-            &&verifier_setup,
+            &verifier_setup,
         );
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -29,6 +29,10 @@ use rand_util::rand_F_tensors;
 use rand_util::rand_G_vecs;
 #[cfg(test)]
 pub use rand_util::test_rng;
+#[cfg(test)]
+use rand_util::test_seed_rng;
+#[cfg(test)]
+use std::sync::OnceLock;
 
 mod dory_messages;
 pub(crate) use dory_messages::DoryMessages;
@@ -162,3 +166,27 @@ pub use dynamic_dory_commitment::DynamicDoryCommitment;
 #[cfg(test)]
 mod dynamic_dory_commitment_evaluation_proof_test;
 pub use dynamic_dory_commitment_evaluation_proof::DynamicDoryEvaluationProof;
+
+#[cfg(test)]
+pub(crate) fn cached_test_public_parameters(max_nu: usize) -> &'static PublicParameters {
+    static NU_4: OnceLock<PublicParameters> = OnceLock::new();
+    static NU_6: OnceLock<PublicParameters> = OnceLock::new();
+
+    match max_nu {
+        4 => NU_4.get_or_init(|| PublicParameters::test_rand(4, &mut test_seed_rng([4; 32]))),
+        6 => NU_6.get_or_init(|| PublicParameters::test_rand(6, &mut test_seed_rng([6; 32]))),
+        _ => panic!("cached Dory test parameters are not configured for nu={max_nu}"),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn cached_test_verifier_setup(max_nu: usize) -> &'static VerifierSetup {
+    static NU_4: OnceLock<VerifierSetup> = OnceLock::new();
+    static NU_6: OnceLock<VerifierSetup> = OnceLock::new();
+
+    match max_nu {
+        4 => NU_4.get_or_init(|| VerifierSetup::from(cached_test_public_parameters(4))),
+        6 => NU_6.get_or_init(|| VerifierSetup::from(cached_test_public_parameters(6))),
+        _ => panic!("cached Dory verifier setup is not configured for nu={max_nu}"),
+    }
+}


### PR DESCRIPTION
## Summary
- add cached Dory public parameters and verifier setup for tests
- reuse cached setup in the Dory commitment evaluation proof tests called out in #557
- keep production setup generation unchanged

## Notes
This reduces repeated `PublicParameters::test_rand` / `VerifierSetup::from` work in the slow IPA test modules while preserving the same proof checks. The negative verifier-size test intentionally keeps independent setup generation.

## Validation
- `git diff --check`
- I could not run `cargo test` locally because this environment does not have `cargo`, `rustup`, `nix`, Docker, or Podman installed.