### PR TITLE
test: cover order by utility variants

### DIFF
--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -88,6 +88,9 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
             (Column::VarChar((left_col, _)), Column::VarChar((right_col, _))) => {
                 left_col[left_row_index].cmp(right_col[right_row_index])
             }
+            (Column::VarBinary((left_col, _)), Column::VarBinary((right_col, _))) => {
+                left_col[left_row_index].cmp(right_col[right_row_index])
+            }
             // Should never happen since we checked the column types
             _ => unreachable!(),
         };

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -1,11 +1,26 @@
 use crate::{
     base::{
         database::{order_by_util::*, Column, ColumnType, TableOperationError},
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
 };
 use core::cmp::Ordering;
+
+fn assert_single_column_ordering(
+    left_column: Column<'_, TestScalar>,
+    right_column: Column<'_, TestScalar>,
+    expected: Ordering,
+) {
+    let left = [left_column];
+    let right = [right_column];
+    assert_eq!(
+        compare_single_row_of_tables(&left, &right, 0, 0).unwrap(),
+        expected
+    );
+}
 
 #[test]
 fn we_can_compare_indexes_by_columns_with_no_columns() {
@@ -187,4 +202,137 @@ fn we_can_compare_indexes_by_columns_for_varbinary_columns() {
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Equal); // "baz" vs "baz"
     assert_eq!(compare_indexes_by_columns(columns, 3, 4), Ordering::Greater); // "baz" vs "bar"
     assert_eq!(compare_indexes_by_columns(columns, 1, 4), Ordering::Equal); // "bar" vs "bar"
+}
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_remaining_column_types() {
+    let uint8_values = [1_u8, 3, 3];
+    let uint8_column = Column::Uint8::<TestScalar>(&uint8_values);
+    assert_eq!(
+        compare_indexes_by_columns(&[uint8_column], 0, 1),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_indexes_by_columns(&[uint8_column], 1, 2),
+        Ordering::Equal
+    );
+
+    let tinyint_values = [-2_i8, 4, 4];
+    let tinyint_column = Column::TinyInt::<TestScalar>(&tinyint_values);
+    assert_eq!(
+        compare_indexes_by_columns(&[tinyint_column], 0, 1),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_indexes_by_columns(&[tinyint_column], 1, 2),
+        Ordering::Equal
+    );
+
+    let smallint_values = [8_i16, -1, -1];
+    let smallint_column = Column::SmallInt::<TestScalar>(&smallint_values);
+    assert_eq!(
+        compare_indexes_by_columns(&[smallint_column], 0, 1),
+        Ordering::Greater
+    );
+    assert_eq!(
+        compare_indexes_by_columns(&[smallint_column], 1, 2),
+        Ordering::Equal
+    );
+
+    let decimal_values = [
+        TestScalar::from(10),
+        TestScalar::from(25),
+        TestScalar::from(25),
+    ];
+    let decimal_column =
+        Column::Decimal75(Precision::new(10).unwrap(), 2, decimal_values.as_slice());
+    assert_eq!(
+        compare_indexes_by_columns(&[decimal_column], 0, 1),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_indexes_by_columns(&[decimal_column], 1, 2),
+        Ordering::Equal
+    );
+}
+
+#[test]
+fn we_can_compare_single_row_of_tables_for_remaining_column_types() {
+    assert_single_column_ordering(
+        Column::Uint8::<TestScalar>(&[1]),
+        Column::Uint8::<TestScalar>(&[2]),
+        Ordering::Less,
+    );
+    assert_single_column_ordering(
+        Column::TinyInt::<TestScalar>(&[-1]),
+        Column::TinyInt::<TestScalar>(&[-2]),
+        Ordering::Greater,
+    );
+    assert_single_column_ordering(
+        Column::SmallInt::<TestScalar>(&[5]),
+        Column::SmallInt::<TestScalar>(&[5]),
+        Ordering::Equal,
+    );
+    assert_single_column_ordering(
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[100]),
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[200]),
+        Ordering::Less,
+    );
+    assert_single_column_ordering(
+        Column::Int128::<TestScalar>(&[123_i128]),
+        Column::Int128::<TestScalar>(&[45_i128]),
+        Ordering::Greater,
+    );
+
+    let left_decimal = [TestScalar::from(12)];
+    let right_decimal = [TestScalar::from(30)];
+    assert_single_column_ordering(
+        Column::Decimal75(Precision::new(10).unwrap(), 2, &left_decimal),
+        Column::Decimal75(Precision::new(10).unwrap(), 2, &right_decimal),
+        Ordering::Less,
+    );
+
+    let left_scalar = [TestScalar::from(9)];
+    let right_scalar = [TestScalar::from(9)];
+    assert_single_column_ordering(
+        Column::Scalar(&left_scalar),
+        Column::Scalar(&right_scalar),
+        Ordering::Equal,
+    );
+
+    let left_strings = ["bbb"];
+    let right_strings = ["aaa"];
+    let left_string_scalars = left_strings
+        .iter()
+        .map(TestScalar::from)
+        .collect::<Vec<_>>();
+    let right_string_scalars = right_strings
+        .iter()
+        .map(TestScalar::from)
+        .collect::<Vec<_>>();
+    assert_single_column_ordering(
+        Column::VarChar((left_strings.as_slice(), left_string_scalars.as_slice())),
+        Column::VarChar((right_strings.as_slice(), right_string_scalars.as_slice())),
+        Ordering::Greater,
+    );
+}
+
+#[test]
+fn we_can_compare_single_row_of_tables_for_varbinary_columns() {
+    let left_bytes = [b"bar".as_ref()];
+    let right_bytes = [b"foo".as_ref()];
+    let left_scalars = left_bytes
+        .iter()
+        .map(|b| TestScalar::from_le_bytes_mod_order(b))
+        .collect::<Vec<_>>();
+    let right_scalars = right_bytes
+        .iter()
+        .map(|b| TestScalar::from_le_bytes_mod_order(b))
+        .collect::<Vec<_>>();
+
+    assert_single_column_ordering(
+        Column::VarBinary((left_bytes.as_slice(), left_scalars.as_slice())),
+        Column::VarBinary((right_bytes.as_slice(), right_scalars.as_slice())),
+        Ordering::Less,
+    );
 }


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for previously missed order-by comparison variants: Uint8, TinyInt, SmallInt, Decimal75, TimestampTZ, Int128, Scalar, VarChar, and VarBinary.
- Fix `compare_single_row_of_tables` so matching VarBinary columns compare their row bytes instead of falling through to `unreachable!()` after the column-type check.

## Coverage
Before this change, `crates/proof-of-sql/src/base/database/order_by_util.rs` had 20 missed lines in my local `cargo llvm-cov` run. After this change it has 1 missed line, covering 19 previously missed lines.

## Verification
- `cargo test -p proof-of-sql base::database::order_by_util --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target\llvm-cov\after-order-by.lcov`
- `cargo fmt --check`
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.