### PR TITLE
test: cover database error displays

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,95 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::math::decimal::DecimalError;
+
+    #[test]
+    fn we_can_display_column_operation_errors() {
+        assert_eq!(
+            ColumnOperationError::DifferentColumnLength { len_a: 2, len_b: 3 }.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+        assert_eq!(
+            ColumnOperationError::BinaryOperationInvalidColumnType {
+                operator: "add".into(),
+                left_type: ColumnType::BigInt,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "\"add\"(lhs: BigInt, rhs: VarChar) is not supported"
+        );
+        assert_eq!(
+            ColumnOperationError::UnaryOperationInvalidColumnType {
+                operator: "neg".into(),
+                operand_type: ColumnType::Boolean,
+            }
+            .to_string(),
+            "\"neg\"(operand: Boolean) is not supported"
+        );
+        assert_eq!(
+            ColumnOperationError::IntegerOverflow {
+                error: "too large".into(),
+            }
+            .to_string(),
+            "Overflow in integer operation: too large"
+        );
+        assert_eq!(
+            ColumnOperationError::IndexOutOfBounds { index: 7, len: 4 }.to_string(),
+            "Index out of bounds: 7 >= 4"
+        );
+    }
+
+    #[test]
+    fn we_can_display_type_conversion_column_operation_errors() {
+        assert_eq!(
+            ColumnOperationError::UnionDifferentTypes {
+                correct_type: ColumnType::Int,
+                actual_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Cannot union columns of different types: Int and BigInt"
+        );
+        assert_eq!(
+            ColumnOperationError::SignedCastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            "Cannot fit TINYINT into UINT8 without losing data"
+        );
+        assert_eq!(
+            ColumnOperationError::CastingError {
+                left_type: ColumnType::BigInt,
+                right_type: ColumnType::Int,
+            }
+            .to_string(),
+            "Cannot fit BIGINT into INT without losing data"
+        );
+        assert_eq!(
+            ColumnOperationError::ScaleCastingError {
+                left_type: ColumnType::Int,
+                right_type: ColumnType::Decimal75(
+                    crate::base::math::decimal::Precision::new(10).unwrap(),
+                    2
+                ),
+            }
+            .to_string(),
+            "Cannot fit INT into DECIMAL75(PRECISION: 10, SCALE: 2) without losing data"
+        );
+    }
+
+    #[test]
+    fn we_can_display_transparent_decimal_operation_errors() {
+        let error = ColumnOperationError::DecimalConversionError {
+            source: DecimalError::InvalidScale {
+                scale: "128".into(),
+            },
+        };
+
+        assert_eq!(error.to_string(), "Decimal scale is not valid: 128");
+    }
+}

--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,19 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_parse_errors() {
+        assert_eq!(
+            ParseError::InvalidTableReference {
+                table_reference: "bad table".into(),
+            }
+            .to_string(),
+            "Invalid table reference: bad table"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,46 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_owned_column_errors() {
+        assert_eq!(
+            OwnedColumnError::TypeCastError {
+                from_type: ColumnType::VarChar,
+                to_type: ColumnType::Int,
+            }
+            .to_string(),
+            "Can not perform type casting from VarChar to Int"
+        );
+        assert_eq!(
+            OwnedColumnError::ScalarConversionError {
+                error: "bad scalar".into(),
+            }
+            .to_string(),
+            "Error in converting scalars to a given column type: bad scalar"
+        );
+        assert_eq!(
+            OwnedColumnError::Unsupported {
+                error: "sort VarBinary".into(),
+            }
+            .to_string(),
+            "Unsupported operation: sort VarBinary"
+        );
+    }
+
+    #[test]
+    fn we_can_display_column_coercion_errors() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,62 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_table_operation_errors() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+        assert_eq!(
+            TableOperationError::JoinWithDifferentNumberOfColumns {
+                left_num_columns: 1,
+                right_num_columns: 2,
+            }
+            .to_string(),
+            "Cannot join tables with different numbers of columns: 1 and 2"
+        );
+        assert_eq!(
+            TableOperationError::JoinIncompatibleTypes {
+                left_type: ColumnType::Int,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Cannot join tables on columns with incompatible types: Int and VarChar"
+        );
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+        assert_eq!(
+            TableOperationError::ColumnIndexOutOfBounds { column_index: 4 }.to_string(),
+            "Column index out of bounds: 4"
+        );
+    }
+
+    #[test]
+    fn we_can_display_table_operation_errors_with_nested_values() {
+        let error = TableOperationError::UnionIncompatibleSchemas {
+            correct_schema: vec![ColumnField::new(Ident::new("id"), ColumnType::Int)],
+            actual_schema: vec![ColumnField::new(Ident::new("id"), ColumnType::BigInt)],
+        };
+        let message = error.to_string();
+        assert!(message.contains("Cannot union tables with incompatible schemas"));
+        assert!(message.contains("Int"));
+        assert!(message.contains("BigInt"));
+
+        let error = TableOperationError::ColumnDoesNotExist {
+            column_ident: Ident::new("missing"),
+        };
+        assert!(error.to_string().contains("missing"));
+
+        let error = TableOperationError::ColumnOperationError {
+            source: ColumnOperationError::DivisionByZero,
+        };
+        assert_eq!(error.to_string(), "Division by zero");
+    }
+}


### PR DESCRIPTION
## Summary

- add focused display tests for database column operation errors
- add display tests for table operation, owned column, coercion, and parse errors
- keep the change scoped to non-overlapping `base/database/*_error.rs` coverage

/claim #560

## Testing

- `cargo test -p proof-of-sql --no-default-features --features test we_can_display --lib` (passes: 8 tests)
- `rustfmt --check crates/proof-of-sql/src/base/database/column_operation_error.rs crates/proof-of-sql/src/base/database/table_operation_error.rs crates/proof-of-sql/src/base/database/owned_column_error.rs crates/proof-of-sql/src/base/database/error.rs`
- `git diff --check`

Note: `cargo test -p proof-of-sql we_can_display --lib` with default features is blocked on this Mac arm64 environment by upstream platform constraints (`blitzar-sys` only supports Linux and `halo2curves/asm` is x86_64-only).