### PR TITLE
test: cover parse error display

### DIFF
--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,18 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn invalid_table_reference_error_displays_reference() {
+        let error = ParseError::InvalidTableReference {
+            table_reference: "bad table".into(),
+        };
+
+        assert_eq!(error.to_string(), "Invalid table reference: bad table");
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused display test for invalid table reference parse errors
- document the formatted parse error message through a unit test

## Verification
- `cargo test -p proof-of-sql base::database::error::tests --no-default-features --features=test`
- `cargo fmt --check`
- `git diff --check`

/claim #560