### PR TITLE
test: cover scalar conversion error display

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,21 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_conversion_error_displays_overflow_message() {
+        let error = ScalarConversionError::Overflow {
+            error: "value exceeds i64".into(),
+        };
+
+        assert!(matches!(
+            error,
+            ScalarConversionError::Overflow { ref error } if error == "value exceeds i64"
+        ));
+        assert_eq!(error.to_string(), "Overflow error: value exceeds i64");
+    }
+}


### PR DESCRIPTION
## Summary
- cover display text for scalar conversion overflow errors

## Verification
- `cargo test -p proof-of-sql base::scalar::error::tests --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

/claim #560