### PR TITLE
test: cover verification builder input paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -1,5 +1,6 @@
 use super::{SumcheckMleEvaluations, VerificationBuilderImpl};
 use crate::{
+    base::{bit::BitDistribution, proof::ProofSizeMismatch},
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::{SumcheckSubpolynomialType, VerificationBuilder},
 };
@@ -88,4 +89,170 @@ fn we_can_consume_post_result_challenges_in_verification_builder() {
         Curve25519Scalar::from(789),
         builder.try_consume_post_result_challenge().unwrap()
     );
+}
+
+#[test]
+fn we_can_consume_all_verification_builder_inputs() {
+    let chi_eval = Curve25519Scalar::from(11);
+    let rho_eval = Curve25519Scalar::from(13);
+    let singleton_chi_eval = Curve25519Scalar::from(17);
+    let random_eval = Curve25519Scalar::from(19);
+    let first_round_evals = [Curve25519Scalar::from(23), Curve25519Scalar::from(29)];
+    let final_round_evals = [Curve25519Scalar::from(31), Curve25519Scalar::from(37)];
+    let rho_256_eval = Curve25519Scalar::from(41);
+    let mle_evaluations = SumcheckMleEvaluations {
+        chi_evaluations: [(4, chi_eval)].into_iter().collect(),
+        rho_evaluations: [(5, rho_eval)].into_iter().collect(),
+        singleton_chi_evaluation: singleton_chi_eval,
+        random_evaluation: random_eval,
+        first_round_pcs_proof_evaluations: &first_round_evals,
+        final_round_pcs_proof_evaluations: &final_round_evals,
+        rho_256_evaluation: Some(rho_256_eval),
+    };
+    let bit_distribution = BitDistribution {
+        vary_mask: [1, 2, 3, 4],
+        leading_bit_mask: [5, 6, 7, 8],
+    };
+    let bit_distributions = [bit_distribution.clone()];
+    let subpolynomial_multipliers = [Curve25519Scalar::from(2), Curve25519Scalar::from(3)];
+    let mut builder = VerificationBuilderImpl::new(
+        mle_evaluations,
+        &bit_distributions,
+        &subpolynomial_multipliers,
+        [Curve25519Scalar::from(43)].into(),
+        vec![4],
+        vec![5],
+        2,
+    );
+
+    assert_eq!(builder.try_consume_chi_evaluation().unwrap(), (chi_eval, 4));
+    assert_eq!(builder.try_consume_rho_evaluation().unwrap(), rho_eval);
+    assert_eq!(
+        builder.try_consume_first_round_mle_evaluations(2).unwrap(),
+        first_round_evals
+    );
+    assert_eq!(
+        builder.try_consume_final_round_mle_evaluations(2).unwrap(),
+        final_round_evals
+    );
+    assert_eq!(
+        builder.try_consume_bit_distribution().unwrap(),
+        bit_distribution
+    );
+    assert_eq!(
+        builder.try_consume_post_result_challenge().unwrap(),
+        Curve25519Scalar::from(43)
+    );
+    assert_eq!(builder.singleton_chi_evaluation(), singleton_chi_eval);
+    assert_eq!(builder.rho_256_evaluation(), Some(rho_256_eval));
+
+    builder
+        .try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            Curve25519Scalar::from(5),
+            1,
+        )
+        .unwrap();
+    builder
+        .try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::ZeroSum,
+            Curve25519Scalar::from(7),
+            2,
+        )
+        .unwrap();
+
+    let expected_sumcheck_evaluation =
+        subpolynomial_multipliers[0] * Curve25519Scalar::from(5) * random_eval
+            + subpolynomial_multipliers[1] * Curve25519Scalar::from(7);
+    assert_eq!(builder.sumcheck_evaluation(), expected_sumcheck_evaluation);
+}
+
+#[test]
+fn we_report_verification_builder_size_mismatches() {
+    let first_round_evals = [Curve25519Scalar::from(1)];
+    let final_round_evals = [Curve25519Scalar::from(2)];
+    let mle_evaluations = SumcheckMleEvaluations {
+        chi_evaluations: [(2, Curve25519Scalar::from(3))].into_iter().collect(),
+        rho_evaluations: [(3, Curve25519Scalar::from(4))].into_iter().collect(),
+        first_round_pcs_proof_evaluations: &first_round_evals,
+        final_round_pcs_proof_evaluations: &final_round_evals,
+        ..Default::default()
+    };
+    let mut builder = VerificationBuilderImpl::new(
+        mle_evaluations,
+        &[][..],
+        &[][..],
+        VecDeque::new(),
+        vec![99],
+        vec![98],
+        0,
+    );
+
+    assert!(matches!(
+        builder.try_consume_chi_evaluation(),
+        Err(ProofSizeMismatch::ChiLengthNotFound)
+    ));
+    assert!(matches!(
+        builder.try_consume_chi_evaluation(),
+        Err(ProofSizeMismatch::TooFewChiLengths)
+    ));
+    assert!(matches!(
+        builder.try_consume_rho_evaluation(),
+        Err(ProofSizeMismatch::RhoLengthNotFound)
+    ));
+    assert!(matches!(
+        builder.try_consume_rho_evaluation(),
+        Err(ProofSizeMismatch::TooFewRhoLengths)
+    ));
+    assert!(matches!(
+        builder.try_consume_first_round_mle_evaluations(2),
+        Err(ProofSizeMismatch::TooFewMLEEvaluations)
+    ));
+    assert!(matches!(
+        builder.try_consume_final_round_mle_evaluations(2),
+        Err(ProofSizeMismatch::TooFewMLEEvaluations)
+    ));
+    assert!(matches!(
+        builder.try_consume_bit_distribution(),
+        Err(ProofSizeMismatch::TooFewBitDistributions)
+    ));
+    assert!(matches!(
+        builder.try_consume_post_result_challenge(),
+        Err(ProofSizeMismatch::PostResultCountMismatch)
+    ));
+    assert!(matches!(
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::ZeroSum,
+            Curve25519Scalar::from(5),
+            0,
+        ),
+        Err(ProofSizeMismatch::ConstraintCountMismatch)
+    ));
+
+    let subpolynomial_multipliers = [Curve25519Scalar::from(1)];
+    let mut builder = VerificationBuilderImpl::new(
+        SumcheckMleEvaluations::default(),
+        &[][..],
+        &subpolynomial_multipliers,
+        VecDeque::new(),
+        Vec::new(),
+        Vec::new(),
+        1,
+    );
+    assert!(matches!(
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            Curve25519Scalar::from(5),
+            1,
+        ),
+        Err(ProofSizeMismatch::SumcheckProofTooSmall)
+    ));
+    assert!(matches!(
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::ZeroSum,
+            Curve25519Scalar::from(5),
+            2,
+        ),
+        Err(ProofSizeMismatch::SumcheckProofTooSmall)
+    ));
 }


### PR DESCRIPTION
## Summary
- cover verification builder consumption paths for chi/rho evaluations, first/final round MLE evaluations, bit distributions, post-result challenges, singleton chi, and rho_256
- cover identity and zero-sum sumcheck subpolynomial evaluation accumulation
- cover size mismatch errors for missing lengths, MLEs, bit distributions, post-result challenges, constraint counts, and undersized sumcheck proofs

## Verification
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test verification_builder_test`
- `cargo llvm-cov --no-default-features --features test --no-report -p proof-of-sql -- verification_builder_test`
- `cargo llvm-cov report --summary-only | rg 'sql/proof/verification_builder.rs|TOTAL'`
  - `sql/proof/verification_builder.rs`: 100.00% line coverage under the targeted test run
- `git diff --check`

/claim #560
