### PR TITLE
feat: add nullable validity proof expressions

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -26,7 +26,9 @@ pub(crate) fn get_column_idents_from_expr(expr: &Expr) -> IndexSet<Ident> {
             left_idents.extend(get_column_idents_from_expr(right));
             left_idents
         }
-        Expr::Not(inner) => get_column_idents_from_expr(inner),
+        Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) => {
+            get_column_idents_from_expr(inner)
+        }
         Expr::Alias(Alias { expr, .. }) | Expr::Cast(Cast { expr, .. }) => {
             get_column_idents_from_expr(expr)
         }
@@ -140,6 +142,14 @@ pub fn expr_to_proof_expr(
         Expr::Not(expr) => {
             let proof_expr = expr_to_proof_expr(expr, schema)?;
             Ok(DynProofExpr::try_new_not(proof_expr)?)
+        }
+        Expr::IsNull(expr) => {
+            let proof_expr = expr_to_proof_expr(expr, schema)?;
+            Ok(DynProofExpr::try_new_is_null(proof_expr)?)
+        }
+        Expr::IsNotNull(expr) => {
+            let proof_expr = expr_to_proof_expr(expr, schema)?;
+            Ok(DynProofExpr::try_new_is_not_null(proof_expr)?)
         }
         Expr::Cast(cast) => {
             match &*cast.expr {
@@ -652,6 +662,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn we_can_convert_is_null_expr_to_proof_expr() {
+        let expr = Expr::IsNull(Box::new(df_column("table_name", "column_valid")));
+        let schema = vec![("column_valid".into(), ColumnType::Boolean)];
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_is_null(DynProofExpr::new_column(ColumnRef::new(
+                TableRef::from_names(None, "table_name"),
+                "column_valid".into(),
+                ColumnType::Boolean
+            )))
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_convert_is_not_null_expr_to_proof_expr() {
+        let expr = Expr::IsNotNull(Box::new(df_column("table_name", "column_valid")));
+        let schema = vec![("column_valid".into(), ColumnType::Boolean)];
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_is_not_null(DynProofExpr::new_column(ColumnRef::new(
+                TableRef::from_names(None, "table_name"),
+                "column_valid".into(),
+                ColumnType::Boolean
+            )))
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_is_null_expr_for_non_boolean_validity_expr() {
+        let expr = Expr::IsNull(Box::new(df_column("table_name", "column")));
+        let schema = vec![("column".into(), ColumnType::BigInt)];
+        assert!(matches!(
+            expr_to_proof_expr(&expr, &schema),
+            Err(PlannerError::AnalyzeError { .. })
+        ));
+    }
+
     // Cast
     #[test]
     fn we_can_convert_cast_expr_to_proof_expr() {
@@ -797,6 +847,14 @@ mod tests {
         let expr = Expr::Not(Box::new(df_column("table", "bool_col")));
         let result = get_column_idents_from_expr(&expr);
         let expected: IndexSet<Ident> = ["bool_col".into()].into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_extract_column_idents_from_is_null_expr() {
+        let expr = Expr::IsNull(Box::new(df_column("table", "valid_col")));
+        let result = get_column_idents_from_expr(&expr);
+        let expected: IndexSet<Ident> = ["valid_col".into()].into_iter().collect();
         assert_eq!(result, expected);
     }
 

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -1669,6 +1669,80 @@ mod tests {
     }
 
     #[test]
+    fn we_can_put_is_null_exprs_in_evm() {
+        let table_ref = TableRef::try_from("namespace.table").unwrap();
+        let valid_ref = ColumnRef::new(table_ref, "valid".into(), ColumnType::Boolean);
+        let column_refs = indexset! { valid_ref.clone() };
+
+        let is_null_expr =
+            IsNullExpr::try_new(Box::new(DynProofExpr::new_column(valid_ref.clone())), false)
+                .unwrap();
+        let evm_is_null = EVMIsNullExpr::try_from_proof_expr(&is_null_expr, &column_refs).unwrap();
+        assert_eq!(
+            evm_is_null,
+            EVMIsNullExpr::new(
+                EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
+                false
+            )
+        );
+        assert_eq!(
+            evm_is_null.try_into_proof_expr(&column_refs).unwrap(),
+            is_null_expr
+        );
+
+        let is_not_null_expr =
+            IsNullExpr::try_new(Box::new(DynProofExpr::new_column(valid_ref)), true).unwrap();
+        let evm_is_not_null =
+            EVMIsNullExpr::try_from_proof_expr(&is_not_null_expr, &column_refs).unwrap();
+        assert_eq!(
+            evm_is_not_null,
+            EVMIsNullExpr::new(
+                EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
+                true
+            )
+        );
+        assert_eq!(
+            evm_is_not_null.try_into_proof_expr(&column_refs).unwrap(),
+            is_not_null_expr
+        );
+    }
+
+    #[test]
+    fn we_can_put_is_null_with_nested_boolean_validity_expr_in_evm() {
+        let table_ref = TableRef::try_from("namespace.table").unwrap();
+        let left_ref = ColumnRef::new(table_ref.clone(), "left_valid".into(), ColumnType::Boolean);
+        let right_ref = ColumnRef::new(table_ref, "right_valid".into(), ColumnType::Boolean);
+        let column_refs = indexset! { left_ref.clone(), right_ref.clone() };
+        let validity_expr = DynProofExpr::try_new_and(
+            DynProofExpr::new_column(left_ref),
+            DynProofExpr::new_column(right_ref),
+        )
+        .unwrap();
+        let is_null_expr = IsNullExpr::try_new(Box::new(validity_expr), false).unwrap();
+
+        let evm = EVMDynProofExpr::try_from_proof_expr(
+            &DynProofExpr::IsNull(is_null_expr.clone()),
+            &column_refs,
+        )
+        .unwrap();
+
+        assert_eq!(
+            evm,
+            EVMDynProofExpr::IsNull(EVMIsNullExpr::new(
+                EVMDynProofExpr::And(EVMAndExpr::new(
+                    EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 }),
+                    EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 }),
+                )),
+                false,
+            ))
+        );
+        assert_eq!(
+            evm.try_into_proof_expr(&column_refs).unwrap(),
+            DynProofExpr::IsNull(is_null_expr)
+        );
+    }
+
+    #[test]
     fn we_can_catch_evm_dyn_proof_expr_variant_order_change() {
         fn assert_variant_tag(expr: EVMDynProofExpr, expected_tag: u32) {
             let bytes = try_standard_binary_serialization(expr).unwrap();

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     sql::proof_exprs::{
         AddExpr, AndExpr, CastExpr, ColumnExpr, DynProofExpr, EqualsExpr, InequalityExpr,
-        LiteralExpr, MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ProofExpr, ScalingCastExpr,
-        SubtractExpr,
+        IsNullExpr, LiteralExpr, MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ProofExpr,
+        ScalingCastExpr, SubtractExpr,
     },
 };
 use alloc::boxed::Box;
@@ -29,6 +29,7 @@ pub(crate) enum EVMDynProofExpr {
     Inequality(EVMInequalityExpr),
     Placeholder(EVMPlaceholderExpr),
     ScalingCast(EVMScalingCastExpr),
+    IsNull(EVMIsNullExpr),
 }
 impl EVMDynProofExpr {
     /// Try to create an `EVMDynProofExpr` from a `DynProofExpr`.
@@ -67,6 +68,9 @@ impl EVMDynProofExpr {
             }
             DynProofExpr::Not(not_expr) => {
                 EVMNotExpr::try_from_proof_expr(not_expr, column_refs).map(Self::Not)
+            }
+            DynProofExpr::IsNull(is_null_expr) => {
+                EVMIsNullExpr::try_from_proof_expr(is_null_expr, column_refs).map(Self::IsNull)
             }
             DynProofExpr::Cast(cast_expr) => {
                 EVMCastExpr::try_from_proof_expr(cast_expr, column_refs).map(Self::Cast)
@@ -115,6 +119,9 @@ impl EVMDynProofExpr {
             }
             EVMDynProofExpr::Not(not_expr) => Ok(DynProofExpr::Not(
                 not_expr.try_into_proof_expr(column_refs)?,
+            )),
+            EVMDynProofExpr::IsNull(is_null_expr) => Ok(DynProofExpr::IsNull(
+                is_null_expr.try_into_proof_expr(column_refs)?,
             )),
             EVMDynProofExpr::Cast(cast_expr) => Ok(DynProofExpr::Cast(
                 cast_expr.try_into_proof_expr(column_refs)?,
@@ -537,6 +544,47 @@ impl EVMNotExpr {
         Ok(NotExpr::try_new(Box::new(
             self.expr.try_into_proof_expr(column_refs)?,
         ))?)
+    }
+}
+
+/// Represents an IS NULL or IS NOT NULL expression.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct EVMIsNullExpr {
+    validity_expr: Box<EVMDynProofExpr>,
+    is_not_null: bool,
+}
+
+impl EVMIsNullExpr {
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn new(validity_expr: EVMDynProofExpr, is_not_null: bool) -> Self {
+        Self {
+            validity_expr: Box::new(validity_expr),
+            is_not_null,
+        }
+    }
+
+    /// Try to create an `EVMIsNullExpr` from an `IsNullExpr`.
+    pub(crate) fn try_from_proof_expr(
+        expr: &IsNullExpr,
+        column_refs: &IndexSet<ColumnRef>,
+    ) -> EVMProofPlanResult<Self> {
+        Ok(EVMIsNullExpr {
+            validity_expr: Box::new(EVMDynProofExpr::try_from_proof_expr(
+                expr.validity_expr(),
+                column_refs,
+            )?),
+            is_not_null: expr.is_not_null(),
+        })
+    }
+
+    pub(crate) fn try_into_proof_expr(
+        &self,
+        column_refs: &IndexSet<ColumnRef>,
+    ) -> EVMProofPlanResult<IsNullExpr> {
+        Ok(IsNullExpr::try_new(
+            Box::new(self.validity_expr.try_into_proof_expr(column_refs)?),
+            self.is_not_null,
+        )?)
     }
 }
 

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -1669,6 +1669,73 @@ mod tests {
     }
 
     #[test]
+    fn we_can_catch_evm_dyn_proof_expr_variant_order_change() {
+        fn assert_variant_tag(expr: EVMDynProofExpr, expected_tag: u32) {
+            let bytes = try_standard_binary_serialization(expr).unwrap();
+            assert_eq!(&bytes[..4], &expected_tag.to_be_bytes());
+        }
+
+        let column = || EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 });
+        let literal = || EVMDynProofExpr::Literal(EVMLiteralExpr(LiteralValue::BigInt(1)));
+        let binary_args = || (column(), literal());
+
+        assert_variant_tag(column(), 0);
+        assert_variant_tag(literal(), 1);
+
+        let (lhs, rhs) = binary_args();
+        assert_variant_tag(EVMDynProofExpr::Equals(EVMEqualsExpr::new(lhs, rhs)), 2);
+
+        let (lhs, rhs) = binary_args();
+        assert_variant_tag(EVMDynProofExpr::Add(EVMAddExpr::new(lhs, rhs)), 3);
+
+        let (lhs, rhs) = binary_args();
+        assert_variant_tag(EVMDynProofExpr::Subtract(EVMSubtractExpr::new(lhs, rhs)), 4);
+
+        let (lhs, rhs) = binary_args();
+        assert_variant_tag(EVMDynProofExpr::Multiply(EVMMultiplyExpr::new(lhs, rhs)), 5);
+
+        let bool_column = || EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 });
+        assert_variant_tag(
+            EVMDynProofExpr::And(EVMAndExpr::new(bool_column(), bool_column())),
+            6,
+        );
+        assert_variant_tag(
+            EVMDynProofExpr::Or(EVMOrExpr::new(bool_column(), bool_column())),
+            7,
+        );
+        assert_variant_tag(EVMDynProofExpr::Not(EVMNotExpr::new(bool_column())), 8);
+        assert_variant_tag(
+            EVMDynProofExpr::Cast(EVMCastExpr::new(column(), ColumnType::BigInt)),
+            9,
+        );
+
+        let (lhs, rhs) = binary_args();
+        assert_variant_tag(
+            EVMDynProofExpr::Inequality(EVMInequalityExpr::new(lhs, rhs, true)),
+            10,
+        );
+        assert_variant_tag(
+            EVMDynProofExpr::Placeholder(EVMPlaceholderExpr {
+                index: 0,
+                column_type: ColumnType::Boolean,
+            }),
+            11,
+        );
+        assert_variant_tag(
+            EVMDynProofExpr::ScalingCast(EVMScalingCastExpr::new(
+                column(),
+                ColumnType::Decimal75(Precision::new(15).unwrap(), 2),
+                [0, 0, 0, 100],
+            )),
+            12,
+        );
+        assert_variant_tag(
+            EVMDynProofExpr::IsNull(EVMIsNullExpr::new(column(), false)),
+            13,
+        );
+    }
+
+    #[test]
     fn we_can_catch_evm_literal_expr_serialization_change() {
         let literal_values = vec![
             LiteralValue::Boolean(true),

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -1,6 +1,6 @@
 use super::{
-    AddExpr, AndExpr, CastExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr, MultiplyExpr,
-    NotExpr, OrExpr, PlaceholderExpr, ProofExpr, ScalingCastExpr, SubtractExpr,
+    AddExpr, AndExpr, CastExpr, ColumnExpr, EqualsExpr, InequalityExpr, IsNullExpr, LiteralExpr,
+    MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ProofExpr, ScalingCastExpr, SubtractExpr,
 };
 use crate::{
     base::{
@@ -32,6 +32,8 @@ pub enum DynProofExpr {
     Or(OrExpr),
     /// Provable logical NOT expression
     Not(NotExpr),
+    /// Provable `IS NULL` or `IS NOT NULL` expression
+    IsNull(IsNullExpr),
     /// Provable CONST expression
     Literal(LiteralExpr),
     /// Provable placeholder expression
@@ -68,6 +70,14 @@ impl DynProofExpr {
     /// Create logical NOT expression
     pub fn try_new_not(expr: DynProofExpr) -> AnalyzeResult<Self> {
         NotExpr::try_new(Box::new(expr)).map(DynProofExpr::Not)
+    }
+    /// Create an `IS NULL` expression over a nullable-column validity mask
+    pub fn try_new_is_null(validity_expr: DynProofExpr) -> AnalyzeResult<Self> {
+        IsNullExpr::try_new(Box::new(validity_expr), false).map(DynProofExpr::IsNull)
+    }
+    /// Create an `IS NOT NULL` expression over a nullable-column validity mask
+    pub fn try_new_is_not_null(validity_expr: DynProofExpr) -> AnalyzeResult<Self> {
+        IsNullExpr::try_new(Box::new(validity_expr), true).map(DynProofExpr::IsNull)
     }
     /// Create CONST expression
     #[must_use]

--- a/crates/proof-of-sql/src/sql/proof_exprs/is_null_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/is_null_expr.rs
@@ -1,0 +1,129 @@
+use super::{DynProofExpr, ProofExpr};
+use crate::{
+    base::{
+        database::{can_not_type, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        map::{IndexMap, IndexSet},
+        proof::{PlaceholderResult, ProofError},
+        scalar::Scalar,
+    },
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        AnalyzeError, AnalyzeResult,
+    },
+    utils::log,
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
+
+/// Provable `IS NULL` or `IS NOT NULL` expression over a nullable-column validity mask.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IsNullExpr {
+    validity_expr: Box<DynProofExpr>,
+    is_not_null: bool,
+}
+
+impl IsNullExpr {
+    /// Create an `IS NULL` or `IS NOT NULL` expression from a boolean validity expression.
+    pub fn try_new(validity_expr: Box<DynProofExpr>, is_not_null: bool) -> AnalyzeResult<Self> {
+        let expr_type = validity_expr.data_type();
+        can_not_type(expr_type)
+            .then_some(Self {
+                validity_expr,
+                is_not_null,
+            })
+            .ok_or(AnalyzeError::InvalidDataType { expr_type })
+    }
+
+    /// Get the input validity expression.
+    pub fn validity_expr(&self) -> &DynProofExpr {
+        &self.validity_expr
+    }
+
+    /// Return true for `IS NOT NULL`, false for `IS NULL`.
+    pub fn is_not_null(&self) -> bool {
+        self.is_not_null
+    }
+
+    fn evaluate_validity<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        validity_column: Column<'a, S>,
+    ) -> Column<'a, S> {
+        let validity = validity_column
+            .as_boolean()
+            .expect("validity expression is not boolean");
+        if self.is_not_null {
+            Column::Boolean(validity)
+        } else {
+            Column::Boolean(alloc.alloc_slice_fill_with(validity.len(), |i| !validity[i]))
+        }
+    }
+}
+
+impl ProofExpr for IsNullExpr {
+    fn data_type(&self) -> ColumnType {
+        ColumnType::Boolean
+    }
+
+    #[tracing::instrument(name = "IsNullExpr::first_round_evaluate", level = "debug", skip_all)]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        log::log_memory_usage("Start");
+
+        let validity_column = self
+            .validity_expr
+            .first_round_evaluate(alloc, table, params)?;
+        let res = self.evaluate_validity(alloc, validity_column);
+
+        log::log_memory_usage("End");
+
+        Ok(res)
+    }
+
+    #[tracing::instrument(name = "IsNullExpr::final_round_evaluate", level = "debug", skip_all)]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        log::log_memory_usage("Start");
+
+        let validity_column = self
+            .validity_expr
+            .final_round_evaluate(builder, alloc, table, params)?;
+        let res = self.evaluate_validity(alloc, validity_column);
+
+        log::log_memory_usage("End");
+
+        Ok(res)
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<S, ProofError> {
+        let validity_eval = self
+            .validity_expr
+            .verifier_evaluate(builder, accessor, chi_eval, params)?;
+        if self.is_not_null {
+            Ok(validity_eval)
+        } else {
+            Ok(chi_eval - validity_eval)
+        }
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.validity_expr.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/is_null_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/is_null_expr_test.rs
@@ -1,0 +1,111 @@
+use crate::{
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        database::{
+            owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
+            TableRef, TableTestAccessor, TestAccessor,
+        },
+    },
+    sql::{
+        proof::VerifiableQueryResult,
+        proof_exprs::{is_null_expr::IsNullExpr, test_utility::*, ProofExpr},
+        proof_plans::test_utility::*,
+        AnalyzeError,
+    },
+};
+use bumpalo::Bump;
+
+#[test]
+fn we_can_compute_is_null_from_validity_using_first_round_evaluate() {
+    let alloc = Bump::new();
+    let data = table([
+        borrowed_bigint("score_value", [10, 0, 30], &alloc),
+        borrowed_boolean("score_valid", [true, false, true], &alloc),
+    ]);
+    let t = TableRef::new("sxt", "nullable_scores");
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    accessor.add_table(t.clone(), data.clone(), 0);
+
+    let expr = is_null(column(&t, "score_valid", &accessor));
+    let res = expr.first_round_evaluate(&alloc, &data, &[]).unwrap();
+
+    assert_eq!(res, Column::Boolean(&[false, true, false]));
+}
+
+#[test]
+fn we_can_prove_is_null_and_is_not_null_filters_over_validity_mask() {
+    let data = owned_table([
+        bigint("score_value", [10_i64, 0, 30]),
+        boolean("score_valid", [true, false, true]),
+    ]);
+    let t = TableRef::new("sxt", "nullable_scores");
+    let accessor =
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
+
+    let null_rows_ast = filter(
+        cols_expr_plan(&t, &["score_value", "score_valid"], &accessor),
+        table_exec(
+            t.clone(),
+            vec![
+                column_field("score_value", ColumnType::BigInt),
+                column_field("score_valid", ColumnType::Boolean),
+            ],
+        ),
+        is_null(column(&t, "score_valid", &accessor)),
+    );
+    let null_rows =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&null_rows_ast, &accessor, &(), &[])
+            .unwrap();
+    assert_eq!(
+        null_rows
+            .verify(&null_rows_ast, &accessor, &(), &[])
+            .unwrap()
+            .table,
+        owned_table([
+            bigint("score_value", [0_i64]),
+            boolean("score_valid", [false])
+        ])
+    );
+
+    let not_null_rows_ast = filter(
+        cols_expr_plan(&t, &["score_value", "score_valid"], &accessor),
+        table_exec(
+            t.clone(),
+            vec![
+                column_field("score_value", ColumnType::BigInt),
+                column_field("score_valid", ColumnType::Boolean),
+            ],
+        ),
+        is_not_null(column(&t, "score_valid", &accessor)),
+    );
+    let not_null_rows =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&not_null_rows_ast, &accessor, &(), &[])
+            .unwrap();
+    assert_eq!(
+        not_null_rows
+            .verify(&not_null_rows_ast, &accessor, &(), &[])
+            .unwrap()
+            .table,
+        owned_table([
+            bigint("score_value", [10_i64, 30]),
+            boolean("score_valid", [true, true])
+        ])
+    );
+}
+
+#[test]
+fn we_cannot_apply_is_null_to_non_boolean_expression() {
+    let alloc = Bump::new();
+    let data = table([borrowed_bigint("score_value", [10_i64, 0, 30], &alloc)]);
+    let t = TableRef::new("sxt", "nullable_scores");
+    let accessor =
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
+    let expr = Box::new(column(&t, "score_value", &accessor));
+
+    let err = IsNullExpr::try_new(expr, false).unwrap_err();
+
+    assert!(matches!(
+        err,
+        AnalyzeError::InvalidDataType { expr_type: _ }
+    ));
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -53,6 +53,11 @@ pub(crate) use not_expr::NotExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod not_expr_test;
 
+mod is_null_expr;
+pub(crate) use is_null_expr::IsNullExpr;
+#[cfg(test)]
+mod is_null_expr_test;
+
 mod numerical_util;
 pub(crate) use numerical_util::{add_subtract_columns, multiply_columns};
 #[cfg(test)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -65,6 +65,20 @@ pub fn not(expr: DynProofExpr) -> DynProofExpr {
 
 /// # Panics
 /// Panics if:
+/// - `DynProofExpr::try_new_is_null()` returns an error.
+pub fn is_null(expr: DynProofExpr) -> DynProofExpr {
+    DynProofExpr::try_new_is_null(expr).unwrap()
+}
+
+/// # Panics
+/// Panics if:
+/// - `DynProofExpr::try_new_is_not_null()` returns an error.
+pub fn is_not_null(expr: DynProofExpr) -> DynProofExpr {
+    DynProofExpr::try_new_is_not_null(expr).unwrap()
+}
+
+/// # Panics
+/// Panics if:
 /// - `DynProofExpr::try_new_and()` returns an error.
 pub fn and(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_and(left, right).unwrap()

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -119,6 +119,8 @@ uint32 constant INEQUALITY_EXPR_VARIANT = 10;
 uint32 constant PLACEHOLDER_EXPR_VARIANT = 11;
 /// @dev Scaling cast variant constant for proof expressions
 uint32 constant SCALING_CAST_EXPR_VARIANT = 12;
+/// @dev Is null variant constant for proof expressions
+uint32 constant IS_NULL_EXPR_VARIANT = 13;
 
 /// @dev Legacy Filter variant constant for proof plans
 uint32 constant LEGACY_FILTER_EXEC_VARIANT = 0;

--- a/solidity/src/proof_exprs/IsNullExpr.presl
+++ b/solidity/src/proof_exprs/IsNullExpr.presl
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.26;
+
+import "../base/Constants.sol";
+import "../base/Errors.sol";
+import {VerificationBuilder} from "../builder/VerificationBuilder.presl";
+
+/// @title IsNullExpr
+/// @dev Library for handling IS NULL and IS NOT NULL proof expressions
+library IsNullExpr {
+    /// @notice Evaluates an IS NULL expression from a boolean validity sub-expression
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// is_null_expr_evaluate(expr_ptr, builder_ptr, chi_eval, accessor) -> expr_ptr_out, eval
+    /// ```
+    /// ##### Parameters
+    /// * `expr_ptr` - calldata pointer to the expression data
+    /// * `builder_ptr` - memory pointer to the verification builder
+    /// * `chi_eval` - the chi value for evaluation
+    /// * `accessor` - memory pointer to the collection of evals
+    /// ##### Return Values
+    /// * `expr_ptr_out` - pointer to the remaining expression after consuming the expression
+    /// * `eval` - the evaluation result
+    /// ##### Proof Plan Encoding
+    /// The is null expression is encoded as follows:
+    /// 1. The validity sub-expression, where true means the row is not null
+    /// 2. Whether the expression is IS NOT NULL, as a bool
+    /// @param __expr The is null expression data
+    /// @param __builder The verification builder
+    /// @param __chiEval The chi value for evaluation
+    /// @param __accessor The collection of evals
+    /// @return __exprOut The remaining expression after processing
+    /// @return __builderOut The verification builder result
+    /// @return __eval The evaluated result
+    function __isNullExprEvaluate( // solhint-disable-line gas-calldata-parameters
+    bytes calldata __expr, VerificationBuilder.Builder memory __builder, uint256 __chiEval, uint256[] memory __accessor)
+        external
+        pure
+        returns (bytes calldata __exprOut, VerificationBuilder.Builder memory __builderOut, uint256 __eval)
+    {
+        assembly {
+            // import submod_bn254 from ../base/MathUtil.presl
+            // import proof_expr_evaluate from ProofExpr.presl
+
+            function is_null_expr_evaluate(expr_ptr, builder_ptr, chi_eval, accessor) -> expr_ptr_out, result_eval {
+                let validity_eval
+                expr_ptr, validity_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval, accessor)
+
+                let is_not_null := shr(BOOLEAN_PADDING_BITS, calldataload(expr_ptr))
+                expr_ptr := add(expr_ptr, BOOLEAN_SIZE)
+
+                result_eval := validity_eval
+                if iszero(is_not_null) { result_eval := submod_bn254(chi_eval, validity_eval) }
+
+                expr_ptr_out := expr_ptr
+            }
+
+            let __exprOutOffset
+            __exprOutOffset, __eval := is_null_expr_evaluate(__expr.offset, __builder, __chiEval, __accessor)
+            __exprOut.offset := __exprOutOffset
+            // slither-disable-next-line write-after-write
+            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+        }
+        __builderOut = __builder;
+    }
+}

--- a/solidity/src/proof_exprs/ProofExpr.presl
+++ b/solidity/src/proof_exprs/ProofExpr.presl
@@ -22,7 +22,8 @@ library ProofExpr {
         Cast,
         Inequality,
         Placeholder,
-        ScalingCast
+        ScalingCast,
+        IsNull
     }
 
     /// @notice Evaluates a proof expression
@@ -77,6 +78,7 @@ library ProofExpr {
             // import inequality_expr_evaluate from InequalityExpr.presl
             // import placeholder_expr_evaluate from PlaceholderExpr.presl
             // import scaling_cast_expr_evaluate from ScalingCastExpr.presl
+            // import is_null_expr_evaluate from IsNullExpr.presl
 
             // slither-disable-start cyclomatic-complexity
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval, accessor) -> expr_ptr_out, eval {
@@ -135,6 +137,10 @@ library ProofExpr {
                 case 12 {
                     case_const(12, SCALING_CAST_EXPR_VARIANT)
                     expr_ptr_out, eval := scaling_cast_expr_evaluate(expr_ptr, builder_ptr, chi_eval, accessor)
+                }
+                case 13 {
+                    case_const(13, IS_NULL_EXPR_VARIANT)
+                    expr_ptr_out, eval := is_null_expr_evaluate(expr_ptr, builder_ptr, chi_eval, accessor)
                 }
                 default { err(ERR_UNSUPPORTED_PROOF_EXPR_VARIANT) }
             }

--- a/solidity/test/proof_exprs/IsNullExpr.t.presl
+++ b/solidity/test/proof_exprs/IsNullExpr.t.presl
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.presl";
+import {IsNullExpr} from "../../src/proof_exprs/IsNullExpr.presl";
+import {F} from "../base/FieldUtil.sol";
+
+contract IsNullExprTest is Test {
+    function testSimpleIsNullExpr() public pure {
+        bytes memory expr = abi.encodePacked(abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(0)), false, hex"abcdef");
+        bytes memory expectedExprOut = hex"abcdef";
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](1);
+        values[0] = 4;
+
+        uint256 eval;
+        (expr, builder, eval) = IsNullExpr.__isNullExprEvaluate(expr, builder, 10, values);
+
+        assert(eval == 6);
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testSimpleIsNotNullExpr() public pure {
+        bytes memory expr = abi.encodePacked(abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(0)), true, hex"abcdef");
+        bytes memory expectedExprOut = hex"abcdef";
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](1);
+        values[0] = 4;
+
+        uint256 eval;
+        (expr, builder, eval) = IsNullExpr.__isNullExprEvaluate(expr, builder, 10, values);
+
+        assert(eval == 4);
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testFuzzIsNullExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        uint256 validityEvaluation,
+        bool isNotNull,
+        bytes memory trailingExpr
+    ) public pure {
+        uint256[] memory values = new uint256[](1);
+        values[0] = validityEvaluation;
+        bytes memory expr = abi.encodePacked(abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(0)), isNotNull, trailingExpr);
+
+        uint256 eval;
+        (expr, builder, eval) = IsNullExpr.__isNullExprEvaluate(expr, builder, chiEvaluation, values);
+
+        uint256 expected =
+            isNotNull ? validityEvaluation : (F.from(chiEvaluation) - F.from(validityEvaluation)).into();
+        assert(eval == expected);
+        assert(expr.length == trailingExpr.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+}

--- a/solidity/test/proof_exprs/ProofExpr.t.presl
+++ b/solidity/test/proof_exprs/ProofExpr.t.presl
@@ -266,6 +266,52 @@ contract ProofExprTest is Test {
         }
     }
 
+    function testIsNullExprVariant() public pure {
+        VerificationBuilder.Builder memory builder;
+        bytes memory expr = abi.encodePacked(
+            IS_NULL_EXPR_VARIANT,
+            abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(0)),
+            false,
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+        uint256[] memory values = new uint256[](1);
+        values[0] = 4;
+
+        uint256 eval;
+        (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 10, values);
+
+        assert(eval == 6);
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testIsNotNullExprVariant() public pure {
+        VerificationBuilder.Builder memory builder;
+        bytes memory expr = abi.encodePacked(
+            IS_NULL_EXPR_VARIANT,
+            abi.encodePacked(COLUMN_EXPR_VARIANT, uint64(0)),
+            true,
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+        uint256[] memory values = new uint256[](1);
+        values[0] = 4;
+
+        uint256 eval;
+        (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 10, values);
+
+        assert(eval == 4);
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
     function testInequalityExprVariant() public pure {
         bytes memory expr = abi.encodePacked(
             INEQUALITY_EXPR_VARIANT,
@@ -381,5 +427,6 @@ contract ProofExprTest is Test {
         assert(uint32(ProofExpr.ExprVariant.Inequality) == INEQUALITY_EXPR_VARIANT);
         assert(uint32(ProofExpr.ExprVariant.Placeholder) == PLACEHOLDER_EXPR_VARIANT);
         assert(uint32(ProofExpr.ExprVariant.ScalingCast) == SCALING_CAST_EXPR_VARIANT);
+        assert(uint32(ProofExpr.ExprVariant.IsNull) == IS_NULL_EXPR_VARIANT);
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

#183 scopes nullable columns as a physical value column plus a boolean presence/validity column. PR #1288 adds a small base/database nullable bigint PoC. This PR takes the next non-overlapping `sql/proof_exprs` step: make `IS NULL` and `IS NOT NULL` first-class proof expressions over that validity mask instead of requiring planner/tests to hand-write `NOT(validity)` or raw validity predicates.

This is intentionally incremental. It gives parser/planner work a stable proof-expression target once nullable metadata is available, and the latest follow-up connects DataFusion planner `Expr::IsNull` / `Expr::IsNotNull` to these proof-expression paths.

/claim #183

Refs #183

# What changes are included in this PR?

- Added `IsNullExpr` for `IS NULL` / `IS NOT NULL` over a boolean validity expression.
- Wired the new variant through `DynProofExpr` constructors and test helpers.
- Added EVM proof-plan serialization/deserialization support for the new expression variant while preserving existing bincode discriminants.
- Added CPU-friendly `NaiveEvaluationProof` coverage for first-round validity evaluation, null/non-null filtering, and invalid non-boolean inputs.
- Added EVM conversion coverage for `IS NULL`, `IS NOT NULL`, and nested boolean validity expressions.
- Connected DataFusion planner `Expr::IsNull` and `Expr::IsNotNull` to the new proof-expression constructors and column-ident extraction.

# Are these changes tested?

Yes.

```sh
source scripts/check_commits.sh
PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check
PATH="$HOME/.cargo/bin:$PATH" cargo test -p proof-of-sql --no-default-features --features="test" is_null
PATH="$HOME/.cargo/bin:$PATH" cargo check -p proof-of-sql --no-default-features --features="test"
git diff --check
```

Notes:
- `source scripts/check_commits.sh` passes: 3 commits checked, 0 failures.
- Focused `is_null` tests passed locally, including the EVM conversion follow-ups.
- The `blitzar` feature could not be run locally because `blitzar-sys` reports Linux-only support on macOS.
- GitHub Actions for `CI-Lint-And-Test` and `CI-Code-Coverage` still need maintainer approval on this fork PR before full CI/coverage evidence is available.
