### PR TITLE
test: cover result serialization and DDL parsing

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -206,6 +206,22 @@ mod tests {
     }
 
     #[test]
+    fn we_can_encode_and_decode_an_owned_string() {
+        let value = String::from("owned test string");
+        let mut out = vec![0_u8; value.required_bytes()];
+        value.encode(&mut out[..]);
+
+        let (decoded_value, read_bytes) = String::decode(&out[..]).unwrap();
+        assert_eq!(read_bytes, out.len());
+        assert_eq!(decoded_value, value);
+
+        let (converted_value, converted_bytes) =
+            decode_and_convert::<&str, String>(&out[..]).unwrap();
+        assert_eq!(converted_bytes, out.len());
+        assert_eq!(converted_value, value);
+    }
+
+    #[test]
     fn we_can_encode_and_decode_a_simple_array() {
         let value = &[1_u8, 3_u8, 5_u8][..];
         let mut out = vec![0_u8; value.required_bytes()];
@@ -392,6 +408,21 @@ mod tests {
     }
 
     #[test]
+    fn multiple_owned_string_rows_are_correctly_encoded_and_decoded() {
+        let data = [
+            String::from("abc1"),
+            String::from("joe123"),
+            String::from("testing435t"),
+        ];
+        let out = encode_multiple_rows(&data);
+        let (decoded_data, decoded_bytes) =
+            decode_multiple_elements::<String>(&out[..], data.len()).unwrap();
+
+        assert_eq!(decoded_data, data);
+        assert_eq!(decoded_bytes, out.len());
+    }
+
+    #[test]
     fn multiple_array_rows_are_correctly_encoded_and_decoded() {
         let data = [
             &[121_u8, 0_u8, 39_u8, 93_u8][..],
@@ -435,10 +466,12 @@ mod tests {
         value.encode(&mut out[..]);
 
         assert!(<&str>::decode(&out[..]).is_ok());
+        assert!(String::decode(&out[..]).is_ok());
 
         let last_element = out.len();
         out[last_element - 3..last_element].clone_from_slice(&[0xed, 0xa0, 0x80]);
         assert!(<&str>::decode(&out[..]).is_err());
+        assert!(String::decode(&out[..]).is_err());
     }
 
     #[test]

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,47 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn find_bigdecimals_ignores_decimal_columns_with_supported_precision() {
+        let sql = "CREATE TABLE PUBLIC.PRICES(
+            ID BIGINT NOT NULL,
+            NORMAL_AMOUNT DECIMAL(38, 2),
+            BIG_AMOUNT DECIMAL(39, 2),
+            UNSCALED_AMOUNT DECIMAL(78),
+            NAME VARCHAR
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+        assert_eq!(
+            bigdecimals.get("PUBLIC.PRICES").unwrap(),
+            &[("BIG_AMOUNT".to_string(), 39, 2)]
+        );
+    }
+
+    #[test]
+    fn find_bigdecimals_preserves_create_tables_without_bigdecimal_columns() {
+        let sql = "CREATE VIEW PUBLIC.PRICE_VIEW AS SELECT 1 AS ID;
+
+        CREATE TABLE PUBLIC.SMALL_DECIMALS(
+            ID BIGINT NOT NULL,
+            AMOUNT DECIMAL(10, 2)
+        );
+
+        CREATE TABLE PUBLIC.BIG_DECIMALS(
+            ID BIGINT NOT NULL,
+            AMOUNT DECIMAL(78, 2)
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+        assert!(!bigdecimals.contains_key("PUBLIC.PRICE_VIEW"));
+        assert_eq!(
+            bigdecimals.get("PUBLIC.SMALL_DECIMALS").unwrap(),
+            &Vec::<(String, u8, i8)>::new()
+        );
+        assert_eq!(
+            bigdecimals.get("PUBLIC.BIG_DECIMALS").unwrap(),
+            &[("AMOUNT".to_string(), 78, 2)]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add owned `String` serialization coverage for `ProvableResultElement`
- cover `find_bigdecimals` behavior for supported decimal precision, non-table statements, and tables with no bigdecimal columns

/claim #560

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" sql::proof::result_element_serialization` (30 passed)
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test" utils::parse` (3 passed)
- `cargo test -p proof-of-sql --lib --no-default-features --features "arrow,test"` (1057 passed)