### PR TITLE
test: cover u256 conversions

### DIFF
--- a/crates/proof-of-sql/src/base/encode/mod.rs
+++ b/crates/proof-of-sql/src/base/encode/mod.rs
@@ -1,6 +1,9 @@
 mod u256;
 pub(crate) use u256::U256;
 
+#[cfg(test)]
+mod u256_test;
+
 mod zigzag;
 pub(crate) use zigzag::ZigZag;
 

--- a/crates/proof-of-sql/src/base/encode/u256_test.rs
+++ b/crates/proof-of-sql/src/base/encode/u256_test.rs
@@ -1,0 +1,40 @@
+use crate::base::{encode::U256, scalar::test_scalar::TestScalar};
+
+#[test]
+fn from_words_preserves_low_and_high_words() {
+    let value = U256::from_words(
+        0x0123_4567_89ab_cdef_fedc_ba98_7654_3210,
+        0x0fed_cba9_8765_4321_1234_5678_9abc_def0,
+    );
+
+    assert!(value.low == 0x0123_4567_89ab_cdef_fedc_ba98_7654_3210);
+    assert!(value.high == 0x0fed_cba9_8765_4321_1234_5678_9abc_def0);
+}
+
+#[test]
+fn small_scalars_round_trip_through_u256_words() {
+    for scalar in [
+        TestScalar::from(0_u64),
+        TestScalar::from(1_u64),
+        TestScalar::from(u64::MAX),
+        TestScalar::from(u128::MAX),
+    ] {
+        let words: U256 = (&scalar).into();
+        let round_trip: TestScalar = (&words).into();
+
+        assert!(round_trip == scalar);
+    }
+}
+
+#[test]
+fn u256_values_below_the_modulus_round_trip_through_scalars() {
+    let value = U256::from_words(
+        0xffff_ffff_ffff_ffff_0000_0000_0000_0001,
+        0x0000_0000_0000_0000_0000_0000_0000_0001,
+    );
+
+    let scalar: TestScalar = (&value).into();
+    let round_trip: U256 = (&scalar).into();
+
+    assert!(round_trip == value);
+}


### PR DESCRIPTION
/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Adds focused test coverage for the `U256` helper conversions as part of the test coverage bounty.

# What changes are included in this PR?

- Register a dedicated `u256_test` module under `base::encode`.
- Cover `U256::from_words` preserving low/high words.
- Cover scalar-to-`U256` and `U256`-to-scalar round trips for representative values below the modulus.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql base::encode::u256_test --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

I did not run `source scripts/run_ci_checks.sh` for this narrow test-only change.
