### PR TITLE
test: cover index map helpers

### DIFF
--- a/crates/proof-of-sql/src/base/map.rs
+++ b/crates/proof-of-sql/src/base/map.rs
@@ -18,3 +18,65 @@ macro_rules! indexset {
 #[cfg(test)]
 pub(crate) use indexmap;
 pub(crate) use indexset;
+
+#[cfg(test)]
+mod tests {
+    use super::{IndexMap, IndexSet};
+    use alloc::{string::String, vec};
+
+    #[test]
+    fn indexmap_macro_preserves_insertion_order() {
+        let map = indexmap! {
+            "first" => 1,
+            "second" => 2,
+            "third" => 3,
+        };
+
+        assert_eq!(
+            map.keys().copied().collect::<Vec<_>>(),
+            vec!["first", "second", "third"]
+        );
+        assert_eq!(map.values().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn indexmap_alias_uses_expected_hasher_and_keeps_latest_duplicate_value() {
+        let mut map: IndexMap<String, usize> = IndexMap::default();
+
+        map.insert("alpha".into(), 1);
+        map.insert("beta".into(), 2);
+        map.insert("alpha".into(), 3);
+
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("alpha"), Some(&3));
+        assert_eq!(
+            map.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
+        );
+    }
+
+    #[test]
+    fn indexset_macro_preserves_insertion_order_and_removes_duplicates() {
+        let set = indexset!["red", "green", "red", "blue"];
+
+        assert_eq!(set.len(), 3);
+        assert_eq!(
+            set.iter().copied().collect::<Vec<_>>(),
+            vec!["red", "green", "blue"]
+        );
+    }
+
+    #[test]
+    fn indexset_alias_uses_expected_hasher() {
+        let mut set: IndexSet<String> = IndexSet::default();
+
+        assert!(set.insert("north".into()));
+        assert!(set.insert("south".into()));
+        assert!(!set.insert("north".into()));
+
+        assert_eq!(
+            set.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["north", "south"]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add focused coverage for the local IndexMap and IndexSet aliases
- cover helper macro insertion order behavior
- cover duplicate-key/value semantics for map and set helpers

/claim #560

## Verification
- cargo fmt --check
- cargo test -p proof-of-sql base::map::tests
- git diff --check