### PR TITLE
perf: cache pre-forge preprocessing outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ cache
 output/
 
 *.post.sol
+solidity/.pre_forge_cache/
 
 **/dependencies/**
 

--- a/solidity/preprocessor/test_pre_forge.py
+++ b/solidity/preprocessor/test_pre_forge.py
@@ -164,6 +164,39 @@ def test_pre_forge_rebuilds_when_generated_output_is_missing(tmp_path: Path) -> 
     assert _forge_log_lines(env) == ["test", "test"]
 
 
+def test_pre_forge_cache_ignores_presl_files_marked_does_not_compile(tmp_path: Path) -> None:
+    workspace, env = _create_workspace(tmp_path)
+    skipped_source = workspace / "src" / "Broken.presl"
+    _write(
+        skipped_source,
+        """
+        // does-not-compile
+        contract Broken {
+            function missingImport() external pure returns (uint256 out) {
+                assembly {
+                    // import missing from Missing.sol
+                    out := missing()
+                }
+            }
+        }
+        """,
+    )
+
+    _run_preforge(workspace, env, "test")
+    assert not skipped_source.with_suffix(".post.sol").exists()
+
+    generated = workspace / GENERATED_FILE
+    initial_mtime = generated.stat().st_mtime_ns
+    time.sleep(0.02)
+
+    second_run = _run_preforge(workspace, env, "test")
+
+    assert "cache hit" in second_run.stdout.lower()
+    assert generated.stat().st_mtime_ns == initial_mtime
+    assert not skipped_source.with_suffix(".post.sol").exists()
+    assert _forge_log_lines(env) == ["test", "test"]
+
+
 def test_pre_forge_clean_removes_generated_files_without_reprocessing(tmp_path: Path) -> None:
     workspace, env = _create_workspace(tmp_path)
     _run_preforge(workspace, env, "test")

--- a/solidity/preprocessor/test_pre_forge.py
+++ b/solidity/preprocessor/test_pre_forge.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+import os
+import shutil
+import subprocess
+import textwrap
+import time
+
+
+SOLIDITY_DIR = Path(__file__).resolve().parent.parent
+CACHE_FILE = ".pre_forge_cache/input_fingerprint.sha256"
+GENERATED_FILE = "src/Example.post.sol"
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+
+
+def _make_executable(path: Path) -> None:
+    path.chmod(path.stat().st_mode | 0o111)
+
+
+def _create_workspace(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    workspace = tmp_path / "solidity"
+    (workspace / "scripts").mkdir(parents=True, exist_ok=True)
+    (workspace / "preprocessor").mkdir(parents=True, exist_ok=True)
+    shutil.copy(SOLIDITY_DIR / "scripts" / "pre_forge.sh", workspace / "scripts" / "pre_forge.sh")
+    shutil.copy(
+        SOLIDITY_DIR / "preprocessor" / "yul_preprocessor.py",
+        workspace / "preprocessor" / "yul_preprocessor.py",
+    )
+    _write(
+        workspace / "src" / "Example.presl",
+        """
+        contract Example {
+            function value() external pure returns (uint256 out) {
+                assembly {
+                    function add1(x) -> result {
+                        result := add(x, 1)
+                    }
+
+                    out := add1(41)
+                }
+            }
+        }
+        """,
+    )
+
+    fake_bin = tmp_path / "bin"
+    forge = fake_bin / "forge"
+    _write(
+        forge,
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [ "${1:-}" != "fmt" ]; then
+            printf '%s\n' "$*" >> "${FAKE_FORGE_LOG:?}"
+        fi
+        """,
+    )
+    _make_executable(forge)
+
+    env = os.environ.copy()
+    env["FAKE_FORGE_LOG"] = str(tmp_path / "forge.log")
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    return workspace, env
+
+
+def _run_preforge(workspace: Path, env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/pre_forge.sh", *args],
+        cwd=workspace,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _forge_log_lines(env: dict[str, str]) -> list[str]:
+    log_file = Path(env["FAKE_FORGE_LOG"])
+    if not log_file.exists():
+        return []
+    return [line for line in log_file.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_pre_forge_uses_cache_when_inputs_are_unchanged(tmp_path: Path) -> None:
+    workspace, env = _create_workspace(tmp_path)
+
+    _run_preforge(workspace, env, "test")
+    generated = workspace / GENERATED_FILE
+    assert generated.exists()
+
+    initial_mtime = generated.stat().st_mtime_ns
+    time.sleep(0.02)
+
+    second_run = _run_preforge(workspace, env, "test")
+
+    assert "cache hit" in second_run.stdout.lower()
+    assert generated.stat().st_mtime_ns == initial_mtime
+    assert _forge_log_lines(env) == ["test", "test"]
+
+
+def test_pre_forge_invalidates_cache_when_presl_inputs_change(tmp_path: Path) -> None:
+    workspace, env = _create_workspace(tmp_path)
+    _run_preforge(workspace, env, "test")
+
+    source_file = workspace / "src" / "Example.presl"
+    source_file.write_text(source_file.read_text(encoding="utf-8").replace("add1(41)", "add1(42)"), encoding="utf-8")
+    time.sleep(0.02)
+
+    rerun = _run_preforge(workspace, env, "test")
+    generated = workspace / GENERATED_FILE
+
+    assert "cache hit" not in rerun.stdout.lower()
+    assert "add1(42)" in generated.read_text(encoding="utf-8")
+    assert _forge_log_lines(env) == ["test", "test"]
+
+
+def test_pre_forge_clean_removes_generated_files_without_reprocessing(tmp_path: Path) -> None:
+    workspace, env = _create_workspace(tmp_path)
+    _run_preforge(workspace, env, "test")
+
+    generated = workspace / GENERATED_FILE
+    cache_file = workspace / CACHE_FILE
+    assert generated.exists()
+    assert cache_file.exists()
+
+    clean_run = _run_preforge(workspace, env, "clean")
+
+    assert "cache hit" not in clean_run.stdout.lower()
+    assert not generated.exists()
+    assert not cache_file.exists()
+    assert _forge_log_lines(env) == ["test", "clean"]

--- a/solidity/preprocessor/test_pre_forge.py
+++ b/solidity/preprocessor/test_pre_forge.py
@@ -30,15 +30,28 @@ def _create_workspace(tmp_path: Path) -> tuple[Path, dict[str, str]]:
         workspace / "preprocessor" / "yul_preprocessor.py",
     )
     _write(
-        workspace / "src" / "Example.presl",
+        workspace / "src" / "Helper.sol",
         """
-        contract Example {
-            function value() external pure returns (uint256 out) {
+        contract Helper {
+            function ignored() external pure returns (uint256 out) {
                 assembly {
                     function add1(x) -> result {
                         result := add(x, 1)
                     }
 
+                    out := add1(0)
+                }
+            }
+        }
+        """,
+    )
+    _write(
+        workspace / "src" / "Example.presl",
+        """
+        contract Example {
+            function value() external pure returns (uint256 out) {
+                assembly {
+                    // import add1 from Helper.sol
                     out := add1(41)
                 }
             }
@@ -114,6 +127,40 @@ def test_pre_forge_invalidates_cache_when_presl_inputs_change(tmp_path: Path) ->
 
     assert "cache hit" not in rerun.stdout.lower()
     assert "add1(42)" in generated.read_text(encoding="utf-8")
+    assert _forge_log_lines(env) == ["test", "test"]
+
+
+def test_pre_forge_invalidates_cache_when_imported_sol_changes(tmp_path: Path) -> None:
+    workspace, env = _create_workspace(tmp_path)
+    _run_preforge(workspace, env, "test")
+
+    helper_file = workspace / "src" / "Helper.sol"
+    helper_file.write_text(
+        helper_file.read_text(encoding="utf-8").replace("add(x, 1)", "add(x, 2)"),
+        encoding="utf-8",
+    )
+    time.sleep(0.02)
+
+    rerun = _run_preforge(workspace, env, "test")
+    generated = workspace / GENERATED_FILE
+
+    assert "cache hit" not in rerun.stdout.lower()
+    assert "result := add(x, 2)" in generated.read_text(encoding="utf-8")
+    assert _forge_log_lines(env) == ["test", "test"]
+
+
+def test_pre_forge_rebuilds_when_generated_output_is_missing(tmp_path: Path) -> None:
+    workspace, env = _create_workspace(tmp_path)
+    _run_preforge(workspace, env, "test")
+
+    generated = workspace / GENERATED_FILE
+    generated.unlink()
+    time.sleep(0.02)
+
+    rerun = _run_preforge(workspace, env, "test")
+
+    assert "cache hit" not in rerun.stdout.lower()
+    assert generated.exists()
     assert _forge_log_lines(env) == ["test", "test"]
 
 

--- a/solidity/scripts/pre_forge.sh
+++ b/solidity/scripts/pre_forge.sh
@@ -1,8 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd $SCRIPT_DIR/..
-# Remove any existing .post.sol files
-find . -type f -name '*.post.sol' -delete
-python3 preprocessor/yul_preprocessor.py .
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$SCRIPT_DIR/.."
+
+CACHE_DIR=.pre_forge_cache
+CACHE_FILE="$CACHE_DIR/input_fingerprint.sha256"
+
+compute_input_fingerprint() {
+  {
+    printf '%s\0' ./preprocessor/yul_preprocessor.py ./scripts/pre_forge.sh
+    find . -type f -name '*.presl' -print0
+  } | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}'
+}
+
+if [[ "${1:-}" == "clean" ]]; then
+  find . -type f -name '*.post.sol' -delete
+  rm -rf "$CACHE_DIR"
+  forge "$@"
+  exit 0
+fi
+
+input_fingerprint=$(compute_input_fingerprint)
+if [[ -f "$CACHE_FILE" ]] && [[ "$(<"$CACHE_FILE")" == "$input_fingerprint" ]]; then
+  echo "pre_forge cache hit: skipping preprocessing"
+else
+  echo "pre_forge cache miss: regenerating .post.sol files"
+  find . -type f -name '*.post.sol' -delete
+  python3 preprocessor/yul_preprocessor.py .
+  mkdir -p "$CACHE_DIR"
+  printf '%s\n' "$input_fingerprint" > "$CACHE_FILE"
+fi
+
 forge "$@"

--- a/solidity/scripts/pre_forge.sh
+++ b/solidity/scripts/pre_forge.sh
@@ -13,8 +13,17 @@ compute_input_fingerprint() {
   } | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}'
 }
 
+should_skip_presl_file() {
+  local source_file=$1
+  head -n 10 "$source_file" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]' | grep -Eq 'does-not-compile|doesnotcompile'
+}
+
 generated_outputs_present() {
   while IFS= read -r -d '' source_file; do
+    if should_skip_presl_file "$source_file"; then
+      continue
+    fi
+
     if [[ ! -f "${source_file%.presl}.post.sol" ]]; then
       return 1
     fi

--- a/solidity/scripts/pre_forge.sh
+++ b/solidity/scripts/pre_forge.sh
@@ -9,8 +9,16 @@ CACHE_FILE="$CACHE_DIR/input_fingerprint.sha256"
 compute_input_fingerprint() {
   {
     printf '%s\0' ./preprocessor/yul_preprocessor.py ./scripts/pre_forge.sh
-    find . -type f -name '*.presl' -print0
+    find . -type f \( -name '*.presl' -o \( -name '*.sol' ! -name '*.post.sol' \) \) -print0
   } | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}'
+}
+
+generated_outputs_present() {
+  while IFS= read -r -d '' source_file; do
+    if [[ ! -f "${source_file%.presl}.post.sol" ]]; then
+      return 1
+    fi
+  done < <(find . -type f -name '*.presl' -print0)
 }
 
 if [[ "${1:-}" == "clean" ]]; then
@@ -21,7 +29,7 @@ if [[ "${1:-}" == "clean" ]]; then
 fi
 
 input_fingerprint=$(compute_input_fingerprint)
-if [[ -f "$CACHE_FILE" ]] && [[ "$(<"$CACHE_FILE")" == "$input_fingerprint" ]]; then
+if [[ -f "$CACHE_FILE" ]] && [[ "$(<"$CACHE_FILE")" == "$input_fingerprint" ]] && generated_outputs_present; then
   echo "pre_forge cache hit: skipping preprocessing"
 else
   echo "pre_forge cache miss: regenerating .post.sol files"


### PR DESCRIPTION
## Summary
- add an input fingerprint cache to `solidity/scripts/pre_forge.sh` so unchanged `.presl` sources skip redundant regeneration
- make `pre_forge.sh clean` remove generated `.post.sol` files and cache state without preprocessing first
- add regression tests covering cache hits, cache invalidation, and clean behavior

## Testing
- `docker run --rm -v /home/olegc/bounty-work/sxt-proof-of-sql:/work -w /work python:3.12-slim bash -lc 'python -m pip install -q pytest && bash -n solidity/scripts/pre_forge.sh && python -m pytest solidity/preprocessor/test_yul_preprocessor.py solidity/preprocessor/test_pre_forge.py -q'`

/claim #557
