### PR TITLE
test: cover fold utility edge cases

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -106,6 +106,24 @@ fn we_can_fold_empty_columns() {
 }
 
 #[test]
+fn fold_columns_leaves_result_unchanged_without_columns() {
+    let alloc = Bump::new();
+    let result = alloc.alloc_slice_fill_copy(3, Curve25519Scalar::from(77));
+    let columns: Vec<Column<Curve25519Scalar>> = vec![];
+
+    fold_columns(result, 33.into(), 10.into(), &columns);
+
+    assert_eq!(
+        result,
+        vec![
+            Curve25519Scalar::from(77),
+            Curve25519Scalar::from(77),
+            Curve25519Scalar::from(77)
+        ]
+    );
+}
+
+#[test]
 fn we_can_fold_vals() {
     assert_eq!(fold_vals(Curve25519Scalar::from(10), &[]), Zero::zero());
     assert_eq!(
@@ -120,5 +138,13 @@ fn we_can_fold_vals() {
             ]
         ),
         (12345).into()
+    );
+}
+
+#[test]
+fn fold_vals_returns_single_value_without_using_beta() {
+    assert_eq!(
+        fold_vals(Curve25519Scalar::from(10), &[Curve25519Scalar::from(7)]),
+        Curve25519Scalar::from(7)
     );
 }


### PR DESCRIPTION
/claim #560

# Rationale for this change

Adds a small, non-overlapping test-only coverage slice for the fold utility helpers.

# What changes are included in this PR?

- Cover `fold_columns` when it receives no columns and should leave an existing result slice unchanged.
- Cover `fold_vals` for the single-value case where the result should be that value regardless of beta.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql sql::proof_plans::fold_util --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

Notes:
- `scripts/check_commits.sh` could not be run directly on this Windows environment because `bash.exe` requires a WSL distribution that is not installed. I manually checked the commit message against the script regex; `test: cover fold utility edge cases` matches.
- Before submitting, I checked current open PR file lists and did not find another open PR touching `crates/proof-of-sql/src/sql/proof_plans/fold_util.rs` or `fold_util_test.rs`.

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.