### PR TITLE
test: cover byte matrix empty and constant columns

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -39,6 +39,36 @@ mod tests {
     use bumpalo::Bump;
 
     #[test]
+    fn we_can_compute_varying_byte_matrix_for_empty_column() {
+        let alloc = Bump::new();
+        let scalars = Vec::<TestScalar>::new();
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert!(varying_columns.is_empty());
+        assert_eq!(
+            byte_distribution,
+            ByteDistribution::new::<TestScalar, TestScalar>(&scalars)
+        );
+        assert_eq!(byte_distribution.varying_byte_count(), 0);
+    }
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_constant_column() {
+        let alloc = Bump::new();
+        let scalars = vec![TestScalar::from(257); 4];
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert!(varying_columns.is_empty());
+        assert_eq!(
+            byte_distribution,
+            ByteDistribution::new::<TestScalar, TestScalar>(&scalars)
+        );
+        assert_eq!(byte_distribution.varying_byte_count(), 0);
+    }
+
+    #[test]
     fn we_can_compute_varying_byte_matrix_for_small_scalars() {
         let alloc = Bump::new();
         let scalars: Vec<TestScalar> = [1, 2, 3, 255, 256, 257]


### PR DESCRIPTION
## Summary
- Add byte matrix coverage for empty scalar columns.
- Add byte matrix coverage for constant scalar columns with no varying byte columns.
- Keep the change test-only and scoped to `byte_matrix_utils`.

/claim #560

## Validation
- `rustfmt --check crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs`
- `cargo test -p proof-of-sql byte_matrix_utils --no-default-features --features test` -> 4 passed

## Note
- Full `cargo fmt --check` currently reports an unrelated import-order diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs` on current main; this PR does not touch that file.