### PR TITLE
test: cover standard serialization helpers

### DIFF
--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -365,4 +365,20 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn i256_json_serialization_uses_standard_limb_order() {
+        let value = I256::new([1, 2, 3, 4]);
+
+        let json = serde_json::to_string(&value).unwrap();
+
+        assert_eq!(json, "[4,3,2,1]");
+    }
+
+    #[test]
+    fn i256_json_deserialization_restores_native_limb_order() {
+        let value: I256 = serde_json::from_str("[4,3,2,1]").unwrap();
+
+        assert_eq!(value.limbs(), [1, 2, 3, 4]);
+    }
 }

--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,27 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn integer_serialization_uses_fixed_width_big_endian_bytes() {
+        let serialized = try_standard_binary_serialization(0x0102_0304_u32).unwrap();
+
+        assert_eq!(serialized, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn deserialization_reports_consumed_byte_count() {
+        let (value, bytes_read): (u16, _) =
+            try_standard_binary_deserialization(&[0x12, 0x34, 0xAA]).unwrap();
+
+        assert_eq!(value, 0x1234);
+        assert_eq!(bytes_read, 2);
+    }
+
+    #[test]
+    fn deserialization_rejects_truncated_fixed_width_values() {
+        let result = try_standard_binary_deserialization::<u32>(&[1, 2, 3]);
+
+        assert!(result.is_err());
+    }
 }

--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,41 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn limb_serialization_uses_big_endian_order() {
+        let wrapper = LimbWrapper {
+            limbs: [1, 2, 3, 4],
+        };
+
+        let json = serde_json::to_string(&wrapper).unwrap();
+
+        assert_eq!(json, r#"{"limbs":[4,3,2,1]}"#);
+    }
+
+    #[test]
+    fn limb_deserialization_restores_native_limb_order() {
+        let wrapper: LimbWrapper = serde_json::from_str(r#"{"limbs":[4,3,2,1]}"#).unwrap();
+
+        assert_eq!(
+            wrapper,
+            LimbWrapper {
+                limbs: [1, 2, 3, 4]
+            }
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused tests for standard fixed-width big-endian binary serialization and deserialization behavior
- cover limb serialization order and native-order deserialization through the shared serde helpers
- cover I256 JSON serialization/deserialization through the same limb serialization path

## Validation
- cargo fmt --check
- cargo test -p proof-of-sql serialization --no-default-features --features test
- cargo test -p proof-of-sql i256_json --no-default-features --features test