### PR TITLE
test: cover boolean proof expression helpers

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -147,3 +147,80 @@ impl ProofExpr for AndExpr {
         self.rhs.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{Column, TableOptions},
+            map::IndexMap,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::mock_verification_builder::MockVerificationBuilder,
+    };
+    use alloc::collections::VecDeque;
+
+    fn empty_table(row_count: usize) -> Table<'static, TestScalar> {
+        Table::try_new_with_options(IndexMap::default(), TableOptions::new(Some(row_count)))
+            .unwrap()
+    }
+
+    fn bool_expr(value: bool) -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_literal(LiteralValue::Boolean(value)))
+    }
+
+    #[test]
+    fn try_new_accepts_boolean_inputs_and_exposes_children() {
+        let lhs = bool_expr(true);
+        let rhs = bool_expr(false);
+        let expr = AndExpr::try_new(lhs.clone(), rhs.clone()).unwrap();
+
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+        assert_eq!(expr.lhs(), lhs.as_ref());
+        assert_eq!(expr.rhs(), rhs.as_ref());
+    }
+
+    #[test]
+    fn first_and_final_round_evaluate_boolean_literals() {
+        let alloc = Bump::new();
+        let table = empty_table(3);
+        let expr = AndExpr::try_new(bool_expr(true), bool_expr(false)).unwrap();
+
+        let first_round = expr.first_round_evaluate(&alloc, &table, &[]).unwrap();
+        assert_eq!(first_round, Column::Boolean(&[false, false, false]));
+
+        let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+        let final_round = expr
+            .final_round_evaluate(&mut builder, &alloc, &table, &[])
+            .unwrap();
+        assert_eq!(final_round, Column::Boolean(&[false, false, false]));
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+    }
+
+    #[test]
+    fn verifier_evaluate_consumes_and_witness_and_checks_identity() {
+        let chi_eval = TestScalar::from(5u64);
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            vec![vec![TestScalar::ZERO]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let expr = AndExpr::try_new(bool_expr(true), bool_expr(false)).unwrap();
+
+        let result = expr
+            .verifier_evaluate(&mut builder, &IndexMap::default(), chi_eval, &[])
+            .unwrap();
+
+        assert_eq!(result, TestScalar::ZERO);
+        assert_eq!(
+            builder.identity_subpolynomial_evaluations,
+            vec![vec![TestScalar::ZERO]]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -99,3 +99,74 @@ impl ProofExpr for NotExpr {
         self.expr.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{Column, TableOptions},
+            map::IndexMap,
+            scalar::test_scalar::TestScalar,
+        },
+        sql::proof::mock_verification_builder::MockVerificationBuilder,
+    };
+    use alloc::collections::VecDeque;
+
+    fn empty_table(row_count: usize) -> Table<'static, TestScalar> {
+        Table::try_new_with_options(IndexMap::default(), TableOptions::new(Some(row_count)))
+            .unwrap()
+    }
+
+    fn bool_expr(value: bool) -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_literal(LiteralValue::Boolean(value)))
+    }
+
+    #[test]
+    fn try_new_accepts_boolean_input_and_exposes_child() {
+        let input = bool_expr(true);
+        let expr = NotExpr::try_new(input.clone()).unwrap();
+
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+        assert_eq!(expr.input(), input.as_ref());
+    }
+
+    #[test]
+    fn first_and_final_round_evaluate_boolean_literal() {
+        let alloc = Bump::new();
+        let table = empty_table(3);
+        let expr = NotExpr::try_new(bool_expr(true)).unwrap();
+
+        let first_round = expr.first_round_evaluate(&alloc, &table, &[]).unwrap();
+        assert_eq!(first_round, Column::Boolean(&[false, false, false]));
+
+        let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+        let final_round = expr
+            .final_round_evaluate(&mut builder, &alloc, &table, &[])
+            .unwrap();
+        assert_eq!(final_round, Column::Boolean(&[false, false, false]));
+        assert!(builder.pcs_proof_mles().is_empty());
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 0);
+    }
+
+    #[test]
+    fn verifier_evaluate_subtracts_input_from_chi() {
+        let chi_eval = TestScalar::from(9u64);
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            0,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let expr = NotExpr::try_new(bool_expr(false)).unwrap();
+
+        let result = expr
+            .verifier_evaluate(&mut builder, &IndexMap::default(), chi_eval, &[])
+            .unwrap();
+
+        assert_eq!(result, chi_eval);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -184,3 +184,92 @@ pub fn verifier_evaluate_or<S: Scalar>(
     // selection
     Ok(*lhs + *rhs - lhs_and_rhs)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{Column, TableOptions},
+            map::IndexMap,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::mock_verification_builder::MockVerificationBuilder,
+    };
+    use alloc::collections::VecDeque;
+
+    fn empty_table(row_count: usize) -> Table<'static, TestScalar> {
+        Table::try_new_with_options(IndexMap::default(), TableOptions::new(Some(row_count)))
+            .unwrap()
+    }
+
+    fn bool_expr(value: bool) -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_literal(LiteralValue::Boolean(value)))
+    }
+
+    #[test]
+    fn try_new_accepts_boolean_inputs_and_exposes_children() {
+        let lhs = bool_expr(true);
+        let rhs = bool_expr(false);
+        let expr = OrExpr::try_new(lhs.clone(), rhs.clone()).unwrap();
+
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+        assert_eq!(expr.lhs(), lhs.as_ref());
+        assert_eq!(expr.rhs(), rhs.as_ref());
+    }
+
+    #[test]
+    fn first_round_evaluate_or_covers_all_truth_table_rows() {
+        let alloc = Bump::new();
+        let lhs = [false, true, false, true];
+        let rhs = [false, false, true, true];
+
+        assert_eq!(
+            first_round_evaluate_or(4, &alloc, &lhs, &rhs),
+            &[false, true, true, true]
+        );
+    }
+
+    #[test]
+    fn first_and_final_round_evaluate_boolean_literals() {
+        let alloc = Bump::new();
+        let table = empty_table(2);
+        let expr = OrExpr::try_new(bool_expr(false), bool_expr(true)).unwrap();
+
+        let first_round = expr.first_round_evaluate(&alloc, &table, &[]).unwrap();
+        assert_eq!(first_round, Column::Boolean(&[true, true]));
+
+        let mut builder = FinalRoundBuilder::new(1, VecDeque::new());
+        let final_round = expr
+            .final_round_evaluate(&mut builder, &alloc, &table, &[])
+            .unwrap();
+        assert_eq!(final_round, Column::Boolean(&[true, true]));
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+    }
+
+    #[test]
+    fn verifier_evaluate_or_combines_inputs_and_checks_identity() {
+        let chi_eval = TestScalar::from(7u64);
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            vec![vec![TestScalar::ZERO]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let expr = OrExpr::try_new(bool_expr(true), bool_expr(false)).unwrap();
+
+        let result = expr
+            .verifier_evaluate(&mut builder, &IndexMap::default(), chi_eval, &[])
+            .unwrap();
+
+        assert_eq!(result, chi_eval);
+        assert_eq!(
+            builder.identity_subpolynomial_evaluations,
+            vec![vec![TestScalar::ZERO]]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add Mac-native unit coverage for boolean proof expression helpers in AND, OR, and NOT expressions
- Cover constructor/accessor paths plus first-round, final-round, and verifier evaluation behavior
- Keep the slice separate from active coverage PRs for Dory, result serialization, proof gadgets, and planner paths

/claim #560

## Validation
- `/opt/homebrew/bin/rustup run 1.91.1 cargo fmt --check`
- `/opt/homebrew/bin/rustup run 1.91.1 cargo test --package proof-of-sql --lib --no-default-features --features test and_expr::tests`
- `/opt/homebrew/bin/rustup run 1.91.1 cargo test --package proof-of-sql --lib --no-default-features --features test or_expr::tests`
- `/opt/homebrew/bin/rustup run 1.91.1 cargo test --package proof-of-sql --lib --no-default-features --features test not_expr::tests`
- `/opt/homebrew/bin/rustup run 1.91.1 cargo llvm-cov --package proof-of-sql --lib --no-default-features --features test --json --summary-only --output-path /tmp/sxt-boolean-proof-expr-cov.json -- proof_exprs`

Coverage check: production executable coverage increased on this slice from about 35 covered lines to 162 covered lines across `and_expr.rs`, `or_expr.rs`, and `not_expr.rs` under the Mac-native `--no-default-features --features test` profile.