### PR TITLE
test: cover dyn proof placeholder constructor

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -122,3 +122,29 @@ impl DynProofExpr {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{base::proof::PlaceholderError, sql::AnalyzeError};
+
+    #[test]
+    fn try_new_placeholder_wraps_placeholder_expression() {
+        assert_eq!(
+            DynProofExpr::try_new_placeholder(1, ColumnType::BigInt).unwrap(),
+            DynProofExpr::Placeholder(PlaceholderExpr::try_new(1, ColumnType::BigInt).unwrap())
+        );
+    }
+
+    #[test]
+    fn try_new_placeholder_forwards_placeholder_errors() {
+        let err = DynProofExpr::try_new_placeholder(0, ColumnType::Boolean).unwrap_err();
+
+        assert!(matches!(
+            err,
+            AnalyzeError::PlaceholderError {
+                source: PlaceholderError::ZeroPlaceholderId
+            }
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused unit coverage for `DynProofExpr::try_new_placeholder` success and placeholder-error forwarding.
- No production behavior changes.

## Coverage
Before this change, `crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs` had 1 missed line in my local `cargo llvm-cov` run: line 82. After this change it has 0 missed lines, covering 1 previously missed line.

## Verification
- `cargo test -p proof-of-sql sql::proof_exprs::dyn_proof_expr::tests --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target\llvm-cov\dyn-proof-placeholder-clean.lcov`
- `C:\Program Files\Git\bin\bash.exe scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.