### PR TITLE
[codex] add database reference tests

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,34 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_stores_column_metadata() {
+        let table_ref = TableRef::new("public", "transactions");
+        let column_id = Ident::new("amount");
+        let column_ref = ColumnRef::new(table_ref.clone(), column_id.clone(), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), column_id);
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+    }
+
+    #[test]
+    fn accessors_return_owned_identifier_values() {
+        let table_ref = TableRef::new("public", "transactions");
+        let column_ref = ColumnRef::new(table_ref, Ident::new("amount"), ColumnType::BigInt);
+
+        let mut returned_column_id = column_ref.column_id();
+        returned_column_id.value = "other_column".into();
+
+        assert_eq!(
+            column_ref.table_ref(),
+            TableRef::new("public", "transactions")
+        );
+        assert_eq!(column_ref.column_id().value, "amount");
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,74 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_omits_empty_schema() {
+        let table_ref = TableRef::new("", "transactions");
+
+        assert_eq!(table_ref.schema_id(), None);
+        assert_eq!(table_ref.table_id().value, "transactions");
+        assert_eq!(table_ref.to_string(), "transactions");
+    }
+
+    #[test]
+    fn new_records_non_empty_schema() {
+        let table_ref = TableRef::new("public", "transactions");
+
+        assert_eq!(
+            table_ref.schema_id().map(|schema| schema.value.as_str()),
+            Some("public")
+        );
+        assert_eq!(table_ref.table_id().value, "transactions");
+        assert_eq!(table_ref.to_string(), "public.transactions");
+    }
+
+    #[test]
+    fn from_strs_accepts_table_and_schema_table_forms() {
+        assert_eq!(
+            TableRef::from_strs(&["transactions"]).unwrap(),
+            TableRef::from_names(None, "transactions")
+        );
+        assert_eq!(
+            TableRef::from_strs(&["public", "transactions"]).unwrap(),
+            TableRef::from_names(Some("public"), "transactions")
+        );
+    }
+
+    #[test]
+    fn from_strs_rejects_invalid_component_counts() {
+        assert!(matches!(
+            TableRef::from_strs::<&str>(&[]),
+            Err(ParseError::InvalidTableReference { table_reference }) if table_reference.is_empty()
+        ));
+        assert!(matches!(
+            TableRef::from_strs(&["catalog", "public", "transactions"]),
+            Err(ParseError::InvalidTableReference { table_reference })
+                if table_reference == "catalog,public,transactions"
+        ));
+    }
+
+    #[test]
+    fn try_from_rejects_too_many_dot_separated_components() {
+        assert!(matches!(
+            TableRef::try_from("catalog.public.transactions"),
+            Err(ParseError::InvalidTableReference { table_reference })
+                if table_reference == "catalog.public.transactions"
+        ));
+    }
+
+    #[test]
+    fn serde_round_trip_uses_display_form() {
+        let table_ref = TableRef::new("public", "transactions");
+
+        let serialized = serde_json::to_string(&table_ref).unwrap();
+        let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(serialized, "\"public.transactions\"");
+        assert_eq!(deserialized, table_ref);
+    }
+}


### PR DESCRIPTION
## Summary
- Add direct unit coverage for `ColumnRef` constructor and accessor behavior.
- Add direct unit coverage for `TableRef` schema handling, parsing forms, invalid references, display formatting, and serde round-trip behavior.

## Why
This contributes a small focused coverage improvement for #560 by covering database reference primitives that were previously exercised mostly through callers.

## Validation
- `cargo fmt`
- `cargo test -p proof-of-sql --no-default-features --features test base::database`

Note: default-feature tests do not build on macOS ARM because `blitzar-sys` supports Linux only and `halo2curves/asm` is x86_64-only. The no-default-features test lane avoids those platform-specific features for these pure unit tests.

## Bounty
/claim #560

Contributes to #560