### PR TITLE
test: cover PoSQL time unit conversions

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,27 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_errors_convert_to_display_strings() {
+        let timezone_error: String = PoSQLTimestampError::InvalidTimezone {
+            timezone: "MARS".into(),
+        }
+        .into();
+        assert_eq!(timezone_error, "invalid timezone string: MARS");
+
+        let unit_error: String = PoSQLTimestampError::InvalidTimeUnit {
+            error: "fortnight".into(),
+        }
+        .into();
+        assert_eq!(unit_error, "Invalid time unit");
+
+        let precision_error: String =
+            PoSQLTimestampError::UnsupportedPrecision { error: "2".into() }.into();
+        assert_eq!(precision_error, "Unsupported precision for timestamp: 2");
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -69,6 +69,31 @@ mod time_unit_tests {
     }
 
     #[test]
+    fn test_time_units_convert_to_precision_values() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn test_time_units_display_with_precision() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
+
+    #[test]
     fn test_invalid_precision() {
         let invalid_precisions = [
             "1", "2", "4", "5", "7", "8", "10", "zero", "three", "cat", "-1", "-2",


### PR DESCRIPTION
## Summary

/claim #560

Adds focused test-only coverage for a small non-overlapping `posql_time` slice:

- covers `From<PoSQLTimeUnit> for u64` precision mappings
- covers `PoSQLTimeUnit` display strings
- covers `From<PoSQLTimestampError> for String` display conversion for representative timestamp errors

I intentionally avoided `PoSQLTimeZone` because an issue comment already claimed that nearby coverage slice.

## Validation

- `cargo fmt --check`
- `cargo test -p proof-of-sql time_unit_tests --no-default-features --features=test`
- `cargo test -p proof-of-sql timestamp_errors_convert_to_display_strings --no-default-features --features=test`
- `git diff --check`

The focused test runs pass. The output includes existing unused/dead-code warnings outside this test-only change.

## Disclosure

This PR was prepared with AI assistance, then manually reviewed and validated before submission.
