### PR TITLE
test: cover add const edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
@@ -7,3 +7,17 @@ fn test_add_const() {
     let b = vec![1 + 10, 2 + 10, 3 + 10, 4 + 10];
     assert_eq!(a, b);
 }
+
+#[test]
+fn we_can_add_const_to_empty_slice() {
+    let mut values: Vec<i32> = Vec::new();
+    add_const(&mut values, 17);
+    assert!(values.is_empty());
+}
+
+#[test]
+fn we_can_add_const_from_convertible_type() {
+    let mut values = vec![1_i64, -2, 3];
+    add_const(&mut values, 4_i32);
+    assert_eq!(values, [5, 2, 7]);
+}


### PR DESCRIPTION
/claim #560

## Summary
- add a no-op empty-slice regression test for `add_const`
- cover the generic `S: Into<T>` path with an `i32` constant added into an `i64` slice

## Validation
- `cargo fmt --check`
- `cargo test -p proof-of-sql add_const --no-default-features --features=test`
- `git diff --check`

This PR is intentionally small and test-only. It was AI-assisted, then manually reviewed and validated before submission.