### PR TITLE
test: cover join prover utility columns

### DIFF
--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -780,6 +780,17 @@ mod tests {
         assert_eq!(result, &[1, 0, 3, 1], "Expected multiplicities");
     }
 
+    #[test]
+    fn we_can_get_multiplicities_with_unmatched_data_before_unique_rows() {
+        let alloc = Bump::new();
+        let data = vec![Column::<TestScalar>::Int(&[1, 2, 2, 4])];
+        let unique = vec![Column::<TestScalar>::Int(&[2, 3])];
+
+        let result = get_multiplicities(&data, &unique, &alloc);
+
+        assert_eq!(result, &[2, 0]);
+    }
+
     // Get Columns of Table
     #[test]
     fn we_can_get_columns_of_table() {
@@ -929,6 +940,16 @@ mod tests {
     }
 
     #[test]
+    fn we_cannot_get_sort_merge_join_indexes_with_incompatible_join_column_types() {
+        let left_on = vec![Column::<TestScalar>::Int(&[1_i32])];
+        let right_on = vec![Column::<TestScalar>::BigInt(&[1_i64])];
+
+        let row_indexes = get_sort_merge_join_indexes(&left_on, &right_on, 1, 1);
+
+        assert!(row_indexes.is_empty());
+    }
+
+    #[test]
     fn we_can_apply_sort_merge_join_indexes_two_tables() {
         let bump = Bump::new();
         let a: Ident = "a".into();
@@ -977,6 +998,37 @@ mod tests {
         assert_eq!(
             join_left_right_columns.remaining_right_columns[0],
             Column::BigInt(&[7_i64, 8, 9, 8, 9])
+        );
+        assert_eq!(
+            join_left_right_columns.right_less_join_columns(),
+            vec![
+                Column::BigInt(&[7_i64, 8, 9, 8, 9]),
+                Column::Int128(&[5_i128, 3, 4, 3, 4])
+            ]
+        );
+        assert_eq!(
+            join_left_right_columns.left_columns(),
+            vec![
+                Column::Int(&[4_i32, 5, 5, 5, 5]),
+                Column::SmallInt(&[1_i16, 2, 2, 3, 3]),
+                Column::Int128(&[3_i128, 1, 1, 4, 4])
+            ]
+        );
+        assert_eq!(
+            join_left_right_columns.right_columns(),
+            vec![
+                Column::Int(&[4_i32, 5, 5, 5, 5]),
+                Column::BigInt(&[7_i64, 8, 9, 8, 9]),
+                Column::Int128(&[5_i128, 3, 4, 3, 4])
+            ]
+        );
+        assert_eq!(
+            join_left_right_columns.result_columns(),
+            vec![
+                Column::Int(&[4_i32, 5, 5, 5, 5]),
+                Column::SmallInt(&[1_i16, 2, 2, 3, 3]),
+                Column::BigInt(&[7_i64, 8, 9, 8, 9])
+            ]
         );
     }
 


### PR DESCRIPTION
Part of #560.

## Summary
- Add coverage for `JoinProverUtilities` column accessor methods in `join_util.rs`.
- Cover `get_multiplicities` when data rows sort before the current unique row.
- Cover sort-merge join index handling for incompatible join column types.

## Coverage
- `base/database/join_util.rs`: missed lines reduced from 40 to 5 in LCOV output.
- Before: 737/777 hit lines.
- After: 808/813 hit lines.

## Verification
- `cargo test -p proof-of-sql base::database::join_util::tests --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"` (21 passed)
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"` (1055 passed)

/claim #560
