### PR TITLE
test: cover merlin transcript vector

### DIFF
--- a/crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs
@@ -14,7 +14,21 @@ impl super::transcript_core::TranscriptCore for merlin::Transcript {
 
 #[cfg(test)]
 mod tests {
-    use super::super::transcript_core::test_util::*;
+    use super::super::transcript_core::{test_util::*, TranscriptCore};
+
+    #[test]
+    fn empty_merlin_transcript_challenge_matches_known_vector() {
+        let mut transcript: merlin::Transcript = TranscriptCore::new();
+
+        assert_eq!(
+            transcript.raw_challenge(),
+            [
+                182, 100, 146, 218, 115, 27, 109, 84, 191, 48, 124, 69, 40, 114, 27, 71, 51, 120,
+                226, 249, 56, 158, 200, 97, 45, 23, 24, 232, 141, 120, 179, 20,
+            ]
+        );
+    }
+
     #[test]
     fn we_get_equivalent_challenges_with_equivalent_merlin_transcripts() {
         we_get_equivalent_challenges_with_equivalent_transcripts::<merlin::Transcript>();


### PR DESCRIPTION
/claim #560

Adds focused test coverage for the Merlin transcript-core wrapper:
- verifies the empty Merlin transcript challenge under the existing transcript-core domain separator against a deterministic vector

Validation:
- cargo test -p proof-of-sql base::proof::merlin_transcript_core --no-default-features --features=test
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.