### PR TITLE
test: cover record batch conversion paths

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -99,34 +99,133 @@ impl<C: Commitment> TableCommitment<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{
+        arrow::arrow_array_to_column_conversion::ArrowArrayToColumnConversionError,
         commitment::naive_commitment::NaiveCommitment, scalar::test_scalar::TestScalar,
     };
     use arrow::{
-        array::{Int64Array, StringArray},
+        array::{BooleanArray, Int64Array, StringArray},
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
     use std::sync::Arc;
 
-    #[test]
-    fn we_can_create_and_append_table_commitments_with_record_batches() {
+    fn int_and_string_batch(ints: Vec<i64>, strings: Vec<&str>) -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int64, false),
             Field::new("b", DataType::Utf8, false),
         ]));
 
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(ints)),
+                Arc::new(StringArray::from(strings)),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn we_can_convert_record_batches_to_named_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("is_active", DataType::Boolean, false),
+            Field::new("amount", DataType::Int64, false),
+            Field::new("label", DataType::Utf8, false),
+        ]));
+
         let batch = RecordBatch::try_new(
             schema,
             vec![
-                Arc::new(Int64Array::from(vec![1, 2, 3])),
-                Arc::new(StringArray::from(vec!["1", "2", "3"])),
+                Arc::new(BooleanArray::from(vec![true, false, true])),
+                Arc::new(Int64Array::from(vec![5, -8, 13])),
+                Arc::new(StringArray::from(vec!["alpha", "beta", "gamma"])),
             ],
         )
         .unwrap();
+        let alloc = Bump::new();
+        let columns = batch_to_columns::<TestScalar>(&batch, &alloc).unwrap();
+
+        assert_eq!(columns.len(), 3);
+        assert_eq!(columns[0].0.value, "is_active");
+        assert_eq!(columns[1].0.value, "amount");
+        assert_eq!(columns[2].0.value, "label");
+        assert_eq!(columns[0].1, Column::Boolean(&[true, false, true]));
+        assert_eq!(columns[1].1, Column::BigInt(&[5, -8, 13]));
+
+        let expected_labels = ["alpha", "beta", "gamma"];
+        let expected_scalars: Vec<TestScalar> = expected_labels
+            .iter()
+            .map(|value| (*value).into())
+            .collect();
+        assert_eq!(
+            columns[2].1,
+            Column::VarChar((&expected_labels, expected_scalars.as_slice()))
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_record_batches_with_nulls_to_columns() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "amount",
+            DataType::Int64,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int64Array::from(vec![Some(5), None, Some(13)]))],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+        let err = batch_to_columns::<TestScalar>(&batch, &alloc).unwrap_err();
+
+        assert!(matches!(
+            err,
+            RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                source: ArrowArrayToColumnConversionError::ArrayContainsNulls
+            }
+        ));
+    }
+
+    #[test]
+    fn record_batch_table_commitments_respect_offsets_and_append_rows() {
+        let batch = int_and_string_batch(vec![1, 2], vec!["1", "2"]);
+        let mut commitment =
+            TableCommitment::<NaiveCommitment>::try_from_record_batch_with_offset(&batch, 2, &())
+                .unwrap();
+
+        assert_eq!(commitment.range(), &(2..4));
+        assert_eq!(commitment.num_rows(), 2);
+
+        let next_batch = int_and_string_batch(vec![3, 4], vec!["3", "4"]);
+        commitment
+            .try_append_record_batch(&next_batch, &())
+            .unwrap();
+
+        let a_ident = "a".into();
+        let b_ident = "b".into();
+        let a_values = [1, 2, 3, 4];
+        let b_values = ["1", "2", "3", "4"];
+        let b_scalars: Vec<TestScalar> = b_values.iter().map(|value| (*value).into()).collect();
+        let a_column = Column::<TestScalar>::BigInt(&a_values);
+        let b_column = Column::VarChar((&b_values, b_scalars.as_slice()));
+        let expected_columns = [(&a_ident, &a_column), (&b_ident, &b_column)];
+        let expected_commitment = TableCommitment::<NaiveCommitment>::try_from_columns_with_offset(
+            expected_columns,
+            2,
+            &(),
+        )
+        .unwrap();
+
+        assert_eq!(commitment, expected_commitment);
+    }
+
+    #[test]
+    fn we_can_create_and_append_table_commitments_with_record_batches() {
+        let batch = int_and_string_batch(vec![1, 2, 3], vec!["1", "2", "3"]);
 
         let b_scals = ["1".into(), "2".into(), "3".into()];
 
@@ -147,19 +246,7 @@ mod tests {
 
         assert_eq!(commitment, expected_commitment);
 
-        let schema2 = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int64, false),
-            Field::new("b", DataType::Utf8, false),
-        ]));
-
-        let batch2 = RecordBatch::try_new(
-            schema2,
-            vec![
-                Arc::new(Int64Array::from(vec![4, 5, 6])),
-                Arc::new(StringArray::from(vec!["4", "5", "6"])),
-            ],
-        )
-        .unwrap();
+        let batch2 = int_and_string_batch(vec![4, 5, 6], vec!["4", "5", "6"]);
 
         let b_scals2 = ["4".into(), "5".into(), "6".into()];
 


### PR DESCRIPTION
Addresses #560

## Summary
- run record batch conversion tests without requiring the `blitzar` feature
- add coverage for batch-to-column field/value conversion
- add coverage for null-array error propagation and offset-aware append behavior

/claim #560

## Validation
- `PATH="$HOME/.cargo/bin:$PATH" BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --no-default-features --features="arrow test" base::arrow::record_batch_conversion -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all -- --config imports_granularity=Crate,group_imports=One`
- `git diff --check`
