### PR TITLE
test: cache Dory evaluation proof setups

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    cached_dory_setup, test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar,
+    DoryVerifierPublicSetup, ProverSetup, PublicParameters,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -8,45 +8,45 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_setup(4);
+    let prover_setup = setup.prover_setup();
+    let verifier_setup = setup.verifier_setup();
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_setup(6);
+    let prover_setup = setup.prover_setup();
+    let verifier_setup = setup.verifier_setup();
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_setup(4);
+    let prover_setup = setup.prover_setup();
+    let verifier_setup = setup.verifier_setup();
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_setup(6);
+    let prover_setup = setup.prover_setup();
+    let verifier_setup = setup.verifier_setup();
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
@@ -55,15 +55,15 @@ fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
     let setup_setup = [(4, 4), (4, 3), (6, 2)];
     for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let setup = cached_dory_setup(setup_p.0);
+        let prover_setup = setup.prover_setup();
+        let verifier_setup = setup.verifier_setup();
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
                 &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &DoryVerifierPublicSetup::new(verifier_setup, setup_p.1),
             );
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
+    cached_dory_setup, test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup,
+    PublicParameters,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -7,53 +8,52 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_setup(4);
+    let prover_setup = setup.prover_setup();
+    let verifier_setup = setup.verifier_setup();
     test_simple_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
         &&prover_setup,
-        &&verifier_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_setup(4);
+    let prover_setup = setup.prover_setup();
+    let verifier_setup = setup.verifier_setup();
     test_commitment_evaluation_proof_with_length_1::<DynamicDoryEvaluationProof>(
         &&prover_setup,
-        &&verifier_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 #[should_panic = "verification improperly failed"]
 fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_setup(6);
+    let prover_setup = setup.prover_setup();
+    let verifier_setup = cached_dory_setup(2).verifier_setup();
     test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
         128,
         0,
         &&prover_setup,
-        &&verifier_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_setup(6);
+    let prover_setup = setup.prover_setup();
+    let verifier_setup = setup.verifier_setup();
     for length in lengths {
         test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
             length,
             0,
             &&prover_setup,
-            &&verifier_setup,
+            &verifier_setup,
         );
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -39,6 +39,50 @@ mod setup;
 pub use setup::{ProverSetup, VerifierSetup};
 #[cfg(test)]
 mod setup_test;
+#[cfg(test)]
+mod test_setup {
+    use super::{test_rng, ProverSetup, PublicParameters, VerifierSetup};
+    use std::sync::LazyLock;
+
+    pub(crate) struct CachedDorySetup {
+        public_parameters: PublicParameters,
+        verifier_setup: VerifierSetup,
+    }
+
+    impl CachedDorySetup {
+        pub(crate) fn prover_setup(&'static self) -> ProverSetup<'static> {
+            ProverSetup::from(&self.public_parameters)
+        }
+
+        pub(crate) fn verifier_setup(&'static self) -> &'static VerifierSetup {
+            &self.verifier_setup
+        }
+    }
+
+    static SETUP_MAX_NU_2: LazyLock<CachedDorySetup> = LazyLock::new(|| new_cached_dory_setup(2));
+    static SETUP_MAX_NU_4: LazyLock<CachedDorySetup> = LazyLock::new(|| new_cached_dory_setup(4));
+    static SETUP_MAX_NU_6: LazyLock<CachedDorySetup> = LazyLock::new(|| new_cached_dory_setup(6));
+
+    fn new_cached_dory_setup(max_nu: usize) -> CachedDorySetup {
+        let public_parameters = PublicParameters::test_rand(max_nu, &mut test_rng());
+        let verifier_setup = VerifierSetup::from(&public_parameters);
+        CachedDorySetup {
+            public_parameters,
+            verifier_setup,
+        }
+    }
+
+    pub(crate) fn cached_dory_setup(max_nu: usize) -> &'static CachedDorySetup {
+        match max_nu {
+            2 => &SETUP_MAX_NU_2,
+            4 => &SETUP_MAX_NU_4,
+            6 => &SETUP_MAX_NU_6,
+            _ => panic!("cached dory setup max_nu {max_nu} is not configured"),
+        }
+    }
+}
+#[cfg(test)]
+pub(crate) use test_setup::cached_dory_setup;
 
 mod state;
 pub(crate) use state::{ProverState, VerifierState};


### PR DESCRIPTION
## Summary
- add a test-only cached Dory setup helper for common `max_nu` sizes
- reuse cached public parameters and verifier setup in Dory evaluation proof tests
- reduce repeated expensive setup generation while keeping prover setup borrowing local to each test

/claim #557

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql proof_primitive::dory::dynamic_dory_commitment_evaluation_proof_test --no-default-features --features="rayon test" --offline` (5 passed)
- `cargo test -p proof-of-sql proof_primitive::dory::dory_commitment_evaluation_proof_test --no-default-features --features="rayon test" --offline` (4 passed)
