### PR TITLE
test: cover order by comparison variants

### DIFF
--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
         database::{order_by_util::*, Column, ColumnType, TableOperationError},
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
@@ -74,6 +76,200 @@ fn we_can_compare_indexes_by_columns_for_mixed_columns() {
     assert_eq!(compare_indexes_by_columns(columns, 3, 4), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 2, 7), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 6, 9), Ordering::Equal);
+}
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_more_column_types() {
+    let bools = &[false, true, true];
+    let uint8s = &[3_u8, 1, 1];
+    let tinyints = &[3_i8, 1, 1];
+    let smallints = &[3_i16, 1, 1];
+    let ints = &[3_i32, 1, 1];
+    let decimals: Vec<TestScalar> = [3, 1, 1].iter().map(core::convert::Into::into).collect();
+
+    assert_eq!(
+        compare_indexes_by_columns(&[Column::Boolean::<TestScalar>(bools)], 0, 1),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_indexes_by_columns(&[Column::Uint8::<TestScalar>(uint8s)], 0, 1),
+        Ordering::Greater
+    );
+    assert_eq!(
+        compare_indexes_by_columns(&[Column::TinyInt::<TestScalar>(tinyints)], 1, 0),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_indexes_by_columns(&[Column::SmallInt::<TestScalar>(smallints)], 1, 2),
+        Ordering::Equal
+    );
+    assert_eq!(
+        compare_indexes_by_columns(&[Column::Int::<TestScalar>(ints)], 0, 1),
+        Ordering::Greater
+    );
+    assert_eq!(
+        compare_indexes_by_columns(
+            &[Column::Decimal75(Precision::new(10).unwrap(), 2, &decimals)],
+            0,
+            1
+        ),
+        Ordering::Greater
+    );
+}
+
+#[test]
+fn we_can_compare_single_row_of_tables_for_more_column_types() {
+    let left_bools = &[false];
+    let right_bools = &[true];
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::Boolean::<TestScalar>(left_bools)],
+            &[Column::Boolean::<TestScalar>(right_bools)],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Less
+    );
+
+    let left_uint8s = &[1_u8];
+    let right_uint8s = &[2_u8];
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::Uint8::<TestScalar>(left_uint8s)],
+            &[Column::Uint8::<TestScalar>(right_uint8s)],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Less
+    );
+
+    let left_tinyints = &[3_i8];
+    let right_tinyints = &[2_i8];
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::TinyInt::<TestScalar>(left_tinyints)],
+            &[Column::TinyInt::<TestScalar>(right_tinyints)],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Greater
+    );
+
+    let left_smallints = &[4_i16];
+    let right_smallints = &[4_i16];
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::SmallInt::<TestScalar>(left_smallints)],
+            &[Column::SmallInt::<TestScalar>(right_smallints)],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Equal
+    );
+
+    let left_ints = &[5_i32];
+    let right_ints = &[4_i32];
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::Int::<TestScalar>(left_ints)],
+            &[Column::Int::<TestScalar>(right_ints)],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Greater
+    );
+
+    let left_timestamps = &[5_i64];
+    let right_timestamps = &[6_i64];
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::<TestScalar>::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                left_timestamps
+            )],
+            &[Column::<TestScalar>::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                right_timestamps
+            )],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Less
+    );
+
+    let left_int128s = &[7_i128];
+    let right_int128s = &[6_i128];
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::Int128::<TestScalar>(left_int128s)],
+            &[Column::Int128::<TestScalar>(right_int128s)],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Greater
+    );
+
+    let left_decimals: Vec<TestScalar> = [8].iter().map(core::convert::Into::into).collect();
+    let right_decimals: Vec<TestScalar> = [8].iter().map(core::convert::Into::into).collect();
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::Decimal75(
+                Precision::new(10).unwrap(),
+                2,
+                &left_decimals
+            )],
+            &[Column::Decimal75(
+                Precision::new(10).unwrap(),
+                2,
+                &right_decimals
+            )],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Equal
+    );
+
+    let left_scalars: Vec<TestScalar> = [9].iter().map(core::convert::Into::into).collect();
+    let right_scalars: Vec<TestScalar> = [10].iter().map(core::convert::Into::into).collect();
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::Scalar(left_scalars.as_slice())],
+            &[Column::Scalar(right_scalars.as_slice())],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Less
+    );
+
+    let left_strings = &["apple"];
+    let right_strings = &["banana"];
+    let left_string_scalars: Vec<TestScalar> =
+        left_strings.iter().map(core::convert::Into::into).collect();
+    let right_string_scalars: Vec<TestScalar> = right_strings
+        .iter()
+        .map(core::convert::Into::into)
+        .collect();
+    assert_eq!(
+        compare_single_row_of_tables(
+            &[Column::VarChar((left_strings, &left_string_scalars))],
+            &[Column::VarChar((right_strings, &right_string_scalars))],
+            0,
+            0
+        )
+        .unwrap(),
+        Ordering::Less
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add coverage for remaining primitive, decimal, timestamp, scalar, and varchar comparison paths in order_by_util
- reduce order_by_util.rs uncovered lines from 20 to 1; remaining uncovered line is the unreachable guard

## Validation
- cargo fmt --check
- cargo test -p proof-of-sql order_by_util --no-default-features --features="std"
- cargo llvm-cov --no-default-features --features="std" -p proof-of-sql --lib --lcov --output-path target/proof-of-sql-order-by-util.lcov -- order_by_util
- cargo test -p proof-of-sql --no-default-features --features="std"

/claim #560