### PR TITLE
test: run scaling cast tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -81,5 +81,5 @@ mod cast_expr_test;
 
 mod scaling_cast_expr;
 pub(crate) use scaling_cast_expr::ScalingCastExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod scaling_cast_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
@@ -1,3 +1,9 @@
+#[cfg(not(feature = "blitzar"))]
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
+#[cfg(feature = "blitzar")]
+use crate::base::commitment::InnerProductProof;
+#[cfg(feature = "blitzar")]
+use crate::sql::proof::exercise_verification;
 use crate::{
     base::{
         database::{
@@ -10,7 +16,7 @@ use crate::{
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::VerifiableQueryResult,
         proof_exprs::{
             test_utility::{aliased_plan, column, scaling_cast},
             LiteralExpr,
@@ -18,7 +24,11 @@ use crate::{
         proof_plans::test_utility::{column_field, filter, table_exec},
     },
 };
-use blitzar::proof::InnerProductProof;
+
+#[cfg(feature = "blitzar")]
+type TestEvaluationProof = InnerProductProof;
+#[cfg(not(feature = "blitzar"))]
+type TestEvaluationProof = NaiveEvaluationProof;
 
 #[test]
 fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
@@ -32,7 +42,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<TestEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             aliased_plan(
@@ -91,7 +101,9 @@ fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -117,7 +129,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_decimal_to_decimal() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<TestEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             aliased_plan(
@@ -152,7 +164,9 @@ fn we_can_prove_a_simple_scale_cast_expr_from_decimal_to_decimal() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -176,7 +190,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_timestamp_to_timestamp() {
     )]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<TestEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_plan(
             scaling_cast(
@@ -194,7 +208,9 @@ fn we_can_prove_a_simple_scale_cast_expr_from_timestamp_to_timestamp() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res =
+        VerifiableQueryResult::<TestEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
+    #[cfg(feature = "blitzar")]
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])


### PR DESCRIPTION
Summary

- enables scaling_cast_expr tests outside the blitzar feature gate
- uses NaiveEvaluationProof for no-blitzar test builds while keeping InnerProductProof verification for blitzar builds
- adds coverage for integer, decimal, and timestamp scaling casts in the no-default-features test path

Coverage

- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/scaling-cast-after.lcov -- sql::proof_exprs::scaling_cast_expr_test`
- conservative local non-overlap estimate: 230 newly covered lines versus existing local llvm-cov reports, estimated $23.00 under #560

Tests

- `cargo test -p proof-of-sql sql::proof_exprs::scaling_cast_expr_test --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/scaling-cast-after.lcov -- sql::proof_exprs::scaling_cast_expr_test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

/claim #560