### PR TITLE
test: cover proof builders without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -1,56 +1,53 @@
-use super::{FinalRoundBuilder, ProvableQueryResult};
-use crate::{
-    base::{
-        commitment::{Commitment, CommittableColumn},
-        database::{Column, ColumnField, ColumnType},
-    },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+use super::FinalRoundBuilder;
+#[cfg(feature = "arrow")]
+use super::ProvableQueryResult;
+#[cfg(feature = "arrow")]
+use crate::base::database::{Column, ColumnField, ColumnType};
+use crate::base::{
+    commitment::{naive_commitment::NaiveCommitment, Commitment, CommittableColumn},
+    scalar::test_scalar::TestScalar,
 };
-use alloc::{collections::VecDeque, sync::Arc};
+use alloc::collections::VecDeque;
+#[cfg(feature = "arrow")]
+use alloc::sync::Arc;
 #[cfg(feature = "arrow")]
 use arrow::{
     array::Int64Array,
     datatypes::{Field, Schema},
     record_batch::RecordBatch,
 };
-use curve25519_dalek::RistrettoPoint;
 
 #[test]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(1, VecDeque::new());
+    let mut builder = FinalRoundBuilder::<TestScalar>::new(1, VecDeque::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 0_usize;
-    let commitments: Vec<RistrettoPoint> = builder.commit_intermediate_mles(offset_generators, &());
-    assert_eq!(
-        commitments,
-        [RistrettoPoint::compute_commitments(
-            &[CommittableColumn::from(&mle2[..])],
-            offset_generators,
-            &()
-        )[0]]
-    );
+    let commitments: Vec<NaiveCommitment> =
+        builder.commit_intermediate_mles(offset_generators, &());
+    let expected_commitments =
+        NaiveCommitment::compute_commitments(&[CommittableColumn::from(&mle2[..])], 0, &());
+    assert_eq!(commitments, expected_commitments);
 }
 
 #[test]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(1, VecDeque::new());
+    let mut builder = FinalRoundBuilder::<TestScalar>::new(1, VecDeque::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 123_usize;
-    let commitments: Vec<RistrettoPoint> = builder.commit_intermediate_mles(offset_generators, &());
-    assert_eq!(
-        commitments,
-        [RistrettoPoint::compute_commitments(
-            &[CommittableColumn::from(&mle2[..])],
-            offset_generators,
-            &()
-        )[0]]
+    let commitments: Vec<NaiveCommitment> =
+        builder.commit_intermediate_mles(offset_generators, &());
+    let expected_commitments = NaiveCommitment::compute_commitments(
+        &[CommittableColumn::from(&mle2[..])],
+        offset_generators,
+        &(),
     );
+    assert_eq!(commitments, expected_commitments);
 }
 
 #[test]
@@ -60,34 +57,25 @@ fn we_can_evaluate_pcs_proof_mles() {
     let mut builder = FinalRoundBuilder::new(1, VecDeque::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
-    let evaluation_vec = [
-        Curve25519Scalar::from(100u64),
-        Curve25519Scalar::from(10u64),
-    ];
+    let evaluation_vec = [TestScalar::from(100u64), TestScalar::from(10u64)];
     let evals = builder.evaluate_pcs_proof_mles(&evaluation_vec);
-    let expected_evals = [
-        Curve25519Scalar::from(120u64),
-        Curve25519Scalar::from(1200u64),
-    ];
+    let expected_evals = [TestScalar::from(120u64), TestScalar::from(1200u64)];
     assert_eq!(evals, expected_evals);
 }
 
 #[cfg(feature = "arrow")]
 #[test]
 fn we_can_form_the_provable_query_result() {
-    let col1: Column<Curve25519Scalar> = Column::BigInt(&[11_i64, 12]);
-    let col2: Column<Curve25519Scalar> = Column::BigInt(&[-3_i64, -4]);
+    let col1: Column<TestScalar> = Column::BigInt(&[11_i64, 12]);
+    let col2: Column<TestScalar> = Column::BigInt(&[-3_i64, -4]);
     let res = ProvableQueryResult::new(2, &[col1, col2]);
 
     let column_fields = vec![
         ColumnField::new("a".into(), ColumnType::BigInt),
         ColumnField::new("b".into(), ColumnType::BigInt),
     ];
-    let res = RecordBatch::try_from(
-        res.to_owned_table::<Curve25519Scalar>(&column_fields)
-            .unwrap(),
-    )
-    .unwrap();
+    let res =
+        RecordBatch::try_from(res.to_owned_table::<TestScalar>(&column_fields).unwrap()).unwrap();
     let column_fields: Vec<Field> = column_fields
         .iter()
         .map(core::convert::Into::into)
@@ -110,22 +98,22 @@ fn we_can_consume_post_result_challenges_in_proof_builder() {
     let mut builder = FinalRoundBuilder::new(
         0,
         [
-            Curve25519Scalar::from(123),
-            Curve25519Scalar::from(456),
-            Curve25519Scalar::from(789),
+            TestScalar::from(123),
+            TestScalar::from(456),
+            TestScalar::from(789),
         ]
         .into(),
     );
     assert_eq!(
-        Curve25519Scalar::from(123),
+        TestScalar::from(123),
         builder.consume_post_result_challenge()
     );
     assert_eq!(
-        Curve25519Scalar::from(456),
+        TestScalar::from(456),
         builder.consume_post_result_challenge()
     );
     assert_eq!(
-        Curve25519Scalar::from(789),
+        TestScalar::from(789),
         builder.consume_post_result_challenge()
     );
 }

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder_test.rs
@@ -1,20 +1,20 @@
 use super::FirstRoundBuilder;
-use crate::{
-    base::commitment::{Commitment, CommittableColumn},
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+use crate::base::{
+    commitment::{naive_commitment::NaiveCommitment, Commitment, CommittableColumn},
+    scalar::test_scalar::TestScalar,
 };
-use curve25519_dalek::RistrettoPoint;
 
 #[test]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FirstRoundBuilder::<Curve25519Scalar>::new(2);
+    let mut builder = FirstRoundBuilder::<TestScalar>::new(2);
     builder.produce_intermediate_mle(&mle1[..]);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 0_usize;
-    let commitments: Vec<RistrettoPoint> = builder.commit_intermediate_mles(offset_generators, &());
-    let expected_commitments: Vec<RistrettoPoint> = RistrettoPoint::compute_commitments(
+    let commitments: Vec<NaiveCommitment> =
+        builder.commit_intermediate_mles(offset_generators, &());
+    let expected_commitments: Vec<NaiveCommitment> = NaiveCommitment::compute_commitments(
         &[
             CommittableColumn::from(&mle1[..]),
             CommittableColumn::from(&mle2[..]),
@@ -29,12 +29,13 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
 fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FirstRoundBuilder::<Curve25519Scalar>::new(2);
+    let mut builder = FirstRoundBuilder::<TestScalar>::new(2);
     builder.produce_intermediate_mle(&mle1[..]);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 123_usize;
-    let commitments: Vec<RistrettoPoint> = builder.commit_intermediate_mles(offset_generators, &());
-    let expected_commitments: Vec<RistrettoPoint> = RistrettoPoint::compute_commitments(
+    let commitments: Vec<NaiveCommitment> =
+        builder.commit_intermediate_mles(offset_generators, &());
+    let expected_commitments: Vec<NaiveCommitment> = NaiveCommitment::compute_commitments(
         &[
             CommittableColumn::from(&mle1[..]),
             CommittableColumn::from(&mle2[..]),
@@ -49,24 +50,18 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
 fn we_can_evaluate_pcs_proof_mles() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FirstRoundBuilder::<Curve25519Scalar>::new(2);
+    let mut builder = FirstRoundBuilder::<TestScalar>::new(2);
     builder.produce_intermediate_mle(&mle1[..]);
     builder.produce_intermediate_mle(&mle2[..]);
-    let evaluation_vec = [
-        Curve25519Scalar::from(100u64),
-        Curve25519Scalar::from(10u64),
-    ];
+    let evaluation_vec = [TestScalar::from(100u64), TestScalar::from(10u64)];
     let evals = builder.evaluate_pcs_proof_mles(&evaluation_vec);
-    let expected_evals = [
-        Curve25519Scalar::from(120u64),
-        Curve25519Scalar::from(1200u64),
-    ];
+    let expected_evals = [TestScalar::from(120u64), TestScalar::from(1200u64)];
     assert_eq!(evals, expected_evals);
 }
 
 #[test]
 fn we_can_add_post_result_challenges() {
-    let mut builder = FirstRoundBuilder::<Curve25519Scalar>::new(0);
+    let mut builder = FirstRoundBuilder::<TestScalar>::new(0);
     assert_eq!(builder.num_post_result_challenges(), 0);
     builder.request_post_result_challenges(1);
     assert_eq!(builder.num_post_result_challenges(), 1);

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -7,7 +7,7 @@ mod final_round_builder;
 #[cfg(test)]
 pub(crate) mod mock_verification_builder;
 pub(crate) use final_round_builder::FinalRoundBuilder;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod final_round_builder_test;
 
 mod composite_polynomial_builder;
@@ -68,7 +68,7 @@ pub(crate) use result_element_serialization::{
 
 mod first_round_builder;
 pub(crate) use first_round_builder::FirstRoundBuilder;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod first_round_builder_test;
 
 #[cfg(all(test, feature = "arrow"))]


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This contributes to #560 by enabling the existing proof builder unit tests under the no-default-features test configuration. These tests were gated behind `feature = "blitzar"`, but the builder behavior they exercise does not require blitzar itself.

The commitment assertions now use the existing test-only `NaiveCommitment` with `TestScalar`, so the same builder paths are covered without reaching the no-blitzar `RistrettoPoint::compute_commitments` `unimplemented!()` branch.

Local LCOV comparison against my main baseline shows 41 newly covered existing source lines:
- `first_round_builder.rs`: 25 lines
- `final_round_builder.rs`: 16 lines

At the issue rate of $0.10 per newly covered line, this is approximately $4.10 of coverage if accepted.

# What changes are included in this PR?

- Make `first_round_builder_test` and `final_round_builder_test` compile for all test builds instead of only `feature = "blitzar"`.
- Switch those builder tests from `RistrettoPoint`/`Curve25519Scalar` to `NaiveCommitment`/`TestScalar` for no-blitzar compatibility.
- Keep the arrow-only provable-result test behind its existing `feature = "arrow"` guard.

# Are these changes tested?

Yes. I ran:

- `cargo +1.91.1-x86_64-pc-windows-msvc fmt --all -- --config imports_granularity=Crate,group_imports=One`
- `cargo +1.91.1-x86_64-pc-windows-msvc test -p proof-of-sql --target x86_64-pc-windows-msvc --no-default-features --features test first_round_builder --lib`
- `cargo +1.91.1-x86_64-pc-windows-msvc test -p proof-of-sql --target x86_64-pc-windows-msvc --no-default-features --features test final_round_builder --lib`
- `cargo +1.91.1-x86_64-pc-windows-msvc llvm-cov -p proof-of-sql --target x86_64-pc-windows-msvc --no-default-features --features test --lib --lcov --output-path target/proof-of-sql-proof-builder.lcov -- round_builder`
- `git diff --check`

The focused llvm-cov run passed 8 tests.

I did not run the Linux shell CI scripts locally because this environment is Windows-based.