### PR TITLE
test: cover extended Dory state validation

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_state_test.rs
@@ -7,6 +7,30 @@ use ark_ec::{pairing::Pairing, VariableBaseMSM};
 use ark_ff::Fp;
 
 #[test]
+#[should_panic(expected = "assertion `left == right` failed")]
+fn extended_prover_state_rejects_s1_tensor_with_wrong_length() {
+    let mut rng = test_rng();
+    let nu = 2;
+    let (v1, v2) = rand_G_vecs(nu, &mut rng);
+    let (mut s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
+    s1_tensor.pop();
+
+    ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
+}
+
+#[test]
+#[should_panic(expected = "assertion `left == right` failed")]
+fn extended_prover_state_rejects_s2_tensor_with_wrong_length() {
+    let mut rng = test_rng();
+    let nu = 2;
+    let (v1, v2) = rand_G_vecs(nu, &mut rng);
+    let (s1_tensor, mut s2_tensor) = rand_F_tensors(nu, &mut rng);
+    s2_tensor.pop();
+
+    ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
+}
+
+#[test]
 pub fn we_can_create_an_extended_verifier_state_from_an_extended_prover_state() {
     let mut rng = test_rng();
     let max_nu = 5;


### PR DESCRIPTION
/claim #560

# Rationale for this change

Adds a small, non-overlapping test-only coverage slice for extended Dory prover state validation.

# What changes are included in this PR?

- Cover `ExtendedProverState::new_from_tensors` rejecting an `s1_tensor` whose length does not match `nu`.
- Cover `ExtendedProverState::new_from_tensors` rejecting an `s2_tensor` whose length does not match `nu`.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql proof_primitive::dory::extended_state_test --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

Notes:
- `scripts/check_commits.sh` could not be run directly on this Windows environment because `bash.exe` requires a WSL distribution that is not installed. I manually checked the commit message against the script regex; `test: cover extended Dory state validation` matches.
- Before submitting, I checked current open PR file lists and did not find another open PR touching `crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs` or `extended_state_test.rs`.

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.