### PR TITLE
test: cover scalar conversion error

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,18 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn scalar_conversion_error_displays_overflow_reason() {
+        let error = ScalarConversionError::Overflow {
+            error: "value too large".into(),
+        };
+
+        assert_eq!(error.to_string(), "Overflow error: value too large");
+    }
+}


### PR DESCRIPTION
/claim #560

Adds focused test coverage for scalar conversion error display behavior:
- verifies `ScalarConversionError::Overflow` includes its underlying reason in the public display output

Validation:
- cargo test -p proof-of-sql base::scalar::error --no-default-features --features=test
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.