### PR TITLE
test: cover database accessors and query errors

### DIFF
--- a/crates/proof-of-sql/src/base/database/accessor.rs
+++ b/crates/proof-of-sql/src/base/database/accessor.rs
@@ -136,6 +136,71 @@ pub trait SchemaAccessor {
     fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)>;
 }
 
+#[cfg(test)]
+mod data_accessor_tests {
+    use super::{DataAccessor, MetadataAccessor};
+    use crate::base::{
+        database::{Column, TableRef},
+        map::IndexSet,
+        scalar::test_scalar::TestScalar,
+    };
+    use sqlparser::ast::Ident;
+
+    struct TestDataAccessor {
+        values: [i64; 2],
+        length: usize,
+    }
+
+    impl MetadataAccessor for TestDataAccessor {
+        fn get_length(&self, _table_ref: &TableRef) -> usize {
+            self.length
+        }
+
+        fn get_offset(&self, _table_ref: &TableRef) -> usize {
+            0
+        }
+    }
+
+    impl DataAccessor<TestScalar> for TestDataAccessor {
+        fn get_column(&self, _table_ref: &TableRef, column_id: &Ident) -> Column<'_, TestScalar> {
+            assert_eq!(column_id.value, "a");
+            Column::BigInt(&self.values)
+        }
+    }
+
+    #[test]
+    fn we_can_get_an_empty_table_from_an_accessor() {
+        let accessor = TestDataAccessor {
+            values: [7, 11],
+            length: 2,
+        };
+        let table_ref = TableRef::new("", "sxt");
+        let table = accessor.get_table(&table_ref, &IndexSet::default());
+
+        assert!(table.is_empty());
+        assert_eq!(table.num_rows(), 2);
+    }
+
+    #[test]
+    fn we_can_get_a_table_from_an_accessor() {
+        let accessor = TestDataAccessor {
+            values: [7, 11],
+            length: 2,
+        };
+        let table_ref = TableRef::new("", "sxt");
+        let mut column_ids = IndexSet::default();
+        column_ids.insert(Ident::new("a"));
+        let table = accessor.get_table(&table_ref, &column_ids);
+
+        assert_eq!(table.num_columns(), 1);
+        assert_eq!(table.num_rows(), 2);
+        match table.column(0).unwrap() {
+            Column::BigInt(values) => assert_eq!(*values, &[7, 11]),
+            _ => panic!("expected bigint column"),
+        }
+    }
+}
+
 /// The simplest implementation of `SchemaAccessor`.
 /// This is effectively an in-memory mapping from table to the schema.
 #[derive(Clone)]

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -102,6 +102,8 @@ pub mod table_utility;
 
 mod table_evaluation;
 pub use table_evaluation::TableEvaluation;
+#[cfg(test)]
+mod table_evaluation_test;
 
 mod test_accessor;
 pub use test_accessor::TestAccessor;

--- a/crates/proof-of-sql/src/base/database/table_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation_test.rs
@@ -1,0 +1,13 @@
+use super::TableEvaluation;
+use crate::base::scalar::test_scalar::TestScalar;
+
+#[test]
+fn we_can_access_table_evaluation_components() {
+    let column_evals = vec![TestScalar::from(3u64), TestScalar::from(5u64)];
+    let chi = (TestScalar::from(7u64), 11);
+    let table_evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+    assert_eq!(table_evaluation.column_evals(), column_evals.as_slice());
+    assert_eq!(table_evaluation.chi_eval(), chi.0);
+    assert_eq!(table_evaluation.chi(), chi);
+}

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -195,6 +195,36 @@ fn we_can_create_a_table_with_data() {
 }
 
 #[test]
+fn we_can_inspect_table_columns() {
+    let alloc = Bump::new();
+    let borrowed_table = table::<TestScalar>([
+        borrowed_bigint("a", [10_i64, 20], &alloc),
+        borrowed_boolean("b", [true, false], &alloc),
+    ]);
+
+    assert!(!borrowed_table.is_empty());
+    assert_eq!(
+        borrowed_table
+            .column_names()
+            .map(|name| name.value.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+    assert_eq!(
+        borrowed_table
+            .columns()
+            .map(Column::len)
+            .collect::<Vec<_>>(),
+        vec![2, 2]
+    );
+
+    match &borrowed_table["a"] {
+        Column::BigInt(values) => assert_eq!(*values, &[10_i64, 20]),
+        _ => panic!("expected bigint column"),
+    }
+}
+
+#[test]
 fn we_get_inequality_between_tables_with_differing_column_order() {
     let alloc = Bump::new();
 

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -123,6 +123,21 @@ fn test_inner_product_different_lengths() {
     assert_eq!(TestScalar::from(40), inner_product(&a, &b));
 }
 
+#[test]
+fn test_inner_product_ref_cast() {
+    let a = vec![1_i64, -2, 3];
+    let b = vec![
+        TestScalar::from(4_i64),
+        TestScalar::from(5_i64),
+        TestScalar::from(6_i64),
+    ];
+
+    assert_eq!(
+        TestScalar::from(12_i64),
+        inner_product_ref_cast::<i64, TestScalar>(&a, &b)
+    );
+}
+
 /// test inner producr with scalar
 #[test]
 fn test_inner_product_scalar() {

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,46 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::QueryError;
+    use crate::base::{
+        database::{ColumnCoercionError, TableCoercionError},
+        proof::ProofError,
+    };
+
+    #[test]
+    fn we_can_convert_table_coercion_errors_to_query_errors() {
+        let overflow_error = QueryError::from(TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::Overflow,
+        });
+        assert!(matches!(overflow_error, QueryError::Overflow));
+
+        let type_error = QueryError::from(TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::InvalidTypeCoercion,
+        });
+        assert!(matches!(
+            type_error,
+            QueryError::ProofError {
+                source: ProofError::InvalidTypeCoercion
+            }
+        ));
+
+        let name_error = QueryError::from(TableCoercionError::NameMismatch);
+        assert!(matches!(
+            name_error,
+            QueryError::ProofError {
+                source: ProofError::FieldNamesMismatch
+            }
+        ));
+
+        let count_error = QueryError::from(TableCoercionError::ColumnCountMismatch);
+        assert!(matches!(
+            count_error,
+            QueryError::ProofError {
+                source: ProofError::FieldCountMismatch
+            }
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary

- Add coverage for `DataAccessor::get_table` empty and nonempty column paths.
- Add coverage for `Table` and `TableEvaluation` accessor helpers.
- Add coverage for `QueryError` conversions from table coercion errors.
- Add coverage for `inner_product_ref_cast`.

## Testing

- `cargo fmt`
- `BLITZAR_BACKEND=cpu cargo llvm-cov -p proof-of-sql --no-default-features --features="std test" --lcov --output-path target/proof-of-sql-std-test-after2.lcov`
  - `966 passed; 0 failed`
  - Local LCOV comparison against the pre-change baseline showed 54 existing source lines newly covered.
