### PR TITLE
test: cover mont scalar byte helpers

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -52,3 +52,37 @@ fn we_can_bound_modulus_using_max_bits() {
     assert!(modulus_of_i_max_bits <= modulus_of_test_scalar);
     assert!(modulus_of_i_max_bits_plus_1 > modulus_of_test_scalar);
 }
+
+#[test]
+fn we_can_roundtrip_mont_scalar_le_bytes() {
+    let scalars = [
+        TestScalar::ZERO,
+        TestScalar::ONE,
+        TestScalar::from(255_u64),
+        TestScalar::MAX_SIGNED,
+        -TestScalar::ONE,
+    ];
+
+    for scalar in scalars {
+        assert_eq!(
+            TestScalar::from_le_bytes_mod_order(&scalar.to_bytes_le()),
+            scalar
+        );
+    }
+}
+
+#[test]
+fn we_can_wrap_and_unwrap_mont_scalar_slices() {
+    let scalars = vec![
+        TestScalar::ZERO,
+        TestScalar::from(17_u64),
+        -TestScalar::from(42_u64),
+        TestScalar::MAX_SIGNED,
+    ];
+
+    let raw_scalars = TestScalar::unwrap_slice(&scalars);
+    let wrapped_scalars = TestScalar::wrap_slice(&raw_scalars);
+
+    assert_eq!(wrapped_scalars, scalars);
+    assert_eq!(TestScalar::unwrap_slice(&wrapped_scalars), raw_scalars);
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for `MontScalar::from_le_bytes_mod_order` and `to_bytes_le` round-tripping
- add focused coverage for the test-only `wrap_slice` / `unwrap_slice` helpers preserving underlying field elements
- test-only change; no production behavior changes

## Validation
- `cargo --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' --config 'target.x86_64-unknown-linux-gnu.linker="cc"' test -p proof-of-sql mont_scalar --no-default-features --features=test`\n  - 4 passed, 0 failed, 958 filtered out\n- `cargo fmt --check`\n- `git diff --check HEAD~1..HEAD`\n- `source scripts/check_commits.sh`\n  - 1 commit checked, 0 failed\n\nAI-assisted with OpenAI Codex; I reviewed the diff and verification output before submitting.