### PR TITLE
test: cover scale and database edge paths

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -39,6 +39,36 @@ mod tests {
     use bumpalo::Bump;
 
     #[test]
+    fn we_can_compute_varying_byte_matrix_for_empty_column() {
+        let alloc = Bump::new();
+        let scalars = Vec::<TestScalar>::new();
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert!(varying_columns.is_empty());
+        assert_eq!(
+            byte_distribution,
+            ByteDistribution::new::<TestScalar, TestScalar>(&scalars)
+        );
+        assert_eq!(byte_distribution.varying_byte_count(), 0);
+    }
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_constant_column() {
+        let alloc = Bump::new();
+        let scalars = vec![TestScalar::from(257); 4];
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert!(varying_columns.is_empty());
+        assert_eq!(
+            byte_distribution,
+            ByteDistribution::new::<TestScalar, TestScalar>(&scalars)
+        );
+        assert_eq!(byte_distribution.varying_byte_count(), 0);
+    }
+
+    #[test]
     fn we_can_compute_varying_byte_matrix_for_small_scalars() {
         let alloc = Bump::new();
         let scalars: Vec<TestScalar> = [1, 2, 3, 255, 256, 257]

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,6 +1,7 @@
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
@@ -117,4 +118,51 @@ fn we_can_filter_columns_with_varbinary() {
             Column::BigInt(&[10, 30, 40]),
         ]
     );
+}
+
+#[test]
+fn we_can_filter_columns_with_primitive_and_timestamp_columns() {
+    let selection = vec![false, true, true, false, true];
+    let timestamps = [1000, 2000, 3000, 4000, 5000];
+    let columns = vec![
+        Column::<TestScalar>::Boolean(&[true, false, true, false, true]),
+        Column::Uint8(&[1, 2, 3, 4, 5]),
+        Column::TinyInt(&[-1, -2, -3, -4, -5]),
+        Column::SmallInt(&[10, 20, 30, 40, 50]),
+        Column::Int(&[100, 200, 300, 400, 500]),
+        Column::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            &timestamps,
+        ),
+    ];
+    let alloc = Bump::new();
+
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+
+    assert_eq!(len, 3);
+    assert_eq!(
+        result,
+        vec![
+            Column::Boolean(&[false, true, true]),
+            Column::Uint8(&[2, 3, 5]),
+            Column::TinyInt(&[-2, -3, -5]),
+            Column::SmallInt(&[20, 30, 50]),
+            Column::Int(&[200, 300, 500]),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                &[2000, 3000, 5000]
+            ),
+        ]
+    );
+}
+
+#[test]
+#[should_panic(expected = "assertion `left == right` failed")]
+fn we_cannot_filter_columns_with_mismatched_selection_length() {
+    let columns = vec![Column::<TestScalar>::BigInt(&[1, 2, 3])];
+    let alloc = Bump::new();
+
+    let _ = filter_columns(&alloc, &columns, &[true, false]);
 }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -464,6 +464,7 @@ mod test {
     use super::*;
     use crate::base::{
         math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::{test_scalar::TestScalar, ScalarExt},
     };
     use alloc::vec;
@@ -486,6 +487,104 @@ mod test {
     }
 
     #[test]
+    fn we_can_slice_and_permute_each_owned_column_variant() {
+        let scalars = vec![
+            TestScalar::from(10),
+            TestScalar::from(20),
+            TestScalar::from(30),
+        ];
+        let precision = Precision::new(12).unwrap();
+        let time_unit = PoSQLTimeUnit::Microsecond;
+        let time_zone = PoSQLTimeZone::utc();
+        let permutation = Permutation::try_new(vec![2, 0, 1]).unwrap();
+
+        let columns = vec![
+            (
+                OwnedColumn::Boolean(vec![true, false, true]),
+                ColumnType::Boolean,
+                OwnedColumn::Boolean(vec![false, true]),
+                OwnedColumn::Boolean(vec![true, true, false]),
+            ),
+            (
+                OwnedColumn::Uint8(vec![1, 2, 3]),
+                ColumnType::Uint8,
+                OwnedColumn::Uint8(vec![2, 3]),
+                OwnedColumn::Uint8(vec![3, 1, 2]),
+            ),
+            (
+                OwnedColumn::TinyInt(vec![-1, 2, -3]),
+                ColumnType::TinyInt,
+                OwnedColumn::TinyInt(vec![2, -3]),
+                OwnedColumn::TinyInt(vec![-3, -1, 2]),
+            ),
+            (
+                OwnedColumn::SmallInt(vec![-10, 20, -30]),
+                ColumnType::SmallInt,
+                OwnedColumn::SmallInt(vec![20, -30]),
+                OwnedColumn::SmallInt(vec![-30, -10, 20]),
+            ),
+            (
+                OwnedColumn::Int(vec![-100, 200, -300]),
+                ColumnType::Int,
+                OwnedColumn::Int(vec![200, -300]),
+                OwnedColumn::Int(vec![-300, -100, 200]),
+            ),
+            (
+                OwnedColumn::BigInt(vec![-1000, 2000, -3000]),
+                ColumnType::BigInt,
+                OwnedColumn::BigInt(vec![2000, -3000]),
+                OwnedColumn::BigInt(vec![-3000, -1000, 2000]),
+            ),
+            (
+                OwnedColumn::Int128(vec![-10000, 20000, -30000]),
+                ColumnType::Int128,
+                OwnedColumn::Int128(vec![20000, -30000]),
+                OwnedColumn::Int128(vec![-30000, -10000, 20000]),
+            ),
+            (
+                OwnedColumn::VarChar(vec!["a".to_string(), "b".to_string(), "c".to_string()]),
+                ColumnType::VarChar,
+                OwnedColumn::VarChar(vec!["b".to_string(), "c".to_string()]),
+                OwnedColumn::VarChar(vec!["c".to_string(), "a".to_string(), "b".to_string()]),
+            ),
+            (
+                OwnedColumn::Decimal75(precision, 2, scalars.clone()),
+                ColumnType::Decimal75(precision, 2),
+                OwnedColumn::Decimal75(precision, 2, scalars[1..3].to_vec()),
+                OwnedColumn::Decimal75(precision, 2, vec![scalars[2], scalars[0], scalars[1]]),
+            ),
+            (
+                OwnedColumn::TimestampTZ(time_unit, time_zone, vec![100, 200, 300]),
+                ColumnType::TimestampTZ(time_unit, time_zone),
+                OwnedColumn::TimestampTZ(time_unit, time_zone, vec![200, 300]),
+                OwnedColumn::TimestampTZ(time_unit, time_zone, vec![300, 100, 200]),
+            ),
+            (
+                OwnedColumn::Scalar(scalars.clone()),
+                ColumnType::Scalar,
+                OwnedColumn::Scalar(scalars[1..3].to_vec()),
+                OwnedColumn::Scalar(vec![scalars[2], scalars[0], scalars[1]]),
+            ),
+            (
+                OwnedColumn::VarBinary(vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]),
+                ColumnType::VarBinary,
+                OwnedColumn::VarBinary(vec![b"b".to_vec(), b"c".to_vec()]),
+                OwnedColumn::VarBinary(vec![b"c".to_vec(), b"a".to_vec(), b"b".to_vec()]),
+            ),
+        ];
+
+        for (column, column_type, sliced, permuted) in columns {
+            assert_eq!(column.len(), 3);
+            assert!(!column.is_empty());
+            assert_eq!(column.column_type(), column_type);
+            assert_eq!(column.slice(1, 3), sliced);
+            assert_eq!(column.try_permute(&permutation).unwrap(), permuted);
+        }
+
+        assert!(OwnedColumn::<TestScalar>::Uint8(vec![]).is_empty());
+    }
+
+    #[test]
     fn we_can_convert_columns_to_owned_columns_round_trip() {
         let alloc = Bump::new();
         // Integers
@@ -494,6 +593,47 @@ mod test {
         assert_eq!(owned_col, OwnedColumn::Int128(vec![1, 2, 3, 4, 5]));
         let new_col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, new_col);
+
+        // Primitive integers
+        let col: Column<'_, TestScalar> = Column::Uint8(&[1, 2, 3]);
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
+        assert_eq!(owned_col, OwnedColumn::Uint8(vec![1, 2, 3]));
+        assert_eq!(
+            col,
+            Column::<TestScalar>::from_owned_column(&owned_col, &alloc)
+        );
+
+        let col: Column<'_, TestScalar> = Column::TinyInt(&[-1, 2, -3]);
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
+        assert_eq!(owned_col, OwnedColumn::TinyInt(vec![-1, 2, -3]));
+        assert_eq!(
+            col,
+            Column::<TestScalar>::from_owned_column(&owned_col, &alloc)
+        );
+
+        let col: Column<'_, TestScalar> = Column::SmallInt(&[-10, 20, -30]);
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
+        assert_eq!(owned_col, OwnedColumn::SmallInt(vec![-10, 20, -30]));
+        assert_eq!(
+            col,
+            Column::<TestScalar>::from_owned_column(&owned_col, &alloc)
+        );
+
+        let col: Column<'_, TestScalar> = Column::Int(&[-100, 200, -300]);
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
+        assert_eq!(owned_col, OwnedColumn::Int(vec![-100, 200, -300]));
+        assert_eq!(
+            col,
+            Column::<TestScalar>::from_owned_column(&owned_col, &alloc)
+        );
+
+        let col: Column<'_, TestScalar> = Column::BigInt(&[-1000, 2000, -3000]);
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
+        assert_eq!(owned_col, OwnedColumn::BigInt(vec![-1000, 2000, -3000]));
+        assert_eq!(
+            col,
+            Column::<TestScalar>::from_owned_column(&owned_col, &alloc)
+        );
 
         // Booleans
         let col: Column<'_, TestScalar> = Column::Boolean(&[true, false, true, false, true]);
@@ -539,6 +679,26 @@ mod test {
         );
         let new_col = Column::<TestScalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, new_col);
+
+        // Timestamps
+        let col: Column<'_, TestScalar> = Column::TimestampTZ(
+            PoSQLTimeUnit::Nanosecond,
+            PoSQLTimeZone::utc(),
+            &[1000, 2000, 3000],
+        );
+        let owned_col: OwnedColumn<TestScalar> = (&col).into();
+        assert_eq!(
+            owned_col,
+            OwnedColumn::TimestampTZ(
+                PoSQLTimeUnit::Nanosecond,
+                PoSQLTimeZone::utc(),
+                vec![1000, 2000, 3000]
+            )
+        );
+        assert_eq!(
+            col,
+            Column::<TestScalar>::from_owned_column(&owned_col, &alloc)
+        );
     }
 
     #[test]
@@ -575,6 +735,40 @@ mod test {
             owned_col,
             OwnedColumn::Decimal75(Precision::new(75).unwrap(), -128, scalars)
         );
+
+        let scalars = [1, 2, 3].iter().map(TestScalar::from).collect::<Vec<_>>();
+        assert_eq!(
+            OwnedColumn::try_from_scalars(&scalars, ColumnType::Uint8).unwrap(),
+            OwnedColumn::Uint8(vec![1, 2, 3])
+        );
+        assert_eq!(
+            OwnedColumn::try_from_scalars(&scalars, ColumnType::TinyInt).unwrap(),
+            OwnedColumn::TinyInt(vec![1, 2, 3])
+        );
+        assert_eq!(
+            OwnedColumn::try_from_scalars(&scalars, ColumnType::SmallInt).unwrap(),
+            OwnedColumn::SmallInt(vec![1, 2, 3])
+        );
+        assert_eq!(
+            OwnedColumn::try_from_scalars(&scalars, ColumnType::Int).unwrap(),
+            OwnedColumn::Int(vec![1, 2, 3])
+        );
+        assert_eq!(
+            OwnedColumn::try_from_scalars(&scalars, ColumnType::BigInt).unwrap(),
+            OwnedColumn::BigInt(vec![1, 2, 3])
+        );
+        assert_eq!(
+            OwnedColumn::try_from_scalars(&scalars, ColumnType::Scalar).unwrap(),
+            OwnedColumn::Scalar(scalars.clone())
+        );
+        assert_eq!(
+            OwnedColumn::try_from_scalars(
+                &scalars,
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc())
+            )
+            .unwrap(),
+            OwnedColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), vec![1, 2, 3])
+        );
     }
 
     #[test]
@@ -585,6 +779,9 @@ mod test {
             .collect::<Vec<_>>();
         let column_type = ColumnType::VarChar;
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
+        assert!(matches!(res, Err(OwnedColumnError::TypeCastError { .. })));
+
+        let res = OwnedColumn::try_from_scalars(&scalars, ColumnType::VarBinary);
         assert!(matches!(res, Err(OwnedColumnError::TypeCastError { .. })));
     }
 

--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -73,7 +73,10 @@ pub fn scale_cast_binary_op(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::{ColumnRef, TableRef};
+    use crate::base::{
+        database::{ColumnRef, TableRef},
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    };
 
     #[expect(non_snake_case)]
     fn COLUMN1_BOOLEAN() -> DynProofExpr {
@@ -138,6 +141,24 @@ mod tests {
                 Precision::new(25).expect("Precision is definitely valid"),
                 5,
             ),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN1_TIMESTAMP_SECOND() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN2_TIMESTAMP_NANOSECOND() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column2".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc()),
         ))
     }
 
@@ -234,5 +255,34 @@ mod tests {
         let right = COLUMN2_DECIMAL_25_5();
         let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
         assert_eq!(proof_exprs, (left, right));
+    }
+
+    #[test]
+    fn we_can_convert_scale_cast_binary_op_upcasting_left_timestamp() {
+        let left = COLUMN1_TIMESTAMP_SECOND();
+        let right = COLUMN2_TIMESTAMP_NANOSECOND();
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+        assert_eq!(
+            proof_exprs,
+            (
+                DynProofExpr::try_new_scaling_cast(left, right.data_type()).unwrap(),
+                right
+            )
+        );
+    }
+
+    #[test]
+    fn we_can_convert_scale_cast_binary_op_upcasting_right_timestamp() {
+        let left = COLUMN2_TIMESTAMP_NANOSECOND();
+        let right = COLUMN1_TIMESTAMP_SECOND();
+        let left_type = left.data_type();
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+        assert_eq!(
+            proof_exprs,
+            (
+                left,
+                DynProofExpr::try_new_scaling_cast(right, left_type).unwrap()
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add timestamp scale-cast coverage for left/right precision conversion paths
- cover byte matrix empty and constant scalar columns
- cover filter utility primitive/timestamp columns plus mismatched selection length errors
- cover owned column enum variants for slice, permutation, type metadata, column round-trips, scalar conversions, and varbinary scalar conversion errors

/claim #560

## Validation
- rustfmt --check crates/proof-of-sql/src/sql/scale.rs crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
- rustfmt --check crates/proof-of-sql/src/base/database/filter_util_test.rs
- rustfmt --check crates/proof-of-sql/src/base/database/owned_column.rs
- cargo test -p proof-of-sql scale_cast_binary_op --no-default-features --features test
- cargo test -p proof-of-sql byte_matrix_utils --no-default-features --features test
- cargo test -p proof-of-sql filter_util --no-default-features --features test
- cargo test -p proof-of-sql owned_column --no-default-features --features test
- rustup run 1.91.1 cargo llvm-cov -p proof-of-sql --no-default-features --features test --summary-only --no-clean

## Coverage summary
- full llvm-cov run passed: 967 tests, 0 failures
- total line coverage: 81.66%
- crates/proof-of-sql/src/sql/scale.rs: 100.00% line coverage
- crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs: 100.00% line coverage
- crates/proof-of-sql/src/base/database/filter_util.rs: 100.00% line coverage
- crates/proof-of-sql/src/base/database/owned_column.rs: 89.74% line coverage