### PR TITLE
test: cover dory fold scalar update

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars_test.rs
@@ -1,7 +1,7 @@
 use super::{
     extended_dory_reduce_helper::extended_dory_reduce_verify_fold_s_vecs, fold_scalars_0_prove,
     fold_scalars_0_verify, rand_F_tensors, rand_G_vecs, test_rng, DoryMessages,
-    ExtendedProverState, PublicParameters,
+    ExtendedProverState, G1Affine, G2Affine, PublicParameters,
 };
 use merlin::Transcript;
 
@@ -34,4 +34,34 @@ fn we_can_fold_scalars() {
         prover_folded_state.calculate_verifier_state(&prover_setup),
         verifier_folded_state
     );
+}
+
+#[test]
+fn fold_scalars_prover_adds_challenge_scaled_hiding_terms() {
+    let mut rng = test_rng();
+    let nu = 0;
+    let pp = PublicParameters::test_rand(nu, &mut rng);
+    let prover_setup = (&pp).into();
+    let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
+    let (v1, v2) = rand_G_vecs(nu, &mut rng);
+    let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
+    let initial_v1 = prover_state.base_state.v1[0];
+    let initial_v2 = prover_state.base_state.v2[0];
+    let s1 = prover_state.s1[0];
+    let s2 = prover_state.s2[0];
+
+    let mut challenge_transcript = Transcript::new(b"fold_scalars_prover_update_test");
+    let mut challenge_messages = DoryMessages::default();
+    let (gamma, gamma_inv) = challenge_messages.verifier_F_message(&mut challenge_transcript);
+
+    let mut transcript = Transcript::new(b"fold_scalars_prover_update_test");
+    let mut messages = DoryMessages::default();
+    let prover_folded_state =
+        fold_scalars_0_prove(&mut messages, &mut transcript, prover_state, &prover_setup);
+    let expected_v1: G1Affine = (initial_v1 + prover_setup.H_1 * s1 * gamma).into();
+    let expected_v2: G2Affine = (initial_v2 + prover_setup.H_2 * s2 * gamma_inv).into();
+
+    assert_eq!(prover_folded_state.nu, 0);
+    assert_eq!(prover_folded_state.v1[0], expected_v1);
+    assert_eq!(prover_folded_state.v2[0], expected_v2);
 }


### PR DESCRIPTION
/claim #560

Summary:
- Adds a focused Dory fold-scalars unit test for the prover-side `v1` and `v2` updates.
- Verifies the updates use the transcript challenge and inverse challenge with the expected hiding terms.

Scope:
- This PR focuses on `crates/proof-of-sql/src/proof_primitive/dory/fold_scalars_test.rs`.
- It does not change production code or attempt to cover other Dory folding paths.

Non-overlap:
- I checked the existing issue comments and open PRs for `fold_scalars` / `fold scalars`.
- This PR covers the direct prover update assertion in `fold_scalars_0_prove`, which appears not to be covered by the existing open #560 PRs.

Verification:
- `cargo fmt --check`: passed
- `cargo test -p proof-of-sql --no-default-features --features test fold_scalars`: passed (2 tests)

Notes:
- Full `cargo test --all-features` was not run locally; this keeps verification targeted and Windows-friendly for this narrow test-only change.

AI assistance:
- AI assistance was used to draft and explore the change; the final diff was reviewed and verified with the commands above.