### PR TITLE
test: run gadget tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -196,15 +196,17 @@ impl ProofPlan for MembershipCheckTestPlan {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof,
+            database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
+            scalar::test_scalar::TestScalar,
+        },
         sql::proof::VerifiableQueryResult,
     };
-    use blitzar::proof::InnerProductProof;
 
     #[test]
     fn we_can_do_minimal_membership_check() {
@@ -213,7 +215,7 @@ mod tests {
         let candidate_table = table([borrowed_bigint("c", [1, 2, 2, 1, 2], &alloc)]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -235,7 +237,7 @@ mod tests {
             )],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let actual = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .unwrap()
@@ -261,7 +263,7 @@ mod tests {
         ]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -283,7 +285,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let actual = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .unwrap()
@@ -309,7 +311,7 @@ mod tests {
         ]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -331,7 +333,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let actual = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .unwrap()
@@ -351,7 +353,7 @@ mod tests {
         let candidate_table = table([borrowed_bigint("a", [1, 2, 1, 1, 2], &alloc)]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -371,25 +373,25 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_can_do_membership_check_if_there_are_no_columns_in_the_tables() {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(5) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(4) },
         )
         .unwrap();
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -403,26 +405,26 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_can_do_membership_check_if_there_are_no_columns_in_the_tables_and_candidate_has_no_rows_either(
     ) {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(5) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -436,25 +438,25 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_cannot_do_membership_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -468,7 +470,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -485,7 +487,7 @@ mod tests {
         ]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -499,6 +501,6 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -159,15 +159,17 @@ impl ProofPlan for PermutationCheckTestPlan {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof,
+            database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
+            scalar::test_scalar::TestScalar,
+        },
         sql::proof::VerifiableQueryResult,
     };
-    use blitzar::proof::InnerProductProof;
 
     #[test]
     fn we_can_do_minimal_permutation_check() {
@@ -176,7 +178,7 @@ mod tests {
         let candidate_table = table([borrowed_bigint("c", [2, 3, 1], &alloc)]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -198,7 +200,7 @@ mod tests {
             )],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
@@ -219,7 +221,7 @@ mod tests {
         ]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -241,7 +243,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
@@ -262,7 +264,7 @@ mod tests {
         ]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -284,7 +286,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
@@ -299,7 +301,7 @@ mod tests {
         let candidate_table = table([borrowed_bigint("a", [1, 2], &alloc)]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -319,25 +321,25 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_can_do_permutation_check_if_there_are_no_columns_in_the_tables() {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(5) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(4) },
         )
         .unwrap();
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -351,26 +353,26 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_cannot_do_permutation_check_if_there_are_no_columns_in_the_tables_and_candidate_has_no_rows_either(
     ) {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(5) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -384,25 +386,25 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_cannot_do_permutation_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -416,7 +418,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -433,7 +435,7 @@ mod tests {
         ]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -447,6 +449,6 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 }


### PR DESCRIPTION
Summary\n- run the existing membership and permutation gadget tests under the no-default test feature by using NaiveEvaluationProof instead of the blitzar-only proof type\n- keep the existing end-to-end gadget scenarios and panic-path checks intact\n- avoid production behavior changes\n\nCoverage\n- baseline focused from full no-default test coverage: membership_check_test.rs had 128 missed / 128 total covered lines; permutation_check_test.rs had 102 missed / 102 total covered lines\n- focused post-change coverage with sql::proof_gadgets: 127 baseline-missed membership lines and 101 baseline-missed permutation lines are now covered\n\nTests\n- cargo test -p proof-of-sql sql::proof_gadgets::membership_check_test --no-default-features --features=test\n- cargo test -p proof-of-sql sql::proof_gadgets::permutation_check_test --no-default-features --features=test\n- cargo test -p proof-of-sql sql::proof_gadgets --no-default-features --features=test\n- cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/gadget-after.lcov -- sql::proof_gadgets\n- cargo fmt --check\n- git diff --check\n- source scripts/check_commits.sh\n\n/claim #560\n\nAI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.