### PR TITLE
test: cover memory usage logging

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -67,7 +67,8 @@ merlin = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["std"] }
 rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -30,3 +30,18 @@ pub fn log_memory_usage(name: &str) {
         );
     }
 }
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_log_memory_usage_when_trace_is_enabled() {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(Level::TRACE)
+            .with_writer(std::io::sink)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || log_memory_usage("test"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused trace-level test for `log_memory_usage`
- enable tracing's std support and add `tracing-subscriber` for dev-only subscriber setup

/claim #560

## Verification
- cargo fmt --check
- cargo test -p proof-of-sql --no-default-features --features="test" we_can_log_memory_usage_when_trace_is_enabled -- --nocapture
- cargo llvm-cov -p proof-of-sql --no-default-features --features="test" --lib --summary-only
