### PR TITLE
test: cover sumcheck prover state construction

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -62,3 +62,57 @@ impl<S: Scalar> ProverState<S> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{polynomial::CompositePolynomial, scalar::test_scalar::TestScalar};
+    use alloc::{rc::Rc, vec};
+
+    #[test]
+    fn create_copies_composite_polynomial_into_initial_state() {
+        let shared_extension = Rc::new(vec![
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+            TestScalar::from(4),
+        ]);
+        let distinct_extension = Rc::new(vec![
+            TestScalar::from(5),
+            TestScalar::from(6),
+            TestScalar::from(7),
+            TestScalar::from(8),
+        ]);
+        let mut polynomial = CompositePolynomial::new(2);
+        polynomial.add_product(
+            [shared_extension.clone(), distinct_extension.clone()],
+            TestScalar::from(11),
+        );
+        polynomial.add_product([shared_extension.clone()], TestScalar::from(13));
+
+        let state = ProverState::create(&polynomial);
+
+        assert_eq!(state.num_vars, 2);
+        assert_eq!(state.max_multiplicands, 2);
+        assert_eq!(state.round, 0);
+        assert_eq!(
+            state.list_of_products,
+            vec![
+                (TestScalar::from(11), vec![0, 1]),
+                (TestScalar::from(13), vec![0])
+            ]
+        );
+        assert_eq!(
+            state.flattened_ml_extensions,
+            vec![(*shared_extension).clone(), (*distinct_extension).clone()]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Attempt to prove a constant.")]
+    fn create_rejects_constant_polynomial() {
+        let polynomial = CompositePolynomial::<TestScalar>::new(0);
+
+        let _ = ProverState::create(&polynomial);
+    }
+}


### PR DESCRIPTION
## Summary
- add direct coverage for `ProverState::create` copying a `CompositePolynomial` into initial prover state
- add panic coverage for rejecting constant polynomials

/claim #560

## Verification
- `cargo fmt --check`
- `cargo test -p proof-of-sql prover_state --no-default-features --features="std"` (6 passed)
- `git diff --check`

Note: local `--all-features` is blocked on Apple Silicon because `halo2curves/asm` only supports x86_64; the targeted std-feature test path passes locally.