### PR TITLE
test: cover database operation errors

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,89 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::math::decimal::Precision;
+    use alloc::{string::ToString, vec};
+
+    #[test]
+    fn column_operation_errors_render_their_context() {
+        let cases = vec![
+            (
+                ColumnOperationError::DifferentColumnLength { len_a: 3, len_b: 2 },
+                "Columns have different lengths: 3 != 2",
+            ),
+            (
+                ColumnOperationError::BinaryOperationInvalidColumnType {
+                    operator: "ADD".to_string(),
+                    left_type: ColumnType::Int,
+                    right_type: ColumnType::VarChar,
+                },
+                "\"ADD\"(lhs: Int, rhs: VarChar) is not supported",
+            ),
+            (
+                ColumnOperationError::UnaryOperationInvalidColumnType {
+                    operator: "NOT".to_string(),
+                    operand_type: ColumnType::BigInt,
+                },
+                "\"NOT\"(operand: BigInt) is not supported",
+            ),
+            (
+                ColumnOperationError::IntegerOverflow {
+                    error: "checked add failed".to_string(),
+                },
+                "Overflow in integer operation: checked add failed",
+            ),
+            (ColumnOperationError::DivisionByZero, "Division by zero"),
+            (
+                ColumnOperationError::UnionDifferentTypes {
+                    correct_type: ColumnType::SmallInt,
+                    actual_type: ColumnType::Boolean,
+                },
+                "Cannot union columns of different types: SmallInt and Boolean",
+            ),
+            (
+                ColumnOperationError::IndexOutOfBounds { index: 5, len: 4 },
+                "Index out of bounds: 5 >= 4",
+            ),
+            (
+                ColumnOperationError::SignedCastingError {
+                    left_type: ColumnType::TinyInt,
+                    right_type: ColumnType::Uint8,
+                },
+                "Cannot fit TINYINT into UINT8 without losing data",
+            ),
+            (
+                ColumnOperationError::CastingError {
+                    left_type: ColumnType::BigInt,
+                    right_type: ColumnType::SmallInt,
+                },
+                "Cannot fit BIGINT into SMALLINT without losing data",
+            ),
+            (
+                ColumnOperationError::ScaleCastingError {
+                    left_type: ColumnType::Decimal75(Precision::new(5).unwrap(), 2),
+                    right_type: ColumnType::Decimal75(Precision::new(4).unwrap(), 3),
+                },
+                "Cannot fit DECIMAL75(PRECISION: 5, SCALE: 2) into DECIMAL75(PRECISION: 4, SCALE: 3) without losing data",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn decimal_conversion_error_is_transparent() {
+        let error = ColumnOperationError::DecimalConversionError {
+            source: DecimalError::InvalidPrecision {
+                error: "76".to_string(),
+            },
+        };
+
+        assert_eq!(error.to_string(), "Decimal precision is not valid: 76");
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,73 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{string::ToString, vec};
+
+    fn field(name: &str, data_type: ColumnType) -> ColumnField {
+        ColumnField::new(Ident::new(name), data_type)
+    }
+
+    #[test]
+    fn table_operation_errors_render_their_context() {
+        let incompatible_schema_message = TableOperationError::UnionIncompatibleSchemas {
+            correct_schema: vec![field("a", ColumnType::Int)],
+            actual_schema: vec![field("a", ColumnType::BigInt)],
+        }
+        .to_string();
+        assert!(
+            incompatible_schema_message.contains("Cannot union tables with incompatible schemas")
+        );
+        assert!(incompatible_schema_message.contains("data_type: Int"));
+        assert!(incompatible_schema_message.contains("data_type: BigInt"));
+
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+        assert_eq!(
+            TableOperationError::JoinWithDifferentNumberOfColumns {
+                left_num_columns: 2,
+                right_num_columns: 3,
+            }
+            .to_string(),
+            "Cannot join tables with different numbers of columns: 2 and 3"
+        );
+        assert_eq!(
+            TableOperationError::JoinIncompatibleTypes {
+                left_type: ColumnType::SmallInt,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Cannot join tables on columns with incompatible types: SmallInt and VarChar"
+        );
+
+        let missing_column_message = TableOperationError::ColumnDoesNotExist {
+            column_ident: Ident::new("missing"),
+        }
+        .to_string();
+        assert!(missing_column_message.contains("missing"));
+        assert!(missing_column_message.contains("does not exist in table"));
+
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+        assert_eq!(
+            TableOperationError::ColumnIndexOutOfBounds { column_index: 7 }.to_string(),
+            "Column index out of bounds: 7"
+        );
+    }
+
+    #[test]
+    fn column_operation_error_is_transparent() {
+        let error = TableOperationError::ColumnOperationError {
+            source: ColumnOperationError::DivisionByZero,
+        };
+
+        assert_eq!(error.to_string(), "Division by zero");
+    }
+}


### PR DESCRIPTION
Addresses #560

## Summary
- add focused coverage for `ColumnOperationError` display strings, including casting, indexing, union, overflow, and transparent decimal errors
- add focused coverage for `TableOperationError` display strings and transparent column-operation errors
- keep the change test-only, with no production behavior changes

## Testing
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p proof-of-sql --no-default-features --features="test" base::database::column_operation_error`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p proof-of-sql --no-default-features --features="test" base::database::table_operation_error`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `git diff --check`

/claim #560
