### PR TITLE
test: add table accessors coverage

### DIFF
--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -168,3 +168,63 @@ impl<'a, S: Scalar> core::ops::Index<&str> for Table<'a, S> {
         self.table.get(&Ident::new(index)).unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{database::ColumnType, map::indexmap, scalar::test_scalar::TestScalar};
+
+    fn sample_table() -> Table<'static, TestScalar> {
+        Table::try_new(indexmap! {
+            "nums".into() => Column::BigInt(&[1, 2]),
+            "flags".into() => Column::Boolean(&[true, false]),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn schema_and_column_names_preserve_table_order() {
+        let table = sample_table();
+
+        assert_eq!(
+            table.schema(),
+            vec![
+                ColumnField::new(Ident::new("nums"), ColumnType::BigInt),
+                ColumnField::new(Ident::new("flags"), ColumnType::Boolean),
+            ]
+        );
+        assert_eq!(
+            table.column_names().cloned().collect::<Vec<_>>(),
+            vec![Ident::new("nums"), Ident::new("flags")]
+        );
+    }
+
+    #[test]
+    fn columns_and_column_accessors_return_expected_columns() {
+        let table = sample_table();
+
+        assert_eq!(
+            table.columns().copied().collect::<Vec<_>>(),
+            vec![Column::BigInt(&[1, 2]), Column::Boolean(&[true, false])]
+        );
+        assert_eq!(table.column(0), Some(&Column::BigInt(&[1, 2])));
+        assert_eq!(table.column(1), Some(&Column::Boolean(&[true, false])));
+        assert_eq!(table.column(2), None);
+    }
+
+    #[test]
+    fn inner_table_exposes_underlying_columns_by_name() {
+        let table = sample_table();
+        let inner_table = table.inner_table();
+
+        assert_eq!(inner_table.len(), 2);
+        assert_eq!(
+            inner_table.get(&Ident::new("nums")),
+            Some(&Column::BigInt(&[1, 2]))
+        );
+        assert_eq!(
+            inner_table.get(&Ident::new("flags")),
+            Some(&Column::Boolean(&[true, false]))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add focused coverage for Table schema and accessor helpers
- verify schema and column_names preserve insertion order
- verify columns(), column(), and inner_table() expose expected data

## Test Plan
- cargo fmt --all
- cargo test -p proof-of-sql --lib base::database::table::tests::schema_and_column_names_preserve_table_order -- --exact
- cargo test -p proof-of-sql --lib base::database::table::tests::columns_and_column_accessors_return_expected_columns -- --exact
- cargo test -p proof-of-sql --lib base::database::table::tests::inner_table_exposes_underlying_columns_by_name -- --exact

/claim #560