### PR TITLE
test: run legacy filter tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
@@ -1,6 +1,11 @@
 use super::{test_utility::*, LegacyFilterExec};
+#[cfg(not(feature = "blitzar"))]
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
+#[cfg(feature = "blitzar")]
+use crate::{base::commitment::InnerProductProof, sql::proof::exercise_verification};
 use crate::{
     base::{
+        commitment::CommitmentEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
             LiteralValue, OwnedTable, OwnedTableTestAccessor, TableRef, TableTestAccessor,
@@ -9,18 +14,22 @@ use crate::{
         map::{indexmap, IndexMap, IndexSet},
         math::decimal::Precision,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
-            exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
-            ProverEvaluate, VerifiableQueryResult,
+            FirstRoundBuilder, ProofPlan, ProvableQueryResult, ProverEvaluate,
+            VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, LiteralExpr, TableExpr},
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
+
+#[cfg(feature = "blitzar")]
+type TestEvaluationProof = InnerProductProof;
+#[cfg(not(feature = "blitzar"))]
+type TestEvaluationProof = NaiveEvaluationProof;
+type TestScalar = <TestEvaluationProof as CommitmentEvaluationProof>::Scalar;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -160,10 +169,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_filter() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<TestEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let where_clause = equal(column(&t, "a", &accessor), const_int128(5_i128));
     let ast = legacy_filter(cols_expr_plan(&t, &["b"], &accessor), tab(&t), where_clause);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -181,14 +192,14 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_first_
         borrowed_bigint("b", [0; 0], &alloc),
         borrowed_int128("c", [0; 0], &alloc),
         borrowed_varchar("d", [""; 0], &alloc),
-        borrowed_scalar("e", [0; 0], &alloc),
+        borrowed_scalar("e", [0_i128; 0], &alloc),
     ]);
     let data_length = data.num_rows();
     let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let expr = legacy_filter(
@@ -206,13 +217,13 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_first_
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -230,14 +241,14 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_first_round_evaluate() {
         borrowed_bigint("b", [1, 2, 3, 4, 5], &alloc),
         borrowed_int128("c", [1, 2, 3, 4, 5], &alloc),
         borrowed_varchar("d", ["1", "2", "3", "4", "5"], &alloc),
-        borrowed_scalar("e", [1, 2, 3, 4, 5], &alloc),
+        borrowed_scalar("e", [1_i128, 2, 3, 4, 5], &alloc),
     ]);
     let data_length = data.num_rows();
     let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let expr = legacy_filter(
@@ -255,13 +266,13 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_first_round_evaluate() {
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -279,20 +290,20 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_firs
         borrowed_bigint("b", [1, 2, 3, 4, 5], &alloc),
         borrowed_int128("c", [1, 2, 3, 4, 5], &alloc),
         borrowed_varchar("d", ["1", "2", "3", "4", "5"], &alloc),
-        borrowed_scalar("e", [1, 2, 3, 4, 5], &alloc),
+        borrowed_scalar("e", [1_i128, 2, 3, 4, 5], &alloc),
     ]);
     let data_length = data.num_rows();
     let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let expr = legacy_filter(cols_expr_plan(&t, &[], &accessor), tab(&t), where_clause);
     let fields = &[];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
@@ -310,14 +321,14 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_first_round_evaluate(
         borrowed_bigint("b", [1, 2, 3, 4, 5], &alloc),
         borrowed_int128("c", [1, 2, 3, 4, 5], &alloc),
         borrowed_varchar("d", ["1", "2", "3", "4", "5"], &alloc),
-        borrowed_scalar("e", [1, 2, 3, 4, 5], &alloc),
+        borrowed_scalar("e", [1_i128, 2, 3, 4, 5], &alloc),
     ]);
     let data_length = data.num_rows();
     let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let expr = legacy_filter(
@@ -335,13 +346,13 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_first_round_evaluate(
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [3, 5]),
         int128("c", [3, 5]),
         varchar("d", ["3", "5"]),
@@ -357,23 +368,24 @@ fn we_can_prove_a_filter_on_an_empty_table() {
         bigint("b", [3; 0]),
         int128("c", [3; 0]),
         varchar("d", ["3"; 0]),
-        scalar("e", [3; 0]),
+        scalar("e", [3_i128; 0]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = legacy_filter(
         cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),
         int128("c", [3; 0]),
         varchar("d", ["3"; 0]),
-        scalar("e", [3; 0]),
+        scalar("e", [3_i128; 0]),
     ]);
     assert_eq!(res, expected);
 }
@@ -385,24 +397,26 @@ fn we_can_prove_a_filter_with_empty_results() {
         bigint("b", [1, 2, 3, 4, 5]),
         int128("c", [1, 2, 3, 4, 5]),
         varchar("d", ["1", "2", "3", "4", "5"]),
-        scalar("e", [1, 2, 3, 4, 5]),
+        scalar("e", [1_i128, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = legacy_filter(
         cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),
         int128("c", [3; 0]),
         varchar("d", ["3"; 0]),
-        scalar("e", [3; 0]),
+        scalar("e", [3_i128; 0]),
     ]);
     assert_eq!(res, expected);
 }
@@ -414,10 +428,10 @@ fn we_can_prove_a_filter() {
         bigint("b", [1, 2, 3, 4, 7]),
         int128("c", [1, 3, 3, 4, 5]),
         varchar("d", ["1", "2", "3", "4", "5"]),
-        scalar("e", [1, 2, 3, 4, 5]),
+        scalar("e", [1_i128, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = legacy_filter(
         vec![
@@ -434,14 +448,16 @@ fn we_can_prove_a_filter() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(105)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3, 7]),
         int128("c", [3, 5]),
         varchar("d", ["3", "5"]),
-        scalar("e", [3, 5]),
+        scalar("e", [3_i128, 5]),
         int128("const", [105, 105]),
         boolean("bool", [true, false]),
     ]);

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -19,7 +19,7 @@ mod legacy_filter_exec;
 pub(crate) use legacy_filter_exec::LegacyFilterExec;
 #[cfg(test)]
 pub(crate) use legacy_filter_exec::OstensibleLegacyFilterExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod legacy_filter_exec_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod legacy_filter_exec_test_dishonest_prover;


### PR DESCRIPTION
## Summary
- run legacy filter proof-plan tests in no-default-features test builds
- parameterize the test proof type so no-blitzar builds use NaiveEvaluationProof while blitzar builds keep InnerProductProof verification

/claim #560

## Coverage
- Target: crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
- Baseline covered lines: 21
- Covered lines after this test run: 170
- Newly covered lines: 158

## Tests
- cargo test -p proof-of-sql sql::proof_plans::legacy_filter_exec_test --no-default-features --features=test
- cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/legacy-filter-after.lcov -- sql::proof_plans::legacy_filter_exec_test
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh