### PR TITLE
test: cover membership verifier paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
@@ -132,3 +132,74 @@ pub(crate) fn verify_membership_check<S: Scalar>(
 
     Ok(multiplicity_eval)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::verify_membership_check;
+    use crate::{
+        base::{
+            proof::ProofError,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::mock_verification_builder::MockVerificationBuilder,
+    };
+
+    #[test]
+    fn verifier_accepts_matching_folded_membership_evaluations() {
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            vec![vec![TestScalar::ONE]],
+            vec![vec![TestScalar::ONE, TestScalar::ONE]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let multiplicity_eval = verify_membership_check(
+            &mut builder,
+            TestScalar::ONE,
+            TestScalar::TEN,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            &[TestScalar::ZERO],
+            &[TestScalar::ZERO],
+        )
+        .unwrap();
+
+        assert_eq!(multiplicity_eval, TestScalar::ONE);
+        assert_eq!(builder.get_identity_results(), vec![vec![true, true]]);
+        assert_eq!(builder.get_zero_sum_results(), vec![true]);
+    }
+
+    #[test]
+    fn verifier_rejects_mismatched_source_and_candidate_column_counts() {
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let error = verify_membership_check(
+            &mut builder,
+            TestScalar::ONE,
+            TestScalar::TEN,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            &[TestScalar::ZERO],
+            &[TestScalar::ZERO, TestScalar::ONE],
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ProofError::VerificationError {
+                error: "The number of source and candidate columns should be equal"
+            }
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
@@ -177,8 +177,8 @@ mod tests {
         let mut builder = MockVerificationBuilder::new(
             Vec::new(),
             3,
-            Vec::new(),
-            Vec::new(),
+            vec![Vec::new()],
+            vec![Vec::new()],
             Vec::new(),
             Vec::new(),
             Vec::new(),


### PR DESCRIPTION
/claim #560

## Summary
- add direct unit coverage for `verify_membership_check` accepting matching folded membership evaluations
- add verifier coverage for rejecting mismatched source/candidate column counts before consuming proof data
- keep the slice isolated to membership-check verifier behavior

## Verification
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test membership_check::tests`

Both commands pass locally on Windows. The targeted cargo test passes with 2 tests.