### PR TITLE
test: cover planner helper paths

### DIFF
--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -181,6 +181,15 @@ mod tests {
         assert_eq!(context_provider.get_function_meta(""), None);
         assert_eq!(context_provider.get_aggregate_meta(""), None);
         assert_eq!(context_provider.get_window_meta(""), None);
+        assert_eq!(
+            context_provider
+                .options()
+                .sql_parser
+                .enable_ident_normalization,
+            ConfigOptions::default()
+                .sql_parser
+                .enable_ident_normalization
+        );
 
         // Non-empty
         let accessor = SchemaAccessorImpl::new(indexmap_with_default! {AHasher;
@@ -207,6 +216,15 @@ mod tests {
         assert_eq!(context_provider.get_window_meta(""), None);
         assert_eq!(
             context_provider
+                .options()
+                .sql_parser
+                .enable_ident_normalization,
+            ConfigOptions::default()
+                .sql_parser
+                .enable_ident_normalization
+        );
+        assert_eq!(
+            context_provider
                 .get_table_source(TableReference::from("namespace.a"))
                 .unwrap()
                 .schema(),
@@ -226,5 +244,18 @@ mod tests {
             context_provider.get_table_source(TableReference::from("catalog.namespace.table")),
             Err(DataFusionError::External(_))
         ));
+    }
+
+    #[test]
+    fn posql_table_source_supports_exact_filter_pushdown_for_each_filter() {
+        let table_source =
+            PoSqlTableSource::new(vec![ColumnField::new("a".into(), ColumnType::Boolean)]);
+        let filter = Expr::Literal(datafusion::common::ScalarValue::Boolean(Some(true)));
+        assert_eq!(
+            table_source
+                .supports_filters_pushdown(&[&filter, &filter])
+                .unwrap(),
+            vec![TableProviderFilterPushDown::Exact; 2]
+        );
     }
 }

--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -25,3 +25,32 @@ pub(crate) fn df_schema(table_name: &str, pairs: Vec<(&str, DataType)>) -> DFSch
     );
     DFSchema::try_from_qualified_schema(table_name, &arrow_schema).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{df_column, df_schema};
+    use arrow::datatypes::DataType;
+    use datafusion::{catalog::TableReference, common::Column, logical_expr::Expr};
+
+    #[test]
+    fn we_can_create_a_datafusion_column_expression() {
+        assert_eq!(
+            df_column("namespace.table", "a"),
+            Expr::Column(Column::new(
+                Some(TableReference::from("namespace.table")),
+                "a"
+            ))
+        );
+    }
+
+    #[test]
+    fn we_can_create_a_qualified_datafusion_schema() {
+        let schema = df_schema("table", vec![("a", DataType::Int32), ("b", DataType::Utf8)]);
+        let fields = schema.fields();
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].name(), "a");
+        assert_eq!(fields[0].data_type(), &DataType::Int32);
+        assert_eq!(fields[1].name(), "b");
+        assert_eq!(fields[1].data_type(), &DataType::Utf8);
+    }
+}

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1286,10 +1286,38 @@ mod tests {
             .unwrap(),
         );
         let alias_map = indexmap! {
+            "table.a".to_string() => "a".to_string(),
             "b+c".to_string() => "b_plus_c".to_string(),
         };
 
         // Test the function - should return an error
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_if_an_aggregate_alias_is_missing() {
+        let group_expr = vec![df_column("table", "a")];
+        let aggr_expr = vec![SUM_B(), COUNT_1()];
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "table.a".to_string() => "a".to_string(),
+            "COUNT(Int64(1))".to_string() => "count_1".to_string(),
+        };
+
         let result =
             aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
         assert!(matches!(
@@ -2222,6 +2250,69 @@ mod tests {
         assert!(
             matches!(join_err, PlannerError::UnsupportedLogicalPlan { plan: logical_plan } if *logical_plan == plan )
         );
+    }
+
+    #[test]
+    fn we_can_convert_inner_join_on_matching_columns() {
+        let left = LogicalPlan::TableScan(
+            TableScan::try_new("table", TABLE_SOURCE(), Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+        let right = LogicalPlan::TableScan(
+            TableScan::try_new("table", TABLE_SOURCE(), Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+        let plan = LogicalPlan::Join(Join {
+            left: Arc::new(left.clone()),
+            right: Arc::new(right.clone()),
+            on: vec![(df_column("table", "a"), df_column("table", "a"))],
+            filter: None,
+            join_type: JoinType::Inner,
+            join_constraint: JoinConstraint::On,
+            schema: Arc::new(DFSchema::empty()),
+            null_equals_null: false,
+        });
+
+        let result = logical_plan_to_proof_plan(&plan, &SCHEMAS()).unwrap();
+        let table_plan = DynProofPlan::new_table(
+            TABLE_REF_TABLE(),
+            vec![
+                ColumnField::new("a".into(), ColumnType::BigInt),
+                ColumnField::new("b".into(), ColumnType::Int),
+            ],
+        );
+        let expected = DynProofPlan::SortMergeJoin(SortMergeJoinExec::new(
+            Box::new(table_plan.clone()),
+            Box::new(table_plan),
+            vec![0],
+            vec![0],
+            vec!["a".into(), "b".into(), "b".into()],
+        ));
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_cannot_convert_inner_join_on_different_column_names() {
+        let left = LogicalPlan::TableScan(
+            TableScan::try_new("table", TABLE_SOURCE(), Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+        let right = LogicalPlan::TableScan(
+            TableScan::try_new("table", TABLE_SOURCE(), Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+        let plan = LogicalPlan::Join(Join {
+            left: Arc::new(left),
+            right: Arc::new(right),
+            on: vec![(df_column("table", "a"), df_column("table", "b"))],
+            filter: None,
+            join_type: JoinType::Inner,
+            join_constraint: JoinConstraint::On,
+            schema: Arc::new(DFSchema::empty()),
+            null_equals_null: false,
+        });
+
+        let result = logical_plan_to_proof_plan(&plan, &SCHEMAS());
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
     }
 
     // Filter (LogicalPlan::Filter) tests - Happy paths

--- a/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
+++ b/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
@@ -47,7 +47,7 @@ pub fn statement_with_uppercase_identifiers(mut statement: Statement) -> Stateme
 
 #[cfg(test)]
 mod tests {
-    use super::statement_with_uppercase_identifiers;
+    use super::{statement_with_uppercase_identifiers, uppercase_identifier};
     use sqlparser::{dialect::GenericDialect, parser::Parser};
 
     #[test]
@@ -55,6 +55,31 @@ mod tests {
         let statement = Parser::parse_sql(&GenericDialect{}, "SELECT a.thissum from (SELECT Sum(uppercase_Value) as thissum, COUNT(puppies) as coUNT fRoM NonSEnSE) as a").unwrap()[0].clone();
         let statement = statement_with_uppercase_identifiers(statement);
         let expected_statement = Parser::parse_sql(&GenericDialect{}, "SELECT A.THISSUM from (SELECT Sum(UPPERCASE_VALUE) as thissum, COUNT(PUPPIES) as coUNT fRoM NONSENSE) as a").unwrap()[0].clone();
+        assert_eq!(statement, expected_statement);
+    }
+
+    #[test]
+    fn we_can_capitalize_a_single_identifier() {
+        let ident = uppercase_identifier("mixed_case".into());
+        assert_eq!(ident.value, "MIXED_CASE");
+        assert_eq!(ident.quote_style, None);
+    }
+
+    #[test]
+    fn we_can_capitalize_quoted_compound_identifiers_and_table_names() {
+        let statement = Parser::parse_sql(
+            &GenericDialect {},
+            r#"SELECT "schema"."columnName" FROM "namespace"."mixedTable""#,
+        )
+        .unwrap()[0]
+            .clone();
+        let statement = statement_with_uppercase_identifiers(statement);
+        let expected_statement = Parser::parse_sql(
+            &GenericDialect {},
+            r#"SELECT "SCHEMA"."COLUMNNAME" FROM "NAMESPACE"."MIXEDTABLE""#,
+        )
+        .unwrap()[0]
+            .clone();
         assert_eq!(statement, expected_statement);
     }
 }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -97,4 +97,4 @@ required-features = [ "std", "blitzar", "utils" ]
 [[bin]]
 name = "commitment-utility"
 path = "utils/commitment-utility/main.rs"
-required-features = [ "std", "blitzar", "utils" ]
+required-features = [ "std", "utils" ]

--- a/crates/proof-of-sql/tests/commitment_utility.rs
+++ b/crates/proof-of-sql/tests/commitment_utility.rs
@@ -1,0 +1,150 @@
+//! Integration tests for the commitment utility CLI.
+
+use curve25519_dalek::ristretto::RistrettoPoint;
+use proof_of_sql::{
+    base::commitment::{ColumnCommitments, TableCommitment},
+    proof_primitive::dory::{DoryCommitment, DynamicDoryCommitment},
+};
+use std::{
+    fs,
+    io::Write,
+    process::{Command, Stdio},
+};
+use tempfile::tempdir;
+
+fn commitment_utility_command() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_commitment-utility"))
+}
+
+fn empty_commitment_bytes<C>() -> Vec<u8>
+where
+    C: proof_of_sql::base::commitment::Commitment + serde::Serialize,
+{
+    let commitment = TableCommitment::<C>::try_new(ColumnCommitments::default(), 0..0).unwrap();
+    postcard::to_allocvec(&commitment).unwrap()
+}
+
+#[test]
+fn default_scheme_reads_dynamic_dory_commitment_from_stdin() {
+    let mut child = commitment_utility_command()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(&empty_commitment_bytes::<DynamicDoryCommitment>())
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(String::from_utf8(output.stdout)
+        .unwrap()
+        .contains("TableCommitment"));
+}
+
+#[test]
+fn selected_scheme_reads_commitment_from_input_file_and_writes_output_file() {
+    let temp_dir = tempdir().unwrap();
+    let input_path = temp_dir.path().join("commitment.bin");
+    let output_path = temp_dir.path().join("commitment.txt");
+    fs::write(&input_path, empty_commitment_bytes::<RistrettoPoint>()).unwrap();
+
+    let output = commitment_utility_command()
+        .args([
+            "--scheme",
+            "ipa",
+            "--input",
+            input_path.to_str().unwrap(),
+            "--output",
+            output_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(fs::read_to_string(output_path)
+        .unwrap()
+        .contains("TableCommitment"));
+}
+
+#[test]
+fn dory_scheme_is_deserialized() {
+    let temp_dir = tempdir().unwrap();
+    let input_path = temp_dir.path().join("commitment.bin");
+    fs::write(&input_path, empty_commitment_bytes::<DoryCommitment>()).unwrap();
+
+    let output = commitment_utility_command()
+        .args(["--scheme", "dory", "--input", input_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(String::from_utf8(output.stdout)
+        .unwrap()
+        .contains("TableCommitment"));
+}
+
+#[test]
+fn invalid_bytes_return_deserialization_error() {
+    let mut child = commitment_utility_command()
+        .args(["--scheme", "dynamic-dory"])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(&[0xff]).unwrap();
+
+    let output = child.wait_with_output().unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    assert!(String::from_utf8(output.stderr)
+        .unwrap()
+        .contains("DeserializationError"));
+}
+
+#[test]
+fn missing_input_file_returns_open_error() {
+    let temp_dir = tempdir().unwrap();
+    let input_path = temp_dir.path().join("missing.bin");
+
+    let output = commitment_utility_command()
+        .args(["--input", input_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    assert!(String::from_utf8(output.stderr)
+        .unwrap()
+        .contains("OpenInputFile"));
+}
+
+#[test]
+fn missing_output_parent_returns_create_error() {
+    let temp_dir = tempdir().unwrap();
+    let input_path = temp_dir.path().join("commitment.bin");
+    let output_path = temp_dir.path().join("missing-dir").join("commitment.txt");
+    fs::write(
+        &input_path,
+        empty_commitment_bytes::<DynamicDoryCommitment>(),
+    )
+    .unwrap();
+
+    let output = commitment_utility_command()
+        .args([
+            "--input",
+            input_path.to_str().unwrap(),
+            "--output",
+            output_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    assert!(String::from_utf8(output.stderr)
+        .unwrap()
+        .contains("CreateOutputFile"));
+}

--- a/crates/proof-of-sql/utils/commitment-utility/main.rs
+++ b/crates/proof-of-sql/utils/commitment-utility/main.rs
@@ -35,7 +35,7 @@ struct Cli {
     output: Option<PathBuf>,
 
     /// Commitment scheme (e.g. `ipa`, `dynamic_dory`, `dory`)
-    #[arg(long, value_enum, default_value = "CommitmentScheme::DynamicDory")]
+    #[arg(long, value_enum, default_value = "dynamic-dory")]
     scheme: CommitmentScheme,
 }
 


### PR DESCRIPTION
## Summary
- add direct coverage for planner DataFusion helper constructors and context provider options/filter pushdown behavior
- cover uppercase identifier helper behavior for single and quoted compound identifiers
- cover planner aggregate alias error handling and inner-join conversion/error branches
- add black-box coverage for the commitment-utility CLI across stdin/stdout, file IO, schemes, and error paths
- fix the commitment-utility default scheme value and allow the CLI to build without the Linux-only blitzar backend

## Verification
- cargo fmt --all --check
- cargo test -p proof-of-sql-planner --lib
- cargo test -p proof-of-sql --test commitment_utility --no-default-features --features "std utils"
- cargo llvm-cov -p proof-of-sql-planner --lib --text --show-missing-lines --ignore-filename-regex ".*(_test|evm_tests).*" --output-path /tmp/proof-of-sql-planner-cov-2.txt
- cargo llvm-cov -p proof-of-sql --test commitment_utility --bin commitment-utility --no-default-features --features "std utils" --text --show-missing-lines --output-path /tmp/commitment-utility-integration-cov.txt

/claim #560