### PR TITLE
test: cover dynamic matrix index boundaries

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/matrix_structure.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/matrix_structure.rs
@@ -273,4 +273,25 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn we_reject_columns_outside_the_full_row_width() {
+        for row in 0..32 {
+            let width = full_width_of_row(row);
+            let row_start = row_start_index(row);
+
+            assert_eq!(
+                index_from_row_and_column(row, width - 1),
+                Some(row_start + width - 1)
+            );
+            assert_eq!(index_from_row_and_column(row, width), None);
+        }
+    }
+
+    #[test]
+    fn we_keep_the_reserved_row_one_column_zero_gap() {
+        assert_eq!(index_from_row_and_column(1, 0), None);
+        assert_eq!(index_from_row_and_column(1, 1), Some(1));
+        assert_eq!(row_and_column_from_index(1), (1, 1));
+    }
 }


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- Adds focused unit coverage for dynamic matrix row/column boundary behavior.
- Verifies the last valid column in each tested row maps to the expected index.
- Verifies out-of-width columns are rejected and the reserved `(1, 0)` gap remains unmapped.

## Validation
- `cargo +1.91.1 fmt --check` passed
- `cargo +1.91.1 test -p proof-of-sql --no-default-features --features test matrix_structure --lib` passed: 8 passed, 0 failed
- `git diff --check` passed

No security research, no protocol changes, test-only coverage.