### PR TITLE
test: cover curve25519 scalar point multiplication

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_scalar.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_scalar.rs
@@ -50,3 +50,31 @@ impl core::ops::Mul<Curve25519Scalar> for &curve25519_dalek::ristretto::Ristrett
         self * curve25519_dalek::scalar::Scalar::from(rhs)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
+
+    #[test]
+    fn multiplies_ristretto_points_from_each_supported_side() {
+        let expected = curve25519_dalek::scalar::Scalar::from(5u64) * RISTRETTO_BASEPOINT_POINT;
+
+        assert_eq!(
+            Curve25519Scalar::from(5u64) * RISTRETTO_BASEPOINT_POINT,
+            expected
+        );
+        assert_eq!(
+            Curve25519Scalar::from(5u64) * &RISTRETTO_BASEPOINT_POINT,
+            expected
+        );
+        assert_eq!(
+            RISTRETTO_BASEPOINT_POINT * Curve25519Scalar::from(5u64),
+            expected
+        );
+        assert_eq!(
+            &RISTRETTO_BASEPOINT_POINT * Curve25519Scalar::from(5u64),
+            expected
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for Curve25519Scalar RistrettoPoint multiplication interop
- exercise scalar-on-point, scalar-on-borrowed-point, point-on-scalar, and borrowed-point-on-scalar implementations
- keep the change limited to tests; no production behavior changes

## Testing
- cargo fmt --check
- cargo test -p proof-of-sql --no-default-features --features="arrow rayon test" proof_primitive::inner_product::curve_25519_scalar::tests
- cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow rayon test" --lib --summary-only -- proof_primitive::inner_product::curve_25519_scalar::tests

Coverage note: `proof_primitive\inner_product\curve_25519_scalar.rs` reports 100% line/function/region coverage under the focused test filter.
