### PR TITLE
test: run sort merge join tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -59,7 +59,7 @@ mod union_exec_test;
 
 mod sort_merge_join_exec;
 pub use sort_merge_join_exec::SortMergeJoinExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod sort_merge_join_exec_test;
 
 mod dyn_proof_plan;

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -1,22 +1,27 @@
 use super::test_utility::*;
+#[cfg(not(feature = "blitzar"))]
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
+#[cfg(feature = "blitzar")]
+use crate::{base::commitment::InnerProductProof, sql::proof::exercise_verification};
 use crate::{
     base::database::{
         owned_table_utility::*, table_utility::*, ColumnType, TableRef, TableTestAccessor,
         TestAccessor,
     },
-    sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-    },
+    sql::{proof::VerifiableQueryResult, proof_exprs::test_utility::*},
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
+
+#[cfg(feature = "blitzar")]
+type TestEvaluationProof = InnerProductProof;
+#[cfg(not(feature = "blitzar"))]
+type TestEvaluationProof = NaiveEvaluationProof;
 
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar(
@@ -56,8 +61,9 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -74,7 +80,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_merge_join() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let cats = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 29, 20, 21], &alloc),
         borrowed_varchar(
@@ -134,8 +140,9 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
         2,
         Some(3),
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -153,7 +160,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
 #[expect(clippy::too_many_lines)]
 fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_sort_merge_joins() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let cats = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 10, 29, 20, 21], &alloc),
         borrowed_varchar(
@@ -267,8 +274,9 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
         ],
     );
 
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -296,7 +304,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
 #[test]
 fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar(
@@ -332,8 +340,9 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -353,7 +362,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
 ) {
     // Left table has no rows but right table has rows
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [0_i64; 0], &alloc),
         borrowed_varchar("name", [""; 0], &alloc),
@@ -385,8 +394,9 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &table_right);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -400,7 +410,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
     assert_eq!(res, expected_res);
 
     // Right table has no rows but left table has rows
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar(
@@ -436,8 +446,9 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -451,7 +462,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
     assert_eq!(res, expected_res);
 
     // Both tables have no rows
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [0_i64; 0], &alloc),
         borrowed_varchar("name", [""; 0], &alloc),
@@ -483,7 +494,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])


### PR DESCRIPTION
/claim #560

## Summary
- run `sort_merge_join_exec_test` under plain `#[cfg(test)]`
- use `NaiveEvaluationProof` for no-blitzar test runs
- keep the existing blitzar tamper verification helper on blitzar-enabled runs

## Coverage
For `crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs`:
- baseline `target/llvm-cov/proof-baseline.lcov`: 73/435 lines covered, 362 missed
- focused run `target/llvm-cov/sort-merge-join-after.lcov`: 404/435 lines covered, 31 missed
- baseline-missed lines newly covered: 346

## Tests
- `cargo test -p proof-of-sql sql::proof_plans::sort_merge_join_exec_test --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/sort-merge-join-after.lcov -- sql::proof_plans::sort_merge_join_exec_test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

## Notes
This PR was prepared with AI assistance and manually verified with the commands above.
