### PR TITLE
test: cover column type helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -301,6 +301,7 @@ impl Display for ColumnType {
 mod tests {
     use super::*;
     use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::format;
 
     #[test]
     fn column_type_serializes_to_string() {
@@ -603,6 +604,195 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<ColumnType>(&decimal75_json).unwrap(),
             decimal75
+        );
+    }
+
+    #[test]
+    fn we_can_get_integer_bits() {
+        assert_eq!(ColumnType::Uint8.to_integer_bits(), Some(8));
+        assert_eq!(ColumnType::TinyInt.to_integer_bits(), Some(8));
+        assert_eq!(ColumnType::SmallInt.to_integer_bits(), Some(16));
+        assert_eq!(ColumnType::Int.to_integer_bits(), Some(32));
+        assert_eq!(ColumnType::BigInt.to_integer_bits(), Some(64));
+        assert_eq!(ColumnType::Int128.to_integer_bits(), Some(128));
+        assert_eq!(ColumnType::Boolean.to_integer_bits(), None);
+
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(8),
+            Some(ColumnType::TinyInt)
+        );
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(16),
+            Some(ColumnType::SmallInt)
+        );
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(32),
+            Some(ColumnType::Int)
+        );
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(64),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::from_signed_integer_bits(128),
+            Some(ColumnType::Int128)
+        );
+        assert_eq!(ColumnType::from_signed_integer_bits(7), None);
+
+        assert_eq!(
+            ColumnType::from_unsigned_integer_bits(8),
+            Some(ColumnType::Uint8)
+        );
+        assert_eq!(ColumnType::from_unsigned_integer_bits(16), None);
+    }
+
+    #[test]
+    fn we_can_get_max_integer_type() {
+        assert_eq!(
+            ColumnType::Uint8.max_integer_type(&ColumnType::TinyInt),
+            Some(ColumnType::TinyInt)
+        );
+        assert_eq!(
+            ColumnType::TinyInt.max_integer_type(&ColumnType::SmallInt),
+            Some(ColumnType::SmallInt)
+        );
+        assert_eq!(
+            ColumnType::SmallInt.max_integer_type(&ColumnType::Int),
+            Some(ColumnType::Int)
+        );
+        assert_eq!(
+            ColumnType::Int.max_integer_type(&ColumnType::BigInt),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::BigInt.max_integer_type(&ColumnType::Int128),
+            Some(ColumnType::Int128)
+        );
+        assert_eq!(ColumnType::Boolean.max_integer_type(&ColumnType::Int), None);
+        assert_eq!(ColumnType::Int.max_integer_type(&ColumnType::Boolean), None);
+    }
+
+    #[test]
+    fn we_can_get_max_unsigned_integer_type() {
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::TinyInt),
+            Some(ColumnType::Uint8)
+        );
+        assert_eq!(
+            ColumnType::SmallInt.max_unsigned_integer_type(&ColumnType::Uint8),
+            None
+        );
+        assert_eq!(
+            ColumnType::Boolean.max_unsigned_integer_type(&ColumnType::Uint8),
+            None
+        );
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::Boolean),
+            None
+        );
+    }
+
+    #[test]
+    fn we_can_get_column_type_precision_and_scale() {
+        assert_eq!(ColumnType::Uint8.precision_value(), Some(3));
+        assert_eq!(ColumnType::TinyInt.precision_value(), Some(3));
+        assert_eq!(ColumnType::SmallInt.precision_value(), Some(5));
+        assert_eq!(ColumnType::Int.precision_value(), Some(10));
+        assert_eq!(ColumnType::BigInt.precision_value(), Some(19));
+        assert_eq!(ColumnType::Int128.precision_value(), Some(39));
+        assert_eq!(ColumnType::Scalar.precision_value(), Some(0));
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(12).unwrap(), -3).precision_value(),
+            Some(12)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).precision_value(),
+            Some(19)
+        );
+        assert_eq!(ColumnType::Boolean.precision_value(), None);
+        assert_eq!(ColumnType::VarChar.precision_value(), None);
+        assert_eq!(ColumnType::VarBinary.precision_value(), None);
+
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(12).unwrap(), -3).scale(),
+            Some(-3)
+        );
+        assert_eq!(ColumnType::Uint8.scale(), Some(0));
+        assert_eq!(ColumnType::TinyInt.scale(), Some(0));
+        assert_eq!(ColumnType::SmallInt.scale(), Some(0));
+        assert_eq!(ColumnType::Int.scale(), Some(0));
+        assert_eq!(ColumnType::BigInt.scale(), Some(0));
+        assert_eq!(ColumnType::Int128.scale(), Some(0));
+        assert_eq!(ColumnType::Scalar.scale(), Some(0));
+        assert_eq!(ColumnType::Boolean.scale(), None);
+        assert_eq!(ColumnType::VarChar.scale(), None);
+        assert_eq!(ColumnType::VarBinary.scale(), None);
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).scale(),
+            Some(0)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()).scale(),
+            Some(3)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc()).scale(),
+            Some(6)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc()).scale(),
+            Some(9)
+        );
+    }
+
+    #[test]
+    fn we_can_get_column_type_sizes() {
+        assert_eq!(ColumnType::Boolean.byte_size(), size_of::<bool>());
+        assert_eq!(ColumnType::Uint8.byte_size(), size_of::<u8>());
+        assert_eq!(ColumnType::TinyInt.byte_size(), size_of::<i8>());
+        assert_eq!(ColumnType::SmallInt.byte_size(), size_of::<i16>());
+        assert_eq!(ColumnType::Int.byte_size(), size_of::<i32>());
+        assert_eq!(ColumnType::BigInt.byte_size(), size_of::<i64>());
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).byte_size(),
+            size_of::<i64>()
+        );
+        assert_eq!(ColumnType::Int128.byte_size(), size_of::<i128>());
+        assert_eq!(ColumnType::Scalar.byte_size(), size_of::<[u64; 4]>());
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(12).unwrap(), -3).byte_size(),
+            size_of::<[u64; 4]>()
+        );
+        assert_eq!(ColumnType::VarChar.byte_size(), size_of::<[u64; 4]>());
+        assert_eq!(ColumnType::VarBinary.byte_size(), size_of::<[u64; 4]>());
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).bit_size(),
+            (size_of::<i64>() * 8) as u32
+        );
+    }
+
+    #[test]
+    fn we_can_display_column_types() {
+        assert_eq!(format!("{}", ColumnType::Boolean), "BOOLEAN");
+        assert_eq!(format!("{}", ColumnType::Uint8), "UINT8");
+        assert_eq!(format!("{}", ColumnType::TinyInt), "TINYINT");
+        assert_eq!(format!("{}", ColumnType::SmallInt), "SMALLINT");
+        assert_eq!(format!("{}", ColumnType::Int), "INT");
+        assert_eq!(format!("{}", ColumnType::BigInt), "BIGINT");
+        assert_eq!(format!("{}", ColumnType::Int128), "DECIMAL");
+        assert_eq!(
+            format!("{}", ColumnType::Decimal75(Precision::new(12).unwrap(), -3)),
+            "DECIMAL75(PRECISION: 12, SCALE: -3)"
+        );
+        assert_eq!(format!("{}", ColumnType::VarChar), "VARCHAR");
+        assert_eq!(format!("{}", ColumnType::VarBinary), "BINARY");
+        assert_eq!(format!("{}", ColumnType::Scalar), "SCALAR");
+        assert_eq!(
+            format!(
+                "{}",
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::new(3600))
+            ),
+            "TIMESTAMP(TIMEUNIT: milliseconds (precision: 3), TIMEZONE: +01:00)"
         );
     }
 


### PR DESCRIPTION
/claim #560

## Summary
- Adds coverage for ColumnType integer bit helpers and max integer type selection.
- Covers precision, scale, byte/bit size, and Display variants that were previously missed.

## Verification
- `PATH=/Users/proxy/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin:$PATH cargo fmt --check`
- `PATH=/Users/proxy/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin:$PATH cargo test -p proof-of-sql column_type --no-default-features --features="std"`
- `PATH=/Users/proxy/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin:$PATH cargo llvm-cov --no-default-features --features="std" -p proof-of-sql --lib --lcov --output-path target/proof-of-sql-column-type.lcov -- column_type`

Coverage check: column_type.rs now reports 0 missed lines in the targeted coverage run, covering 59 lines that were missed in the prior full std lcov artifact.
