### PR TITLE
test: cover dory scalar product verification

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
@@ -104,7 +104,7 @@ mod tests {
     }
 
     #[test]
-    fn scalar_product_verifies_matching_messages() {
+    fn we_can_verify_scalar_product_with_matching_messages() {
         let (mut messages, verifier_state, verifier_setup) = scalar_product_fixture();
 
         let mut transcript = Transcript::new(b"scalar_product_test");
@@ -118,7 +118,7 @@ mod tests {
     }
 
     #[test]
-    fn scalar_product_rejects_missing_messages() {
+    fn we_fail_to_verify_scalar_product_with_missing_messages() {
         let (_, verifier_state, verifier_setup) = scalar_product_fixture();
         let mut messages = DoryMessages::default();
         let mut transcript = Transcript::new(b"scalar_product_test");
@@ -132,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    fn scalar_product_rejects_unexpected_gt_messages() {
+    fn we_fail_to_verify_scalar_product_with_unexpected_gt_messages() {
         let (mut messages, verifier_state, verifier_setup) = scalar_product_fixture();
         messages
             .GT_messages

--- a/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
@@ -79,3 +79,71 @@ pub fn scalar_product_verify(
 
     res
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{
+        rand_G_vecs, test_rng, G1Affine, G2Affine, PublicParameters,
+    };
+    use merlin::Transcript;
+
+    fn scalar_product_fixture() -> (DoryMessages, VerifierState, VerifierSetup) {
+        let mut rng = test_rng();
+        let nu = 0;
+        let pp = PublicParameters::test_rand(nu, &mut rng);
+        let prover_setup = (&pp).into();
+        let verifier_setup = (&pp).into();
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let prover_state = ProverState::new(v1, v2, nu);
+        let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+        let mut messages = DoryMessages::default();
+        let mut transcript = Transcript::new(b"scalar_product_test");
+        scalar_product_prove(&mut messages, &mut transcript, &prover_state);
+        (messages, verifier_state, verifier_setup)
+    }
+
+    #[test]
+    fn scalar_product_verifies_matching_messages() {
+        let (mut messages, verifier_state, verifier_setup) = scalar_product_fixture();
+
+        let mut transcript = Transcript::new(b"scalar_product_test");
+
+        assert!(scalar_product_verify(
+            &mut messages,
+            &mut transcript,
+            verifier_state,
+            &verifier_setup,
+        ));
+    }
+
+    #[test]
+    fn scalar_product_rejects_missing_messages() {
+        let (_, verifier_state, verifier_setup) = scalar_product_fixture();
+        let mut messages = DoryMessages::default();
+        let mut transcript = Transcript::new(b"scalar_product_test");
+
+        assert!(!scalar_product_verify(
+            &mut messages,
+            &mut transcript,
+            verifier_state,
+            &verifier_setup,
+        ));
+    }
+
+    #[test]
+    fn scalar_product_rejects_unexpected_gt_messages() {
+        let (mut messages, verifier_state, verifier_setup) = scalar_product_fixture();
+        messages
+            .GT_messages
+            .push(pairings::pairing(G1Affine::default(), G2Affine::default()));
+        let mut transcript = Transcript::new(b"scalar_product_test");
+
+        assert!(!scalar_product_verify(
+            &mut messages,
+            &mut transcript,
+            verifier_state,
+            &verifier_setup,
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a small non-overlapping test coverage slice for #560. It covers the Dory scalar-product verifier directly instead of relying only on higher-level inner-product paths.

# What changes are included in this PR?

- Adds a valid scalar-product prover/verifier round-trip test.
- Adds direct rejection coverage for malformed prover message queues:
  - missing G1/G2 messages
  - unexpected GT messages

# Are these changes tested?

Yes.

- `cargo fmt --all -- --check`
- `source scripts/check_commits.sh`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' cargo test -p proof-of-sql --no-default-features --features test proof_primitive::dory::scalar_product --lib`

The targeted test passed with 3 tests passing and 960 filtered out. I did not run the full CI script locally because this macOS machine has very limited free disk space and the full workspace lanes are much heavier than this isolated coverage slice.
