### PR TITLE
test: cover column commitment extension path

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -953,3 +953,55 @@ mod tests {
         ));
     }
 }
+
+#[cfg(test)]
+mod coverage_tests {
+    use super::*;
+    use crate::base::{commitment::naive_commitment::NaiveCommitment, database::ColumnType};
+
+    #[test]
+    fn we_can_extend_column_commitments_without_blitzar() {
+        let first_id: Ident = "first_column".into();
+        let second_id: Ident = "second_column".into();
+        let first_values = [1_i64, 2, 3];
+        let second_values = [4_i64, 5, 6];
+
+        let mut actual = ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
+            [(&first_id, first_values.as_slice())],
+            2,
+            &(),
+        )
+        .unwrap();
+
+        actual
+            .try_extend_columns_with_offset([(&second_id, second_values.as_slice())], 2, &())
+            .unwrap();
+
+        let expected = ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
+            [
+                (&first_id, first_values.as_slice()),
+                (&second_id, second_values.as_slice()),
+            ],
+            2,
+            &(),
+        )
+        .unwrap();
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), 2);
+
+        let mut metadata_keys = actual.column_metadata().keys();
+        assert_eq!(metadata_keys.next(), Some(&first_id));
+        assert_eq!(metadata_keys.next(), Some(&second_id));
+        assert_eq!(metadata_keys.next(), None);
+
+        assert_eq!(
+            actual.get_metadata(&first_id).unwrap().column_type(),
+            &ColumnType::BigInt
+        );
+        assert_eq!(
+            actual.get_metadata(&second_id).unwrap().column_type(),
+            &ColumnType::BigInt
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -1004,4 +1004,49 @@ mod coverage_tests {
             &ColumnType::BigInt
         );
     }
+
+    #[test]
+    fn we_can_append_rows_to_column_commitments_without_blitzar() {
+        let first_id: Ident = "first_column".into();
+        let second_id: Ident = "second_column".into();
+        let first_initial_values = [1_i64, 2];
+        let second_initial_values = [7_i64, 8];
+        let first_appended_values = [3_i64, 4];
+        let second_appended_values = [9_i64, 10];
+
+        let mut actual = ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
+            [
+                (&first_id, first_initial_values.as_slice()),
+                (&second_id, second_initial_values.as_slice()),
+            ],
+            0,
+            &(),
+        )
+        .unwrap();
+
+        actual
+            .try_append_rows_with_offset(
+                [
+                    (&first_id, first_appended_values.as_slice()),
+                    (&second_id, second_appended_values.as_slice()),
+                ],
+                first_initial_values.len(),
+                &(),
+            )
+            .unwrap();
+
+        let first_values = [1_i64, 2, 3, 4];
+        let second_values = [7_i64, 8, 9, 10];
+        let expected = ColumnCommitments::<NaiveCommitment>::try_from_columns_with_offset(
+            [
+                (&first_id, first_values.as_slice()),
+                (&second_id, second_values.as_slice()),
+            ],
+            0,
+            &(),
+        )
+        .unwrap();
+
+        assert_eq!(actual, expected);
+    }
 }


### PR DESCRIPTION
## Summary
- add non-blitzar unit tests for `ColumnCommitments::try_extend_columns_with_offset` and `try_append_rows_with_offset`
- cover the successful extension and append branches under the no-default-features test configuration used by the coverage bounty

## Verification
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features="test" base::commitment::column_commitments::coverage_tests --lib`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features="test" --lib --summary-only`

/claim #560