### PR TITLE
test: cover no lead bit distribution error

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -208,6 +208,12 @@ fn we_can_get_leading_bit_eval_while_constant_and_non_zero() {
     assert_eq!(bit_eval, TestScalar::TWO);
 }
 
+#[test]
+#[should_panic(expected = "No lead bit available despite variable lead bit.")]
+fn no_lead_bit_error_panics_when_converted_to_proof_error() {
+    let _: crate::base::proof::ProofError = BitDistributionError::NoLeadBit.into();
+}
+
 // leading_bit_eval functions start
 
 // leading_bit_eval functions end


### PR DESCRIPTION
/claim #560

## Summary
- Add focused unit coverage for the `BitDistributionError::NoLeadBit` conversion panic path.
- No production behavior changes.

## Coverage
Before this change, `crates/proof-of-sql/src/base/bit/bit_distribution.rs` had 1 missed line in my local `cargo llvm-cov` run: line 49. After this change it has 0 missed lines, covering 1 previously missed line.

## Verification
- `cargo test -p proof-of-sql base::bit::bit_distribution_test --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target\llvm-cov\bit-distribution-no-lead-bit.lcov`
- `C:\Program Files\Git\bin\bash.exe scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.