### PR TITLE
test: cover column metadata accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,26 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_access_column_field_metadata() {
+        let field = ColumnField::new(Ident::new("amount"), ColumnType::BigInt);
+
+        assert_eq!(field.name(), Ident::new("amount"));
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn we_can_roundtrip_column_field_through_json() {
+        let field = ColumnField::new(Ident::new("is_active"), ColumnType::Boolean);
+
+        let serialized = serde_json::to_string(&field).unwrap();
+        let deserialized: ColumnField = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, field);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,33 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_access_column_ref_metadata() {
+        let table_ref = TableRef::new("analytics", "accounts");
+        let column_ref =
+            ColumnRef::new(table_ref.clone(), Ident::new("balance"), ColumnType::Int128);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), Ident::new("balance"));
+        assert_eq!(column_ref.column_type(), &ColumnType::Int128);
+    }
+
+    #[test]
+    fn we_can_roundtrip_column_ref_through_json() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("analytics", "accounts"),
+            Ident::new("email"),
+            ColumnType::VarChar,
+        );
+
+        let serialized = serde_json::to_string(&column_ref).unwrap();
+        let deserialized: ColumnRef = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, column_ref);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This adds a small, focused coverage slice for database column metadata types as part of #560.

/claim #560

# What changes are included in this PR?

- Covers `ColumnField::new`, `name`, and `data_type`.
- Covers `ColumnRef::new`, `table_ref`, `column_id`, and `column_type`.
- Adds JSON round-trip tests for both metadata types to exercise their serde derives and nested `TableRef` serialization.

# Are these changes tested?

Yes. Added focused unit tests for the covered behavior.

Local validation:
- `cargo fmt --check` passes in WSL.
- Attempted targeted validation with `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql column_ref --no-default-features --features std,test`, but local compilation is blocked because this WSL image does not have the repo-configured `clang` linker installed (`linker clang not found`).
- The upstream lint/test and coverage workflows are currently waiting on maintainer approval for the forked PR run.