### PR TITLE
test: run vec commitment tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -171,7 +171,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{


### PR DESCRIPTION
/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This PR enables existing `VecCommitmentExt` tests to run in the no-default `test` feature configuration. The tests use `NaiveCommitment` only, so they do not require the `blitzar` feature gate that previously skipped them in that coverage configuration.

# What changes are included in this PR?

- Change the `vec_commitment_ext.rs` test module gate from `#[cfg(all(test, feature = "blitzar"))]` to `#[cfg(test)]`.

# Are these changes tested?

Yes:
- `cargo test -p proof-of-sql --no-default-features --features=test vec_commitment_ext --lib`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

I did not run the full `source scripts/run_ci_checks.sh` locally for this small test-only coverage change.

AI-assisted with Codex and manually reviewed before submission.
