### PR TITLE
test: run provable query result tests without arrow

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -71,7 +71,7 @@ pub(crate) use first_round_builder::FirstRoundBuilder;
 #[cfg(all(test, feature = "blitzar"))]
 mod first_round_builder_test;
 
-#[cfg(all(test, feature = "arrow"))]
+#[cfg(test)]
 mod provable_query_result_test;
 
 mod make_sumcheck_state;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -2,21 +2,26 @@ use super::{ProvableQueryResult, QueryError};
 use crate::base::scalar::test_scalar::TestScalar;
 use crate::{
     base::{
-        database::{Column, ColumnField, ColumnType},
+        database::{owned_table_utility, table_utility, Column, ColumnField, ColumnType},
         math::decimal::Precision,
         polynomial::compute_evaluation_vector,
-        scalar::Scalar,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::{Scalar, ScalarExt},
     },
     // proof_primitive::inner_product::TestScalar,
 };
+#[cfg(feature = "arrow")]
 use alloc::sync::Arc;
+#[cfg(feature = "arrow")]
 use arrow::{
     array::{Decimal128Array, Decimal256Array, Int64Array, LargeBinaryArray, StringArray},
     datatypes::{i256, Field, Schema},
     record_batch::RecordBatch,
 };
+use bumpalo::Bump;
 use num_traits::Zero;
 
+#[cfg(feature = "arrow")]
 #[test]
 fn we_can_convert_an_empty_provable_result_to_a_final_result() {
     let cols: [Column<TestScalar>; 1] = [Column::BigInt(&[0_i64; 0])];
@@ -152,6 +157,67 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
 }
 
 #[test]
+fn we_can_evaluate_non_numeric_result_columns_as_mles() {
+    let boolean_values = [true, false];
+    let uint8_values = [1_u8, 2];
+    let tinyint_values = [3_i8, 4];
+    let smallint_values = [5_i16, 6];
+    let varchar_values = ["alpha", "beta"];
+    let varchar_scalars = varchar_values
+        .iter()
+        .map(|v| TestScalar::from(*v))
+        .collect::<Vec<_>>();
+    let varbinary_values = [b"foo".as_ref(), b"bar".as_ref()];
+    let varbinary_scalars = varbinary_values
+        .iter()
+        .map(|v| TestScalar::from_byte_slice_via_hash(v))
+        .collect::<Vec<_>>();
+    let timestamp_values = [7_i64, 8];
+    let cols: [Column<TestScalar>; 7] = [
+        Column::Boolean(&boolean_values),
+        Column::Uint8(&uint8_values),
+        Column::TinyInt(&tinyint_values),
+        Column::SmallInt(&smallint_values),
+        Column::VarChar((&varchar_values, &varchar_scalars)),
+        Column::VarBinary((&varbinary_values, &varbinary_scalars)),
+        Column::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            &timestamp_values,
+        ),
+    ];
+    let res = ProvableQueryResult::new(2, &cols);
+    let evaluation_point = [TestScalar::from(10u64), TestScalar::from(100u64)];
+    let mut evaluation_vec = [TestScalar::ZERO; 2];
+    compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
+    let column_fields = [
+        ColumnField::new("boolean_col".into(), ColumnType::Boolean),
+        ColumnField::new("uint8_col".into(), ColumnType::Uint8),
+        ColumnField::new("tinyint_col".into(), ColumnType::TinyInt),
+        ColumnField::new("smallint_col".into(), ColumnType::SmallInt),
+        ColumnField::new("varchar_col".into(), ColumnType::VarChar),
+        ColumnField::new("varbinary_col".into(), ColumnType::VarBinary),
+        ColumnField::new(
+            "timestamp_col".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ),
+    ];
+    let evals = res
+        .evaluate(&evaluation_point, 2, &column_fields[..])
+        .unwrap();
+    let expected_evals = [
+        TestScalar::from(1u64) * evaluation_vec[0] + TestScalar::ZERO * evaluation_vec[1],
+        TestScalar::from(1u64) * evaluation_vec[0] + TestScalar::from(2u64) * evaluation_vec[1],
+        TestScalar::from(3u64) * evaluation_vec[0] + TestScalar::from(4u64) * evaluation_vec[1],
+        TestScalar::from(5u64) * evaluation_vec[0] + TestScalar::from(6u64) * evaluation_vec[1],
+        varchar_scalars[0] * evaluation_vec[0] + varchar_scalars[1] * evaluation_vec[1],
+        varbinary_scalars[0] * evaluation_vec[0] + varbinary_scalars[1] * evaluation_vec[1],
+        TestScalar::from(7u64) * evaluation_vec[0] + TestScalar::from(8u64) * evaluation_vec[1],
+    ];
+    assert_eq!(evals, expected_evals);
+}
+
+#[test]
 fn evaluation_fails_if_extra_data_is_included() {
     let cols: [Column<TestScalar>; 1] = [Column::BigInt(&[10, 12])];
     let mut res = ProvableQueryResult::new(2, &cols);
@@ -211,6 +277,149 @@ fn evaluation_fails_if_data_is_missing() {
 }
 
 #[test]
+fn evaluation_fails_if_column_count_differs() {
+    let cols: [Column<TestScalar>; 1] = [Column::BigInt(&[10, 12])];
+    let res = ProvableQueryResult::new(2, &cols);
+    assert!(matches!(
+        res.evaluate(&[TestScalar::from(1), TestScalar::from(2)], 2, &[]),
+        Err(QueryError::InvalidColumnCount)
+    ));
+}
+
+#[test]
+fn to_owned_table_fails_if_column_count_differs() {
+    let cols: [Column<TestScalar>; 1] = [Column::BigInt(&[10, 12])];
+    let res = ProvableQueryResult::new(2, &cols);
+    assert!(matches!(
+        res.to_owned_table::<TestScalar>(&[]),
+        Err(QueryError::InvalidColumnCount)
+    ));
+}
+
+#[test]
+fn to_owned_table_fails_if_data_is_missing() {
+    let cols: [Column<TestScalar>; 1] = [Column::BigInt(&[10, 12])];
+    let mut res = ProvableQueryResult::new(2, &cols);
+    res.data_mut().pop();
+    let column_fields = [ColumnField::new("a".into(), ColumnType::BigInt)];
+    assert!(matches!(
+        res.to_owned_table::<TestScalar>(&column_fields),
+        Err(QueryError::Overflow)
+    ));
+}
+
+#[test]
+fn we_can_convert_all_supported_types_to_owned_table_without_arrow() {
+    let boolean_values = [true, false];
+    let uint8_values = [1_u8, 2];
+    let tinyint_values = [-1_i8, 2];
+    let smallint_values = [-3_i16, 4];
+    let int_values = [-5_i32, 6];
+    let bigint_values = [-7_i64, 8];
+    let int128_values = [-9_i128, 10];
+    let varchar_values = ["alpha", "beta"];
+    let varchar_scalars = varchar_values
+        .iter()
+        .map(|v| TestScalar::from(*v))
+        .collect::<Vec<_>>();
+    let varbinary_values = [b"foo".as_ref(), b"bar".as_ref()];
+    let varbinary_scalars = varbinary_values
+        .iter()
+        .map(|v| TestScalar::from_le_bytes_mod_order(v))
+        .collect::<Vec<_>>();
+    let scalar_values = [TestScalar::from(11), TestScalar::from(12)];
+    let decimal_values = [TestScalar::from(13), TestScalar::from(14)];
+    let timestamp_values = [15_i64, 16];
+
+    let cols: [Column<TestScalar>; 12] = [
+        Column::Boolean(&boolean_values),
+        Column::Uint8(&uint8_values),
+        Column::TinyInt(&tinyint_values),
+        Column::SmallInt(&smallint_values),
+        Column::Int(&int_values),
+        Column::BigInt(&bigint_values),
+        Column::Int128(&int128_values),
+        Column::VarChar((&varchar_values, &varchar_scalars)),
+        Column::VarBinary((&varbinary_values, &varbinary_scalars)),
+        Column::Scalar(&scalar_values),
+        Column::Decimal75(Precision::new(75).unwrap(), -2, &decimal_values),
+        Column::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            &timestamp_values,
+        ),
+    ];
+    let res = ProvableQueryResult::new(2, &cols);
+    let column_fields = vec![
+        ColumnField::new("bool_col".into(), ColumnType::Boolean),
+        ColumnField::new("u8_col".into(), ColumnType::Uint8),
+        ColumnField::new("i8_col".into(), ColumnType::TinyInt),
+        ColumnField::new("i16_col".into(), ColumnType::SmallInt),
+        ColumnField::new("i32_col".into(), ColumnType::Int),
+        ColumnField::new("i64_col".into(), ColumnType::BigInt),
+        ColumnField::new("i128_col".into(), ColumnType::Int128),
+        ColumnField::new("varchar_col".into(), ColumnType::VarChar),
+        ColumnField::new("varbinary_col".into(), ColumnType::VarBinary),
+        ColumnField::new("scalar_col".into(), ColumnType::Scalar),
+        ColumnField::new(
+            "decimal_col".into(),
+            ColumnType::Decimal75(Precision::new(75).unwrap(), -2),
+        ),
+        ColumnField::new(
+            "timestamp_col".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ),
+    ];
+    let table = res.to_owned_table::<TestScalar>(&column_fields).unwrap();
+    let expected = owned_table_utility::owned_table::<TestScalar>([
+        owned_table_utility::boolean("bool_col", [true, false]),
+        owned_table_utility::uint8("u8_col", [1_u8, 2]),
+        owned_table_utility::tinyint("i8_col", [-1_i8, 2]),
+        owned_table_utility::smallint("i16_col", [-3_i16, 4]),
+        owned_table_utility::int("i32_col", [-5_i32, 6]),
+        owned_table_utility::bigint("i64_col", [-7_i64, 8]),
+        owned_table_utility::int128("i128_col", [-9_i128, 10]),
+        owned_table_utility::varchar("varchar_col", ["alpha", "beta"]),
+        owned_table_utility::varbinary("varbinary_col", [b"foo".to_vec(), b"bar".to_vec()]),
+        owned_table_utility::scalar("scalar_col", [TestScalar::from(11), TestScalar::from(12)]),
+        owned_table_utility::decimal75(
+            "decimal_col",
+            75,
+            -2,
+            [TestScalar::from(13), TestScalar::from(14)],
+        ),
+        owned_table_utility::timestamptz(
+            "timestamp_col",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            [15_i64, 16],
+        ),
+    ]);
+
+    assert_eq!(res.table_length(), 2);
+    assert_eq!(table, expected);
+}
+
+#[test]
+fn we_can_form_a_provable_result_from_a_table() {
+    let alloc = Bump::new();
+    let table = table_utility::table::<TestScalar>([
+        table_utility::borrowed_bigint("bigint", [1_i64, -2], &alloc),
+        table_utility::borrowed_varchar("varchar", ["alpha", "beta"], &alloc),
+    ]);
+    let fields = table.schema();
+    let res = ProvableQueryResult::from(table);
+    let table = res.to_owned_table::<TestScalar>(&fields).unwrap();
+    let expected = owned_table_utility::owned_table::<TestScalar>([
+        owned_table_utility::bigint("bigint", [1_i64, -2]),
+        owned_table_utility::varchar("varchar", ["alpha", "beta"]),
+    ]);
+
+    assert_eq!(table, expected);
+}
+
+#[cfg(feature = "arrow")]
+#[test]
 fn we_can_convert_a_provable_result_to_a_final_result() {
     let cols: [Column<TestScalar>; 1] = [Column::BigInt(&[10, 12])];
     let res = ProvableQueryResult::new(2, &cols);
@@ -227,6 +436,7 @@ fn we_can_convert_a_provable_result_to_a_final_result() {
     assert_eq!(res, expected_res);
 }
 
+#[cfg(feature = "arrow")]
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_128_bits() {
     let cols: [Column<TestScalar>; 1] = [Column::Int128(&[10, i128::MAX])];
@@ -251,6 +461,7 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_128_bits() {
     assert_eq!(res, expected_res);
 }
 
+#[cfg(feature = "arrow")]
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_252_bits() {
     let values = [TestScalar::from(10), TestScalar::MAX_SIGNED];
@@ -281,6 +492,7 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_252_bits() {
     assert_eq!(res, expected_res);
 }
 
+#[cfg(feature = "arrow")]
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_mixed_data_types() {
     let values1: [i64; 2] = [6, i64::MAX];
@@ -336,6 +548,7 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_mixed_data_types() {
     assert_eq!(res, expected_res);
 }
 
+#[cfg(feature = "arrow")]
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_varbinary() {
     let raw_bytes = [b"foo".as_ref(), b"bar"];


### PR DESCRIPTION
/claim #560

## Summary
- make `provable_query_result_test` run under plain `#[cfg(test)]`
- keep Arrow/RecordBatch conversion assertions gated behind `feature = "arrow"`
- add non-Arrow assertions for evaluate, error handling, `to_owned_table`, and `From<Table>` coverage

## Coverage
For `crates/proof-of-sql/src/sql/proof/provable_query_result.rs`:
- baseline `target/llvm-cov/proof-baseline.lcov`: 0/147 lines covered
- focused run `target/llvm-cov/provable-query-result-after.lcov`: 146/147 lines covered
- baseline-missed lines newly covered: 146

## Tests
- `cargo test -p proof-of-sql sql::proof::provable_query_result_test --no-default-features --features=test`
- `cargo test -p proof-of-sql sql::proof::provable_query_result_test --no-default-features --features=test,arrow`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/provable-query-result-after.lcov -- sql::proof::provable_query_result_test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

## Notes
This PR was prepared with AI assistance and manually verified with the commands above.
