### PR TITLE
test: cover dory public parameters serialization

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -225,6 +225,48 @@ impl Valid for PublicParameters {
 }
 
 #[cfg(test)]
+mod non_std_tests {
+    use super::*;
+
+    #[test]
+    fn test_rand_sets_expected_vector_lengths_and_validates() {
+        let mut rng = ark_std::test_rng();
+        let max_nu = 3;
+        let params = PublicParameters::test_rand(max_nu, &mut rng);
+
+        assert_eq!(params.Gamma_1.len(), 1 << max_nu);
+        assert_eq!(params.Gamma_2.len(), 1 << max_nu);
+        assert_eq!(params.max_nu, max_nu);
+        params
+            .check()
+            .expect("generated parameters should validate");
+    }
+
+    #[test]
+    fn canonical_serialized_size_matches_written_bytes() {
+        let mut rng = ark_std::test_rng();
+        let params = PublicParameters::test_rand(2, &mut rng);
+
+        let mut bytes = Vec::new();
+        params
+            .serialize_with_mode(&mut bytes, Compress::No)
+            .expect("serialize PublicParameters");
+
+        assert_eq!(params.serialized_size(Compress::No), bytes.len());
+
+        let decoded =
+            PublicParameters::deserialize_with_mode(&mut &bytes[..], Compress::No, Validate::Yes)
+                .expect("deserialize PublicParameters");
+        assert_eq!(decoded.Gamma_1, params.Gamma_1);
+        assert_eq!(decoded.Gamma_2, params.Gamma_2);
+        assert_eq!(decoded.H_1, params.H_1);
+        assert_eq!(decoded.H_2, params.H_2);
+        assert_eq!(decoded.Gamma_2_fin, params.Gamma_2_fin);
+        assert_eq!(decoded.max_nu, params.max_nu);
+    }
+}
+
+#[cfg(test)]
 #[cfg(feature = "std")]
 mod tests {
     use super::*;


### PR DESCRIPTION
/claim #560

## Summary
- add no-std coverage for `PublicParameters::test_rand` vector sizing and validation
- cover canonical serialization size accounting against actual written bytes
- round-trip Dory public parameters through canonical serialization/deserialization
- keep the change limited to tests; no production behavior changes

## Testing
- cargo fmt --check
- cargo test -p proof-of-sql --no-default-features --features="arrow rayon test" proof_primitive::dory::public_parameters::non_std_tests
- cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow rayon test" --lib --summary-only -- proof_primitive::dory::public_parameters::non_std_tests

Coverage note: `proof_primitive\dory\public_parameters.rs` reports 56.32% line coverage under the focused no-std test filter.
