### PR TITLE
test: cover proof error display

### DIFF
--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,122 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_errors_preserve_payloads() {
+        let verification_error = ProofError::VerificationError {
+            error: "bad opening",
+        };
+        assert!(matches!(
+            verification_error,
+            ProofError::VerificationError {
+                error: "bad opening"
+            }
+        ));
+
+        let unsupported_query_plan = ProofError::UnsupportedQueryPlan {
+            error: "window function",
+        };
+        assert!(matches!(
+            unsupported_query_plan,
+            ProofError::UnsupportedQueryPlan {
+                error: "window function"
+            }
+        ));
+    }
+
+    #[test]
+    fn proof_errors_display_readable_messages() {
+        assert_eq!(
+            ProofError::VerificationError {
+                error: "bad opening"
+            }
+            .to_string(),
+            "Verification error: bad opening"
+        );
+        assert_eq!(
+            ProofError::UnsupportedQueryPlan {
+                error: "window function"
+            }
+            .to_string(),
+            "Unsupported query plan: window function"
+        );
+        assert_eq!(
+            ProofError::InvalidTypeCoercion.to_string(),
+            "Result does not match query: type mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldNamesMismatch.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldCountMismatch.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_size_errors_display_readable_messages() {
+        assert_eq!(
+            ProofSizeMismatch::SumcheckProofTooSmall.to_string(),
+            "Sumcheck proof is too small"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewMLEEvaluations.to_string(),
+            "Proof has too few MLE evaluations"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewBitDistributions.to_string(),
+            "Proof has too few bit distributions"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewChiLengths.to_string(),
+            "Proof has too few one lengths"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewRhoLengths.to_string(),
+            "Proof has too few rho lengths"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewSumcheckVariables.to_string(),
+            "Proof has too few sumcheck variables"
+        );
+        assert_eq!(
+            ProofSizeMismatch::ChiLengthNotFound.to_string(),
+            "Proof doesn't have requested one length"
+        );
+        assert_eq!(
+            ProofSizeMismatch::RhoLengthNotFound.to_string(),
+            "Proof doesn't have requested rho length"
+        );
+    }
+
+    #[test]
+    fn placeholder_errors_display_readable_messages() {
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderIndex {
+                index: 3,
+                num_params: 2
+            }
+            .to_string(),
+            "Invalid placeholder index: 3, number of params: 2"
+        );
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderType {
+                index: 1,
+                expected: ColumnType::Int,
+                actual: ColumnType::VarChar
+            }
+            .to_string(),
+            "Invalid placeholder type: 1, expected: INT, actual: VARCHAR"
+        );
+        assert_eq!(
+            PlaceholderError::ZeroPlaceholderId.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- cover display text for top-level proof errors
- cover proof size mismatch display messages
- cover placeholder error display messages for index, type, and zero-id failures

## Verification
- `cargo test -p proof-of-sql base::proof::error::tests --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

/claim #560