### PR TITLE
test: cover multilinear extension variants

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,6 +1,12 @@
 use super::MultilinearExtension;
-use crate::base::{database::Column, scalar::test_scalar::TestScalar};
+use crate::base::{
+    database::Column,
+    math::decimal::Precision,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    scalar::test_scalar::TestScalar,
+};
 use bumpalo::Bump;
+use num_traits::{One, Zero};
 
 #[test]
 fn allocated_slices_must_have_different_ids_even_when_one_is_empty() {
@@ -113,4 +119,130 @@ fn we_can_use_multilinear_extension_methods_for_i64_vec() {
         MultilinearExtension::<TestScalar>::id(&slice),
         MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
+}
+
+#[test]
+fn we_can_evaluate_multilinear_extensions_at_a_point() {
+    let values: &[i64] = &[2, 4, 6, 8];
+    assert_eq!(
+        values.evaluate_at_point(&[TestScalar::zero(), TestScalar::one()]),
+        6.into()
+    );
+}
+
+#[test]
+fn we_can_use_multilinear_extension_methods_for_all_column_variants() {
+    let evaluation_vec: Vec<TestScalar> = vec![2.into(), 3.into(), 5.into()];
+    let multiplier = TestScalar::from(7);
+
+    let booleans = [true, false, true];
+    let uint8s = [1_u8, 2, 3];
+    let tiny_ints = [-1_i8, 2, -3];
+    let small_ints = [-10_i16, 20, -30];
+    let ints = [-100_i32, 200, -300];
+    let big_ints = [-1000_i64, 2000, -3000];
+    let int128s = [-10000_i128, 20000, -30000];
+    let scalar_values = [11.into(), 12.into(), 13.into()];
+    let decimal_values = [21.into(), 22.into(), 23.into()];
+    let timestamp_values = [31_i64, 32, 33];
+    let varchar_values = ["alpha", "beta", "gamma"];
+    let varchar_scalars = [41.into(), 42.into(), 43.into()];
+    let binary_a: &[u8] = &[1, 2];
+    let binary_b: &[u8] = &[3, 4];
+    let binary_c: &[u8] = &[5, 6];
+    let binary_values = [binary_a, binary_b, binary_c];
+    let binary_scalars = [51.into(), 52.into(), 53.into()];
+
+    let cases = [
+        (
+            Column::Boolean(&booleans),
+            vec![1.into(), 0.into(), 1.into()],
+        ),
+        (Column::Uint8(&uint8s), vec![1.into(), 2.into(), 3.into()]),
+        (
+            Column::TinyInt(&tiny_ints),
+            vec![(-1).into(), 2.into(), (-3).into()],
+        ),
+        (
+            Column::SmallInt(&small_ints),
+            vec![(-10).into(), 20.into(), (-30).into()],
+        ),
+        (
+            Column::Int(&ints),
+            vec![(-100).into(), 200.into(), (-300).into()],
+        ),
+        (
+            Column::BigInt(&big_ints),
+            vec![(-1000).into(), 2000.into(), (-3000).into()],
+        ),
+        (
+            Column::Int128(&int128s),
+            vec![(-10000).into(), 20000.into(), (-30000).into()],
+        ),
+        (Column::Scalar(&scalar_values), scalar_values.to_vec()),
+        (
+            Column::Decimal75(Precision::new(75).unwrap(), 2, &decimal_values),
+            decimal_values.to_vec(),
+        ),
+        (
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                &timestamp_values,
+            ),
+            vec![31.into(), 32.into(), 33.into()],
+        ),
+        (
+            Column::VarChar((&varchar_values, &varchar_scalars)),
+            varchar_scalars.to_vec(),
+        ),
+        (
+            Column::VarBinary((&binary_values, &binary_scalars)),
+            binary_scalars.to_vec(),
+        ),
+    ];
+
+    for (column, expected_values) in cases {
+        assert_eq!(
+            column.inner_product(&evaluation_vec),
+            expected_inner_product(&expected_values, &evaluation_vec)
+        );
+
+        let mut res = evaluation_vec.clone();
+        column.mul_add(&mut res, &multiplier);
+        assert_eq!(
+            res,
+            expected_mul_add(&expected_values, &evaluation_vec, multiplier)
+        );
+
+        let mut expected_sumcheck_term = expected_values.clone();
+        expected_sumcheck_term.push(TestScalar::zero());
+        assert_eq!(column.to_sumcheck_term(2), expected_sumcheck_term);
+
+        assert_eq!(
+            MultilinearExtension::<TestScalar>::id(&column).1,
+            column.len()
+        );
+    }
+}
+
+fn expected_inner_product(values: &[TestScalar], evaluation_vec: &[TestScalar]) -> TestScalar {
+    values
+        .iter()
+        .zip(evaluation_vec)
+        .fold(TestScalar::zero(), |acc, (value, evaluation)| {
+            acc + *value * *evaluation
+        })
+}
+
+fn expected_mul_add(
+    values: &[TestScalar],
+    base: &[TestScalar],
+    multiplier: TestScalar,
+) -> Vec<TestScalar> {
+    values
+        .iter()
+        .zip(base)
+        .map(|(value, base)| *base + *value * multiplier)
+        .collect()
 }


### PR DESCRIPTION
/claim #560

## Summary
- add direct coverage for the test-only multilinear extension point evaluator
- exercise `inner_product`, `mul_add`, `to_sumcheck_term`, and `id` across every `Column` variant

## Verification
- `PATH="/opt/homebrew/opt/rustup/bin:$PATH" cargo fmt --check`
- `PATH="/opt/homebrew/opt/rustup/bin:$PATH" cargo test -p proof-of-sql multilinear_extension --no-default-features --features="std"`
- `PATH="/Users/proxy/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH" cargo llvm-cov --no-default-features --features="std" -p proof-of-sql --lib --lcov --output-path target/proof-of-sql-multilinear-extension.lcov -- multilinear_extension`
- `multilinear_extension.rs`: 0 missed lines / 106 instrumented lines in targeted coverage
- `PATH="/opt/homebrew/opt/rustup/bin:$PATH" cargo test -p proof-of-sql --no-default-features --features="std"`
