### PR TITLE
test: cover constant byte matrix paths

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -39,6 +39,29 @@ mod tests {
     use bumpalo::Bump;
 
     #[test]
+    fn we_can_compute_varying_byte_matrix_for_empty_scalars() {
+        let alloc = Bump::new();
+        let scalars: Vec<TestScalar> = vec![];
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_constant_scalars() {
+        let alloc = Bump::new();
+        let scalars = vec![TestScalar::from(42); 4];
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert_eq!(byte_distribution.varying_byte_count(), 0);
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
     fn we_can_compute_varying_byte_matrix_for_small_scalars() {
         let alloc = Bump::new();
         let scalars: Vec<TestScalar> = [1, 2, 3, 255, 256, 257]


### PR DESCRIPTION
/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to the contribution guidelines. No breaking change is introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines.
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Issue #560 asks for incremental test coverage improvements. This is a small, separate slice for `base::byte::byte_matrix_utils`: existing tests cover varying byte columns, but not the empty and constant-column cases where `compute_varying_byte_matrix` should return no varying byte columns while still returning the correct distribution.

# What changes are included in this PR?
- Adds an empty-column test for `compute_varying_byte_matrix`.
- Adds a constant-column test proving no varying byte columns are produced.
- Keeps the change test-only and does not alter production behavior.

# Are these changes tested?
Yes.

- `cargo test -p proof-of-sql base::byte::byte_matrix_utils --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

I did not run the full `source scripts/run_ci_checks.sh` because this is a narrow test-only coverage slice; the focused module test and formatting checks passed locally.

Note: I accidentally ran `source scripts/check_commits.sh` once before committing, which reported an empty message because there was no commit yet. After committing, the actual branch commit check passed.

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submitting.