### PR TITLE
test: cover monotonic verifier paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -124,7 +124,11 @@ impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
     }
 
     fn singleton_chi_evaluation(&self) -> S {
-        unimplemented!("No tests currently use this function")
+        if self.evaluation_row_index == 0 {
+            S::ONE
+        } else {
+            S::ZERO
+        }
     }
 
     fn rho_256_evaluation(&self) -> Option<S> {
@@ -407,10 +411,9 @@ mod tests {
         assert!(matches!(err, ProofSizeMismatch::TooFewMLEEvaluations));
     }
 
-    #[should_panic(expected = "No tests currently use this function")]
     #[test]
-    fn we_can_get_unimplemented_error_for_singleton_chi_evaluation() {
-        let verification_builder: MockVerificationBuilder<TestScalar> =
+    fn we_can_get_singleton_chi_evaluation() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
             MockVerificationBuilder::new(
                 Vec::new(),
                 2,
@@ -420,7 +423,15 @@ mod tests {
                 Vec::new(),
                 Vec::new(),
             );
-        verification_builder.singleton_chi_evaluation();
+        assert_eq!(
+            verification_builder.singleton_chi_evaluation(),
+            TestScalar::ONE
+        );
+        verification_builder.increment_row_index();
+        assert_eq!(
+            verification_builder.singleton_chi_evaluation(),
+            TestScalar::ZERO
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -134,3 +134,89 @@ pub(crate) fn verify_monotonic<S: Scalar, const STRICT: bool, const ASC: bool>(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic};
+    use crate::{
+        base::{
+            polynomial::MultilinearExtension,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::{
+            mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
+            FirstRoundBuilder,
+        },
+    };
+    use bumpalo::Bump;
+    use core::convert::identity;
+    use std::collections::VecDeque;
+
+    fn verify_monotonic_column<const STRICT: bool, const ASC: bool>(column_data: &[TestScalar]) {
+        let alloc = Bump::new();
+        let alpha = TestScalar::from(13);
+        let beta = TestScalar::from(29);
+
+        let mut first_round_builder = FirstRoundBuilder::new(column_data.len());
+        first_round_evaluate_monotonic(&mut first_round_builder, &alloc, column_data);
+
+        let mut final_round_builder = FinalRoundBuilder::new(2, VecDeque::new());
+        final_round_evaluate_monotonic::<TestScalar, STRICT, ASC>(
+            &mut final_round_builder,
+            &alloc,
+            alpha,
+            beta,
+            column_data,
+        );
+
+        let mock_verification_builder = run_verify_for_each_row(
+            column_data.len(),
+            &first_round_builder,
+            &final_round_builder,
+            Vec::new(),
+            3,
+            |verification_builder, chi_eval, evaluation_point| {
+                verify_monotonic::<TestScalar, STRICT, ASC>(
+                    verification_builder,
+                    alpha,
+                    beta,
+                    column_data.inner_product(evaluation_point),
+                    chi_eval,
+                )
+                .unwrap();
+            },
+        );
+
+        assert!(mock_verification_builder
+            .get_identity_results()
+            .iter()
+            .all(|v| v.iter().copied().all(identity)));
+        assert!(mock_verification_builder
+            .get_zero_sum_results()
+            .iter()
+            .copied()
+            .all(identity));
+    }
+
+    #[test]
+    fn we_can_verify_strictly_ascending_monotonic_column() {
+        let column_data = [
+            TestScalar::ONE,
+            TestScalar::TWO,
+            TestScalar::from(3),
+            TestScalar::from(5),
+        ];
+        verify_monotonic_column::<true, true>(&column_data);
+    }
+
+    #[test]
+    fn we_can_verify_non_strictly_descending_monotonic_column() {
+        let column_data = [
+            TestScalar::from(5),
+            TestScalar::from(3),
+            TestScalar::from(3),
+            TestScalar::ONE,
+        ];
+        verify_monotonic_column::<false, false>(&column_data);
+    }
+}


### PR DESCRIPTION
Refs #560

/claim #560

Summary:
- Implement `MockVerificationBuilder::singleton_chi_evaluation` for row-by-row verifier tests.
- Add monotonic verifier coverage for strict ascending and non-strict descending columns.
- Assert the generated identity and zero-sum constraints are satisfied.

Verification:
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test monotonic`
- `cargo test -p proof-of-sql --no-default-features --features test singleton_chi_evaluation`