### PR TITLE
test: cover encoding serialization helpers

### DIFF
--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -35,3 +35,44 @@ impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
         MontScalar::<T>::from_le_bytes_mod_order(&bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::U256;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn from_words_preserves_low_and_high_words() {
+        let value = U256::from_words(17, 23);
+
+        assert_eq!(value.low, 17);
+        assert_eq!(value.high, 23);
+    }
+
+    #[test]
+    fn we_can_convert_scalar_to_u256_words() {
+        let scalar = TestScalar::from_bigint([1, 2, 3, 4]);
+        let value = U256::from(&scalar);
+
+        assert_eq!(value.low, 1 | (2_u128 << 64));
+        assert_eq!(value.high, 3 | (4_u128 << 64));
+    }
+
+    #[test]
+    fn we_can_convert_u256_to_scalar_mod_order() {
+        let value = U256::from_words(5 | (6_u128 << 64), 7 | (8_u128 << 64));
+        let expected = TestScalar::from_le_bytes_mod_order(
+            &[value.low.to_le_bytes(), value.high.to_le_bytes()].concat(),
+        );
+
+        assert_eq!(TestScalar::from(&value), expected);
+    }
+
+    #[test]
+    fn u256_scalar_conversion_round_trips_canonical_scalar() {
+        let scalar = TestScalar::from(123_456_789_u64);
+        let value = U256::from(&scalar);
+
+        assert_eq!(TestScalar::from(&value), scalar);
+    }
+}

--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,32 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Deserialize, Serialize)]
+    struct LimbsJson(
+        #[serde(
+            deserialize_with = "deserialize_to_limbs",
+            serialize_with = "serialize_limbs"
+        )]
+        [u64; 4],
+    );
+
+    #[test]
+    fn serialize_limbs_reverses_limb_order() {
+        let serialized = serde_json::to_string(&LimbsJson([1, 2, 3, 4])).unwrap();
+
+        assert_eq!(serialized, "[4,3,2,1]");
+    }
+
+    #[test]
+    fn deserialize_to_limbs_restores_internal_limb_order() {
+        let deserialized: LimbsJson = serde_json::from_str("[4,3,2,1]").unwrap();
+
+        assert_eq!(deserialized.0, [1, 2, 3, 4]);
+    }
+}


### PR DESCRIPTION
## Summary
- add direct unit coverage for `U256` word/scalar conversions
- add direct unit coverage for limb serde order reversal helpers

## Validation
- `cargo fmt --check`
- `git diff --check -- crates/proof-of-sql/src/base/encode/u256.rs crates/proof-of-sql/src/base/standard_serializations/limbs.rs`
- `cargo test -p proof-of-sql u256 --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"`
- `cargo test -p proof-of-sql limbs --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm" --text --output-path /tmp/bounty-pr002-current-u256.txt -- u256`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm" --no-clean --text --output-path /tmp/bounty-pr002-current-limbs.txt -- limbs`

/claim #560