### PR TITLE
test: cover base helper paths

### DIFF
--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -29,7 +29,7 @@ pub struct Permutation {
 
 impl Permutation {
     /// Create a new permutation from a comparison function with the given length
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn unchecked_new_from_cmp<F>(length: usize, cmp: F) -> Self
     where
         F: Fn(&usize, &usize) -> Ordering + Sync,
@@ -100,6 +100,24 @@ mod test {
             permutation.try_apply(&["and", "Space", "Time"]).unwrap(),
             vec!["Space", "and", "Time"]
         );
+    }
+
+    #[test]
+    fn unchecked_new_from_cmp_sorts_indexes_by_comparator() {
+        let values = [30, 10, 20];
+        let permutation =
+            Permutation::unchecked_new_from_cmp(values.len(), |a, b| values[*a].cmp(&values[*b]));
+
+        assert_eq!(permutation, Permutation::try_new(vec![1, 2, 0]).unwrap());
+        assert_eq!(permutation.try_apply(&values).unwrap(), vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn unchecked_new_from_cmp_handles_empty_inputs() {
+        let permutation = Permutation::unchecked_new_from_cmp(0, usize::cmp);
+
+        assert_eq!(permutation.size(), 0);
+        assert_eq!(permutation.try_apply::<u8>(&[]).unwrap(), Vec::<u8>::new());
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -69,6 +69,21 @@ mod time_unit_tests {
     }
 
     #[test]
+    fn test_precision_values_and_display() {
+        let cases = [
+            (PoSQLTimeUnit::Second, 0, "seconds (precision: 0)"),
+            (PoSQLTimeUnit::Millisecond, 3, "milliseconds (precision: 3)"),
+            (PoSQLTimeUnit::Microsecond, 6, "microseconds (precision: 6)"),
+            (PoSQLTimeUnit::Nanosecond, 9, "nanoseconds (precision: 9)"),
+        ];
+
+        for (unit, precision, display) in cases {
+            assert_eq!(u64::from(unit), precision);
+            assert_eq!(unit.to_string(), display);
+        }
+    }
+
+    #[test]
     fn test_invalid_precision() {
         let invalid_precisions = [
             "1", "2", "4", "5", "7", "8", "10", "zero", "three", "cat", "-1", "-2",


### PR DESCRIPTION
## Summary
- add ordering and empty-input coverage for `Permutation::unchecked_new_from_cmp`
- cover `PoSQLTimeUnit` precision conversion and display output
- keep the existing dead-code expectation for non-test builds while allowing the helper to be exercised in tests

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql --no-default-features --features test unchecked_new_from_cmp`
- `cargo test -p proof-of-sql --no-default-features --features test test_precision_values_and_display`
- `cargo llvm-cov --no-default-features --features test --no-report -p proof-of-sql -- unchecked_new_from_cmp`
- `cargo llvm-cov --no-default-features --features test --no-report -p proof-of-sql -- test_precision_values_and_display`
- `cargo llvm-cov report --summary-only`

/claim #560
