### PR TITLE
fix: reject nullable arrow owned column input

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -23,7 +23,7 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
+        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
         Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
         TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
     },
@@ -148,6 +148,10 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
     /// - `Decimal256Array` when converting from `DataType::Decimal256` if precision is less than or equal to 75.
     /// - `StringArray` when converting from `DataType::Utf8`.
     fn try_from(value: &ArrayRef) -> Result<Self, Self::Error> {
+        if value.null_count() > 0 {
+            return Err(OwnedArrowConversionError::NullNotSupportedYet);
+        }
+
         match &value.data_type() {
             // Arrow uses a bit-packed representation for booleans.
             // Hence we need to unpack the bits to get the actual boolean values.

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -8,7 +8,7 @@ use alloc::sync::Arc;
 use arrow::{
     array::{
         ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
-        StringArray,
+        StringArray, TimestampSecondArray,
     },
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
@@ -99,6 +99,33 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
         OwnedColumn::<TestScalar>::try_from(array_ref),
         Err(OwnedArrowConversionError::UnsupportedType { .. })
     ));
+}
+
+#[test]
+fn we_reject_arrow_arrays_with_nulls_when_converting_to_owned_columns() {
+    let arrays: Vec<ArrayRef> = vec![
+        Arc::new(BooleanArray::from(vec![Some(true), None, Some(false)])),
+        Arc::new(Int64Array::from(vec![Some(1), None, Some(3)])),
+        Arc::new(
+            Decimal128Array::from(vec![Some(1), None, Some(3)])
+                .with_precision_and_scale(38, 0)
+                .unwrap(),
+        ),
+        Arc::new(StringArray::from(vec![Some("a"), None, Some("c")])),
+        Arc::new(LargeBinaryArray::from(vec![
+            Some(&b"a"[..]),
+            None,
+            Some(&b"c"[..]),
+        ])),
+        Arc::new(TimestampSecondArray::from(vec![Some(1), None, Some(3)])),
+    ];
+
+    for array in arrays {
+        assert!(matches!(
+            OwnedColumn::<TestScalar>::try_from(array),
+            Err(OwnedArrowConversionError::NullNotSupportedYet)
+        ));
+    }
 }
 
 fn we_can_convert_between_owned_table_and_record_batch_impl(


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a small correctness guard for #183. Until nullable columns are represented explicitly, converting an Arrow array with nulls into a non-nullable `OwnedColumn` should fail before any type-specific conversion reads Arrow values.

Before this change, some supported Arrow arrays could pass through `OwnedColumn::try_from(&ArrayRef)` with nulls and silently use Arrow backing values for null slots, while other paths would panic or return `NullNotSupportedYet`. That is risky for the nullable-column work because it can hide null presence instead of forcing callers onto an explicit nullable representation.

/claim #183

Refs #183

# What changes are included in this PR?

- Added a uniform `value.null_count() > 0` guard at the start of `OwnedColumn::try_from(&ArrayRef)`.
- Reused the existing `OwnedArrowConversionError::NullNotSupportedYet` error.
- Added regression coverage for nullable Boolean, BigInt, Decimal128, Utf8, LargeBinary, and TimestampSecond arrays.

# Are these changes tested?

Yes. Ran locally:

```sh
cargo fmt --check
cargo test -p proof-of-sql --no-default-features --features="arrow test" we_reject_arrow_arrays_with_nulls_when_converting_to_owned_columns -- --nocapture
cargo test -p proof-of-sql --no-default-features --features="arrow test" owned_and_arrow_conversions_test -- --nocapture
git diff --check
source scripts/check_commits.sh
```

Results:
- focused nullable-array regression test passed
- owned/arrow conversion test module passed: 6 passed, 0 failed
- formatting, whitespace, and commit-message checks passed

I did not run `source scripts/run_ci_checks.sh` locally; this PR is intentionally narrow and should be covered by the repo CI plus the focused/module tests above.

This submission was AI-assisted and manually reviewed before opening.