### PR TITLE
test: cover Dory VMV state builders

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/build_vmv_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/build_vmv_state.rs
@@ -46,3 +46,44 @@ pub(super) fn build_vmv_verifier_state(
         nu,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_ec::{pairing::PairingOutput, AffineRepr};
+    use num_traits::One;
+
+    fn g1(scale: u64) -> G1Affine {
+        (G1Affine::generator() * F::from(scale)).into()
+    }
+
+    #[test]
+    fn build_vmv_prover_state_populates_vectors_and_tensors() {
+        let a = [F::from(5), F::from(7), F::from(11), F::from(13)];
+        let b_point = [F::from(2), F::from(3)];
+        let T_vec_prime = vec![g1(17), g1(19)];
+
+        let state = build_vmv_prover_state(&a, &b_point, T_vec_prime.clone(), 1, 1);
+
+        assert_eq!(state.v_vec, vec![F::from(23), F::from(25)]);
+        assert_eq!(state.T_vec_prime, T_vec_prime);
+        assert_eq!(state.l_tensor, vec![F::from(3)]);
+        assert_eq!(state.r_tensor, vec![F::from(2)]);
+        assert_eq!(state.L_vec, vec![F::from(-2), F::from(3)]);
+        assert_eq!(state.R_vec, vec![F::from(-1), F::from(2)]);
+        assert_eq!(state.nu, 1);
+    }
+
+    #[test]
+    fn build_vmv_verifier_state_populates_tensors() {
+        let b_point = [F::from(2), F::from(3)];
+        let T = DeferredGT::from(PairingOutput::<ark_bls12_381::Bls12_381>(One::one()));
+
+        let state = build_vmv_verifier_state(F::from(29), &b_point, T, 1, 1);
+
+        assert_eq!(state.y, F::from(29));
+        assert_eq!(state.l_tensor, vec![F::from(3)]);
+        assert_eq!(state.r_tensor, vec![F::from(2)]);
+        assert_eq!(state.nu, 1);
+    }
+}


### PR DESCRIPTION
/claim #560

Contributes to #560.

Summary:
- Adds focused unit coverage for the Dory VMV prover/verifier state builders.
- Keeps the patch test-only and limited to `proof_primitive/dory/build_vmv_state.rs`.
- I checked the Dory pairing helper wrapper slice first, but did not add it because open PR #1293 already covers that duplicate area.

Validation:
- `cargo +1.91.1 fmt --check` passed
- `cargo +1.91.1 test -p proof-of-sql --no-default-features --features test build_vmv_state --lib` passed: 2 passed
- `cargo +1.91.1 test -p proof-of-sql --no-default-features --features test pairings --lib` passed: 1 passed
- `git diff --check` passed

No security research, no cryptanalysis, no exploit work, no live probing, and no protocol changes. Test-only coverage.