### PR TITLE
test: cover filter base proof gadget paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -150,3 +150,98 @@ pub(crate) fn final_round_filter_constraints<'a, S: Scalar + 'a>(
         ],
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{final_round_evaluate_filter, verify_evaluate_filter};
+    use crate::{
+        base::{
+            database::Column,
+            proof::{ProofError, ProofSizeMismatch},
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
+    };
+    use bumpalo::Bump;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn we_can_verify_filter_base_constraints() {
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            vec![vec![TestScalar::ONE, TestScalar::from(3u64)]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        verify_evaluate_filter(
+            &mut builder,
+            TestScalar::from(2u64),
+            TestScalar::ZERO,
+            TestScalar::from(3u64),
+            TestScalar::from(3u64),
+            TestScalar::from(3u64),
+        )
+        .unwrap();
+
+        assert_eq!(builder.get_identity_results(), vec![vec![true, true, true]]);
+        assert_eq!(builder.get_zero_sum_results(), vec![true]);
+    }
+
+    #[test]
+    fn verifier_errors_when_filter_base_has_too_few_final_round_mles() {
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            vec![vec![TestScalar::ONE]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let error = verify_evaluate_filter(
+            &mut builder,
+            TestScalar::from(2u64),
+            TestScalar::ZERO,
+            TestScalar::from(3u64),
+            TestScalar::from(3u64),
+            TestScalar::from(3u64),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewMLEEvaluations
+            }
+        ));
+    }
+
+    #[test]
+    fn final_round_evaluate_filter_produces_mles_and_constraints() {
+        let alloc = Bump::new();
+        let columns = [Column::Int128::<TestScalar>(&[1, 2, 3])];
+        let filtered_columns = [Column::Int128::<TestScalar>(&[1, 3])];
+        let selection = &[true, false, true];
+        let mut builder = FinalRoundBuilder::new(columns.len(), VecDeque::new());
+
+        final_round_evaluate_filter(
+            &mut builder,
+            &alloc,
+            TestScalar::from(2u64),
+            TestScalar::from(3u64),
+            &columns,
+            selection,
+            &filtered_columns,
+            3,
+            2,
+        );
+
+        assert_eq!(builder.pcs_proof_mles().len(), 2);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 4);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -157,12 +157,17 @@ mod tests {
     use crate::{
         base::{
             database::Column,
+            math::log2_up,
             proof::{ProofError, ProofSizeMismatch},
             scalar::{test_scalar::TestScalar, Scalar},
         },
-        sql::proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
+        sql::proof::{
+            mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder,
+            SumcheckSubpolynomialType,
+        },
     };
     use bumpalo::Bump;
+    use num_traits::Inv;
     use std::collections::VecDeque;
 
     #[test]
@@ -227,7 +232,7 @@ mod tests {
         let columns = [Column::Int128::<TestScalar>(&[1, 2, 3])];
         let filtered_columns = [Column::Int128::<TestScalar>(&[1, 3])];
         let selection = &[true, false, true];
-        let mut builder = FinalRoundBuilder::new(columns.len(), VecDeque::new());
+        let mut builder = FinalRoundBuilder::new(log2_up(selection.len()).max(1), VecDeque::new());
 
         final_round_evaluate_filter(
             &mut builder,
@@ -241,7 +246,62 @@ mod tests {
             2,
         );
 
-        assert_eq!(builder.pcs_proof_mles().len(), 2);
-        assert_eq!(builder.num_sumcheck_subpolynomials(), 4);
+        let inverse = |value| TestScalar::from(value).inv().unwrap();
+        let sumcheck_variables = builder.num_sumcheck_variables();
+        assert_eq!(
+            builder.pcs_proof_mles()[0].to_sumcheck_term(sumcheck_variables),
+            vec![
+                inverse(3u64),
+                inverse(5u64),
+                inverse(7u64),
+                TestScalar::ZERO
+            ]
+        );
+        assert_eq!(
+            builder.pcs_proof_mles()[1].to_sumcheck_term(sumcheck_variables),
+            vec![
+                inverse(3u64),
+                inverse(7u64),
+                TestScalar::ZERO,
+                TestScalar::ZERO
+            ]
+        );
+
+        let subpolynomial_term_shapes: Vec<Vec<_>> = builder
+            .sumcheck_subpolynomials()
+            .iter()
+            .map(|subpolynomial| {
+                subpolynomial
+                    .iter_mul_by(TestScalar::ONE)
+                    .map(|(subpolynomial_type, coefficient, multiplicands)| {
+                        (subpolynomial_type, coefficient, multiplicands.len())
+                    })
+                    .collect()
+            })
+            .collect();
+
+        assert_eq!(
+            subpolynomial_term_shapes,
+            vec![
+                vec![
+                    (SumcheckSubpolynomialType::Identity, TestScalar::ONE, 1),
+                    (SumcheckSubpolynomialType::Identity, TestScalar::ONE, 2),
+                    (SumcheckSubpolynomialType::Identity, -TestScalar::ONE, 1),
+                ],
+                vec![
+                    (SumcheckSubpolynomialType::Identity, TestScalar::ONE, 1),
+                    (SumcheckSubpolynomialType::Identity, TestScalar::ONE, 2),
+                    (SumcheckSubpolynomialType::Identity, -TestScalar::ONE, 1),
+                ],
+                vec![
+                    (SumcheckSubpolynomialType::ZeroSum, TestScalar::ONE, 2),
+                    (SumcheckSubpolynomialType::ZeroSum, -TestScalar::ONE, 1),
+                ],
+                vec![
+                    (SumcheckSubpolynomialType::Identity, TestScalar::ONE, 2),
+                    (SumcheckSubpolynomialType::Identity, -TestScalar::ONE, 1),
+                ],
+            ]
+        );
     }
 }


### PR DESCRIPTION
/claim #560

Adds a second focused, non-overlapping coverage slice for the filter proof gadget base helpers:
- verifies `verify_evaluate_filter` produces satisfied identity and zero-sum constraints for a deterministic row
- verifies incomplete final-round MLE evaluations surface `ProofSizeMismatch`
- verifies `final_round_evaluate_filter` records the expected intermediate MLEs and four filter constraints

Verification:
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test filter_base`

Note: On Windows, default features cannot build because `blitzar-sys` rejects non-Linux hosts in its build script, so the focused tests were run with the repo's non-default test feature set.