### PR TITLE
test: cover constant bit matrix inputs

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
@@ -22,6 +22,19 @@ fn we_can_compute_the_bit_matrix_for_a_single_element() {
 }
 
 #[test]
+fn we_can_compute_the_bit_matrix_for_constant_data() {
+    let data: Vec<TestScalar> = vec![
+        TestScalar::from(7),
+        TestScalar::from(7),
+        TestScalar::from(7),
+    ];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
+    let alloc = Bump::new();
+    let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
+    assert!(matrix.is_empty());
+}
+
+#[test]
 fn we_can_compute_the_bit_matrix_for_data_with_a_single_varying_bit() {
     let data: Vec<TestScalar> = vec![TestScalar::one(), TestScalar::zero()];
     let dist = BitDistribution::new::<TestScalar, _>(&data);


### PR DESCRIPTION
/claim #560

# Rationale for this change

Adds a small, non-overlapping test-only coverage slice for bit matrix behavior.

# What changes are included in this PR?

- Cover `compute_varying_bit_matrix` for multi-row constant scalar input.
- Assert the function returns no matrix columns when `BitDistribution` has no varying bits, matching the existing single-row constant-input behavior.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql base::bit::bit_matrix_test --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

Notes:
- `scripts/check_commits.sh` could not be run directly on this Windows environment because `bash.exe` requires a WSL distribution that is not installed. I manually checked the commit message against the script regex; `test: cover constant bit matrix inputs` matches.
- Before submitting, I checked current open PR file lists and did not find another open PR touching `crates/proof-of-sql/src/base/bit/bit_matrix.rs` or `bit_matrix_test.rs`.

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.