### PR TITLE
test: cover varying byte matrix edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -54,6 +54,32 @@ mod tests {
     }
 
     #[test]
+    fn we_can_compute_varying_byte_matrix_for_empty_scalars() {
+        let alloc = Bump::new();
+        let scalars = Vec::<TestScalar>::new();
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_constant_scalars() {
+        let alloc = Bump::new();
+        let scalars = vec![TestScalar::from(42u64); 4];
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
     fn we_can_compute_varying_byte_matrix_for_large_scalars() {
         let alloc = Bump::new();
         let scalars = vec![


### PR DESCRIPTION
/claim #560

Adds focused coverage for `compute_varying_byte_matrix` edge cases:
- empty scalar input returns no varying columns and the expected byte distribution
- constant scalar input returns no varying columns while preserving byte distribution

Validation:
- `rustfmt crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs`
- `cargo test -p proof-of-sql byte_matrix_utils --lib --no-default-features --features test` (4 passed)
- `git diff --check`

Note: the default-feature test path reaches `blitzar-sys`, whose build script reports `Unsupported OS. Only Linux is supported` on this Windows shell. The focused no-default-features library test passes locally and upstream CI should cover the default Linux path.