### PR TITLE
ci: speed up toolchain setup

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   BLITZAR_BACKEND: cpu
-  # MSRV: `cargo install wasm-pack` can pull in home 0.5.12, which requires Rust 1.89
+  # MSRV: wasm-pack and the workspace dependency graph require Rust 1.89.
   MSRV: "1.89"
 
 jobs:
@@ -37,7 +37,9 @@ jobs:
             echo "version=${{ matrix.rust }}" >> $GITHUB_OUTPUT
           fi
       - name: Install toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install ${{ steps.rust-version.outputs.version }} && rustup default ${{ steps.rust-version.outputs.version }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust-version.outputs.version }}
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -84,11 +86,11 @@ jobs:
         run: |
           rustup target add thumbv7em-none-eabi
           cargo check -p proof-of-sql --target thumbv7em-none-eabi --no-default-features
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@wasm-pack
       - name: Check that we can compile `proof-of-sql-planner` to WebAssembly
         working-directory: ./crates/proof-of-sql-planner
-        run: |
-          cargo install wasm-pack
-          wasm-pack build --target deno
+        run: wasm-pack build --target deno
 
   test:
     name: Test Suite (${{ matrix.rust }})
@@ -109,7 +111,9 @@ jobs:
             echo "version=${{ matrix.rust }}" >> $GITHUB_OUTPUT
           fi
       - name: Install toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install ${{ steps.rust-version.outputs.version }} && rustup default ${{ steps.rust-version.outputs.version }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust-version.outputs.version }}
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -137,7 +141,9 @@ jobs:
             echo "version=${{ matrix.rust }}" >> $GITHUB_OUTPUT
           fi
       - name: Install toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install ${{ steps.rust-version.outputs.version }} && rustup default ${{ steps.rust-version.outputs.version }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust-version.outputs.version }}
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -165,7 +171,9 @@ jobs:
             echo "version=${{ matrix.rust }}" >> $GITHUB_OUTPUT
           fi
       - name: Install toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install ${{ steps.rust-version.outputs.version }} && rustup default ${{ steps.rust-version.outputs.version }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust-version.outputs.version }}
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -204,7 +212,9 @@ jobs:
               echo "version=${{ matrix.rust }}" >> $GITHUB_OUTPUT
             fi
         - name: Install toolchain
-          run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install ${{ steps.rust-version.outputs.version }} && rustup default ${{ steps.rust-version.outputs.version }}
+          uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ steps.rust-version.outputs.version }}
         - name: Setup Rust cache
           uses: Swatinem/rust-cache@v2
           with:
@@ -235,9 +245,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install toolchain from rust-toolchain.toml
-        run: |
-          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install
-          rustup component add clippy
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91.1
+          components: clippy
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install Dependencies
@@ -253,9 +264,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install toolchain from rust-toolchain.toml
-        run: |
-          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install
-          rustup component add rustfmt
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91.1
+          components: rustfmt
       - name: Run cargo fmt
         run: cargo f --check
 
@@ -266,9 +278,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install nightly toolchain
-        run: |
-          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install nightly
-          cargo +nightly install cargo-udeps --locked
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-udeps
+        run: cargo +nightly install cargo-udeps --locked
       - name: Run cargo udeps
         run: cargo +nightly udeps --all-targets
 
@@ -330,7 +342,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install Dependencies


### PR DESCRIPTION
﻿Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

Issue #557 was clarified to include broad CI runtime improvements. This workflow currently bootstraps Rust in many jobs by downloading and running `rustup` through shell commands, then separately installing components. The `check` matrix also recompiles and installs `wasm-pack` with Cargo before every WebAssembly compile check.

Those setup steps do not add validation coverage; they only prepare tools before the same Cargo, wasm-pack, clippy, rustfmt, and udeps commands run. This PR moves that setup work to maintained GitHub Actions:

- `dtolnay/rust-toolchain` installs the same requested Rust channels/versions for the matrix jobs, stable/nightly jobs, and component jobs.
- `taiki-e/install-action@wasm-pack` installs wasm-pack instead of compiling it from source in every check matrix lane.

/claim #557

# What changes are included in this PR?

- Replace repeated `curl https://sh.rustup.rs ... rustup toolchain install ...` workflow steps with `dtolnay/rust-toolchain`.
- Preserve the dynamic `msrv`, `stable`, and `nightly` matrix resolution in the `check`, `test`, `testnorayon`, `testother`, and `examples` jobs.
- Preserve clippy and rustfmt component installation for their dedicated jobs.
- Preserve the nightly udeps lane while separating toolchain setup from `cargo +nightly install cargo-udeps --locked`.
- Replace `cargo install wasm-pack` with `taiki-e/install-action@wasm-pack` before the existing `wasm-pack build --target deno` command.
- Leave the actual validation commands unchanged.

# Are these changes tested?

Static/local validation on Windows:

- YAML parse of `.github/workflows/lint-and-test.yml` succeeded.
- `git diff --check` passed.
- Custom workflow sanity check confirmed no `curl https://sh.rustup.rs` or `cargo install wasm-pack` setup paths remain.
- Verified the referenced action refs exist via GitHub API: `taiki-e/install-action@wasm-pack` and `dtolnay/rust-toolchain@master`.

Limitations:

- I could not run `source scripts/run_ci_checks.sh` fully on this Windows host because the CI wrapper/Rust toolchain path is not faithful to the Linux CI environment here.
- The meaningful runtime evidence for this PR is GitHub Actions setup timing, since the patch changes workflow setup, not Rust source behavior.
