### PR TITLE
test: cover log2 helper branches

### DIFF
--- a/crates/proof-of-sql/src/base/math/log.rs
+++ b/crates/proof-of-sql/src/base/math/log.rs
@@ -71,6 +71,37 @@ mod tests {
         assert_eq!(log2_up(4u32), 2);
     }
 
+    #[test]
+    fn we_can_detect_integer_powers_of_two() {
+        assert!(is_pow2(1u8));
+        assert!(is_pow2(128u8));
+        assert!(is_pow2(1_u64 << 42));
+
+        assert!(!is_pow2(3u8));
+        assert!(!is_pow2((1_u64 << 42) + 1));
+    }
+
+    #[test]
+    fn we_can_detect_little_endian_byte_powers_of_two() {
+        assert!(is_pow2_bytes(&[0, 0, 0, 0]));
+        assert!(is_pow2_bytes(&[1, 0, 0, 0]));
+        assert!(is_pow2_bytes(&[0, 1, 0, 0]));
+        assert!(is_pow2_bytes(&[0, 0, 128, 0]));
+
+        assert!(!is_pow2_bytes(&[3, 0, 0, 0]));
+        assert!(!is_pow2_bytes(&[0, 128, 1, 0]));
+        assert!(!is_pow2_bytes(&[0, 0, 128, 1]));
+    }
+
+    #[test]
+    fn we_can_calculate_floor_log2_for_little_endian_bytes() {
+        assert_eq!(log2_down_bytes(&[0, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[1, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[0, 1, 0, 0]), 8);
+        assert_eq!(log2_down_bytes(&[0, 0, 128, 0]), 23);
+        assert_eq!(log2_down_bytes(&[255, 255, 255, 255]), 31);
+    }
+
     #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     #[test]
     fn test_log2_bytes_ceil() {


### PR DESCRIPTION
/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to the contribution guidelines. No breaking change is introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines.
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Issue #560 asks for incremental coverage improvements. This takes a small test-only slice in `base::math::log` that is separate from the active coverage PRs I checked: direct coverage for integer power-of-two helpers and little-endian byte floor-log behavior.

# What changes are included in this PR?
- Adds direct tests for `is_pow2` over small and wide integer values.
- Adds tests for `is_pow2_bytes` over zero, single-byte, multi-byte, and non-power byte arrays.
- Adds tests for `log2_down_bytes` including zero, byte-boundary, high-bit, and all-ones inputs.

# Are these changes tested?
Yes.

- `cargo test -p proof-of-sql base::math::log --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

I did not run the full `source scripts/run_ci_checks.sh` because this is a narrow test-only coverage slice; the focused module test and formatting checks passed locally.

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submitting.