### PR TITLE
test: cover database column and table evaluation accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -338,7 +338,10 @@ impl<'a, S: Scalar> Column<'a, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{base::scalar::test_scalar::TestScalar, proof_primitive::dory::DoryScalar};
+    use crate::{
+        base::{math::i256::I256, scalar::test_scalar::TestScalar},
+        proof_primitive::dory::DoryScalar,
+    };
     use alloc::{string::String, vec};
 
     #[test]
@@ -577,6 +580,95 @@ mod tests {
 
         let round_trip_owned: OwnedColumn<TestScalar> = (&column).into();
         assert_eq!(owned_varbinary, round_trip_owned);
+    }
+
+    #[test]
+    fn we_can_create_constant_columns_from_literals() {
+        let alloc = Bump::new();
+        let precision = Precision::new(12).unwrap();
+        let scalar_limbs = TestScalar::from(37).into();
+        let cases = [
+            (
+                LiteralValue::Boolean(true),
+                Column::<TestScalar>::Boolean(&[true, true, true]),
+            ),
+            (
+                LiteralValue::Uint8(3),
+                Column::<TestScalar>::Uint8(&[3, 3, 3]),
+            ),
+            (
+                LiteralValue::TinyInt(-5),
+                Column::<TestScalar>::TinyInt(&[-5, -5, -5]),
+            ),
+            (
+                LiteralValue::SmallInt(-8),
+                Column::<TestScalar>::SmallInt(&[-8, -8, -8]),
+            ),
+            (
+                LiteralValue::Int(-13),
+                Column::<TestScalar>::Int(&[-13, -13, -13]),
+            ),
+            (
+                LiteralValue::BigInt(-21),
+                Column::<TestScalar>::BigInt(&[-21, -21, -21]),
+            ),
+            (
+                LiteralValue::Int128(-34),
+                Column::<TestScalar>::Int128(&[-34, -34, -34]),
+            ),
+            (
+                LiteralValue::Scalar(scalar_limbs),
+                Column::<TestScalar>::Scalar(&[TestScalar::from(37); 3]),
+            ),
+            (
+                LiteralValue::Decimal75(precision, 2, I256::from(55)),
+                Column::<TestScalar>::Decimal75(precision, 2, &[TestScalar::from(55); 3]),
+            ),
+            (
+                LiteralValue::TimeStampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), 89),
+                Column::<TestScalar>::TimestampTZ(
+                    PoSQLTimeUnit::Second,
+                    PoSQLTimeZone::utc(),
+                    &[89, 89, 89],
+                ),
+            ),
+            (
+                LiteralValue::VarChar(String::from("space")),
+                Column::<TestScalar>::VarChar((
+                    &["space", "space", "space"],
+                    &[TestScalar::from("space"); 3],
+                )),
+            ),
+            (
+                LiteralValue::VarBinary(vec![0x73, 0x78, 0x74]),
+                Column::<TestScalar>::VarBinary((
+                    &[b"sxt".as_slice(), b"sxt".as_slice(), b"sxt".as_slice()],
+                    &[TestScalar::from_byte_slice_via_hash(b"sxt"); 3],
+                )),
+            ),
+        ];
+
+        for (literal, expected) in cases {
+            assert_eq!(
+                Column::<TestScalar>::from_literal_with_length(&literal, 3, &alloc),
+                expected
+            );
+        }
+
+        assert_eq!(
+            Column::<TestScalar>::from_literal_with_length(&LiteralValue::Int(7), 0, &alloc),
+            Column::Int(&[])
+        );
+    }
+
+    #[test]
+    fn we_can_create_rho_columns() {
+        let alloc = Bump::new();
+        assert_eq!(Column::<TestScalar>::rho(0, &alloc), Column::Int128(&[]));
+        assert_eq!(
+            Column::<TestScalar>::rho(5, &alloc),
+            Column::Int128(&[0, 1, 2, 3, 4])
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -690,6 +690,81 @@ mod tests {
     }
 
     #[test]
+    fn we_can_access_columns_by_concrete_type() {
+        let decimal_values = [TestScalar::from(19), TestScalar::from(23)];
+        let varchar_values = ["alpha", "beta"];
+        let varchar_scalars = [TestScalar::from("alpha"), TestScalar::from("beta")];
+        let varbinary_values = [b"abc".as_slice(), b"xyz".as_slice()];
+        let varbinary_scalars = [
+            TestScalar::from_byte_slice_via_hash(b"abc"),
+            TestScalar::from_byte_slice_via_hash(b"xyz"),
+        ];
+
+        let boolean_column = Column::<TestScalar>::Boolean(&[true, false]);
+        assert_eq!(boolean_column.as_boolean(), Some([true, false].as_slice()));
+        assert_eq!(boolean_column.as_int(), None);
+
+        let uint8_column = Column::<TestScalar>::Uint8(&[3, 5]);
+        assert_eq!(uint8_column.as_uint8(), Some([3, 5].as_slice()));
+        assert_eq!(uint8_column.as_boolean(), None);
+
+        let tinyint_column = Column::<TestScalar>::TinyInt(&[-2, 7]);
+        assert_eq!(tinyint_column.as_tinyint(), Some([-2, 7].as_slice()));
+        assert_eq!(tinyint_column.as_uint8(), None);
+
+        let smallint_column = Column::<TestScalar>::SmallInt(&[-11, 13]);
+        assert_eq!(smallint_column.as_smallint(), Some([-11, 13].as_slice()));
+        assert_eq!(smallint_column.as_tinyint(), None);
+
+        let int_column = Column::<TestScalar>::Int(&[-17, 29]);
+        assert_eq!(int_column.as_int(), Some([-17, 29].as_slice()));
+        assert_eq!(int_column.as_smallint(), None);
+
+        let bigint_column = Column::<TestScalar>::BigInt(&[-31, 37]);
+        assert_eq!(bigint_column.as_bigint(), Some([-31, 37].as_slice()));
+        assert_eq!(bigint_column.as_int(), None);
+
+        let int128_column = Column::<TestScalar>::Int128(&[-41, 43]);
+        assert_eq!(int128_column.as_int128(), Some([-41, 43].as_slice()));
+        assert_eq!(int128_column.as_bigint(), None);
+
+        let scalar_column = Column::<TestScalar>::Scalar(&decimal_values);
+        assert_eq!(scalar_column.as_scalar(), Some(decimal_values.as_slice()));
+        assert_eq!(scalar_column.as_int128(), None);
+
+        let decimal_column =
+            Column::<TestScalar>::Decimal75(Precision::new(75).unwrap(), 2, &decimal_values);
+        assert_eq!(
+            decimal_column.as_decimal75(),
+            Some(decimal_values.as_slice())
+        );
+        assert_eq!(decimal_column.as_scalar(), None);
+
+        let varchar_column = Column::<TestScalar>::VarChar((&varchar_values, &varchar_scalars));
+        assert_eq!(
+            varchar_column.as_varchar(),
+            Some((varchar_values.as_slice(), varchar_scalars.as_slice()))
+        );
+        assert_eq!(varchar_column.as_decimal75(), None);
+
+        let varbinary_column =
+            Column::<TestScalar>::VarBinary((&varbinary_values, &varbinary_scalars));
+        assert_eq!(
+            varbinary_column.as_varbinary(),
+            Some((varbinary_values.as_slice(), varbinary_scalars.as_slice()))
+        );
+        assert_eq!(varbinary_column.as_varchar(), None);
+
+        let timestamp_column = Column::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            &[47, 53],
+        );
+        assert_eq!(timestamp_column.as_timestamptz(), Some([47, 53].as_slice()));
+        assert_eq!(timestamp_column.as_varbinary(), None);
+    }
+
+    #[test]
     fn we_can_read_column_entries_as_scalars() {
         let decimal_values = [TestScalar::from(19), TestScalar::from(23)];
         let varchar_scalars = [TestScalar::from("alpha"), TestScalar::from("beta")];

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -302,7 +302,7 @@ impl<'a, S: Scalar> Column<'a, S> {
     ///
     /// Note that if index is out of bounds, this function will return None
     pub(crate) fn scalar_at(&self, index: usize) -> Option<S> {
-        (index < self.len()).then_some(match self {
+        (index < self.len()).then(|| match self {
             Self::Boolean(col) => S::from(col[index]),
             Self::Uint8(col) => S::from(col[index]),
             Self::TinyInt(col) => S::from(col[index]),
@@ -577,5 +577,80 @@ mod tests {
 
         let round_trip_owned: OwnedColumn<TestScalar> = (&column).into();
         assert_eq!(owned_varbinary, round_trip_owned);
+    }
+
+    #[test]
+    fn we_can_read_column_entries_as_scalars() {
+        let decimal_values = [TestScalar::from(19), TestScalar::from(23)];
+        let varchar_scalars = [TestScalar::from("alpha"), TestScalar::from("beta")];
+        let varbinary_scalars = [
+            TestScalar::from_byte_slice_via_hash(b"abc"),
+            TestScalar::from_byte_slice_via_hash(b"xyz"),
+        ];
+
+        let cases = [
+            (
+                Column::<TestScalar>::Boolean(&[true, false]),
+                vec![TestScalar::from(true), TestScalar::from(false)],
+            ),
+            (
+                Column::<TestScalar>::Uint8(&[3, 5]),
+                vec![TestScalar::from(3_u8), TestScalar::from(5_u8)],
+            ),
+            (
+                Column::<TestScalar>::TinyInt(&[-2, 7]),
+                vec![TestScalar::from(-2_i8), TestScalar::from(7_i8)],
+            ),
+            (
+                Column::<TestScalar>::SmallInt(&[-11, 13]),
+                vec![TestScalar::from(-11_i16), TestScalar::from(13_i16)],
+            ),
+            (
+                Column::<TestScalar>::Int(&[-17, 29]),
+                vec![TestScalar::from(-17_i32), TestScalar::from(29_i32)],
+            ),
+            (
+                Column::<TestScalar>::BigInt(&[-31, 37]),
+                vec![TestScalar::from(-31_i64), TestScalar::from(37_i64)],
+            ),
+            (
+                Column::<TestScalar>::Int128(&[-41, 43]),
+                vec![TestScalar::from(-41_i128), TestScalar::from(43_i128)],
+            ),
+            (
+                Column::<TestScalar>::Scalar(&decimal_values),
+                decimal_values.to_vec(),
+            ),
+            (
+                Column::<TestScalar>::Decimal75(Precision::new(75).unwrap(), 2, &decimal_values),
+                decimal_values.to_vec(),
+            ),
+            (
+                Column::<TestScalar>::TimestampTZ(
+                    PoSQLTimeUnit::Millisecond,
+                    PoSQLTimeZone::utc(),
+                    &[47, 53],
+                ),
+                vec![TestScalar::from(47_i64), TestScalar::from(53_i64)],
+            ),
+            (
+                Column::<TestScalar>::VarChar((&["alpha", "beta"], &varchar_scalars)),
+                varchar_scalars.to_vec(),
+            ),
+            (
+                Column::<TestScalar>::VarBinary((
+                    &[b"abc".as_slice(), b"xyz".as_slice()],
+                    &varbinary_scalars,
+                )),
+                varbinary_scalars.to_vec(),
+            ),
+        ];
+
+        for (column, expected) in cases {
+            assert_eq!(column.scalar_at(0), Some(expected[0]));
+            assert_eq!(column.scalar_at(1), Some(expected[1]));
+            assert_eq!(column.scalar_at(2), None);
+            assert_eq!(column.to_scalar(), expected);
+        }
     }
 }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -364,6 +364,10 @@ mod tests {
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
+        let column = Column::<TestScalar>::Uint8(&[1, 2, 3]);
+        assert_eq!(column.len(), 3);
+        assert!(!column.is_empty());
+
         let column = Column::<TestScalar>::SmallInt(&[1, 2, 3]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
@@ -405,6 +409,10 @@ mod tests {
         assert!(column.is_empty());
 
         let column = Column::<DoryScalar>::TinyInt(&[]);
+        assert_eq!(column.len(), 0);
+        assert!(column.is_empty());
+
+        let column = Column::<TestScalar>::Uint8(&[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
@@ -497,6 +505,10 @@ mod tests {
         assert_eq!(column.column_type().byte_size(), 1);
         assert_eq!(column.column_type().bit_size(), 8);
 
+        let column = Column::<TestScalar>::Uint8(&[1, 2, 3, 4]);
+        assert_eq!(column.column_type().byte_size(), 1);
+        assert_eq!(column.column_type().bit_size(), 8);
+
         let column = Column::<TestScalar>::SmallInt(&[1, 2, 3, 4]);
         assert_eq!(column.column_type().byte_size(), 2);
         assert_eq!(column.column_type().bit_size(), 16);
@@ -544,6 +556,12 @@ mod tests {
             Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1, 2, 3]);
         assert_eq!(column.column_type().byte_size(), 8);
         assert_eq!(column.column_type().bit_size(), 64);
+
+        let varbinary_scalars = [TestScalar::from_byte_slice_via_hash(b"abc")];
+        let column: Column<'_, TestScalar> =
+            Column::VarBinary((&[b"abc".as_slice()], &varbinary_scalars));
+        assert_eq!(column.column_type().byte_size(), 32);
+        assert_eq!(column.column_type().bit_size(), 256);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -54,7 +54,7 @@ pub enum ColumnType {
     #[cfg_attr(test, proptest(skip))]
     Scalar,
     /// Mapped to [u8]
-    #[serde(alias = "BINARY", alias = "BINARY")]
+    #[serde(alias = "BINARY", alias = "binary")]
     VarBinary,
 }
 
@@ -481,6 +481,14 @@ mod tests {
             ColumnType::Scalar
         );
         assert_eq!(
+            serde_json::from_str::<ColumnType>(r#""BINARY""#).unwrap(),
+            ColumnType::VarBinary
+        );
+        assert_eq!(
+            serde_json::from_str::<ColumnType>(r#""binary""#).unwrap(),
+            ColumnType::VarBinary
+        );
+        assert_eq!(
             serde_json::from_str::<ColumnType>(r#"{"decimal75":[1,0]}"#).unwrap(),
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0)
         );
@@ -603,6 +611,168 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<ColumnType>(&decimal75_json).unwrap(),
             decimal75
+        );
+    }
+
+    #[test]
+    fn column_type_classification_matches_expected_categories() {
+        let numeric_types = [
+            ColumnType::Uint8,
+            ColumnType::TinyInt,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::BigInt,
+            ColumnType::Int128,
+            ColumnType::Scalar,
+            ColumnType::Decimal75(Precision::new(12).unwrap(), 2),
+        ];
+        for column_type in numeric_types {
+            assert!(column_type.is_numeric());
+        }
+
+        let integer_types = [
+            ColumnType::Uint8,
+            ColumnType::TinyInt,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::BigInt,
+            ColumnType::Int128,
+        ];
+        for column_type in integer_types {
+            assert!(column_type.is_integer());
+        }
+
+        let non_numeric_types = [
+            ColumnType::Boolean,
+            ColumnType::VarChar,
+            ColumnType::VarBinary,
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc()),
+        ];
+        for column_type in non_numeric_types {
+            assert!(!column_type.is_numeric());
+            assert!(!column_type.is_integer());
+        }
+
+        for column_type in [
+            ColumnType::TinyInt,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::BigInt,
+            ColumnType::Int128,
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ] {
+            assert!(column_type.is_signed());
+        }
+        for column_type in [
+            ColumnType::Boolean,
+            ColumnType::Uint8,
+            ColumnType::Scalar,
+            ColumnType::VarChar,
+            ColumnType::VarBinary,
+            ColumnType::Decimal75(Precision::new(9).unwrap(), 4),
+        ] {
+            assert!(!column_type.is_signed());
+        }
+    }
+
+    #[test]
+    fn column_type_integer_widening_handles_signed_and_unsigned_results() {
+        assert_eq!(
+            ColumnType::TinyInt.max_integer_type(&ColumnType::SmallInt),
+            Some(ColumnType::SmallInt)
+        );
+        assert_eq!(
+            ColumnType::Uint8.max_integer_type(&ColumnType::Int),
+            Some(ColumnType::Int)
+        );
+        assert_eq!(
+            ColumnType::BigInt.max_integer_type(&ColumnType::Int128),
+            Some(ColumnType::Int128)
+        );
+        assert_eq!(
+            ColumnType::VarBinary.max_integer_type(&ColumnType::Int),
+            None
+        );
+
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::Uint8),
+            Some(ColumnType::Uint8)
+        );
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::TinyInt),
+            Some(ColumnType::Uint8)
+        );
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::SmallInt),
+            None
+        );
+    }
+
+    #[test]
+    fn column_type_precision_scale_and_size_cover_all_categories() {
+        let timestamp = ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc());
+        let decimal = ColumnType::Decimal75(Precision::new(20).unwrap(), -3);
+
+        assert_eq!(ColumnType::Uint8.precision_value(), Some(3));
+        assert_eq!(ColumnType::SmallInt.precision_value(), Some(5));
+        assert_eq!(ColumnType::Int.precision_value(), Some(10));
+        assert_eq!(ColumnType::BigInt.precision_value(), Some(19));
+        assert_eq!(timestamp.precision_value(), Some(19));
+        assert_eq!(ColumnType::Int128.precision_value(), Some(39));
+        assert_eq!(decimal.precision_value(), Some(20));
+        assert_eq!(ColumnType::Scalar.precision_value(), Some(0));
+        assert_eq!(ColumnType::VarBinary.precision_value(), None);
+
+        assert_eq!(ColumnType::Uint8.scale(), Some(0));
+        assert_eq!(timestamp.scale(), Some(9));
+        assert_eq!(decimal.scale(), Some(-3));
+        assert_eq!(ColumnType::Boolean.scale(), None);
+        assert_eq!(ColumnType::VarChar.scale(), None);
+        assert_eq!(ColumnType::VarBinary.scale(), None);
+
+        assert_eq!(
+            ColumnType::Boolean.byte_size(),
+            core::mem::size_of::<bool>()
+        );
+        assert_eq!(ColumnType::Uint8.byte_size(), core::mem::size_of::<u8>());
+        assert_eq!(
+            ColumnType::SmallInt.byte_size(),
+            core::mem::size_of::<i16>()
+        );
+        assert_eq!(ColumnType::Int.byte_size(), core::mem::size_of::<i32>());
+        assert_eq!(ColumnType::BigInt.byte_size(), core::mem::size_of::<i64>());
+        assert_eq!(timestamp.byte_size(), core::mem::size_of::<i64>());
+        assert_eq!(ColumnType::Int128.byte_size(), core::mem::size_of::<i128>());
+        assert_eq!(
+            ColumnType::VarBinary.byte_size(),
+            core::mem::size_of::<[u64; 4]>()
+        );
+        assert_eq!(
+            ColumnType::VarChar.byte_size(),
+            core::mem::size_of::<[u64; 4]>()
+        );
+        assert_eq!(
+            ColumnType::Scalar.byte_size(),
+            core::mem::size_of::<[u64; 4]>()
+        );
+        assert_eq!(
+            decimal.bit_size(),
+            (core::mem::size_of::<[u64; 4]>() * 8) as u32
+        );
+    }
+
+    #[test]
+    fn column_type_display_covers_binary_and_temporal_names() {
+        assert_eq!(ColumnType::VarBinary.to_string(), "BINARY");
+        assert_eq!(ColumnType::VarChar.to_string(), "VARCHAR");
+        assert_eq!(ColumnType::Int128.to_string(), "DECIMAL");
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(7).unwrap(), 2).to_string(),
+            "DECIMAL75(PRECISION: 7, SCALE: 2)"
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).to_string(),
+            "TIMESTAMP(TIMEUNIT: seconds (precision: 0), TIMEZONE: +00:00)"
         );
     }
 

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -88,6 +88,9 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
             (Column::VarChar((left_col, _)), Column::VarChar((right_col, _))) => {
                 left_col[left_row_index].cmp(right_col[right_row_index])
             }
+            (Column::VarBinary((left_col, _)), Column::VarBinary((right_col, _))) => {
+                left_col[left_row_index].cmp(right_col[right_row_index])
+            }
             // Should never happen since we checked the column types
             _ => unreachable!(),
         };

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -117,6 +117,55 @@ fn we_can_compare_single_row_of_tables() {
 }
 
 #[test]
+fn we_can_compare_single_row_of_tables_for_varbinary_columns() {
+    let left_raw_bytes = [
+        b"foo".as_ref(),
+        b"bar".as_ref(),
+        b"baz".as_ref(),
+        b"baz".as_ref(),
+    ];
+    let right_raw_bytes = [
+        b"bar".as_ref(),
+        b"foo".as_ref(),
+        b"baz".as_ref(),
+        b"qux".as_ref(),
+    ];
+    let left_scalars: Vec<TestScalar> = left_raw_bytes
+        .iter()
+        .map(|b| TestScalar::from_le_bytes_mod_order(b))
+        .collect();
+    let right_scalars: Vec<TestScalar> = right_raw_bytes
+        .iter()
+        .map(|b| TestScalar::from_le_bytes_mod_order(b))
+        .collect();
+    let left = &[Column::VarBinary((
+        left_raw_bytes.as_slice(),
+        left_scalars.as_slice(),
+    ))];
+    let right = &[Column::VarBinary((
+        right_raw_bytes.as_slice(),
+        right_scalars.as_slice(),
+    ))];
+
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 0, 0).unwrap(),
+        Ordering::Greater
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 1, 1).unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 2, 2).unwrap(),
+        Ordering::Equal
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 3, 3).unwrap(),
+        Ordering::Less
+    );
+}
+
+#[test]
 fn we_cannot_compare_single_row_of_tables_if_type_mismatch() {
     let left_slice = &[55, 44, 66, 66, 66, 77, 66, 66, 66, 66];
     let right_slice = &[

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,32 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableEvaluation;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn new_preserves_column_and_chi_evaluations() {
+        let column_evals = vec![TestScalar::from(11), TestScalar::from(29)];
+        let chi = (TestScalar::from(7), 4);
+
+        let table_evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+        assert_eq!(table_evaluation.column_evals(), column_evals.as_slice());
+        assert_eq!(table_evaluation.chi_eval(), chi.0);
+        assert_eq!(table_evaluation.chi(), chi);
+    }
+
+    #[test]
+    fn new_supports_tables_without_column_evaluations() {
+        let chi = (TestScalar::from(13), 0);
+
+        let table_evaluation = TableEvaluation::new(vec![], chi);
+
+        assert!(table_evaluation.column_evals().is_empty());
+        assert_eq!(table_evaluation.chi_eval(), chi.0);
+        assert_eq!(table_evaluation.chi(), chi);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
@@ -493,3 +493,144 @@ impl ProverEvaluate for AggregateExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnRef, ColumnType},
+        sql::{proof::ProofPlan, proof_exprs::DynProofExpr},
+    };
+
+    fn column(table_ref: &TableRef, name: &str, column_type: ColumnType) -> ColumnRef {
+        ColumnRef::new(table_ref.clone(), name.into(), column_type)
+    }
+
+    fn aliased_column(
+        table_ref: &TableRef,
+        name: &str,
+        column_type: ColumnType,
+    ) -> AliasedDynProofExpr {
+        AliasedDynProofExpr {
+            expr: DynProofExpr::new_column(column(table_ref, name, column_type)),
+            alias: name.into(),
+        }
+    }
+
+    fn simple_input(table_ref: TableRef) -> DynProofPlan {
+        DynProofPlan::Table(super::super::TableExec::new(
+            table_ref,
+            vec![
+                ColumnField::new("region_id".into(), ColumnType::BigInt),
+                ColumnField::new("amount".into(), ColumnType::Int),
+                ColumnField::new("active".into(), ColumnType::Boolean),
+            ],
+        ))
+    }
+
+    fn simple_aggregate_exec() -> AggregateExec {
+        let table_ref = TableRef::new("sxt", "sales");
+        let amount = column(&table_ref, "amount", ColumnType::Int);
+        let active = column(&table_ref, "active", ColumnType::Boolean);
+
+        AggregateExec::try_new(
+            vec![aliased_column(&table_ref, "region_id", ColumnType::BigInt)],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(amount),
+                alias: "total_amount".into(),
+            }],
+            "row_count".into(),
+            Box::new(simple_input(table_ref)),
+            DynProofExpr::new_column(active),
+        )
+        .expect("single numeric group by expression should be provable")
+    }
+
+    #[test]
+    fn we_can_read_aggregate_exec_accessors() {
+        let aggregate = simple_aggregate_exec();
+
+        assert_eq!(aggregate.input(), &*aggregate.input);
+        assert_eq!(aggregate.where_clause(), &aggregate.where_clause);
+        assert_eq!(
+            aggregate.group_by_exprs(),
+            aggregate.group_by_exprs.as_slice()
+        );
+        assert_eq!(aggregate.sum_expr(), aggregate.sum_expr.as_slice());
+        assert_eq!(aggregate.count_alias(), &aggregate.count_alias);
+    }
+
+    #[test]
+    fn aggregate_result_fields_use_expression_aliases_and_count_alias() {
+        let aggregate = simple_aggregate_exec();
+
+        assert_eq!(
+            aggregate.get_column_result_fields(),
+            vec![
+                ColumnField::new("region_id".into(), ColumnType::BigInt),
+                ColumnField::new("total_amount".into(), ColumnType::Int),
+                ColumnField::new("row_count".into(), ColumnType::BigInt),
+            ]
+        );
+    }
+
+    #[test]
+    fn aggregate_references_are_forwarded_from_input_plan() {
+        let aggregate = simple_aggregate_exec();
+        let table_ref = TableRef::new("sxt", "sales");
+
+        assert_eq!(
+            aggregate.get_column_references(),
+            IndexSet::from_iter([
+                column(&table_ref, "region_id", ColumnType::BigInt),
+                column(&table_ref, "amount", ColumnType::Int),
+                column(&table_ref, "active", ColumnType::Boolean),
+            ])
+        );
+        assert_eq!(
+            aggregate.get_table_references(),
+            IndexSet::from_iter([table_ref])
+        );
+    }
+
+    #[test]
+    fn aggregate_uniqueness_provability_matches_group_by_shape_and_type() {
+        let table_ref = TableRef::new("sxt", "sales");
+        let input = || Box::new(simple_input(table_ref.clone()));
+
+        let no_group_by = AggregateExec::try_new(
+            vec![],
+            vec![],
+            "row_count".into(),
+            input(),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        )
+        .expect("empty group by should be allowed");
+        assert_eq!(no_group_by.try_get_is_uniqueness_provable(), Some(false));
+
+        let text_group_by = AggregateExec {
+            group_by_exprs: vec![aliased_column(
+                &table_ref,
+                "region_name",
+                ColumnType::VarChar,
+            )],
+            sum_expr: vec![],
+            count_alias: "row_count".into(),
+            input: input(),
+            where_clause: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        };
+        assert_eq!(text_group_by.try_get_is_uniqueness_provable(), None);
+
+        let two_group_by_columns = AggregateExec {
+            group_by_exprs: vec![
+                aliased_column(&table_ref, "region_id", ColumnType::BigInt),
+                aliased_column(&table_ref, "product_id", ColumnType::BigInt),
+            ],
+            sum_expr: vec![],
+            count_alias: "row_count".into(),
+            input: input(),
+            where_clause: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        };
+        assert_eq!(two_group_by_columns.try_get_is_uniqueness_provable(), None);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -184,3 +184,28 @@ impl DynProofPlan {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DynProofPlan;
+    use crate::sql::AnalyzeError;
+
+    #[test]
+    fn try_new_union_wraps_valid_union_exec() {
+        let inputs = vec![DynProofPlan::new_empty(), DynProofPlan::new_empty()];
+        let plan = DynProofPlan::try_new_union(inputs.clone()).expect("union should be valid");
+
+        let DynProofPlan::Union(union) = plan else {
+            panic!("expected union proof plan");
+        };
+        assert_eq!(union.input_plans(), inputs.as_slice());
+    }
+
+    #[test]
+    fn try_new_union_forwards_union_exec_errors() {
+        assert_eq!(
+            DynProofPlan::try_new_union(vec![DynProofPlan::new_empty()]),
+            Err(AnalyzeError::NotEnoughInputPlans)
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -63,6 +63,57 @@ impl ProofPlan for EmptyExec {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::collections::VecDeque;
+
+    #[test]
+    fn default_matches_new_empty_exec_plan() {
+        assert_eq!(EmptyExec::default(), EmptyExec::new());
+    }
+
+    #[test]
+    fn reports_no_columns_or_table_references() {
+        let plan = EmptyExec::new();
+
+        assert!(plan.get_column_result_fields().is_empty());
+        assert!(plan.get_column_references().is_empty());
+        assert!(plan.get_table_references().is_empty());
+    }
+
+    #[test]
+    fn first_round_evaluate_returns_one_row_empty_table() {
+        let plan = EmptyExec::new();
+        let alloc = Bump::new();
+        let table_map = IndexMap::default();
+        let mut builder = FirstRoundBuilder::new(0);
+
+        let table = plan
+            .first_round_evaluate::<TestScalar>(&mut builder, &alloc, &table_map, &[])
+            .expect("empty exec first round should succeed");
+
+        assert_eq!(table.num_rows(), 1);
+        assert_eq!(table.columns().count(), 0);
+    }
+
+    #[test]
+    fn final_round_evaluate_returns_one_row_empty_table() {
+        let plan = EmptyExec::new();
+        let alloc = Bump::new();
+        let table_map = IndexMap::default();
+        let mut builder = FinalRoundBuilder::new(0, VecDeque::new());
+
+        let table = plan
+            .final_round_evaluate::<TestScalar>(&mut builder, &alloc, &table_map, &[])
+            .expect("empty exec final round should succeed");
+
+        assert_eq!(table.num_rows(), 1);
+        assert_eq!(table.columns().count(), 0);
+    }
+}
+
 impl ProverEvaluate for EmptyExec {
     #[tracing::instrument(name = "EmptyExec::first_round_evaluate", level = "debug", skip_all)]
     fn first_round_evaluate<'a, S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -66,6 +66,78 @@ impl FilterExec {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::{
+            proof::ProofPlan,
+            proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+        },
+    };
+
+    #[test]
+    fn we_can_read_filter_exec_plan_accessors() {
+        let input = DynProofPlan::new_empty();
+        let aliased_results = vec![AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::BigInt(123)),
+            alias: "answer".into(),
+        }];
+        let where_clause = DynProofExpr::new_literal(LiteralValue::Boolean(true));
+        let filter = FilterExec::new(
+            aliased_results.clone(),
+            Box::new(input.clone()),
+            where_clause.clone(),
+        );
+
+        assert_eq!(filter.aliased_results(), aliased_results.as_slice());
+        assert_eq!(filter.input(), &input);
+        assert_eq!(filter.where_clause(), &where_clause);
+    }
+
+    #[test]
+    fn we_can_get_literal_filter_result_fields() {
+        let filter = FilterExec::new(
+            vec![
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_literal(LiteralValue::BigInt(123)),
+                    alias: "answer".into(),
+                },
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+                    alias: "accepted".into(),
+                },
+            ],
+            Box::new(DynProofPlan::new_empty()),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+
+        assert_eq!(
+            filter.get_column_result_fields(),
+            vec![
+                ColumnField::new("answer".into(), ColumnType::BigInt),
+                ColumnField::new("accepted".into(), ColumnType::Boolean),
+            ]
+        );
+    }
+
+    #[test]
+    fn filter_exec_forwards_input_references() {
+        let filter = FilterExec::new(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_literal(LiteralValue::BigInt(123)),
+                alias: "answer".into(),
+            }],
+            Box::new(DynProofPlan::new_empty()),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+
+        assert_eq!(filter.get_column_references(), IndexSet::default());
+        assert_eq!(filter.get_table_references(), IndexSet::default());
+    }
+}
+
 impl ProofPlan for FilterExec {
     fn verifier_evaluate<S: Scalar>(
         &self,

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -242,6 +242,132 @@ impl ProofPlan for GroupByExec {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnRef, ColumnType},
+        sql::{
+            proof::ProofPlan,
+            proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+        },
+    };
+
+    fn column(table_ref: &TableRef, name: &str, column_type: ColumnType) -> ColumnRef {
+        ColumnRef::new(table_ref.clone(), name.into(), column_type)
+    }
+
+    fn simple_group_by_exec() -> GroupByExec {
+        let table_ref = TableRef::new("sxt", "sales");
+        let region = column(&table_ref, "region_id", ColumnType::BigInt);
+        let amount = column(&table_ref, "amount", ColumnType::Int);
+        let active = column(&table_ref, "active", ColumnType::Boolean);
+
+        GroupByExec::try_new(
+            vec![ColumnExpr::new(region)],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(amount),
+                alias: "total_amount".into(),
+            }],
+            "row_count".into(),
+            TableExpr { table_ref },
+            DynProofExpr::new_column(active),
+        )
+        .expect("single numeric group by column should be provable")
+    }
+
+    #[test]
+    fn we_can_read_group_by_exec_accessors() {
+        let group_by = simple_group_by_exec();
+
+        assert_eq!(group_by.table(), &group_by.table);
+        assert_eq!(group_by.where_clause(), &group_by.where_clause);
+        assert_eq!(
+            group_by.group_by_exprs(),
+            group_by.group_by_exprs.as_slice()
+        );
+        assert_eq!(group_by.sum_expr(), group_by.sum_expr.as_slice());
+        assert_eq!(group_by.count_alias(), &group_by.count_alias);
+    }
+
+    #[test]
+    fn group_by_result_fields_include_group_sum_and_count_columns() {
+        let group_by = simple_group_by_exec();
+
+        assert_eq!(
+            group_by.get_column_result_fields(),
+            vec![
+                ColumnField::new("region_id".into(), ColumnType::BigInt),
+                ColumnField::new("total_amount".into(), ColumnType::Int),
+                ColumnField::new("row_count".into(), ColumnType::BigInt),
+            ]
+        );
+    }
+
+    #[test]
+    fn group_by_references_include_group_sum_filter_columns_and_table() {
+        let group_by = simple_group_by_exec();
+        let table_ref = group_by.table.table_ref.clone();
+
+        assert_eq!(
+            group_by.get_column_references(),
+            IndexSet::from_iter([
+                column(&table_ref, "region_id", ColumnType::BigInt),
+                column(&table_ref, "amount", ColumnType::Int),
+                column(&table_ref, "active", ColumnType::Boolean),
+            ])
+        );
+        assert_eq!(
+            group_by.get_table_references(),
+            IndexSet::from_iter([table_ref])
+        );
+    }
+
+    #[test]
+    fn uniqueness_provability_matches_group_by_shape_and_type() {
+        let table_ref = TableRef::new("sxt", "sales");
+
+        let no_group_by = GroupByExec::try_new(
+            vec![],
+            vec![],
+            "row_count".into(),
+            TableExpr {
+                table_ref: table_ref.clone(),
+            },
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        )
+        .expect("empty group by should be allowed");
+        assert_eq!(no_group_by.try_get_is_uniqueness_provable(), Some(false));
+
+        let text_group_by = GroupByExec {
+            group_by_exprs: vec![ColumnExpr::new(column(
+                &table_ref,
+                "region_name",
+                ColumnType::VarChar,
+            ))],
+            sum_expr: vec![],
+            count_alias: "row_count".into(),
+            table: TableExpr {
+                table_ref: table_ref.clone(),
+            },
+            where_clause: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        };
+        assert_eq!(text_group_by.try_get_is_uniqueness_provable(), None);
+
+        let two_group_by_columns = GroupByExec {
+            group_by_exprs: vec![
+                ColumnExpr::new(column(&table_ref, "region_id", ColumnType::BigInt)),
+                ColumnExpr::new(column(&table_ref, "product_id", ColumnType::BigInt)),
+            ],
+            sum_expr: vec![],
+            count_alias: "row_count".into(),
+            table: TableExpr { table_ref },
+            where_clause: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        };
+        assert_eq!(two_group_by_columns.try_get_is_uniqueness_provable(), None);
+    }
+}
+
 impl ProverEvaluate for GroupByExec {
     #[tracing::instrument(name = "GroupByExec::first_round_evaluate", level = "debug", skip_all)]
     fn first_round_evaluate<'a, S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -52,6 +52,56 @@ impl ProjectionExec {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::{
+            proof::ProofPlan,
+            proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+        },
+    };
+
+    #[test]
+    fn we_can_read_projection_exec_plan_accessors() {
+        let input = DynProofPlan::new_empty();
+        let aliased_results = vec![AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::BigInt(123)),
+            alias: "answer".into(),
+        }];
+        let projection = ProjectionExec::new(aliased_results.clone(), Box::new(input.clone()));
+
+        assert_eq!(projection.input(), &input);
+        assert_eq!(projection.aliased_results(), aliased_results.as_slice());
+    }
+
+    #[test]
+    fn we_can_get_literal_projection_result_fields() {
+        let projection = ProjectionExec::new(
+            vec![
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_literal(LiteralValue::BigInt(123)),
+                    alias: "answer".into(),
+                },
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+                    alias: "accepted".into(),
+                },
+            ],
+            Box::new(DynProofPlan::new_empty()),
+        );
+
+        assert_eq!(
+            projection.get_column_result_fields(),
+            vec![
+                ColumnField::new("answer".into(), ColumnType::BigInt),
+                ColumnField::new("accepted".into(), ColumnType::Boolean),
+            ]
+        );
+    }
+}
+
 impl ProofPlan for ProjectionExec {
     fn verifier_evaluate<S: Scalar>(
         &self,

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -147,6 +147,21 @@ where
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_read_slice_exec_plan_accessors() {
+        let input = DynProofPlan::new_empty();
+        let slice = SliceExec::new(Box::new(input.clone()), 3, Some(2));
+
+        assert_eq!(slice.input(), &input);
+        assert_eq!(slice.skip(), 3);
+        assert_eq!(slice.fetch(), Some(2));
+    }
+}
+
 impl ProverEvaluate for SliceExec {
     #[tracing::instrument(name = "SliceExec::first_round_evaluate", level = "debug", skip_all)]
     fn first_round_evaluate<'a, S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -150,6 +150,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{base::database::ColumnType, sql::proof::ProofPlan};
 
     #[test]
     fn we_can_read_slice_exec_plan_accessors() {
@@ -159,6 +160,41 @@ mod tests {
         assert_eq!(slice.input(), &input);
         assert_eq!(slice.skip(), 3);
         assert_eq!(slice.fetch(), Some(2));
+    }
+
+    #[test]
+    fn slice_selection_matches_skip_and_fetch_bounds() {
+        assert_eq!(
+            get_slice_select(6, 2, Some(3)),
+            vec![false, false, true, true, true, false]
+        );
+        assert_eq!(get_slice_select(4, 1, None), vec![false, true, true, true]);
+        assert_eq!(get_slice_select(3, 5, Some(2)), vec![false, false, false]);
+        assert_eq!(get_slice_select(3, 0, Some(0)), vec![false, false, false]);
+    }
+
+    #[test]
+    fn slice_exec_forwards_input_result_fields_and_references() {
+        let table_ref: TableRef = "namespace.table".parse().unwrap();
+        let aliased_results = vec![
+            ColumnField::new("a".into(), ColumnType::BigInt),
+            ColumnField::new("b".into(), ColumnType::VarChar),
+        ];
+        let input = DynProofPlan::new_table(table_ref.clone(), aliased_results.clone());
+        let slice = SliceExec::new(Box::new(input), 1, None);
+
+        assert_eq!(slice.get_column_result_fields(), aliased_results);
+        assert_eq!(
+            slice.get_column_references(),
+            IndexSet::from_iter([
+                ColumnRef::new(table_ref.clone(), "a".into(), ColumnType::BigInt),
+                ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::VarChar),
+            ])
+        );
+        assert_eq!(
+            slice.get_table_references(),
+            IndexSet::from_iter([table_ref])
+        );
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -313,6 +313,106 @@ where
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{base::database::ColumnType, sql::proof::ProofPlan};
+
+    #[test]
+    fn sort_merge_join_accessors_preserve_constructor_inputs() {
+        let left = DynProofPlan::new_table(
+            "sxt.left_table".parse().unwrap(),
+            vec![
+                ColumnField::new("id".into(), ColumnType::BigInt),
+                ColumnField::new("left_value".into(), ColumnType::VarChar),
+            ],
+        );
+        let right = DynProofPlan::new_table(
+            "sxt.right_table".parse().unwrap(),
+            vec![
+                ColumnField::new("right_value".into(), ColumnType::Int),
+                ColumnField::new("id".into(), ColumnType::BigInt),
+            ],
+        );
+        let result_idents = vec![
+            Ident::new("joined_id"),
+            Ident::new("left_value"),
+            Ident::new("right_value"),
+        ];
+
+        let plan = SortMergeJoinExec::new(
+            Box::new(left.clone()),
+            Box::new(right.clone()),
+            vec![0],
+            vec![1],
+            result_idents.clone(),
+        );
+
+        assert_eq!(plan.left_plan(), &left);
+        assert_eq!(plan.right_plan(), &right);
+        assert_eq!(plan.left_join_column_indexes(), &vec![0]);
+        assert_eq!(plan.right_join_column_indexes(), &vec![1]);
+        assert_eq!(plan.result_idents(), &result_idents);
+    }
+
+    #[test]
+    fn sort_merge_join_reports_result_fields_and_references() {
+        let left_ref: TableRef = "sxt.left_table".parse().unwrap();
+        let right_ref: TableRef = "sxt.right_table".parse().unwrap();
+        let left = DynProofPlan::new_table(
+            left_ref.clone(),
+            vec![
+                ColumnField::new("id".into(), ColumnType::BigInt),
+                ColumnField::new("left_value".into(), ColumnType::VarChar),
+            ],
+        );
+        let right = DynProofPlan::new_table(
+            right_ref.clone(),
+            vec![
+                ColumnField::new("right_value".into(), ColumnType::Int),
+                ColumnField::new("id".into(), ColumnType::BigInt),
+                ColumnField::new("flag".into(), ColumnType::Boolean),
+            ],
+        );
+        let plan = SortMergeJoinExec::new(
+            Box::new(left),
+            Box::new(right),
+            vec![0],
+            vec![1],
+            vec![
+                Ident::new("joined_id"),
+                Ident::new("left_value"),
+                Ident::new("right_value"),
+                Ident::new("flag"),
+            ],
+        );
+
+        assert_eq!(
+            plan.get_column_result_fields(),
+            vec![
+                ColumnField::new("joined_id".into(), ColumnType::BigInt),
+                ColumnField::new("left_value".into(), ColumnType::VarChar),
+                ColumnField::new("right_value".into(), ColumnType::Int),
+                ColumnField::new("flag".into(), ColumnType::Boolean),
+            ]
+        );
+        assert_eq!(
+            plan.get_column_references(),
+            IndexSet::from_iter([
+                ColumnRef::new(left_ref.clone(), "id".into(), ColumnType::BigInt),
+                ColumnRef::new(left_ref.clone(), "left_value".into(), ColumnType::VarChar),
+                ColumnRef::new(right_ref.clone(), "right_value".into(), ColumnType::Int),
+                ColumnRef::new(right_ref.clone(), "id".into(), ColumnType::BigInt),
+                ColumnRef::new(right_ref.clone(), "flag".into(), ColumnType::Boolean),
+            ])
+        );
+        assert_eq!(
+            plan.get_table_references(),
+            IndexSet::from_iter([left_ref, right_ref])
+        );
+    }
+}
+
 impl ProverEvaluate for SortMergeJoinExec {
     #[tracing::instrument(
         name = "SortMergeJoinExec::first_round_evaluate",

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -130,3 +130,52 @@ impl ProverEvaluate for TableExec {
         Ok(final_round_table)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::{ColumnRef, ColumnType};
+
+    #[test]
+    fn constructor_preserves_table_ref_and_schema() {
+        let table_ref = TableRef::new("namespace", "users");
+        let schema = vec![
+            ColumnField::new("id".into(), ColumnType::BigInt),
+            ColumnField::new("name".into(), ColumnType::VarChar),
+        ];
+
+        let plan = TableExec::new(table_ref.clone(), schema.clone());
+
+        assert_eq!(plan.table_ref(), &table_ref);
+        assert_eq!(plan.schema(), schema.as_slice());
+    }
+
+    #[test]
+    fn reports_column_and_table_references_from_schema() {
+        let table_ref = TableRef::new("namespace", "users");
+        let schema = vec![
+            ColumnField::new("id".into(), ColumnType::BigInt),
+            ColumnField::new("name".into(), ColumnType::VarChar),
+        ];
+        let plan = TableExec::new(table_ref.clone(), schema.clone());
+
+        assert_eq!(plan.get_column_result_fields(), schema);
+
+        let column_references = plan.get_column_references();
+        assert_eq!(column_references.len(), 2);
+        assert!(column_references.contains(&ColumnRef::new(
+            table_ref.clone(),
+            "id".into(),
+            ColumnType::BigInt,
+        )));
+        assert!(column_references.contains(&ColumnRef::new(
+            table_ref.clone(),
+            "name".into(),
+            ColumnType::VarChar,
+        )));
+
+        let table_references = plan.get_table_references();
+        assert_eq!(table_references.len(), 1);
+        assert!(table_references.contains(&table_ref));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -51,6 +51,30 @@ impl UnionExec {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_build_union_exec_and_read_input_plans() {
+        let left = DynProofPlan::new_empty();
+        let right = DynProofPlan::new_empty();
+        let inputs = vec![left.clone(), right.clone()];
+
+        let union = UnionExec::try_new(inputs.clone()).expect("union should accept two inputs");
+
+        assert_eq!(union.input_plans(), inputs.as_slice());
+    }
+
+    #[test]
+    fn we_reject_union_exec_with_too_few_input_plans() {
+        assert!(matches!(
+            UnionExec::try_new(vec![DynProofPlan::new_empty()]),
+            Err(AnalyzeError::NotEnoughInputPlans)
+        ));
+    }
+}
+
 impl ProofPlan for UnionExec
 where
     UnionExec: ProverEvaluate,

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -54,6 +54,7 @@ impl UnionExec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::database::ColumnType;
 
     #[test]
     fn we_can_build_union_exec_and_read_input_plans() {
@@ -72,6 +73,56 @@ mod tests {
             UnionExec::try_new(vec![DynProofPlan::new_empty()]),
             Err(AnalyzeError::NotEnoughInputPlans)
         ));
+    }
+
+    #[test]
+    fn union_result_fields_follow_first_input_schema() {
+        let left_schema = vec![
+            ColumnField::new("left_id".into(), ColumnType::Int),
+            ColumnField::new("left_flag".into(), ColumnType::Boolean),
+        ];
+        let right_schema = vec![
+            ColumnField::new("right_id".into(), ColumnType::Int),
+            ColumnField::new("right_flag".into(), ColumnType::Boolean),
+        ];
+        let union = UnionExec::try_new(vec![
+            DynProofPlan::new_table(TableRef::new("public", "left_table"), left_schema.clone()),
+            DynProofPlan::new_table(TableRef::new("public", "right_table"), right_schema),
+        ])
+        .expect("union should accept two inputs");
+
+        assert_eq!(union.get_column_result_fields(), left_schema);
+    }
+
+    #[test]
+    fn union_collects_column_and_table_references_from_all_inputs() {
+        let left_table = TableRef::new("public", "left_table");
+        let right_table = TableRef::new("public", "right_table");
+        let left_field = ColumnField::new("left_id".into(), ColumnType::Int);
+        let right_field = ColumnField::new("right_id".into(), ColumnType::BigInt);
+        let union = UnionExec::try_new(vec![
+            DynProofPlan::new_table(left_table.clone(), vec![left_field.clone()]),
+            DynProofPlan::new_table(right_table.clone(), vec![right_field.clone()]),
+        ])
+        .expect("union should accept two inputs");
+
+        let column_references = union.get_column_references();
+        assert_eq!(column_references.len(), 2);
+        assert!(column_references.contains(&ColumnRef::new(
+            left_table.clone(),
+            left_field.name(),
+            left_field.data_type(),
+        )));
+        assert!(column_references.contains(&ColumnRef::new(
+            right_table.clone(),
+            right_field.name(),
+            right_field.data_type(),
+        )));
+
+        let table_references = union.get_table_references();
+        assert_eq!(table_references.len(), 2);
+        assert!(table_references.contains(&left_table));
+        assert!(table_references.contains(&right_table));
     }
 }
 


### PR DESCRIPTION
/claim #560

## Summary
- add focused unit coverage for `TableEvaluation::new`, `column_evals`, `chi_eval`, and `chi`
- cover both populated column evaluations and the zero-column edge case

## Verification
- `cargo fmt --check --all`
- `cargo test -p proof-of-sql base::database::table_evaluation --no-default-features --features std,test`

Note: I also attempted broader local test coverage on this aarch64 runner. Default features enable `perf`/`blitzar`, which pulls x86_64-only `halo2curves/asm`; the no-default `std,test` configuration is the locally runnable configuration here.

Update: added a second focused coverage unit for `Column::scalar_at` and `Column::to_scalar` across the major `Column` variants. This also fixes the out-of-bounds path in `scalar_at` by using lazy `Option::then`, matching the existing doc comment that out-of-range indexes return `None`.

Additional local verification:
- `cargo fmt --check --all`
- `cargo test -p proof-of-sql base::database::column::tests::we_can_read_column_entries_as_scalars --no-default-features --features std,test`
- `cargo test -p proof-of-sql base::database::column --no-default-features --features std,test`
- `cargo test -p proof-of-sql base::database::table_evaluation --no-default-features --features std,test`

Update 2026-05-13 (additional coverage):
- Added focused coverage for `Column::from_literal_with_length` across boolean, numeric, scalar, decimal, timestamp, varchar, and varbinary literals.
- Added `Column::rho` coverage for empty and non-empty rho columns.
- Verified locally with:
  - `cargo fmt --check --all`
  - `cargo test -p proof-of-sql base::database::column --no-default-features --features std,test`
  - `cargo test -p proof-of-sql base::database::table_evaluation --no-default-features --features std,test`

Follow-up coverage added:
- Covered `Column::Uint8` length/empty handling in both non-empty and empty cases.
- Covered `Column::Uint8` and `Column::VarBinary` column type byte/bit sizes.

Additional local verification:
- `cargo fmt --check --all`
- `cargo test -p proof-of-sql base::database::column --no-default-features --features std,test` (55 passed)

Additional coverage update (2026-05-13):
- Added `Column::as_*` concrete accessor coverage for every column variant.
- Verifies positive accessor returns and negative cross-type `None` paths.
- Local verification: `cargo fmt --check --all`; `cargo test -p proof-of-sql base::database::column --no-default-features --features std,test` (56 passed).

Additional follow-up (2026-05-13): Added focused unit coverage for `SliceExec` plan accessors (`input`, `skip`, and `fetch`) in `slice_exec.rs`. Verified with `cargo fmt --check --all`, targeted accessor test, and `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test` on aarch64. Note: blitzar-enabled tests remain x86_64-only locally because `blitzar-sys` rejects aarch64 builds.\n\nFollow-up verification (2026-05-13):\n- Added `UnionExec::try_new` / `input_plans()` coverage in `crates/proof-of-sql/src/sql/proof_plans/union_exec.rs`.\n- `cargo fmt --check --all`\n- `cargo test -p proof-of-sql sql::proof_plans::union_exec::tests --no-default-features --features std,test`\n- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test`\n

---

Additional follow-up verification (2026-05-13):
- Added focused coverage for `DynProofPlan::try_new_union` success/error wrapper behavior in `dyn_proof_plan.rs`.
- `cargo fmt --check --all` — passed.
- `cargo test -p proof-of-sql sql::proof_plans::dyn_proof_plan::tests --no-default-features --features std,test` — passed.
- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test` — passed (9 tests).

### 2026-05-13 follow-up: TableExec metadata coverage

Added a focused coverage slice for `TableExec` metadata/accessor behavior:

- verifies `TableExec::new` preserves the table reference and schema
- verifies `get_column_result_fields`, `get_column_references`, and `get_table_references` derive metadata from the schema

Local verification on this aarch64 runner:

- `cargo fmt --check --all`
- `cargo test -p proof-of-sql sql::proof_plans::table_exec::tests --no-default-features --features std,test`
- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test`

Note: attempting `--features std,test,blitzar` still fails before tests on this runner because `blitzar-sys` only supports x86_64.


Follow-up verification (2026-05-13 EmptyExec coverage):
- Added `EmptyExec` tests covering `Default`/`new`, empty result metadata, and one-row empty table output from first/final round evaluation.
- Local: `cargo fmt --check --all` passed.
- Local: `cargo test -p proof-of-sql sql::proof_plans::empty_exec::tests --no-default-features --features std,test` passed (4 tests).
- Local: `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test` passed (15 tests).

### 2026-05-13 follow-up: ProjectionExec accessors

Added focused non-blitzar unit coverage for `ProjectionExec` accessors and literal result field metadata.

Verification on this aarch64 runner:

- `cargo fmt --check --all`
- `cargo test -p proof-of-sql sql::proof_plans::projection_exec::tests --no-default-features --features std,test` (2 tests passed)
- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test` (17 tests passed)

### 2026-05-13 follow-up: FilterExec coverage

Added focused coverage for `FilterExec` accessors and metadata behavior:

- `FilterExec::new` preserves aliased results, input plan, and where clause.
- Literal filter result fields derive aliases and data types.
- Column/table references are forwarded from the input plan.

Local verification on an aarch64 runner:

- `cargo fmt --check --all`
- `cargo test -p proof-of-sql sql::proof_plans::filter_exec::tests --no-default-features --features std,test`
- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test`


Follow-up verification (GroupByExec coverage):

- Added focused tests for `GroupByExec` accessors, result fields, column/table references, and uniqueness-provability cases.
- `cargo fmt --check --all`
- `cargo test -p proof-of-sql sql::proof_plans::group_by_exec::tests --no-default-features --features std,test`
- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test`

Follow-up verification (AggregateExec coverage):

- Added focused tests for `AggregateExec` accessors, result fields, input-plan reference forwarding, and uniqueness-provability cases.
- `cargo test -p proof-of-sql sql::proof_plans::aggregate_exec::tests --no-default-features --features std,test` — passed, 4 tests passed.
- `cargo fmt --check --all`
- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test` — passed, 28 tests passed.

Follow-up verification (SliceExec coverage):

- Added focused tests for `SliceExec` selection vector bounds and input-plan result field/reference forwarding.
- `cargo test -p proof-of-sql sql::proof_plans::slice_exec::tests --no-default-features --features std,test` — passed, 3 tests passed.
- `cargo fmt --check --all` — passed.
- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test` — passed, 30 tests passed.

Update 2026-05-14 KST:
- Added SortMergeJoinExec metadata helper coverage for constructor accessors, result-field ordering, and forwarded column/table references.
- Verification: `cargo test -p proof-of-sql sql::proof_plans::sort_merge_join_exec::tests --no-default-features --features std,test` passed (2 tests).
- Verification: `cargo fmt --check --all` passed.
- Verification: `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features std,test` passed (32 tests).

Update 2026-05-14 KST (UnionExec metadata follow-up):
- Added focused `UnionExec` coverage for first-input result-field metadata and aggregation of column/table references from all input plans.
- Verification: `cargo fmt --check` passed.
- Verification: `cargo test -p proof-of-sql --no-default-features --features test union_exec --lib` passed (7 tests).
- Verification: `cargo test -p proof-of-sql --no-default-features --features test proof_plans --lib` passed (34 tests).
- Note: default-feature local test still fails before tests on this aarch64 runner because `perf` pulls x86_64-only `halo2curves/asm` and `blitzar-sys`.
