### PR TITLE
test: cover proof error and serialization helpers

### DIFF
--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,152 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{PlaceholderError, PlaceholderResult, ProofError, ProofSizeMismatch};
+    use crate::base::database::ColumnType;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_proof_errors() {
+        let cases = [
+            (
+                ProofError::VerificationError {
+                    error: "bad transcript",
+                }
+                .to_string(),
+                "Verification error: bad transcript",
+            ),
+            (
+                ProofError::UnsupportedQueryPlan {
+                    error: "unsupported join",
+                }
+                .to_string(),
+                "Unsupported query plan: unsupported join",
+            ),
+            (
+                ProofError::InvalidTypeCoercion.to_string(),
+                "Result does not match query: type mismatch",
+            ),
+            (
+                ProofError::FieldNamesMismatch.to_string(),
+                "Result does not match query: field names mismatch",
+            ),
+            (
+                ProofError::FieldCountMismatch.to_string(),
+                "Result does not match query: field count mismatch",
+            ),
+        ];
+
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn we_can_display_proof_size_mismatch_errors() {
+        let cases = [
+            (
+                ProofSizeMismatch::SumcheckProofTooSmall.to_string(),
+                "Sumcheck proof is too small",
+            ),
+            (
+                ProofSizeMismatch::TooFewMLEEvaluations.to_string(),
+                "Proof has too few MLE evaluations",
+            ),
+            (
+                ProofSizeMismatch::PostResultCountMismatch.to_string(),
+                "Post result challenge count mismatch",
+            ),
+            (
+                ProofSizeMismatch::ConstraintCountMismatch.to_string(),
+                "Constraint count mismatch",
+            ),
+            (
+                ProofSizeMismatch::TooFewBitDistributions.to_string(),
+                "Proof has too few bit distributions",
+            ),
+            (
+                ProofSizeMismatch::TooFewChiLengths.to_string(),
+                "Proof has too few one lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewRhoLengths.to_string(),
+                "Proof has too few rho lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewSumcheckVariables.to_string(),
+                "Proof has too few sumcheck variables",
+            ),
+            (
+                ProofSizeMismatch::ChiLengthNotFound.to_string(),
+                "Proof doesn't have requested one length",
+            ),
+            (
+                ProofSizeMismatch::RhoLengthNotFound.to_string(),
+                "Proof doesn't have requested rho length",
+            ),
+        ];
+
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn we_can_display_placeholder_errors() {
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderIndex {
+                index: 3,
+                num_params: 2
+            }
+            .to_string(),
+            "Invalid placeholder index: 3, number of params: 2"
+        );
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderType {
+                index: 1,
+                expected: ColumnType::BigInt,
+                actual: ColumnType::Boolean,
+            }
+            .to_string(),
+            "Invalid placeholder type: 1, expected: BIGINT, actual: BOOLEAN"
+        );
+        assert_eq!(
+            PlaceholderError::ZeroPlaceholderId.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn proof_error_preserves_transparent_sources() {
+        assert_eq!(
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewRhoLengths
+            }
+            .to_string(),
+            "Proof has too few rho lengths"
+        );
+        assert_eq!(
+            ProofError::PlaceholderError {
+                source: PlaceholderError::ZeroPlaceholderId
+            }
+            .to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn placeholder_result_uses_placeholder_error() {
+        let result: PlaceholderResult<()> = Err(PlaceholderError::InvalidPlaceholderIndex {
+            index: 5,
+            num_params: 3,
+        });
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid placeholder index: 5, number of params: 3"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,21 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn we_can_serialize_fixed_width_integers_as_big_endian() {
+        let serialized = try_standard_binary_serialization((0x1234_u16, 0x0102_0304_u32)).unwrap();
+
+        assert_eq!(serialized, [0x12, 0x34, 0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn we_can_deserialize_with_consumed_byte_count() {
+        let bytes = [0x12, 0x34, 0x01, 0x02, 0x03, 0x04, 0xff];
+        let (deserialized, bytes_read): ((u16, u32), usize) =
+            try_standard_binary_deserialization(&bytes).unwrap();
+
+        assert_eq!(deserialized, (0x1234, 0x0102_0304));
+        assert_eq!(bytes_read, 6);
+    }
 }

--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,55 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn we_can_serialize_limbs_in_big_endian_limb_order() {
+        let wrapper = LimbWrapper {
+            limbs: [1, 2, 3, 4],
+        };
+
+        assert_eq!(
+            serde_json::to_string(&wrapper).unwrap(),
+            r#"{"limbs":[4,3,2,1]}"#
+        );
+    }
+
+    #[test]
+    fn we_can_deserialize_limbs_from_big_endian_limb_order() {
+        let wrapper: LimbWrapper = serde_json::from_str(r#"{"limbs":[4,3,2,1]}"#).unwrap();
+
+        assert_eq!(
+            wrapper,
+            LimbWrapper {
+                limbs: [1, 2, 3, 4]
+            }
+        );
+    }
+
+    #[test]
+    fn limbs_round_trip_asymmetric_values() {
+        let wrapper = LimbWrapper {
+            limbs: [0, u64::MAX, 42, 7],
+        };
+
+        let serialized = serde_json::to_string(&wrapper).unwrap();
+        let deserialized: LimbWrapper = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, wrapper);
+        assert_eq!(serialized, r#"{"limbs":[7,42,18446744073709551615,0]}"#);
+    }
+}


### PR DESCRIPTION
## Summary
- add focused coverage for proof error display strings and transparent source propagation
- cover limb serde helper endianness and round-trip behavior
- cover standard binary serialization big-endian fixed-width integers and consumed byte counts

/claim #560

## Verification
- cargo fmt --check
- cargo test -p proof-of-sql base::proof::error::tests
- cargo test -p proof-of-sql base::standard_serializations::limbs::tests
- cargo test -p proof-of-sql base::standard_serializations::binary::tests