### PR TITLE
test: cover empty dynamic Dory CPU commitment

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -107,3 +107,21 @@ pub(super) fn compute_dynamic_dory_commitments(
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{test_rng, PublicParameters};
+
+    #[test]
+    fn we_return_default_commitment_for_empty_column_impl() {
+        let public_parameters = PublicParameters::test_rand(0, &mut test_rng());
+        let setup = ProverSetup::from(&public_parameters);
+        let column: [i64; 0] = [];
+
+        assert_eq!(
+            compute_dory_commitment_impl(&column, 7, &setup),
+            DynamicDoryCommitment::default()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused unit test for the empty-column fast path in `compute_dory_commitment_impl`
- cover the default dynamic Dory commitment return without touching setup-dependent paths

/claim #560

## Verification
- cargo fmt --check
- cargo test -p proof-of-sql --no-default-features --features="test" we_return_default_commitment_for_empty_column_impl -- --nocapture
- cargo llvm-cov -p proof-of-sql --no-default-features --features="test" --lib --summary-only
