### PR TITLE
test: cover filter and fold-log proof gadgets

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -150,3 +150,83 @@ pub(crate) fn final_round_filter_constraints<'a, S: Scalar + 'a>(
         ],
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{final_round_evaluate_filter, verify_evaluate_filter};
+    use crate::{
+        base::{
+            database::table_utility::borrowed_bigint,
+            polynomial::MultilinearExtension,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::{
+            proof::{
+                mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
+                FirstRoundBuilder,
+            },
+            proof_plans::fold_vals,
+        },
+    };
+    use bumpalo::Bump;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn we_can_evaluate_and_verify_filter_constraints() {
+        let alloc = Bump::new();
+        let column = borrowed_bigint::<TestScalar>("a", [1, 2, 3, 4], &alloc).1;
+        let filtered_column = borrowed_bigint::<TestScalar>("a", [1, 3], &alloc).1;
+        let selection = alloc.alloc_slice_copy(&[true, false, true, false]);
+        let output_chi = alloc.alloc_slice_fill_copy(2, true);
+        let first_round_builder = FirstRoundBuilder::new(4);
+        let mut final_round_builder = FinalRoundBuilder::new(4, VecDeque::new());
+
+        final_round_evaluate_filter(
+            &mut final_round_builder,
+            &alloc,
+            TestScalar::TWO,
+            TestScalar::TEN,
+            &[column.clone()],
+            selection,
+            &[filtered_column.clone()],
+            4,
+            2,
+        );
+
+        let verification_builder = run_verify_for_each_row(
+            4,
+            &first_round_builder,
+            &final_round_builder,
+            Vec::new(),
+            3,
+            |verification_builder, input_chi_eval, evaluation_point| {
+                let column_eval = column.inner_product(evaluation_point);
+                let filtered_column_eval = filtered_column.inner_product(evaluation_point);
+                let c_fold_eval = TestScalar::TWO * fold_vals(TestScalar::TEN, &[column_eval]);
+                let d_fold_eval =
+                    TestScalar::TWO * fold_vals(TestScalar::TEN, &[filtered_column_eval]);
+                let output_chi_eval = (output_chi as &[_]).inner_product(evaluation_point);
+                let selection_eval = (selection as &[_]).inner_product(evaluation_point);
+
+                verify_evaluate_filter(
+                    verification_builder,
+                    c_fold_eval,
+                    d_fold_eval,
+                    input_chi_eval,
+                    output_chi_eval,
+                    selection_eval,
+                )
+                .unwrap();
+            },
+        );
+
+        assert!(verification_builder
+            .get_identity_results()
+            .iter()
+            .all(|row| row.iter().all(|is_zero| *is_zero)));
+        assert!(verification_builder
+            .get_zero_sum_results()
+            .iter()
+            .all(|is_zero| *is_zero));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
@@ -83,3 +83,89 @@ impl<S: Scalar> FoldLogExpr<S> {
         self.final_round_evaluate_with_chi(builder, alloc, columns, length, chi)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FoldLogExpr;
+    use crate::{
+        base::{
+            database::table_utility::borrowed_bigint,
+            polynomial::MultilinearExtension,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::{
+            mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
+            FirstRoundBuilder,
+        },
+    };
+    use bumpalo::Bump;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn we_can_evaluate_and_verify_fold_log_expr_with_custom_chi() {
+        let alloc = Bump::new();
+        let column = borrowed_bigint::<TestScalar>("a", [2, 4, 6, 8], &alloc).1;
+        let chi = alloc.alloc_slice_copy(&[true, true, false, false]);
+        let expr = FoldLogExpr::new(TestScalar::TWO, TestScalar::TEN);
+        let first_round_builder = FirstRoundBuilder::new(4);
+        let mut final_round_builder = FinalRoundBuilder::new(4, VecDeque::new());
+
+        let (_, fold) = expr.final_round_evaluate_with_chi(
+            &mut final_round_builder,
+            &alloc,
+            &[column.clone()],
+            4,
+            chi,
+        );
+        assert_eq!(
+            fold,
+            &[
+                TestScalar::from(4),
+                TestScalar::from(8),
+                TestScalar::from(12),
+                TestScalar::from(16),
+            ]
+        );
+
+        let verification_builder = run_verify_for_each_row(
+            4,
+            &first_round_builder,
+            &final_round_builder,
+            Vec::new(),
+            3,
+            |verification_builder, chi_eval, evaluation_point| {
+                let column_eval = column.inner_product(evaluation_point);
+                let (star_eval, fold_eval) = expr
+                    .verify_evaluate(verification_builder, &[column_eval], chi_eval)
+                    .unwrap();
+
+                assert_eq!(fold_eval, TestScalar::TWO * column_eval);
+                if chi_eval != TestScalar::ZERO {
+                    assert_eq!(star_eval + fold_eval * star_eval, TestScalar::ONE);
+                }
+            },
+        );
+
+        assert!(verification_builder
+            .get_identity_results()
+            .iter()
+            .all(|row| row.iter().all(|is_zero| *is_zero)));
+    }
+
+    #[test]
+    fn we_can_evaluate_fold_log_expr_with_default_chi() {
+        let alloc = Bump::new();
+        let column = borrowed_bigint::<TestScalar>("a", [3, 5], &alloc).1;
+        let expr = FoldLogExpr::new(TestScalar::TWO, TestScalar::TEN);
+        let mut final_round_builder = FinalRoundBuilder::new(2, VecDeque::new());
+
+        let (star, fold) =
+            expr.final_round_evaluate(&mut final_round_builder, &alloc, &[column], 2);
+
+        assert_eq!(fold, &[TestScalar::from(6), TestScalar::from(10)]);
+        assert_eq!(star[0] + fold[0] * star[0], TestScalar::ONE);
+        assert_eq!(star[1] + fold[1] * star[1], TestScalar::ONE);
+        assert_eq!(final_round_builder.pcs_proof_mles().len(), 1);
+        assert_eq!(final_round_builder.num_sumcheck_subpolynomials(), 1);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add direct coverage for filter_base final-round constraint construction and verifier evaluation.
- Add direct coverage for FoldLogExpr final-round evaluation with custom/default chi and verifier evaluation.

## Verification
- cargo test -p proof-of-sql --no-default-features --features arrow filter_base::tests
- cargo test -p proof-of-sql --no-default-features --features arrow fold_log_expr::tests
- cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/coverage-proof-gadgets.lcov -- proof_gadgets

## Coverage note
Compared against a local full-library baseline from main, the proof_gadgets llvm-cov run newly covers 143 previously uncovered source lines:
- filter_base.rs: 92 lines
- fold_log_expr.rs: 51 lines

At $0.10 per newly covered line, this is approximately $14.30 of coverage.

## Checklist
- [x] Focused unit tests were run locally.
- [x] A local llvm-cov run was used to estimate newly covered baseline-uncovered lines.
- [ ] Full CI script was not run locally.