### PR TITLE
test: cover empty exec plan

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec_test.rs
@@ -1,0 +1,77 @@
+use super::EmptyExec;
+use crate::{
+    base::{
+        database::{LiteralValue, Table, TableRef},
+        map::IndexMap,
+        scalar::test_scalar::TestScalar,
+    },
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, SumcheckMleEvaluations,
+        VerificationBuilderImpl,
+    },
+};
+use alloc::collections::VecDeque;
+use bumpalo::Bump;
+use sqlparser::ast::Ident;
+
+#[test]
+fn empty_exec_reports_empty_metadata() {
+    let empty = EmptyExec::new();
+
+    assert_eq!(EmptyExec::default(), empty);
+    assert!(empty.get_column_result_fields().is_empty());
+    assert!(empty.get_column_references().is_empty());
+    assert!(empty.get_table_references().is_empty());
+}
+
+#[test]
+fn empty_exec_verifier_returns_singleton_chi_for_one_empty_row() {
+    let empty = EmptyExec::new();
+    let singleton_chi_evaluation = TestScalar::from(17u64);
+    let mle_evaluations = SumcheckMleEvaluations {
+        singleton_chi_evaluation,
+        ..Default::default()
+    };
+    let mut builder = VerificationBuilderImpl::new(
+        mle_evaluations,
+        &[][..],
+        &[][..],
+        VecDeque::new(),
+        Vec::new(),
+        Vec::new(),
+        0,
+    );
+    let accessor: IndexMap<TableRef, IndexMap<Ident, TestScalar>> = IndexMap::default();
+    let chi_eval_map: IndexMap<TableRef, (TestScalar, usize)> = IndexMap::default();
+
+    let table_evaluation = empty
+        .verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[])
+        .unwrap();
+
+    assert!(table_evaluation.column_evals().is_empty());
+    assert_eq!(table_evaluation.chi(), (singleton_chi_evaluation, 1));
+}
+
+#[test]
+fn empty_exec_prover_rounds_return_one_row_without_columns() {
+    let empty = EmptyExec::new();
+    let alloc = Bump::new();
+    let table_map: IndexMap<TableRef, Table<'_, TestScalar>> = IndexMap::default();
+    let params: &[LiteralValue] = &[];
+
+    let mut first_round_builder = FirstRoundBuilder::new(0);
+    let first_round_table = empty
+        .first_round_evaluate(&mut first_round_builder, &alloc, &table_map, params)
+        .unwrap();
+    assert!(first_round_table.is_empty());
+    assert_eq!(first_round_table.num_columns(), 0);
+    assert_eq!(first_round_table.num_rows(), 1);
+
+    let mut final_round_builder = FinalRoundBuilder::new(0, VecDeque::new());
+    let final_round_table = empty
+        .final_round_evaluate(&mut final_round_builder, &alloc, &table_map, params)
+        .unwrap();
+    assert!(final_round_table.is_empty());
+    assert_eq!(final_round_table.num_columns(), 0);
+    assert_eq!(final_round_table.num_rows(), 1);
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -1,6 +1,8 @@
 //! This module proves provable execution plans.
 mod empty_exec;
 pub use empty_exec::EmptyExec;
+#[cfg(test)]
+mod empty_exec_test;
 
 mod table_exec;
 pub use table_exec::TableExec;


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This contributes to #560 by adding focused no-default-features unit coverage for `EmptyExec`, which previously had a small uncovered proof-plan surface.

Local targeted llvm-cov shows `empty_exec.rs` at 55/55 covered lines. The earlier local baseline had 52 missed existing production lines for this file, so this PR estimates approximately 52 newly covered production lines.

At the bounty rate of $0.10 per newly covered line, this is approximately $5.20 of coverage if accepted.

# What changes are included in this PR?

- Add metadata coverage for `EmptyExec::new`, `Default`, result fields, column references, and table references.
- Add verifier coverage for returning the singleton chi evaluation with one empty row.
- Add prover first- and final-round coverage for producing a one-row, zero-column table.
- Register the focused test module under `#[cfg(test)]`.

# Are these changes tested?

Yes. I ran:

- `cargo +1.91.1-x86_64-pc-windows-msvc fmt --all -- --config imports_granularity=Crate,group_imports=One`
- `cargo +1.91.1-x86_64-pc-windows-msvc test -p proof-of-sql --target x86_64-pc-windows-msvc --no-default-features --features test empty_exec --lib`
  - Result: 4 passed; 0 failed; 959 filtered out.
- `cargo +1.91.1-x86_64-pc-windows-msvc llvm-cov -p proof-of-sql --target x86_64-pc-windows-msvc --no-default-features --features test --lib --lcov --output-path target/proof-of-sql-empty-exec.lcov -- empty_exec`
  - `empty_exec.rs`: 55 hit, 0 missed, 55 total.
- `git diff --check`

I did not run `source scripts/run_ci_checks.sh` or `source scripts/check_commits.sh` locally because this environment is Windows-based and the repository scripts are Linux shell workflows.