### PR TITLE
test: cover fold log proof gadget paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
@@ -163,7 +163,7 @@ mod tests {
             Column::Int128::<TestScalar>(&[1, 2]),
             Column::Int128::<TestScalar>(&[3, 4]),
         ];
-        let chi = &[true, false];
+        let chi = &[true, true];
         let mut builder = FinalRoundBuilder::new(columns.len(), VecDeque::new());
 
         let (star, fold) =

--- a/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
@@ -83,3 +83,116 @@ impl<S: Scalar> FoldLogExpr<S> {
         self.final_round_evaluate_with_chi(builder, alloc, columns, length, chi)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FoldLogExpr;
+    use crate::{
+        base::{
+            database::Column,
+            proof::{ProofError, ProofSizeMismatch},
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::{
+            proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
+            proof_plans::fold_vals,
+        },
+    };
+    use bumpalo::Bump;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn we_can_verify_fold_log_constraint() {
+        let expr = FoldLogExpr::new(TestScalar::from(2u64), TestScalar::from(10u64));
+        let column_evals = [TestScalar::from(3u64), TestScalar::from(4u64)];
+        let expected_fold_eval =
+            TestScalar::from(2u64) * fold_vals(TestScalar::from(10u64), &column_evals);
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            vec![vec![TestScalar::ONE]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let (star_eval, fold_eval) = expr
+            .verify_evaluate(
+                &mut builder,
+                &column_evals,
+                expected_fold_eval + TestScalar::ONE,
+            )
+            .unwrap();
+
+        assert_eq!(star_eval, TestScalar::ONE);
+        assert_eq!(fold_eval, expected_fold_eval);
+        assert_eq!(builder.get_identity_results(), vec![vec![true]]);
+    }
+
+    #[test]
+    fn verifier_errors_when_fold_log_has_too_few_final_round_mles() {
+        let expr = FoldLogExpr::new(TestScalar::from(2u64), TestScalar::from(10u64));
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            vec![Vec::new()],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let error = expr
+            .verify_evaluate(&mut builder, &[TestScalar::ONE], TestScalar::ONE)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewMLEEvaluations
+            }
+        ));
+    }
+
+    #[test]
+    fn final_round_evaluate_with_chi_returns_fold_and_inverse_star_columns() {
+        let alloc = Bump::new();
+        let expr = FoldLogExpr::new(TestScalar::from(2u64), TestScalar::from(10u64));
+        let columns = [
+            Column::Int128::<TestScalar>(&[1, 2]),
+            Column::Int128::<TestScalar>(&[3, 4]),
+        ];
+        let chi = &[true, false];
+        let mut builder = FinalRoundBuilder::new(columns.len(), VecDeque::new());
+
+        let (star, fold) =
+            expr.final_round_evaluate_with_chi(&mut builder, &alloc, &columns, 2, chi);
+
+        assert_eq!(fold, &[TestScalar::from(26u64), TestScalar::from(48u64)]);
+        assert!(star
+            .iter()
+            .zip(fold.iter())
+            .all(
+                |(star_eval, fold_eval)| *star_eval * (*fold_eval + TestScalar::ONE)
+                    == TestScalar::ONE
+            ));
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+    }
+
+    #[test]
+    fn final_round_evaluate_uses_true_chi_column() {
+        let alloc = Bump::new();
+        let expr = FoldLogExpr::new(TestScalar::from(2u64), TestScalar::from(10u64));
+        let columns = [Column::Int128::<TestScalar>(&[1, 2])];
+        let mut builder = FinalRoundBuilder::new(columns.len(), VecDeque::new());
+
+        let (star, fold) = expr.final_round_evaluate(&mut builder, &alloc, &columns, 2);
+
+        assert_eq!(fold, &[TestScalar::from(2u64), TestScalar::from(4u64)]);
+        assert_eq!(star.len(), 2);
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+    }
+}


### PR DESCRIPTION
/claim #560

Adds another focused, non-overlapping coverage slice for `FoldLogExpr`:
- verifies `verify_evaluate` records a satisfied fold-log identity constraint
- verifies incomplete final-round MLE evaluations surface `ProofSizeMismatch`
- verifies final-round evaluation returns the expected fold column and inverse star column
- covers the `final_round_evaluate` wrapper that supplies the all-true chi column

Verification:
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test fold_log_expr`

Note: On Windows, default features cannot build because `blitzar-sys` rejects non-Linux hosts in its build script, so the focused tests were run with the repo's non-default test feature set.