### PR TITLE
test: cover union column variants

### DIFF
--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -245,7 +245,12 @@ pub fn table_union<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{map::IndexMap, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        map::IndexMap,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn we_can_union_no_columns() {
@@ -278,6 +283,86 @@ mod tests {
         assert_eq!(
             result,
             Column::VarChar((&doubled_strings, &doubled_scalars))
+        );
+    }
+
+    #[test]
+    fn we_can_union_remaining_column_types() {
+        macro_rules! assert_column_union {
+            ($alloc:expr, $column_type:expr, $left:expr, $right:expr, $expected:expr) => {{
+                let left: Column<TestScalar> = $left;
+                let right: Column<TestScalar> = $right;
+                let result = column_union(&[&left, &right], $alloc, $column_type).unwrap();
+                assert_eq!(result, $expected);
+            }};
+        }
+
+        let alloc = Bump::new();
+        assert_column_union!(
+            &alloc,
+            ColumnType::Uint8,
+            Column::Uint8(&[1, 2]),
+            Column::Uint8(&[3]),
+            Column::Uint8(&[1, 2, 3])
+        );
+        assert_column_union!(
+            &alloc,
+            ColumnType::TinyInt,
+            Column::TinyInt(&[-1, 2]),
+            Column::TinyInt(&[3]),
+            Column::TinyInt(&[-1, 2, 3])
+        );
+        assert_column_union!(
+            &alloc,
+            ColumnType::SmallInt,
+            Column::SmallInt(&[-10, 20]),
+            Column::SmallInt(&[30]),
+            Column::SmallInt(&[-10, 20, 30])
+        );
+        assert_column_union!(
+            &alloc,
+            ColumnType::Int128,
+            Column::Int128(&[-100, 200]),
+            Column::Int128(&[300]),
+            Column::Int128(&[-100, 200, 300])
+        );
+
+        let scalar_left = [TestScalar::from(1u64), TestScalar::from(2u64)];
+        let scalar_right = [TestScalar::from(3u64)];
+        let scalar_expected = [
+            TestScalar::from(1u64),
+            TestScalar::from(2u64),
+            TestScalar::from(3u64),
+        ];
+        assert_column_union!(
+            &alloc,
+            ColumnType::Scalar,
+            Column::Scalar(&scalar_left),
+            Column::Scalar(&scalar_right),
+            Column::Scalar(&scalar_expected)
+        );
+
+        let precision = Precision::new(9).unwrap();
+        assert_column_union!(
+            &alloc,
+            ColumnType::Decimal75(precision, 2),
+            Column::Decimal75(precision, 2, &scalar_left),
+            Column::Decimal75(precision, 2, &scalar_right),
+            Column::Decimal75(precision, 2, &scalar_expected)
+        );
+
+        let time_unit = PoSQLTimeUnit::Microsecond;
+        let timezone = PoSQLTimeZone::new(19_800);
+        assert_column_union!(
+            &alloc,
+            ColumnType::TimestampTZ(time_unit, timezone),
+            Column::TimestampTZ(time_unit, timezone, &[1_700_000_000, 1_700_000_001]),
+            Column::TimestampTZ(time_unit, timezone, &[1_700_000_002]),
+            Column::TimestampTZ(
+                time_unit,
+                timezone,
+                &[1_700_000_000, 1_700_000_001, 1_700_000_002]
+            )
         );
     }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Adds focused coverage for `column_union` branches that were still uncovered in `union_util`.

# What changes are included in this PR?

- Cover `Uint8`, `TinyInt`, `SmallInt`, `Int128`, `Scalar`, `Decimal75`, and `TimestampTZ` column unions.
- Keep the coverage local to the existing `union_util` test module.

# Are these changes tested?

Yes.

- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features="test" we_can_union_remaining_column_types`
- `cargo test -p proof-of-sql --no-default-features --features="test" base::database::union_util::tests`
- `bash scripts/check_commits.sh`

Note: I did not run the full CI script locally because the default local build on this Apple Silicon machine enables the `perf`/`asm` feature path and fails in `halo2curves` with `Currently feature asm can only be enabled on x86_64 arch`. The targeted no-default test feature path passes.