### PR TITLE
test: ungate vec commitment coverage

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -171,7 +171,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{


### PR DESCRIPTION
## Summary
- remove the unnecessary `feature = "blitzar"` gate from the `VecCommitmentExt` NaiveCommitment tests
- keep the change test-only so the existing extension trait behavior is covered under the no-default `test` coverage configuration

/claim #560

## Validation
- `cargo test -p proof-of-sql vec_commitment_ext --no-default-features --features=test` -> 8 passed
- `rustfmt --check crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs`
- `git diff --check`
- `rustup run 1.91.1 cargo llvm-cov --no-default-features --features=test -p proof-of-sql --summary-only -- vec_commitment_ext` -> 8 passed; `base/commitment/vec_commitment_ext.rs` line coverage 99.01%

Note: full `cargo fmt --check` currently reports an unrelated ordering diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs` on `origin/main`; this PR does not touch that file.