### PR TITLE
test: cover ristretto commitment helper paths

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs
@@ -62,4 +62,22 @@ mod tests {
             commitment2.to_transcript_bytes()
         );
     }
+
+    #[test]
+    fn transcript_bytes_are_compressed_ristretto_bytes() {
+        assert_eq!(RISTRETTO_BASEPOINT_POINT.to_transcript_bytes().len(), 32);
+        assert_eq!(
+            RISTRETTO_BASEPOINT_POINT.to_transcript_bytes(),
+            RISTRETTO_BASEPOINT_POINT.compress().as_bytes()
+        );
+    }
+
+    #[cfg(not(feature = "blitzar"))]
+    #[test]
+    #[should_panic(expected = "not implemented")]
+    fn compute_commitments_panics_without_blitzar() {
+        let columns: &[CommittableColumn<'_>] = &[];
+
+        let _commitments = RistrettoPoint::compute_commitments(columns, 0, &());
+    }
 }


### PR DESCRIPTION
## Summary
- add direct coverage for Ristretto transcript byte serialization
- assert the non-blitzar commitment path fails explicitly on builds without the blitzar feature
- keep the slice isolated to `proof_primitive/inner_product/ristretto_point.rs`

/claim #560

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p proof-of-sql --no-default-features --features="std" ristretto -- --nocapture`
- `cargo llvm-cov --package proof-of-sql --no-default-features --features="std" --lib --summary-only -- ristretto` -> `ristretto_point.rs` 100.00% line coverage