### PR TITLE
test: cover generate parameter round trip helpers

### DIFF
--- a/crates/proof-of-sql/utils/generate-parameters/round_trip_test.rs
+++ b/crates/proof-of-sql/utils/generate-parameters/round_trip_test.rs
@@ -93,6 +93,55 @@ fn we_can_generate_save_and_load_public_setups() {
     }
 }
 
+/// # Panics
+/// because it is a test and is allowed to panic
+#[test]
+fn we_can_compute_sha256_for_existing_files() {
+    let temp_dir = tempdir().expect("Failed to create a temporary directory");
+    let file_path = temp_dir.path().join("payload.bin");
+    std::fs::write(&file_path, b"abc").expect("Failed to write payload file");
+
+    assert_eq!(
+        compute_sha256(file_path.to_str().unwrap()),
+        Some("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".to_string())
+    );
+}
+
+/// # Panics
+/// because it is a test and is allowed to panic
+#[test]
+fn compute_sha256_returns_none_for_missing_files() {
+    let temp_dir = tempdir().expect("Failed to create a temporary directory");
+    let missing_path = temp_dir.path().join("missing.bin");
+
+    assert_eq!(compute_sha256(missing_path.to_str().unwrap()), None);
+}
+
+/// # Panics
+/// because it is a test and is allowed to panic
+#[test]
+fn we_can_read_digest_entries_from_file() {
+    let temp_dir = tempdir().expect("Failed to create a temporary directory");
+    let digests_path = temp_dir.path().join("digests.txt");
+    std::fs::write(
+        &digests_path,
+        "abc123 /tmp/public_parameters.bin\nignored-line\nbad line with extra columns\nfff456 /tmp/verifier_setup.bin\n",
+    )
+    .expect("Failed to write digest file");
+
+    let actual_digests = read_digests_from_file(digests_path.to_str().unwrap());
+
+    assert_eq!(actual_digests.len(), 2);
+    assert_eq!(
+        actual_digests.get("/tmp/public_parameters.bin").unwrap(),
+        "abc123"
+    );
+    assert_eq!(
+        actual_digests.get("/tmp/verifier_setup.bin").unwrap(),
+        "fff456"
+    );
+}
+
 /// Compute SHA-256 hash of a file and return it as a hex string.
 fn compute_sha256(file_path: &str) -> Option<String> {
     let mut file = File::open(file_path).ok()?;


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Issue #560 pays for meaningful coverage of previously uncovered lines. This PR targets `crates/proof-of-sql/utils/generate-parameters/round_trip_test.rs`, the remaining generate-parameters round-trip helper file with misses that was not present in the open PR file list I checked before submission.

The existing end-to-end round-trip test remains ignored because it invokes the external binary recursively. These tests cover helper behavior directly without changing production code or invoking Cargo from the test.

# What changes are included in this PR?

- Add fast unit coverage for `round_trip_test.rs` digest helpers.
- Verify SHA-256 output for a known payload.
- Cover missing-file handling.
- Cover digest-file parsing of valid and invalid rows.

# Are these changes tested?

Local validation completed:

- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`
- Linux/WSL: `cargo test -p proof-of-sql --no-default-features --features std,blitzar,utils --bin generate-parameters round_trip_test::`
  - 3 passed, 0 failed, 1 ignored (`round_trip_test::we_can_generate_save_and_load_public_setups`, marked ignored because it requires running the external binary)
