### PR TITLE
Preserve nullable column metadata in planner schemas

### DIFF
--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -95,7 +95,7 @@ impl PoSqlTableSource {
                     Field::new(
                         column_field.name().value.as_str(),
                         (&column_field.data_type()).into(),
-                        false,
+                        column_field.is_nullable(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -144,14 +144,14 @@ mod tests {
         // Non-empty
         let column_fields = vec![
             ColumnField::new("a".into(), ColumnType::SmallInt),
-            ColumnField::new("b".into(), ColumnType::VarChar),
+            ColumnField::new_nullable("b".into(), ColumnType::VarChar),
         ];
         let table_source = PoSqlTableSource::new(column_fields);
         assert_eq!(
             table_source.schema().all_fields(),
             vec![
                 &Field::new("a", DataType::Int16, false),
-                &Field::new("b", DataType::Utf8, false),
+                &Field::new("b", DataType::Utf8, true),
             ]
         );
         assert_eq!(

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -137,9 +137,12 @@ pub fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
         column_fields
             .into_iter()
             .map(|column_field| {
-                //TODO: Make columns nullable
                 let data_type = (&column_field.data_type()).into();
-                Field::new(column_field.name().value.as_str(), data_type, false)
+                Field::new(
+                    column_field.name().value.as_str(),
+                    data_type,
+                    column_field.is_nullable(),
+                )
             })
             .collect::<Vec<_>>(),
     )
@@ -515,14 +518,14 @@ mod tests {
         // Non-empty
         let column_fields = vec![
             ColumnField::new("a".into(), ColumnType::SmallInt),
-            ColumnField::new("b".into(), ColumnType::VarChar),
+            ColumnField::new_nullable("b".into(), ColumnType::VarChar),
         ];
         let schema = column_fields_to_schema(column_fields);
         assert_eq!(
             schema.all_fields(),
             vec![
                 &Field::new("a", DataType::Int16, false),
-                &Field::new("b", DataType::Utf8, false),
+                &Field::new("b", DataType::Utf8, true),
             ]
         );
     }

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -77,7 +77,7 @@ impl From<&ColumnField> for Field {
         Field::new(
             column_field.name().value.as_str(),
             (&column_field.data_type()).into(),
-            false,
+            column_field.is_nullable(),
         )
     }
 }
@@ -95,5 +95,22 @@ mod tests {
 
             prop_assert_eq!(actual, column_type);
         }
+    }
+
+    #[test]
+    fn column_field_arrow_conversion_preserves_nullability() {
+        let non_nullable = ColumnField::new("amount".into(), ColumnType::BigInt);
+        let nullable = ColumnField::new_nullable("memo".into(), ColumnType::VarChar);
+
+        let non_nullable_arrow = Field::from(&non_nullable);
+        let nullable_arrow = Field::from(&nullable);
+
+        assert_eq!(non_nullable_arrow.name(), "amount");
+        assert_eq!(non_nullable_arrow.data_type(), &DataType::Int64);
+        assert!(!non_nullable_arrow.is_nullable());
+
+        assert_eq!(nullable_arrow.name(), "memo");
+        assert_eq!(nullable_arrow.data_type(), &DataType::Utf8);
+        assert!(nullable_arrow.is_nullable());
     }
 }

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -148,6 +148,10 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
     /// - `Decimal256Array` when converting from `DataType::Decimal256` if precision is less than or equal to 75.
     /// - `StringArray` when converting from `DataType::Utf8`.
     fn try_from(value: &ArrayRef) -> Result<Self, Self::Error> {
+        if value.null_count() > 0 {
+            return Err(OwnedArrowConversionError::NullNotSupportedYet);
+        }
+
         match &value.data_type() {
             // Arrow uses a bit-packed representation for booleans.
             // Hence we need to unpack the bits to get the actual boolean values.

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -101,6 +101,22 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
     ));
 }
 
+#[test]
+fn we_return_null_not_supported_when_converting_nullable_arrow_arrays() {
+    let arrays: Vec<ArrayRef> = vec![
+        Arc::new(Int64Array::from(vec![Some(1), None, Some(3)])),
+        Arc::new(StringArray::from(vec![Some("ok"), None])),
+        Arc::new(BooleanArray::from(vec![Some(true), None])),
+    ];
+
+    for array_ref in arrays {
+        assert!(matches!(
+            OwnedColumn::<TestScalar>::try_from(array_ref),
+            Err(OwnedArrowConversionError::NullNotSupportedYet)
+        ));
+    }
+}
+
 fn we_can_convert_between_owned_table_and_record_batch_impl(
     owned_table: &OwnedTable<TestScalar>,
     record_batch: &RecordBatch,

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -10,13 +10,29 @@ use sqlparser::ast::Ident;
 pub struct ColumnField {
     name: Ident,
     data_type: ColumnType,
+    #[serde(default)]
+    nullable: bool,
 }
 
 impl ColumnField {
     /// Create a new `ColumnField` from a name and a type
     #[must_use]
     pub fn new(name: Ident, data_type: ColumnType) -> ColumnField {
-        ColumnField { name, data_type }
+        ColumnField {
+            name,
+            data_type,
+            nullable: false,
+        }
+    }
+
+    /// Create a new nullable `ColumnField` from a name and a type.
+    #[must_use]
+    pub fn new_nullable(name: Ident, data_type: ColumnType) -> ColumnField {
+        ColumnField {
+            name,
+            data_type,
+            nullable: true,
+        }
     }
 
     /// Returns the name of the column
@@ -29,5 +45,11 @@ impl ColumnField {
     #[must_use]
     pub fn data_type(&self) -> ColumnType {
         self.data_type
+    }
+
+    /// Returns whether the column may contain null values.
+    #[must_use]
+    pub fn is_nullable(&self) -> bool {
+        self.nullable
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -53,3 +53,36 @@ impl ColumnField {
         self.nullable
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_columns_are_not_nullable_by_default() {
+        let column_field = ColumnField::new("amount".into(), ColumnType::BigInt);
+
+        assert_eq!(column_field.name(), "amount".into());
+        assert_eq!(column_field.data_type(), ColumnType::BigInt);
+        assert!(!column_field.is_nullable());
+    }
+
+    #[test]
+    fn nullable_columns_are_marked_nullable() {
+        let column_field = ColumnField::new_nullable("amount".into(), ColumnType::BigInt);
+
+        assert_eq!(column_field.name(), "amount".into());
+        assert_eq!(column_field.data_type(), ColumnType::BigInt);
+        assert!(column_field.is_nullable());
+    }
+
+    #[test]
+    fn serde_defaults_missing_nullable_to_false() {
+        let json = r#"{"name":{"value":"amount","quote_style":null},"data_type":"BIGINT"}"#;
+        let column_field: ColumnField = serde_json::from_str(json).unwrap();
+
+        assert_eq!(column_field.name(), "amount".into());
+        assert_eq!(column_field.data_type(), ColumnType::BigInt);
+        assert!(!column_field.is_nullable());
+    }
+}


### PR DESCRIPTION
/claim #183

## Summary

This PR adds the first nullable-column metadata plumbing needed by the nullable column support work:

- adds a nullable flag to `ColumnField`, defaulting existing fields to non-nullable
- adds `ColumnField::new_nullable` and `ColumnField::is_nullable`
- preserves `ColumnField` nullability when converting planner metadata into Arrow/DataFusion `Field`s
- updates planner tests so one field is explicitly nullable and must stay nullable in the Arrow schema

## Scope

This is intentionally a small, reviewable step rather than a full nullable proof implementation. It does not yet add nullable column storage, validity masks, nullable expression evaluation, or proof support. The goal is to stop planner/schema metadata from erasing nullability so the larger nullable-column implementation has a stable base to build on.

## Validation

Passed:

```bash
cargo fmt --all --check
cargo check -p proof-of-sql-planner
cargo check -p proof-of-sql --no-default-features --features 'rayon test'
```

I also attempted the focused planner unit tests, but local test linking is currently blocked by this machine's unaccepted Xcode license/macOS SDK state:

```text
unable to find dynamic system library 'objc'
unable to find dynamic system library 'iconv'
```

The compile/type checks above pass with the same code changes.
