### PR TITLE
test: run dishonest legacy filter test without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test_dishonest_prover.rs
@@ -21,8 +21,17 @@ use crate::{
     },
     utils::log,
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
+
+#[cfg(not(feature = "blitzar"))]
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
+#[cfg(feature = "blitzar")]
+use crate::base::commitment::InnerProductProof;
+
+#[cfg(feature = "blitzar")]
+type TestEvaluationProof = InnerProductProof;
+#[cfg(not(feature = "blitzar"))]
+type TestEvaluationProof = NaiveEvaluationProof;
 
 #[derive(Debug, PartialEq)]
 struct Dishonest;
@@ -180,17 +189,18 @@ fn we_fail_to_verify_a_basic_filter_with_a_dishonest_prover() {
         bigint("b", [1, 2, 3, 4, 5]),
         int128("c", [1, 2, 3, 4, 5]),
         varchar("d", ["1", "2", "3", "4", "5"]),
-        scalar("e", [1, 2, 3, 4, 5]),
+        scalar("e", [1_i128, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = DishonestFilterExec::new(
         cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(105_i128)),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     assert!(matches!(
         res.verify(&expr, &accessor, &(), &[]),
         Err(QueryError::ProofError {

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use legacy_filter_exec::LegacyFilterExec;
 pub(crate) use legacy_filter_exec::OstensibleLegacyFilterExec;
 #[cfg(all(test, feature = "blitzar"))]
 mod legacy_filter_exec_test;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod legacy_filter_exec_test_dishonest_prover;
 
 mod fold_util;


### PR DESCRIPTION
Summary
- enable the dishonest legacy filter prover test under no-default test builds
- use NaiveEvaluationProof when blitzar is disabled and keep InnerProductProof for blitzar builds
- preserve the existing dishonest prover behavior and verification failure assertion

Bounty claim
/claim #560

Coverage evidence
- Before this change, the focused no-default command ran 0 tests for this module.
- After this change, `legacy_filter_exec_test_dishonest_prover` runs 1 passing test under `--no-default-features --features=test`.
- Conservative non-overlap accounting against my existing local #560 coverage reports: 126 newly covered source lines, estimated $12.60 at $0.10/line, subject to maintainer review and final Algora accounting.

Tests
- cargo test -p proof-of-sql sql::proof_plans::legacy_filter_exec_test_dishonest_prover --no-default-features --features=test
- cargo test -p proof-of-sql sql::proof_plans --no-default-features --features=test
- cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/dishonest-legacy-filter-after.lcov -- sql::proof_plans::legacy_filter_exec_test_dishonest_prover
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.