### PR TITLE
test: reject zero-variable sumcheck proofs

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -69,7 +69,7 @@ impl<S: Scalar> SumcheckProof<S> {
         log::log_memory_usage("Start");
 
         let coefficients_len = self.coefficients.len();
-        if !coefficients_len.is_multiple_of(num_variables) {
+        if num_variables == 0 || !coefficients_len.is_multiple_of(num_variables) {
             return Err(ProofError::VerificationError {
                 error: "invalid proof size",
             });

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
@@ -7,7 +7,7 @@ use super::test_cases::sumcheck_test_cases;
 use crate::{
     base::{
         polynomial::CompositePolynomial,
-        proof::Transcript as _,
+        proof::{ProofError, Transcript as _},
         scalar::{test_scalar::TestScalar, MontScalar, Scalar},
     },
     proof_primitive::{
@@ -19,6 +19,46 @@ use alloc::rc::Rc;
 use ark_std::UniformRand;
 use merlin::Transcript;
 use num_traits::{One, Zero};
+
+#[test]
+fn verify_rejects_empty_num_variables_as_invalid_proof_size() {
+    let proof = SumcheckProof::<TestScalar> {
+        coefficients: Vec::new(),
+    };
+    let mut transcript = Transcript::new(b"sumchecktest");
+
+    let err = proof
+        .verify_without_evaluation(&mut transcript, 0, &TestScalar::ZERO)
+        .err()
+        .expect("verification should fail for zero variables");
+
+    assert!(matches!(
+        err,
+        ProofError::VerificationError {
+            error: "invalid proof size"
+        }
+    ));
+}
+
+#[test]
+fn verify_rejects_coefficient_counts_that_do_not_match_num_variables() {
+    let proof = SumcheckProof::<TestScalar> {
+        coefficients: vec![TestScalar::ONE],
+    };
+    let mut transcript = Transcript::new(b"sumchecktest");
+
+    let err = proof
+        .verify_without_evaluation(&mut transcript, 2, &TestScalar::ZERO)
+        .err()
+        .expect("verification should fail for mismatched coefficient count");
+
+    assert!(matches!(
+        err,
+        ProofError::VerificationError {
+            error: "invalid proof size"
+        }
+    ));
+}
 
 #[test]
 fn test_create_verify_proof() {


### PR DESCRIPTION
## Summary
- reject zero-variable sumcheck proofs as an invalid proof size before checking coefficient divisibility
- add focused regression coverage for zero-variable proofs and mismatched coefficient counts

## Why
`SumcheckProof::verify_without_evaluation` used `coefficients_len.is_multiple_of(num_variables)` before guarding `num_variables`, so a malformed proof with `num_variables = 0` could panic instead of returning a normal verification error.

## Validation
- `cargo fmt --check`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql verify_rejects_ --no-default-features --features="arrow rayon test"`

Note: local macOS/Apple Silicon validation cannot use default/all-features because `blitzar-sys` is Linux-only and `halo2curves/asm` is x86_64-only.

/claim #560