### PR TITLE
test: cover record batch errors

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -29,3 +29,44 @@ pub enum AppendRecordBatchTableCommitmentError {
         source: RecordBatchToColumnsError,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn record_batch_to_columns_error_forwards_arrow_conversion_display() {
+        let error = RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+            source: ArrowArrayToColumnConversionError::ArrayContainsNulls,
+        };
+
+        assert_eq!(error.to_string(), "arrow array must not contain nulls");
+    }
+
+    #[test]
+    fn append_record_batch_error_forwards_column_commitment_mismatch_display() {
+        let error = AppendRecordBatchTableCommitmentError::ColumnCommitmentsMismatch {
+            source: ColumnCommitmentsMismatch::NumColumns,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "commitments with different column counts cannot operate with each other"
+        );
+    }
+
+    #[test]
+    fn append_record_batch_error_forwards_batch_to_column_display() {
+        let error = AppendRecordBatchTableCommitmentError::ArrowBatchToColumnError {
+            source: RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                source: ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 3 },
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "index out of bounds: the len is 2 but the index is 3"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

Adds focused tests for record batch error wrappers:
- RecordBatchToColumnsError forwards Arrow conversion display output
- AppendRecordBatchTableCommitmentError forwards ColumnCommitmentsMismatch display output
- AppendRecordBatchTableCommitmentError forwards nested RecordBatchToColumnsError display output

Validation:
- cargo test -p proof-of-sql base::arrow::record_batch_errors --no-default-features --features='test arrow'
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.