### PR TITLE
test: cover base utility helpers

### DIFF
--- a/crates/proof-of-sql/src/base/rayon_cfg.rs
+++ b/crates/proof-of-sql/src/base/rayon_cfg.rs
@@ -11,3 +11,18 @@ macro_rules! if_rayon {
     }};
 }
 pub(crate) use if_rayon;
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(feature = "rayon"))]
+    #[test]
+    fn if_rayon_selects_fallback_value_without_rayon_feature() {
+        assert_eq!(if_rayon!("rayon", "fallback"), "fallback");
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn if_rayon_selects_rayon_value_with_rayon_feature() {
+        assert_eq!(if_rayon!("rayon", "fallback"), "rayon");
+    }
+}

--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,26 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+
+    struct WrappedValue(u32);
+
+    impl From<&WrappedValue> for u32 {
+        fn from(value: &WrappedValue) -> Self {
+            value.0
+        }
+    }
+
+    #[test]
+    fn blanket_impl_uses_reference_conversion_without_consuming_value() {
+        let value = WrappedValue(7);
+
+        let converted: u32 = value.ref_into();
+
+        assert_eq!(converted, 7);
+        assert_eq!(value.0, 7);
+    }
+}


### PR DESCRIPTION
## Summary
- Contributes to #560
- Adds focused unit coverage for the `RefInto` blanket implementation
- Adds focused unit coverage for the `if_rayon!` feature-selection macro in no-rayon and rayon builds

## Scope
- Test-only coverage for base utility helpers
- No security research, no protocol changes, no runtime behavior changes

## Validation
- `cargo +1.91.1 fmt --check` passed
- `cargo +1.91.1 test -p proof-of-sql --no-default-features --features test ref_into --lib` passed: 1 passed
- `cargo +1.91.1 test -p proof-of-sql --no-default-features --features test if_rayon --lib` passed: 1 passed
- `git diff --check` passed

/claim #560