### PR TITLE
test: cover TableRef and Arrow schema utility

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,68 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_floating_point_fields_to_decimal256() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("half", DataType::Float16, true),
+            Field::new("single", DataType::Float32, false),
+            Field::new("double", DataType::Float64, true),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(
+            converted
+                .fields()
+                .iter()
+                .map(|field| field.data_type())
+                .collect::<Vec<_>>(),
+            vec![
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+            ]
+        );
+        assert!(converted.field(0).is_nullable());
+        assert!(!converted.field(1).is_nullable());
+        assert!(converted.field(2).is_nullable());
+    }
+
+    #[test]
+    fn preserves_non_floating_point_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("payload", DataType::Utf8, true),
+            Field::new("amount", DataType::Decimal256(75, 30), false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(converted.field(0), schema.field(0));
+        assert_eq!(converted.field(1), schema.field(1));
+        assert_eq!(converted.field(2), schema.field(2));
+    }
+
+    #[test]
+    fn returns_new_schema_without_mutating_input() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "score",
+            DataType::Float64,
+            false,
+        )]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(schema.field(0).data_type(), &DataType::Float64);
+        assert_eq!(
+            converted.field(0).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert!(!Arc::ptr_eq(&schema, &converted));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,111 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::Equivalent;
+
+    #[test]
+    fn new_omits_empty_schema_name() {
+        let table_ref = TableRef::new("", "orders");
+
+        assert_eq!(table_ref.schema_id(), None);
+        assert_eq!(table_ref.table_id().value, "orders");
+        assert_eq!(table_ref.to_string(), "orders");
+    }
+
+    #[test]
+    fn constructors_preserve_schema_and_table_names() {
+        let from_new = TableRef::new("analytics", "events");
+        let from_names = TableRef::from_names(Some("analytics"), "events");
+        let from_idents =
+            TableRef::from_idents(Some(Ident::new("analytics")), Ident::new("events"));
+
+        assert_eq!(from_new, from_names);
+        assert_eq!(from_names, from_idents);
+        assert_eq!(from_idents.schema_id().unwrap().value, "analytics");
+        assert_eq!(from_idents.table_id().value, "events");
+        assert_eq!(from_idents.to_string(), "analytics.events");
+    }
+
+    #[test]
+    fn from_strs_accepts_one_or_two_components() {
+        let table_only = TableRef::from_strs(&["orders"]).unwrap();
+        assert_eq!(table_only, TableRef::from_names(None, "orders"));
+
+        let schema_table = TableRef::from_strs(&["analytics", "events"]).unwrap();
+        assert_eq!(
+            schema_table,
+            TableRef::from_names(Some("analytics"), "events")
+        );
+    }
+
+    #[test]
+    fn from_strs_rejects_invalid_component_counts() {
+        let empty_components: [&str; 0] = [];
+        let empty_error = TableRef::from_strs(&empty_components).unwrap_err();
+        assert!(matches!(
+            empty_error,
+            ParseError::InvalidTableReference { .. }
+        ));
+
+        let too_many_error = TableRef::from_strs(&["a", "b", "c"]).unwrap_err();
+        assert!(matches!(
+            too_many_error,
+            ParseError::InvalidTableReference { table_reference }
+                if table_reference == "a,b,c"
+        ));
+    }
+
+    #[test]
+    fn dot_separated_parsing_matches_from_str() {
+        let parsed = TableRef::try_from("analytics.events").unwrap();
+        let from_str = "analytics.events".parse::<TableRef>().unwrap();
+
+        assert_eq!(parsed, TableRef::new("analytics", "events"));
+        assert_eq!(parsed, from_str);
+    }
+
+    #[test]
+    fn dot_separated_parsing_rejects_too_many_components() {
+        let error = TableRef::try_from("catalog.analytics.events").unwrap_err();
+
+        assert!(matches!(
+            error,
+            ParseError::InvalidTableReference { table_reference }
+                if table_reference == "catalog.analytics.events"
+        ));
+    }
+
+    #[test]
+    fn equivalent_matches_identical_table_refs_only() {
+        let table_ref = TableRef::new("analytics", "events");
+        let same = TableRef::new("analytics", "events");
+        let different_schema = TableRef::new("warehouse", "events");
+        let different_table = TableRef::new("analytics", "orders");
+
+        assert!((&table_ref).equivalent(&same));
+        assert!(!(&table_ref).equivalent(&different_schema));
+        assert!(!(&table_ref).equivalent(&different_table));
+    }
+
+    #[test]
+    fn serde_round_trips_table_refs_as_strings() {
+        let table_ref = TableRef::new("analytics", "events");
+
+        let encoded = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(encoded, "\"analytics.events\"");
+
+        let decoded: TableRef = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, table_ref);
+    }
+
+    #[test]
+    fn serde_rejects_invalid_table_ref_strings() {
+        let error = serde_json::from_str::<TableRef>("\"a.b.c\"").unwrap_err();
+
+        assert!(error.to_string().contains("Invalid table reference: a.b.c"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add direct unit coverage for TableRef construction, parsing, display, equivalence, and serde behavior.
- Add Arrow schema utility coverage for floating-point conversion, non-floating preservation, and input immutability.

## Validation
- cargo fmt --check
- cargo test -p proof-of-sql --no-default-features --features std,test,arrow table_ref
- cargo test -p proof-of-sql --no-default-features --features std,test,arrow arrow_schema_utility

Note: I used the macOS-compatible feature set above because the default perf feature pulls blitzar, whose build script is Linux-only, and halo2curves asm is x86_64-only.

/claim #560