### PR TITLE
ci: drop redundant proof-of-sql checks

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -53,33 +53,19 @@ jobs:
       - name: Run cargo check (proof-of-sql) (no features)
         run: cargo check -p proof-of-sql --no-default-features
       - name: Run cargo check (proof-of-sql) (all features)
-        run: |
-          cargo check -p proof-of-sql --all-features
-          cargo check -p proof-of-sql --all-targets --all-features
+        run: cargo check -p proof-of-sql --all-targets --all-features
       - name: Run cargo check (proof-of-sql) (just "test" feature)
-        run: |
-          cargo check -p proof-of-sql --no-default-features --features="test"
-          cargo check -p proof-of-sql --all-targets --no-default-features --features="test"
+        run: cargo check -p proof-of-sql --all-targets --no-default-features --features="test"
       - name: Run cargo check (proof-of-sql) (just "blitzar" feature)
-        run: |
-          cargo check -p proof-of-sql --no-default-features --features="blitzar"
-          cargo check -p proof-of-sql --all-targets --no-default-features --features="blitzar"
+        run: cargo check -p proof-of-sql --all-targets --no-default-features --features="blitzar"
       - name: Run cargo check (proof-of-sql) (just "arrow" feature)
-        run: |
-          cargo check -p proof-of-sql --no-default-features --features="arrow"
-          cargo check -p proof-of-sql --all-targets --no-default-features --features="arrow"
+        run: cargo check -p proof-of-sql --all-targets --no-default-features --features="arrow"
       - name: Run cargo check (proof-of-sql) (just "rayon" feature)
-        run: |
-          cargo check -p proof-of-sql --no-default-features --features="rayon"
-          cargo check -p proof-of-sql --all-targets --no-default-features --features="rayon"
+        run: cargo check -p proof-of-sql --all-targets --no-default-features --features="rayon"
       - name: Run cargo check (proof-of-sql) (just "perf" feature)
-        run: |
-          cargo check -p proof-of-sql --no-default-features --features="perf"
-          cargo check -p proof-of-sql --all-targets --no-default-features --features="perf"
+        run: cargo check -p proof-of-sql --all-targets --no-default-features --features="perf"
       - name: Run cargo check (proof-of-sql) (just "std" feature)
-        run: |
-          cargo check -p proof-of-sql --no-default-features --features="std"
-          cargo check -p proof-of-sql --all-targets --no-default-features --features="std"
+        run: cargo check -p proof-of-sql --all-targets --no-default-features --features="std"
       - name: Run cargo check (proof-of-sql) with no_std target.
         run: |
           rustup target add thumbv7em-none-eabi


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Issue #557 was clarified to include broad CI runtime improvements. The `check` job currently runs several `cargo check -p proof-of-sql ...` commands immediately before equivalent `cargo check -p proof-of-sql --all-targets ...` commands with the same feature set.

The `--all-targets` checks are the stricter/superset checks for those feature combinations, so the earlier package-only invocations add another Cargo process without increasing the validation surface.

/claim #557

# What changes are included in this PR?

- Drop the package-only `proof-of-sql` check before the `--all-targets --all-features` check.
- Drop the package-only `proof-of-sql` checks before the `--all-targets` checks for the `test`, `blitzar`, `arrow`, `rayon`, `perf`, and `std` feature-only lanes.
- Keep the existing `--all-targets` checks intact, so CI still checks the same feature combinations across all package targets.

# Are these changes tested?

Partially, with static/workflow validation plus local Cargo checks for the Windows-compatible retained lanes.

Static/workflow validation:

- `git diff --check origin/main...HEAD`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/lint-and-test.yml').read_text()); print('yaml ok')"`
- `bash -lc "tr -d '\r' < scripts/check_commits.sh | bash"`
- Verified every removed package-only command still has the corresponding retained `--all-targets` command for the same feature lane.

Local Cargo checks using `rustc 1.91.1` / `cargo 1.91.1`:

- `cargo +1.91.1 check -p proof-of-sql --no-default-features`
- `rustup +1.91.1 target add thumbv7em-none-eabi`
- `cargo +1.91.1 check -p proof-of-sql --target thumbv7em-none-eabi --no-default-features`
- `cargo +1.91.1 check -p proof-of-sql --all-targets --no-default-features --features="std"`
- `cargo +1.91.1 check -p proof-of-sql --all-targets --no-default-features --features="test"`
- `cargo +1.91.1 check -p proof-of-sql --all-targets --no-default-features --features="arrow"`
- `cargo +1.91.1 check -p proof-of-sql --all-targets --no-default-features --features="rayon"`

Windows limitation:

- `cargo +1.91.1 check -p proof-of-sql --all-targets --all-features`
- `cargo +1.91.1 check -p proof-of-sql --all-targets --no-default-features --features="perf"`

Those two reached `blitzar-sys v1.115.1` and stopped in its build script with `Unsupported OS. Only Linux is supported.` The retained Linux-only `blitzar`/`all-features`/`perf` lanes should be covered by project CI.
