### PR TITLE
test: cover aggregate and group by metadata

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_metadata_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_metadata_test.rs
@@ -1,0 +1,125 @@
+use super::{test_utility::table_exec, AggregateExec};
+use crate::{
+    base::database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef},
+    sql::{
+        proof::ProofPlan,
+        proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr},
+    },
+};
+
+fn table_schema() -> Vec<ColumnField> {
+    vec![
+        ColumnField::new("a".into(), ColumnType::BigInt),
+        ColumnField::new("b".into(), ColumnType::Boolean),
+        ColumnField::new("c".into(), ColumnType::BigInt),
+        ColumnField::new("name".into(), ColumnType::VarChar),
+    ]
+}
+
+fn column_ref(table_ref: &TableRef, name: &str, column_type: ColumnType) -> ColumnRef {
+    ColumnRef::new(table_ref.clone(), name.into(), column_type)
+}
+
+fn column(table_ref: &TableRef, name: &str, column_type: ColumnType) -> DynProofExpr {
+    DynProofExpr::Column(ColumnExpr::new(column_ref(table_ref, name, column_type)))
+}
+
+fn aliased_column(
+    table_ref: &TableRef,
+    name: &str,
+    column_type: ColumnType,
+    alias: &str,
+) -> AliasedDynProofExpr {
+    AliasedDynProofExpr {
+        expr: column(table_ref, name, column_type),
+        alias: alias.into(),
+    }
+}
+
+fn count_all_filter() -> DynProofExpr {
+    DynProofExpr::new_literal(LiteralValue::Boolean(true))
+}
+
+#[test]
+fn aggregate_exec_reports_result_fields_and_references() {
+    let table_ref = TableRef::new("sxt", "t");
+    let aggregate = AggregateExec::try_new(
+        vec![aliased_column(
+            &table_ref,
+            "a",
+            ColumnType::BigInt,
+            "group_a",
+        )],
+        vec![aliased_column(&table_ref, "c", ColumnType::BigInt, "sum_c")],
+        "__count__".into(),
+        Box::new(table_exec(table_ref.clone(), table_schema())),
+        count_all_filter(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        aggregate.get_column_result_fields(),
+        vec![
+            ColumnField::new("group_a".into(), ColumnType::BigInt),
+            ColumnField::new("sum_c".into(), ColumnType::BigInt),
+            ColumnField::new("__count__".into(), ColumnType::BigInt),
+        ]
+    );
+
+    let column_refs = aggregate.get_column_references();
+    assert_eq!(column_refs.len(), 4);
+    assert!(column_refs.contains(&column_ref(&table_ref, "a", ColumnType::BigInt)));
+    assert!(column_refs.contains(&column_ref(&table_ref, "b", ColumnType::Boolean)));
+    assert!(column_refs.contains(&column_ref(&table_ref, "c", ColumnType::BigInt)));
+    assert!(column_refs.contains(&column_ref(&table_ref, "name", ColumnType::VarChar)));
+
+    let table_refs = aggregate.get_table_references();
+    assert_eq!(table_refs.len(), 1);
+    assert!(table_refs.contains(&table_ref));
+}
+
+#[test]
+fn aggregate_exec_distinguishes_uniqueness_modes() {
+    let table_ref = TableRef::new("sxt", "t");
+    let input = table_exec(table_ref.clone(), table_schema());
+    let sum_expr = vec![aliased_column(&table_ref, "c", ColumnType::BigInt, "sum_c")];
+
+    let ungrouped = AggregateExec::try_new(
+        vec![],
+        sum_expr.clone(),
+        "__count__".into(),
+        Box::new(input.clone()),
+        count_all_filter(),
+    )
+    .unwrap();
+    assert_eq!(ungrouped.try_get_is_uniqueness_provable(), Some(false));
+
+    let numeric_group = AggregateExec::try_new(
+        vec![aliased_column(
+            &table_ref,
+            "a",
+            ColumnType::BigInt,
+            "group_a",
+        )],
+        sum_expr.clone(),
+        "__count__".into(),
+        Box::new(input.clone()),
+        count_all_filter(),
+    )
+    .unwrap();
+    assert_eq!(numeric_group.try_get_is_uniqueness_provable(), Some(true));
+
+    assert!(AggregateExec::try_new(
+        vec![aliased_column(
+            &table_ref,
+            "name",
+            ColumnType::VarChar,
+            "group_name",
+        )],
+        sum_expr,
+        "__count__".into(),
+        Box::new(input),
+        count_all_filter(),
+    )
+    .is_none());
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_metadata_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_metadata_test.rs
@@ -1,0 +1,112 @@
+use super::GroupByExec;
+use crate::{
+    base::database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef},
+    sql::{
+        proof::ProofPlan,
+        proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
+    },
+};
+
+fn table_ref() -> TableRef {
+    TableRef::new("sxt", "t")
+}
+
+fn column_ref(table_ref: &TableRef, name: &str, column_type: ColumnType) -> ColumnRef {
+    ColumnRef::new(table_ref.clone(), name.into(), column_type)
+}
+
+fn column_expr(table_ref: &TableRef, name: &str, column_type: ColumnType) -> ColumnExpr {
+    ColumnExpr::new(column_ref(table_ref, name, column_type))
+}
+
+fn column(table_ref: &TableRef, name: &str, column_type: ColumnType) -> DynProofExpr {
+    DynProofExpr::Column(column_expr(table_ref, name, column_type))
+}
+
+fn aliased_column(
+    table_ref: &TableRef,
+    name: &str,
+    column_type: ColumnType,
+    alias: &str,
+) -> AliasedDynProofExpr {
+    AliasedDynProofExpr {
+        expr: column(table_ref, name, column_type),
+        alias: alias.into(),
+    }
+}
+
+fn table_expr(table_ref: &TableRef) -> TableExpr {
+    TableExpr {
+        table_ref: table_ref.clone(),
+    }
+}
+
+fn count_all_filter() -> DynProofExpr {
+    DynProofExpr::new_literal(LiteralValue::Boolean(true))
+}
+
+#[test]
+fn group_by_exec_reports_result_fields_and_references() {
+    let table_ref = table_ref();
+    let group_by = GroupByExec::try_new(
+        vec![column_expr(&table_ref, "a", ColumnType::BigInt)],
+        vec![aliased_column(&table_ref, "c", ColumnType::BigInt, "sum_c")],
+        "__count__".into(),
+        table_expr(&table_ref),
+        count_all_filter(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        group_by.get_column_result_fields(),
+        vec![
+            ColumnField::new("a".into(), ColumnType::BigInt),
+            ColumnField::new("sum_c".into(), ColumnType::BigInt),
+            ColumnField::new("__count__".into(), ColumnType::BigInt),
+        ]
+    );
+
+    let column_refs = group_by.get_column_references();
+    assert_eq!(column_refs.len(), 2);
+    assert!(column_refs.contains(&column_ref(&table_ref, "a", ColumnType::BigInt)));
+    assert!(column_refs.contains(&column_ref(&table_ref, "c", ColumnType::BigInt)));
+
+    let table_refs = group_by.get_table_references();
+    assert_eq!(table_refs.len(), 1);
+    assert!(table_refs.contains(&table_ref));
+}
+
+#[test]
+fn group_by_exec_distinguishes_uniqueness_modes() {
+    let table_ref = table_ref();
+    let sum_expr = vec![aliased_column(&table_ref, "c", ColumnType::BigInt, "sum_c")];
+
+    let ungrouped = GroupByExec::try_new(
+        vec![],
+        sum_expr.clone(),
+        "__count__".into(),
+        table_expr(&table_ref),
+        count_all_filter(),
+    )
+    .unwrap();
+    assert_eq!(ungrouped.try_get_is_uniqueness_provable(), Some(false));
+
+    let numeric_group = GroupByExec::try_new(
+        vec![column_expr(&table_ref, "a", ColumnType::BigInt)],
+        sum_expr.clone(),
+        "__count__".into(),
+        table_expr(&table_ref),
+        count_all_filter(),
+    )
+    .unwrap();
+    assert_eq!(numeric_group.try_get_is_uniqueness_provable(), Some(true));
+
+    assert!(GroupByExec::try_new(
+        vec![column_expr(&table_ref, "name", ColumnType::VarChar)],
+        sum_expr,
+        "__count__".into(),
+        table_expr(&table_ref),
+        count_all_filter(),
+    )
+    .is_none());
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -32,6 +32,8 @@ mod fold_util_test;
 mod group_by_exec;
 pub(crate) use group_by_exec::GroupByExec;
 
+#[cfg(test)]
+mod group_by_exec_metadata_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod group_by_exec_test;
 
@@ -44,6 +46,8 @@ mod filter_exec_test;
 mod aggregate_exec;
 pub(crate) use aggregate_exec::AggregateExec;
 
+#[cfg(test)]
+mod aggregate_exec_metadata_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod aggregate_exec_test;
 


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This contributes to #560 by adding test-only coverage for proof plan metadata behavior in `AggregateExec` and `GroupByExec`.

Local llvm-cov comparison against `main` shows 64 newly covered existing production lines:
- `group_by_exec.rs`: 28
- `aggregate_exec.rs`: 22
- `column_expr.rs`: 6
- `proof_plans/test_utility.rs`: 3
- `literal_expr.rs`: 1

At the bounty rate of $0.10 per newly covered line, this is approximately $6.40 of coverage if accepted.

# What changes are included in this PR?

- Add no-default-features unit coverage for `AggregateExec` result fields, table/column references, and uniqueness-mode behavior.
- Add matching `GroupByExec` coverage for result fields, table/column references, and varchar grouping rejection.
- Keep the patch limited to tests and test module wiring.

# Are these changes tested?

Yes. I ran:

- `cargo +1.91.1-x86_64-pc-windows-msvc fmt --all -- --config imports_granularity=Crate,group_imports=One`
- `cargo +1.91.1-x86_64-pc-windows-msvc test -p proof-of-sql --target x86_64-pc-windows-msvc --no-default-features --features test aggregate_exec_metadata_test --lib`
- `cargo +1.91.1-x86_64-pc-windows-msvc test -p proof-of-sql --target x86_64-pc-windows-msvc --no-default-features --features test group_by_exec_metadata_test --lib`
- `cargo +1.91.1-x86_64-pc-windows-msvc llvm-cov -p proof-of-sql --target x86_64-pc-windows-msvc --no-default-features --features test --lib --lcov --output-path target/proof-of-sql-after-metadata.lcov`
- `git diff --check`

Full no-default-features library coverage run passed locally: 964 tests.

I did not run `source scripts/run_ci_checks.sh` or `source scripts/check_commits.sh` locally because this environment is Windows-based and the repository scripts are Linux shell workflows.