### PR TITLE
test: run slice and union tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -49,12 +49,12 @@ mod aggregate_exec_test;
 
 mod slice_exec;
 pub(crate) use slice_exec::SliceExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod slice_exec_test;
 
 mod union_exec;
 pub(crate) use union_exec::UnionExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod union_exec_test;
 
 mod sort_merge_join_exec;

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -1,6 +1,11 @@
 use super::test_utility::*;
+#[cfg(not(feature = "blitzar"))]
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
+#[cfg(feature = "blitzar")]
+use crate::{base::commitment::InnerProductProof, sql::proof::exercise_verification};
 use crate::{
     base::{
+        commitment::CommitmentEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnType, OwnedTable,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
@@ -8,17 +13,18 @@ use crate::{
         map::{indexmap, IndexMap},
         math::decimal::Precision,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{
-            exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
-            VerifiableQueryResult,
-        },
+        proof::{FirstRoundBuilder, ProvableQueryResult, ProverEvaluate, VerifiableQueryResult},
         proof_exprs::{test_utility::*, DynProofExpr},
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
+
+#[cfg(feature = "blitzar")]
+type TestEvaluationProof = InnerProductProof;
+#[cfg(not(feature = "blitzar"))]
+type TestEvaluationProof = NaiveEvaluationProof;
+type TestScalar = <TestEvaluationProof as CommitmentEvaluationProof>::Scalar;
 
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
@@ -28,7 +34,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
     ]);
     let t: TableRef = "sxt.t".parse().unwrap();
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<TestEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = slice_exec(
         projection(
             cols_expr_plan(&t, &["a", "b"], &accessor),
@@ -43,7 +49,9 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -61,7 +69,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<TestEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(2));
     let table_plan = table_exec(
         t.clone(),
@@ -79,7 +87,9 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -97,14 +107,14 @@ fn we_can_get_an_empty_result_from_a_slice_on_an_empty_table_using_first_round_e
         borrowed_bigint("b", [0; 0], &alloc),
         borrowed_int128("c", [0; 0], &alloc),
         borrowed_varchar("d", [""; 0], &alloc),
-        borrowed_scalar("e", [0; 0], &alloc),
+        borrowed_scalar("e", [0_i128; 0], &alloc),
     ]);
     let data_length = data.num_rows();
     let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let table_plan = table_exec(
@@ -137,13 +147,13 @@ fn we_can_get_an_empty_result_from_a_slice_on_an_empty_table_using_first_round_e
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -168,7 +178,7 @@ fn we_can_get_an_empty_result_from_a_slice_using_first_round_evaluate() {
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let table_plan = table_exec(
@@ -201,13 +211,13 @@ fn we_can_get_an_empty_result_from_a_slice_using_first_round_evaluate() {
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -225,14 +235,14 @@ fn we_can_get_no_columns_from_a_slice_with_empty_input_using_first_round_evaluat
         borrowed_bigint("b", [1, 2, 3, 4, 5], &alloc),
         borrowed_int128("c", [1, 2, 3, 4, 5], &alloc),
         borrowed_varchar("d", ["1", "2", "3", "4", "5"], &alloc),
-        borrowed_scalar("e", [1, 2, 3, 4, 5], &alloc),
+        borrowed_scalar("e", [1_i128, 2, 3, 4, 5], &alloc),
     ]);
     let data_length = data.num_rows();
     let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let table_plan = table_exec(
@@ -252,7 +262,7 @@ fn we_can_get_no_columns_from_a_slice_with_empty_input_using_first_round_evaluat
     );
     let fields = &[];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
@@ -277,7 +287,7 @@ fn we_can_get_the_correct_result_from_a_slice_using_first_round_evaluate() {
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let table_plan = table_exec(
@@ -309,13 +319,13 @@ fn we_can_get_the_correct_result_from_a_slice_using_first_round_evaluate() {
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [5]),
         int128("c", [5]),
         varchar("d", ["5"]),
@@ -331,10 +341,10 @@ fn we_can_prove_a_slice_exec() {
         bigint("b", [1, 2, 3, 4, 7]),
         int128("c", [1, 3, 3, 4, 5]),
         varchar("d", ["1", "2", "3", "4", "5"]),
-        scalar("e", [1, 2, 3, 4, 5]),
+        scalar("e", [1_i128, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -365,14 +375,16 @@ fn we_can_prove_a_slice_exec() {
         2,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [4]),
         int128("c", [4]),
         varchar("d", ["4"]),
-        scalar("e", [4]),
+        scalar("e", [4_i128]),
         int128("const", [105]),
         boolean("bool", [true]),
     ]);
@@ -386,10 +398,10 @@ fn we_can_prove_a_nested_slice_exec() {
         bigint("b", [1, 2, 3, 4, 7]),
         int128("c", [1, 3, 3, 4, 5]),
         varchar("d", ["1", "2", "3", "4", "5"]),
-        scalar("e", [1, 2, 3, 4, 5]),
+        scalar("e", [1_i128, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -424,14 +436,16 @@ fn we_can_prove_a_nested_slice_exec() {
         1,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [4]),
         int128("c", [4]),
         varchar("d", ["4"]),
-        scalar("e", [4]),
+        scalar("e", [4_i128]),
         int128("const", [105]),
         boolean("bool", [true]),
     ]);
@@ -445,10 +459,10 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         bigint("b", [1, 2, 3, 4, 7]),
         int128("c", [1, 3, 3, 4, 5]),
         varchar("d", ["1", "2", "3", "4", "5"]),
-        scalar("e", [1, 2, 3, 4, 5]),
+        scalar("e", [1_i128, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -483,14 +497,16 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
-        scalar("e", [0; 0]),
+        scalar("e", [0_i128; 0]),
         int128("const", [0; 0]),
         boolean("bool", [true; 0]),
     ]);
@@ -504,10 +520,10 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         bigint("b", [1, 2, 3, 4, 7]),
         int128("c", [1, 3, 3, 4, 5]),
         varchar("d", ["1", "2", "3", "4", "5"]),
-        scalar("e", [1, 2, 3, 4, 5]),
+        scalar("e", [1_i128, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -542,14 +558,16 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
-        scalar("e", [0; 0]),
+        scalar("e", [0_i128; 0]),
         int128("const", [0; 0]),
         boolean("bool", [true; 0]),
     ]);
@@ -572,7 +590,7 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         1,
         Some(4),
     );
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+    let accessor = TableTestAccessor::<TestEvaluationProof>::new_from_table(
         table_ref.clone(),
         table([
             borrowed_bigint("language_rank", [0_i64, 1, 2, 3], &alloc),
@@ -595,7 +613,9 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])
@@ -615,9 +635,10 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
 #[test]
 fn we_can_create_and_prove_a_slice_exec_on_top_of_an_empty_exec() {
     let empty_table = owned_table([]);
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let expr = slice_exec(empty_exec(), 3, Some(2));
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     assert_eq!(res, empty_table);
 }
@@ -630,7 +651,7 @@ fn we_can_prove_a_slice_exec_if_it_has_groupby_with_provable_uniqueness_as_input
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let plan = slice_exec(
         group_by(
@@ -643,8 +664,9 @@ fn we_can_prove_a_slice_exec_if_it_has_groupby_with_provable_uniqueness_as_input
         1,
         None,
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
+    let verifiable_res: VerifiableQueryResult<TestEvaluationProof> =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &plan, &accessor, &t);
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -1,23 +1,29 @@
 use super::test_utility::*;
+#[cfg(not(feature = "blitzar"))]
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
+#[cfg(feature = "blitzar")]
+use crate::{base::commitment::InnerProductProof, sql::proof::exercise_verification};
 use crate::{
     base::{
+        commitment::CommitmentEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnType, OwnedTable,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         map::indexmap,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{
-            exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
-            VerifiableQueryResult,
-        },
+        proof::{FirstRoundBuilder, ProvableQueryResult, ProverEvaluate, VerifiableQueryResult},
         proof_exprs::test_utility::*,
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
+
+#[cfg(feature = "blitzar")]
+type TestEvaluationProof = InnerProductProof;
+#[cfg(not(feature = "blitzar"))]
+type TestEvaluationProof = NaiveEvaluationProof;
+type TestScalar = <TestEvaluationProof as CommitmentEvaluationProof>::Scalar;
 
 #[test]
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: NotEnoughInputPlans")]
@@ -33,7 +39,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_with_one_table() {
         varchar("b0", ["", "1", "2", "3", "4"]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -55,7 +61,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
     let t0 = TableRef::new("sxt", "t0");
     let data1 = owned_table([bigint("a1", [0_i64; 0])]);
     let t1 = TableRef::new("sxt", "t1");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t0.clone(), data0, 0);
     accessor.add_table(t1.clone(), data1, 0);
     let ast = union_exec(vec![
@@ -69,7 +75,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
         ),
     ]);
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<TestEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -91,7 +97,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
         borrowed_varchar("b1", ["2", "3", "4", "5", "6"], &alloc),
     ]);
     let t1 = TableRef::new("sxt", "t1");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t0.clone(), data0, 0);
     accessor.add_table(t1.clone(), data1, 0);
     let ast = union_exec(vec![
@@ -113,7 +119,9 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
             ],
         ),
     ]);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -165,7 +173,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
         borrowed_varchar("b6", ["8", "9", "10", "11"], &alloc),
     ]);
     let t6 = TableRef::new("sxt", "t6");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t0.clone(), data0, 0);
     accessor.add_table(t1.clone(), data1, 0);
     accessor.add_table(t2.clone(), data2, 0);
@@ -254,7 +262,9 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
             ],
         ),
     ]);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -296,7 +306,7 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
 
     let data_length = std::cmp::max(len_0, len_1);
 
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t0.clone(), data0, 0);
     accessor.add_table(t1.clone(), data1, 0);
     let fields = vec![
@@ -326,14 +336,14 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
         ),
     ]);
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         ast.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(&fields)
     .unwrap();
 
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("a", [1_i64, 2, 3, 4, 5, 2, 3, 4, 5, 6]),
         varchar("b", ["1", "2", "3", "4", "5", "2", "3", "4", "5", "6"]),
     ]);


### PR DESCRIPTION
## Summary

- run `slice_exec_test` and `union_exec_test` under the no-default/no-blitzar test configuration
- use `NaiveEvaluationProof` as the non-blitzar evaluation proof while keeping `InnerProductProof` for blitzar builds
- keep `exercise_verification(...)` gated to blitzar, matching the existing proof-plan test pattern

/claim #560

## Coverage note

Focused llvm-cov run for `sql::proof_plans` reports 265 covered source lines across:

- `crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs`: 137 covered lines
- `crates/proof-of-sql/src/sql/proof_plans/union_exec.rs`: 128 covered lines

At the issue's `$0.10` per newly covered line rule, this is an estimated `$26.50`, subject to maintainer/Algora final accounting.

## Tests

- `cargo test -p proof-of-sql sql::proof_plans::slice_exec_test --no-default-features --features=test`
- `cargo test -p proof-of-sql sql::proof_plans::union_exec_test --no-default-features --features=test`
- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/slice-union-after.lcov -- sql::proof_plans`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`
