### PR TITLE
test: cover sumcheck random scalars

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -33,6 +33,8 @@ mod sumcheck_mle_evaluations_test;
 
 mod sumcheck_random_scalars;
 pub(crate) use sumcheck_random_scalars::SumcheckRandomScalars;
+#[cfg(test)]
+mod sumcheck_random_scalars_test;
 
 mod proof_plan;
 pub use proof_plan::ProofPlan;

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars_test.rs
@@ -1,0 +1,69 @@
+use super::SumcheckRandomScalars;
+use crate::base::scalar::test_scalar::TestScalar;
+
+#[test]
+fn sumcheck_random_scalars_splits_multipliers_from_entrywise_point() {
+    let scalars = [
+        TestScalar::from(11u8),
+        TestScalar::from(22u8),
+        TestScalar::from(33u8),
+        TestScalar::from(44u8),
+        TestScalar::from(55u8),
+    ];
+
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 7, 2);
+
+    assert_eq!(
+        random_scalars.subpolynomial_multipliers,
+        &[
+            TestScalar::from(11u8),
+            TestScalar::from(22u8),
+            TestScalar::from(33u8)
+        ]
+    );
+    assert_eq!(
+        random_scalars.entrywise_point,
+        &[TestScalar::from(44u8), TestScalar::from(55u8)]
+    );
+    assert_eq!(random_scalars.table_length, 7);
+}
+
+#[test]
+fn sumcheck_random_scalars_uses_all_scalars_as_entrywise_point_when_there_are_no_multipliers() {
+    let scalars = [TestScalar::from(3u8), TestScalar::from(5u8)];
+
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 4, scalars.len());
+
+    assert!(random_scalars.subpolynomial_multipliers.is_empty());
+    assert_eq!(random_scalars.entrywise_point, scalars);
+}
+
+#[test]
+fn compute_entrywise_multipliers_respects_truncated_table_length() {
+    let scalars = [
+        TestScalar::from(99u8),
+        TestScalar::from(2u8),
+        TestScalar::from(3u8),
+    ];
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 3, 2);
+
+    let multipliers = random_scalars.compute_entrywise_multipliers();
+
+    assert_eq!(
+        multipliers,
+        vec![
+            (TestScalar::from(1u8) - TestScalar::from(2u8))
+                * (TestScalar::from(1u8) - TestScalar::from(3u8)),
+            TestScalar::from(2u8) * (TestScalar::from(1u8) - TestScalar::from(3u8)),
+            (TestScalar::from(1u8) - TestScalar::from(2u8)) * TestScalar::from(3u8),
+        ]
+    );
+}
+
+#[test]
+fn compute_entrywise_multipliers_can_return_an_empty_vector() {
+    let scalars = [TestScalar::from(2u8), TestScalar::from(3u8)];
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 0, 2);
+
+    assert!(random_scalars.compute_entrywise_multipliers().is_empty());
+}


### PR DESCRIPTION
Addresses #560

## Summary
- add direct unit coverage for `SumcheckRandomScalars::new` split behavior
- cover the no-subpolynomial-multipliers case
- verify entrywise multiplier generation for truncated and empty table lengths

/claim #560

## Validation
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p proof-of-sql --no-default-features --features="test" sql::proof::sumcheck_random_scalars_test -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all -- --config imports_granularity=Crate,group_imports=One`
- `git diff --check`
