### PR TITLE
test: cover table ref parsing

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,52 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+    use serde_json;
+
+    #[test]
+    fn from_strs_handles_schema_variants() {
+        let unqualified = TableRef::from_strs(&["orders"]).unwrap();
+        assert_eq!(unqualified.schema_id(), None);
+        assert_eq!(unqualified.table_id().value, "orders");
+        assert_eq!(unqualified.to_string(), "orders");
+
+        let qualified = TableRef::from_strs(&["analytics", "orders"]).unwrap();
+        assert_eq!(qualified.schema_id().unwrap().value, "analytics");
+        assert_eq!(qualified.table_id().value, "orders");
+        assert_eq!(qualified.to_string(), "analytics.orders");
+    }
+
+    #[test]
+    fn from_strs_rejects_invalid_component_counts() {
+        let empty = TableRef::from_strs::<&str>(&[]).unwrap_err();
+        assert_eq!(
+            empty,
+            ParseError::InvalidTableReference {
+                table_reference: "".to_string()
+            }
+        );
+
+        let too_many = TableRef::from_strs(&["a", "b", "c"]).unwrap_err();
+        assert_eq!(
+            too_many,
+            ParseError::InvalidTableReference {
+                table_reference: "a,b,c".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn serde_round_trips_table_refs_as_strings() {
+        let table_ref = TableRef::new("analytics", "orders");
+        let serialized = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(serialized, "\"analytics.orders\"");
+
+        let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, table_ref);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -147,6 +147,7 @@ impl<'d> Deserialize<'d> for TableRef {
 mod tests {
     use super::*;
     use alloc::string::ToString;
+    use proptest::prelude::*;
     use serde_json;
 
     #[test]
@@ -189,5 +190,46 @@ mod tests {
 
         let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, table_ref);
+    }
+
+    proptest! {
+        #[test]
+        fn prop_unqualified_table_refs_roundtrip(table in "[A-Za-z_][A-Za-z0-9_]{0,31}") {
+            let table_ref = TableRef::try_from(table.as_str()).unwrap();
+
+            prop_assert_eq!(table_ref.schema_id(), None);
+            prop_assert_eq!(table_ref.table_id().value.as_str(), table.as_str());
+            prop_assert_eq!(TableRef::try_from(table_ref.to_string().as_str()).unwrap(), table_ref);
+        }
+
+        #[test]
+        fn prop_qualified_table_refs_roundtrip(
+            schema in "[A-Za-z_][A-Za-z0-9_]{0,31}",
+            table in "[A-Za-z_][A-Za-z0-9_]{0,31}",
+        ) {
+            let input = alloc::format!("{schema}.{table}");
+            let table_ref = TableRef::try_from(input.as_str()).unwrap();
+
+            prop_assert_eq!(table_ref.schema_id().unwrap().value.as_str(), schema.as_str());
+            prop_assert_eq!(table_ref.table_id().value.as_str(), table.as_str());
+            prop_assert_eq!(TableRef::try_from(table_ref.to_string().as_str()).unwrap(), table_ref);
+        }
+
+        #[test]
+        fn prop_dot_separated_refs_with_too_many_components_are_rejected(
+            a in "[A-Za-z_][A-Za-z0-9_]{0,8}",
+            b in "[A-Za-z_][A-Za-z0-9_]{0,8}",
+            c in "[A-Za-z_][A-Za-z0-9_]{0,8}",
+        ) {
+            let input = alloc::format!("{a}.{b}.{c}");
+            let err = TableRef::try_from(input.as_str()).unwrap_err();
+
+            prop_assert_eq!(
+                err,
+                ParseError::InvalidTableReference {
+                    table_reference: input
+                }
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- cover `TableRef::from_strs` for qualified and unqualified table names
- cover invalid component counts and the resulting parse error payload
- cover serde string round-tripping for table refs

## Verification
- `cargo test -p proof-of-sql base::database::table_ref::tests --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

/claim #560