### PR TITLE
test: cover RefInto blanket conversion

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,26 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Wrapper(u64);
+
+    impl From<&Wrapper> for u64 {
+        fn from(value: &Wrapper) -> Self {
+            value.0
+        }
+    }
+
+    #[test]
+    fn ref_into_converts_from_reference_without_consuming_value() {
+        let wrapper = Wrapper(42);
+        let converted: u64 = wrapper.ref_into();
+
+        assert_eq!(converted, 42);
+        assert_eq!(wrapper, Wrapper(42));
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused test for the `RefInto` blanket implementation
- verify reference conversion works without consuming the source value

## Verification
- `cargo test -p proof-of-sql base::ref_into::tests --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

/claim #560