### PR TITLE
test: cover timestamp errors

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,60 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    fn assert_json_round_trip(error: PoSQLTimestampError) {
+        let serialized = serde_json::to_string(&error).unwrap();
+        let deserialized: PoSQLTimestampError = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, error);
+    }
+
+    #[test]
+    fn timestamp_errors_display_expected_messages() {
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezone {
+                timezone: "mars".into()
+            }
+            .to_string(),
+            "invalid timezone string: mars"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezoneOffset.to_string(),
+            "invalid timezone offset"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimeUnit {
+                error: "fortnight".into()
+            }
+            .to_string(),
+            "Invalid time unit"
+        );
+        assert_eq!(
+            PoSQLTimestampError::UnsupportedPrecision { error: "7".into() }.to_string(),
+            "Unsupported precision for timestamp: 7"
+        );
+    }
+
+    #[test]
+    fn timestamp_errors_convert_into_strings() {
+        let converted: String =
+            PoSQLTimestampError::UnsupportedPrecision { error: "2".into() }.into();
+        assert_eq!(converted, "Unsupported precision for timestamp: 2");
+    }
+
+    #[test]
+    fn timestamp_errors_serde_round_trip() {
+        assert_json_round_trip(PoSQLTimestampError::InvalidTimezone {
+            timezone: "UTC+99".into(),
+        });
+        assert_json_round_trip(PoSQLTimestampError::InvalidTimezoneOffset);
+        assert_json_round_trip(PoSQLTimestampError::InvalidTimeUnit {
+            error: "minutes".into(),
+        });
+        assert_json_round_trip(PoSQLTimestampError::UnsupportedPrecision { error: "10".into() });
+    }
+}


### PR DESCRIPTION
/claim #560

Adds a focused test-only coverage slice for `PoSQLTimestampError` in `crates/proof-of-sql/src/base/posql_time/error.rs`. The tests cover display output, conversion into `String`, and serde round trips for every current timestamp error variant.

I checked the current open PR file list before submitting and did not find another active PR touching this file.

Validation:
- `/Users/ishanramrakhiani/.cargo/bin/cargo test -p proof-of-sql posql_time::error --no-default-features --features=test`
- `/Users/ishanramrakhiani/.cargo/bin/cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.