### PR TITLE
fix: handle empty powers of tau args

### DIFF
--- a/crates/powers-of-tau-util/src/main.rs
+++ b/crates/powers-of-tau-util/src/main.rs
@@ -30,8 +30,9 @@ type E = Bn256EngineKZG;
 ///
 /// This function returns an error if the arguments are invalid.
 fn parse_args(args: &[String]) -> Result<(&str, &str, usize), String> {
+    let program = args.first().map_or("program", String::as_str);
     if args.len() < 4 {
-        return Err(format!("Usage: {} <ptau_path> <binary_path> <n>", args[0]));
+        return Err(format!("Usage: {program} <ptau_path> <binary_path> <n>"));
     }
 
     let ptau_path = &args[1];
@@ -228,6 +229,18 @@ mod tests {
 
         // Clean up
         fs::remove_file(file_name).unwrap();
+    }
+
+    #[test]
+    fn we_can_parse_args_with_no_args() {
+        let args = Vec::new();
+        let result = parse_args(&args);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "Usage: program <ptau_path> <binary_path> <n>"
+        );
     }
 
     /// # Panics


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The powers-of-tau utility argument parser currently indexes the first argument before validating the provided argument slice. This PR adds a small guard and regression coverage for the empty-argument case so the utility returns its usage error instead of panicking.

# What changes are included in this PR?

- Avoid panicking when powers-of-tau-util argument parsing is called with an empty args slice.
- Add regression coverage for the no-args usage error.

# Are these changes tested?

Local validation completed:

- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`
- Linux/WSL: `cargo test -p powers-of-tau-util we_can_parse_args_with_no_args`
  - 1 passed, 0 failed
