### PR TITLE
test: run aggregate tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
@@ -1,20 +1,21 @@
 use super::test_utility::*;
+#[cfg(not(feature = "blitzar"))]
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
+#[cfg(feature = "blitzar")]
+use crate::{base::commitment::InnerProductProof, sql::proof::exercise_verification};
 use crate::{
-    base::{
-        commitment::InnerProductProof,
-        database::{
-            owned_table_utility::*, table_utility::*, ColumnField, ColumnType,
-            OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
-        },
+    base::database::{
+        owned_table_utility::*, table_utility::*, ColumnField, ColumnType, OwnedTableTestAccessor,
+        TableRef, TableTestAccessor, TestAccessor,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
-    sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-        proof_plans::AggregateExec,
-    },
+    sql::{proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::AggregateExec},
 };
 use bumpalo::Bump;
+
+#[cfg(feature = "blitzar")]
+type TestEvaluationProof = InnerProductProof;
+#[cfg(not(feature = "blitzar"))]
+type TestEvaluationProof = NaiveEvaluationProof;
 
 /// `select sum(c) as sum_c, count(*) as __count__ from sxt.t where b = 99`
 #[test]
@@ -25,7 +26,7 @@ fn we_can_prove_aggregation_without_group_by() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = aggregate(
         vec![],
@@ -41,7 +42,9 @@ fn we_can_prove_aggregation_without_group_by() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -60,7 +63,7 @@ fn we_can_prove_a_simple_aggregate_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = aggregate(
         cols_expr_plan(&t, &["a"], &accessor),
@@ -76,7 +79,9 @@ fn we_can_prove_a_simple_aggregate_with_bigint_columns() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -96,7 +101,7 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = aggregate(
         cols_expr_plan(&t, &["a"], &accessor),
@@ -118,7 +123,9 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -134,25 +141,6 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
 #[expect(clippy::too_many_lines)]
 #[test]
 fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
-    let scalar_filter_data: Vec<Curve25519Scalar> = [
-        333, 222, 222, 333, 222, 333, 333, 333, 222, 222, 222, 333, 222, 222, 222, 222, 222, 222,
-        333, 333,
-    ]
-    .iter()
-    .map(core::convert::Into::into)
-    .collect();
-    let scalar_group_data: Vec<Curve25519Scalar> =
-        [5, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 4, 5]
-            .iter()
-            .map(core::convert::Into::into)
-            .collect();
-    let scalar_sum_data: Vec<Curve25519Scalar> = [
-        119, 522, 100, 325, 501, 447, 759, 375, 212, 532, 459, 616, 579, 179, 695, 963, 532, 868,
-        331, 830,
-    ]
-    .iter()
-    .map(core::convert::Into::into)
-    .collect();
     let data = owned_table([
         bigint(
             "bigint_filter",
@@ -203,13 +191,30 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
                 "g1", "g2", "g1", "g2", "g1", "g1",
             ],
         ),
-        scalar("scalar_filter", scalar_filter_data),
-        scalar("scalar_group", scalar_group_data),
-        scalar("scalar_sum", scalar_sum_data),
+        scalar(
+            "scalar_filter",
+            [
+                333_i128, 222, 222, 333, 222, 333, 333, 333, 222, 222, 222, 333, 222, 222, 222,
+                222, 222, 222, 333, 333,
+            ],
+        ),
+        scalar(
+            "scalar_group",
+            [
+                5_i128, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 4, 5,
+            ],
+        ),
+        scalar(
+            "scalar_sum",
+            [
+                119_i128, 522, 100, 325, 501, 447, 759, 375, 212, 532, 459, 616, 579, 179, 695,
+                963, 532, 868, 331, 830,
+            ],
+        ),
     ]);
 
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // SELECT scalar_group, int128_group, bigint_group, sum(bigint_sum + 1) as sum_int, sum(bigint_sum - int128_sum) as sum_bigint, sum(scalar_filter) as sum_scal, count(*) as __count__
@@ -306,7 +311,9 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -328,7 +335,7 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         borrowed_bigint("b", [10, 20, 30, 40, 50], &alloc),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // Intermediate data after FilterExec: rows where b > 15
@@ -337,7 +344,7 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         borrowed_bigint("b", [20, 30, 40, 50], &alloc),
     ]);
     let mut intermediate_accessor =
-        TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+        TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     intermediate_accessor.add_table(t.clone(), intermediate_data, 0);
 
     // Create a TableExec as input
@@ -377,7 +384,9 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         const_bool(true),
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -44,7 +44,7 @@ mod filter_exec_test;
 mod aggregate_exec;
 pub(crate) use aggregate_exec::AggregateExec;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod aggregate_exec_test;
 
 mod slice_exec;


### PR DESCRIPTION
/claim #560

## Summary
- run `aggregate_exec_test` under plain `#[cfg(test)]`
- use `NaiveEvaluationProof` for no-blitzar test runs
- keep the existing blitzar tamper verification helper on blitzar-enabled runs

## Coverage
For `crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs`:
- baseline `target/llvm-cov/proof-baseline.lcov`: 40/319 lines covered, 279 missed
- focused run `target/llvm-cov/aggregate-after.lcov`: 299/319 lines covered, 20 missed
- baseline-missed lines newly covered: 274

## Tests
- `cargo test -p proof-of-sql sql::proof_plans::aggregate_exec_test --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/aggregate-after.lcov -- sql::proof_plans::aggregate_exec_test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

## Notes
This PR was prepared with AI assistance and manually verified with the commands above.
