### PR TITLE
test: cover evaluation vector edges

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
@@ -66,6 +66,20 @@ fn we_compute_the_evaluation_vector_for_an_empty_point() {
 }
 
 #[test]
+fn we_compute_an_empty_evaluation_vector_for_a_non_empty_point() {
+    let mut v = [];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64)]);
+    assert!(v.is_empty());
+}
+
+#[test]
+#[should_panic]
+fn we_reject_an_evaluation_vector_larger_than_the_point_domain() {
+    let mut v = [TestScalar::zero(); 3];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64)]);
+}
+
+#[test]
 fn we_get_the_same_result_using_evaluation_vector_as_direct_evaluation() {
     let xs = [
         TestScalar::from(3u64),


### PR DESCRIPTION
/claim #560

Adds focused tests for evaluation-vector edge behavior:
- empty output vectors return cleanly for non-empty evaluation points
- output vectors larger than the point domain are rejected by the existing assertion

Validation:
- cargo test -p proof-of-sql base::polynomial::evaluation_vector_test --no-default-features --features=test
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.