### PR TITLE
test: cover inner product ref cast

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -162,3 +162,24 @@ fn test_inner_product_testscalar_uneven() {
     ];
     assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
+
+#[test]
+fn test_inner_product_ref_cast() {
+    let a = vec![1i64, -2, 3, -4];
+    let b = vec![
+        TestScalar::from(5u64),
+        TestScalar::from(7u64),
+        TestScalar::from(11u64),
+        TestScalar::from(13u64),
+    ];
+
+    assert_eq!(-TestScalar::from(28u64), inner_product_ref_cast(&a, &b));
+}
+
+#[test]
+fn test_inner_product_ref_cast_uneven() {
+    let a = vec![1i64, 2, 3, 4];
+    let b = vec![TestScalar::from(5u64), TestScalar::from(7u64)];
+
+    assert_eq!(TestScalar::from(19u64), inner_product_ref_cast(&a, &b));
+}


### PR DESCRIPTION
## Summary
- add direct coverage for inner_product_ref_cast with signed integer inputs cast into TestScalar values
- cover the uneven-length behavior so the helper keeps the same zip semantics as the other inner-product helpers

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p proof-of-sql --no-default-features --features test inner_product
- cargo llvm-cov clean --workspace
- cargo llvm-cov --no-default-features --features test --no-report -p proof-of-sql -- base::slice_ops::inner_product_test
- cargo llvm-cov report --summary-only | rg 'base/slice_ops/inner_product.rs|TOTAL'\n\nCoverage: base/slice_ops/inner_product.rs now reports 100.00% line coverage for the focused inner_product_test run.\n\n/claim #560