### PR TITLE
test: cover table utility column helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -363,3 +363,49 @@ pub fn borrowed_timestamptz<S: Scalar>(
         Column::TimestampTZ(time_unit, timezone, alloc_data),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{math::decimal::Precision, scalar::test_scalar::TestScalar};
+
+    #[test]
+    fn we_can_create_borrowed_integer_columns() {
+        let alloc = Bump::new();
+
+        let (name, column) = borrowed_uint8::<TestScalar>("uint8", [1_u8, 2, 3], &alloc);
+        assert_eq!(name, Ident::new("uint8"));
+        assert_eq!(column, Column::Uint8(&[1, 2, 3]));
+
+        let (name, column) = borrowed_tinyint::<TestScalar>("tinyint", [-1_i8, 0, 1], &alloc);
+        assert_eq!(name, Ident::new("tinyint"));
+        assert_eq!(column, Column::TinyInt(&[-1, 0, 1]));
+
+        let (name, column) = borrowed_smallint::<TestScalar>("smallint", [-2_i16, 0, 2], &alloc);
+        assert_eq!(name, Ident::new("smallint"));
+        assert_eq!(column, Column::SmallInt(&[-2, 0, 2]));
+
+        let (name, column) = borrowed_int::<TestScalar>("int", [-3_i32, 0, 3], &alloc);
+        assert_eq!(name, Ident::new("int"));
+        assert_eq!(column, Column::Int(&[-3, 0, 3]));
+    }
+
+    #[test]
+    fn we_can_create_borrowed_decimal75_columns() {
+        let alloc = Bump::new();
+
+        let (name, column) =
+            borrowed_decimal75::<TestScalar>("decimal", 12, -2, [-100_i64, 0, 250], &alloc);
+        let expected = [
+            TestScalar::from(-100_i64),
+            TestScalar::from(0_i64),
+            TestScalar::from(250_i64),
+        ];
+
+        assert_eq!(name, Ident::new("decimal"));
+        assert_eq!(
+            column,
+            Column::Decimal75(Precision::new(12).unwrap(), -2, &expected)
+        );
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

/claim #560

This adds a small test-only coverage slice for the borrowed table utility column constructors. I checked the current open PR file lists before claiming this slice and did not find `crates/proof-of-sql/src/base/database/table_utility.rs` touched.

# What changes are included in this PR?

- Add unit coverage for `borrowed_uint8`, `borrowed_tinyint`, `borrowed_smallint`, and `borrowed_int`.
- Add unit coverage for `borrowed_decimal75`.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql --no-default-features --features="test" base::database::table_utility::tests --lib`
- `BLITZAR_BACKEND=cpu cargo llvm-cov --no-report -p proof-of-sql --no-default-features --features="test" --lib -- base::database::table_utility::tests`
- `BLITZAR_BACKEND=cpu cargo llvm-cov report --lcov --output-path target/sxt-table-utility-after.lcov`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

I did not run the full all-features suite or `source scripts/run_ci_checks.sh` locally because this macOS/aarch64 machine cannot build the Linux-only `blitzar-sys` dependency used by the all-features path.