### PR TITLE
test: run projection tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -9,7 +9,7 @@ mod table_exec_test;
 
 mod projection_exec;
 pub(crate) use projection_exec::ProjectionExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod projection_exec_test;
 
 #[cfg(test)]

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -1,6 +1,11 @@
 use super::{test_utility::*, DynProofPlan, ProjectionExec};
+#[cfg(not(feature = "blitzar"))]
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
+#[cfg(feature = "blitzar")]
+use crate::{base::commitment::InnerProductProof, sql::proof::exercise_verification};
 use crate::{
     base::{
+        commitment::CommitmentEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
             OwnedTable, OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
@@ -8,19 +13,23 @@ use crate::{
         map::{indexmap, IndexMap, IndexSet},
         math::decimal::Precision,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
-            exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
-            ProverEvaluate, VerifiableQueryResult,
+            FirstRoundBuilder, ProofPlan, ProvableQueryResult, ProverEvaluate,
+            VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr},
         proof_plans::TableExec,
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
+
+#[cfg(feature = "blitzar")]
+type TestEvaluationProof = InnerProductProof;
+#[cfg(not(feature = "blitzar"))]
+type TestEvaluationProof = NaiveEvaluationProof;
+type TestScalar = <TestEvaluationProof as CommitmentEvaluationProof>::Scalar;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -119,7 +128,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_projection() {
         bigint("b", [1_i64, 2, 3, 4, 5, 1, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let ast = projection(
         cols_expr_plan(&t, &["b"], &accessor),
@@ -131,7 +140,9 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -148,7 +159,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
         bigint("b", [1_i64, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let ast = projection(
         vec![
@@ -166,7 +177,9 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -187,14 +200,14 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
         bigint("b", [1_i64, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let intermediate_data = owned_table([
         decimal75("a", 20, 0, [8_i64, 10]),
         decimal75("b", 20, 0, [4_i64, 6]),
     ]);
     let mut intermediate_accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+        OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     intermediate_accessor.add_table(t.clone(), intermediate_data, 0);
     let ast = projection(
         vec![
@@ -228,7 +241,9 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
             equal(column(&t, "a", &accessor), const_int128(5)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -250,14 +265,14 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_fi
         borrowed_bigint("b", [0; 0], &alloc),
         borrowed_int128("c", [0; 0], &alloc),
         borrowed_varchar("d", [""; 0], &alloc),
-        borrowed_scalar("e", [0; 0], &alloc),
+        borrowed_scalar("e", [0_i128; 0], &alloc),
     ]);
     let data_length = data.num_rows();
     let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr: DynProofPlan = projection(
         cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
@@ -282,13 +297,13 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_fi
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -307,14 +322,14 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
         borrowed_bigint("b", [1, 2, 3, 4, 5], &alloc),
         borrowed_int128("c", [1, 2, 3, 4, 5], &alloc),
         borrowed_varchar("d", ["1", "2", "3", "4", "5"], &alloc),
-        borrowed_scalar("e", [1, 2, 3, 4, 5], &alloc),
+        borrowed_scalar("e", [1_i128, 2, 3, 4, 5], &alloc),
     ]);
     let data_length = data.num_rows();
     let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr: DynProofPlan = projection(
         cols_expr_plan(&t, &[], &accessor),
@@ -331,7 +346,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     );
     let fields = &[];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
@@ -349,14 +364,14 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_first_round_evalu
         borrowed_bigint("b", [1, 2, 3, 4, 5], &alloc),
         borrowed_int128("c", [1, 2, 3, 4, 5], &alloc),
         borrowed_varchar("d", ["1", "2", "3", "4", "5"], &alloc),
-        borrowed_scalar("e", [1, 2, 3, 4, 5], &alloc),
+        borrowed_scalar("e", [1_i128, 2, 3, 4, 5], &alloc),
     ]);
     let data_length = data.num_rows();
     let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr: DynProofPlan = projection(
         vec![
@@ -389,13 +404,13 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_first_round_evalu
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [2, 3, 4, 5, 6]),
         int128("prod", [1, 4, 9, 16, 25]),
         varchar("d", ["1", "2", "3", "4", "5"]),
@@ -411,10 +426,10 @@ fn we_can_prove_a_projection_on_an_empty_table() {
         bigint("b", [3; 0]),
         int128("c", [3; 0]),
         varchar("d", ["3"; 0]),
-        scalar("e", [3; 0]),
+        scalar("e", [3_i128; 0]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = projection(
         vec![
@@ -437,7 +452,8 @@ fn we_can_prove_a_projection_on_an_empty_table() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         decimal75("b", 20, 0, [3; 0]),
@@ -455,10 +471,10 @@ fn we_can_prove_a_projection() {
         bigint("b", [1, 2, 3, 4, 7]),
         int128("c", [1, 3, 3, 4, 5]),
         varchar("d", ["1", "2", "3", "4", "5"]),
-        scalar("e", [1, 2, 3, 4, 5]),
+        scalar("e", [1_i128, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = projection(
         vec![
@@ -483,14 +499,16 @@ fn we_can_prove_a_projection() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [1, 2, 3, 4, 7]),
         int128("c", [1, 3, 3, 4, 5]),
         varchar("d", ["1", "2", "3", "4", "5"]),
-        scalar("e", [1, 2, 3, 4, 5]),
+        scalar("e", [1_i128, 2, 3, 4, 5]),
         int128("const", [105; 5]),
         boolean("bool", [true, false, true, true, false]),
     ]);


### PR DESCRIPTION
/claim #560

## Summary
- run `projection_exec_test` under plain `#[cfg(test)]`
- use `NaiveEvaluationProof` for no-blitzar test runs
- keep the existing blitzar tamper verification helper on blitzar-enabled runs

## Coverage
For `crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs`:
- baseline `target/llvm-cov/proof-baseline.lcov`: 20/110 lines covered, 90 missed
- focused run `target/llvm-cov/projection-after.lcov`: 104/110 lines covered, 6 missed
- baseline-missed lines newly covered: 90

## Tests
- `cargo test -p proof-of-sql sql::proof_plans::projection_exec_test --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/projection-after.lcov -- sql::proof_plans::projection_exec_test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

## Notes
This PR was prepared with AI assistance and manually verified with the commands above.
