### PR TITLE
test: cover lagrange basis assertions

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
@@ -192,6 +192,23 @@ fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_0_va
         TestScalar::from(0u32)
     );
 }
+
+#[test]
+#[should_panic]
+fn compute_truncated_lagrange_basis_inner_product_rejects_length_beyond_0_variable_domain() {
+    let a: Vec<TestScalar> = vec![];
+    let b = vec![];
+    compute_truncated_lagrange_basis_inner_product(2, &a, &b);
+}
+
+#[test]
+#[should_panic]
+fn compute_truncated_lagrange_basis_inner_product_rejects_mismatched_point_lengths() {
+    let a = vec![TestScalar::from(2u8)];
+    let b = vec![];
+    compute_truncated_lagrange_basis_inner_product(1, &a, &b);
+}
+
 #[test]
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_1_variables() {
     let a = vec![TestScalar::from(2u8)];


### PR DESCRIPTION
/claim #560

Adds focused tests for truncated Lagrange-basis inner-product assertion paths:
- rejects requested length beyond the zero-variable domain
- rejects mismatched point lengths

Validation:
- cargo test -p proof-of-sql base::polynomial::lagrange_basis_evaluation_test --no-default-features --features=test
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.