### PR TITLE
test: cover Dory prover state validation

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
@@ -2,6 +2,28 @@ use super::{rand_G_vecs, test_rng, ProverState, PublicParameters};
 use ark_ec::pairing::Pairing;
 
 #[test]
+#[should_panic(expected = "assertion `left == right` failed")]
+fn prover_state_rejects_v1_with_wrong_length() {
+    let mut rng = test_rng();
+    let nu = 2;
+    let (mut v1, v2) = rand_G_vecs(nu, &mut rng);
+    v1.pop();
+
+    ProverState::new(v1, v2, nu);
+}
+
+#[test]
+#[should_panic(expected = "assertion `left == right` failed")]
+fn prover_state_rejects_v2_with_wrong_length() {
+    let mut rng = test_rng();
+    let nu = 2;
+    let (v1, mut v2) = rand_G_vecs(nu, &mut rng);
+    v2.pop();
+
+    ProverState::new(v1, v2, nu);
+}
+
+#[test]
 pub fn we_can_create_a_verifier_state_from_a_prover_state() {
     let mut rng = test_rng();
     let max_nu = 5;


### PR DESCRIPTION
/claim #560

# Rationale for this change

Adds a small, non-overlapping test-only coverage slice for Dory prover state validation.

# What changes are included in this PR?

- Cover `ProverState::new` rejecting a `v1` witness vector whose length does not match `2^nu`.
- Cover `ProverState::new` rejecting a `v2` witness vector whose length does not match `2^nu`.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql proof_primitive::dory::state_test --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

Notes:
- `scripts/check_commits.sh` could not be run directly on this Windows environment because `bash.exe` requires a WSL distribution that is not installed. I manually checked the commit message against the script regex; `test: cover Dory prover state validation` matches.
- Before submitting, I checked current open PR file lists and did not find another open PR touching `crates/proof-of-sql/src/proof_primitive/dory/state.rs` or `state_test.rs`.

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.