### PR TITLE
test: cover column field helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,37 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::String;
+
+    #[test]
+    fn we_can_create_and_read_column_fields() {
+        let field = ColumnField::new(Ident::new("amount"), ColumnType::BigInt);
+
+        assert_eq!(field.name().value, "amount");
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_field_name_accessor_returns_a_clone() {
+        let field = ColumnField::new(Ident::new("customer_id"), ColumnType::VarChar);
+        let mut cloned_name = field.name();
+        cloned_name.value = String::from("changed");
+
+        assert_eq!(field.name().value, "customer_id");
+        assert_eq!(cloned_name.value, "changed");
+    }
+
+    #[test]
+    fn column_fields_round_trip_through_serde_json() {
+        let field = ColumnField::new(Ident::new("is_active"), ColumnType::Boolean);
+
+        let serialized = serde_json::to_string(&field).unwrap();
+        let deserialized: ColumnField = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, field);
+    }
+}


### PR DESCRIPTION
/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to the contribution guidelines. No breaking change is introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines.
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Issue #560 asks for incremental test coverage improvements. This is a small, separate slice for `base::database::column_field`, covering the constructor/accessors and serde behavior for `ColumnField`.

# What changes are included in this PR?
- Adds coverage for `ColumnField::new`, `name`, and `data_type`.
- Verifies the `name` accessor returns a clone rather than exposing mutable internal state.
- Adds serde JSON round-trip coverage for `ColumnField`.

# Are these changes tested?
Yes.

- `cargo test -p proof-of-sql base::database::column_field --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

I did not run the full `source scripts/run_ci_checks.sh` because this is a narrow test-only coverage slice; the focused module test and formatting checks passed locally.

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submitting.