### PR TITLE
test: cover columnar value literal expansion

### DIFF
--- a/crates/proof-of-sql/src/base/database/columnar_value.rs
+++ b/crates/proof-of-sql/src/base/database/columnar_value.rs
@@ -65,7 +65,11 @@ impl<'a, S: Scalar> ColumnarValue<'a, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::{
+        math::{decimal::Precision, i256::I256},
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::{test_scalar::TestScalar, ScalarExt},
+    };
     use core::convert::Into;
 
     #[test]
@@ -134,6 +138,99 @@ mod tests {
                 columnar_value_length: 0,
                 attempt_to_convert_length: 1,
             })
+        );
+    }
+
+    #[test]
+    fn we_can_expand_numeric_literals_into_columns() {
+        let bump = Bump::new();
+        let decimal = I256::from(12345_i32);
+        let scalar_limbs = [7, 8, 9, 10];
+
+        let cases = [
+            (
+                ColumnarValue::<TestScalar>::Literal(LiteralValue::Uint8(2)),
+                Column::Uint8(&[2, 2, 2]),
+            ),
+            (
+                ColumnarValue::<TestScalar>::Literal(LiteralValue::SmallInt(-3)),
+                Column::SmallInt(&[-3, -3, -3]),
+            ),
+            (
+                ColumnarValue::<TestScalar>::Literal(LiteralValue::Int(4)),
+                Column::Int(&[4, 4, 4]),
+            ),
+            (
+                ColumnarValue::<TestScalar>::Literal(LiteralValue::BigInt(-5)),
+                Column::BigInt(&[-5, -5, -5]),
+            ),
+            (
+                ColumnarValue::<TestScalar>::Literal(LiteralValue::Int128(6)),
+                Column::Int128(&[6, 6, 6]),
+            ),
+            (
+                ColumnarValue::<TestScalar>::Literal(LiteralValue::Decimal75(
+                    Precision::new(9).unwrap(),
+                    2,
+                    decimal,
+                )),
+                Column::Decimal75(
+                    Precision::new(9).unwrap(),
+                    2,
+                    &[decimal.into_scalar::<TestScalar>(); 3],
+                ),
+            ),
+            (
+                ColumnarValue::<TestScalar>::Literal(LiteralValue::Scalar(scalar_limbs)),
+                Column::Scalar(&[TestScalar::from(scalar_limbs); 3]),
+            ),
+        ];
+
+        for (value, expected) in cases {
+            assert_eq!(value.column_type(), expected.column_type());
+            assert_eq!(value.into_column(3, &bump).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn we_can_expand_text_binary_and_timestamp_literals_into_columns() {
+        let bump = Bump::new();
+
+        let varchar =
+            ColumnarValue::<TestScalar>::Literal(LiteralValue::VarChar("paid".to_string()));
+        let column = varchar.into_column(2, &bump).unwrap();
+        let expected_strings = ["paid", "paid"];
+        let expected_scalars = [TestScalar::from("paid"); 2];
+        assert_eq!(
+            column,
+            Column::VarChar((&expected_strings, &expected_scalars))
+        );
+
+        let bytes = vec![1, 2, 3, 4];
+        let varbinary =
+            ColumnarValue::<TestScalar>::Literal(LiteralValue::VarBinary(bytes.clone()));
+        let column = varbinary.into_column(2, &bump).unwrap();
+        let expected_scalars = [TestScalar::from_byte_slice_via_hash(&bytes); 2];
+        match column {
+            Column::VarBinary((values, scalars)) => {
+                assert_eq!(values, [&bytes[..], &bytes[..]]);
+                assert_eq!(scalars, expected_scalars);
+            }
+            _ => panic!("expected a VarBinary column"),
+        }
+
+        let timestamp = ColumnarValue::<TestScalar>::Literal(LiteralValue::TimeStampTZ(
+            PoSQLTimeUnit::Microsecond,
+            PoSQLTimeZone::new(-3600),
+            1_700_000_000,
+        ));
+        assert_eq!(
+            timestamp.into_column(2, &bump).unwrap(),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Microsecond,
+                PoSQLTimeZone::new(-3600),
+                &[1_700_000_000, 1_700_000_000],
+            )
         );
     }
 }


### PR DESCRIPTION
Addresses #560

## Summary
- add focused `ColumnarValue` coverage for numeric literal expansion
- cover decimal, scalar, text, binary, and timestamp literal-to-column paths
- keep the change test-only and limited to `columnar_value.rs`

/claim #560

## Validation
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p proof-of-sql --no-default-features --features="test" base::database::columnar_value -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all -- --config imports_granularity=Crate,group_imports=One`
- `git diff --check`
