### PR TITLE
test: cover column metadata accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,16 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_field_returns_name_and_type() {
+        let field = ColumnField::new(Ident::new("amount"), ColumnType::BigInt);
+
+        assert_eq!(field.name().value, "amount");
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,19 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_ref_returns_table_column_and_type() {
+        let table_ref = TableRef::new("analytics", "orders");
+        let column_ref =
+            ColumnRef::new(table_ref.clone(), Ident::new("amount"), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id().value, "amount");
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+    }
+}


### PR DESCRIPTION
## Summary
- add focused tests for `ColumnField` metadata accessors
- add focused tests for `ColumnRef` table, column, and type accessors

## Verification
- `cargo test -p proof-of-sql base::database::column_field::tests --no-default-features --features=test`
- `cargo test -p proof-of-sql base::database::column_ref::tests --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

/claim #560