### PR TITLE
test: run commitment tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -349,7 +349,7 @@ impl<C> FromIterator<(Ident, ColumnCommitmentMetadata, C)> for ColumnCommitments
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -374,20 +374,24 @@ fn num_rows_of_columns<'a>(
     Ok(num_rows)
 }
 
-#[cfg(all(test, feature = "arrow", feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "arrow")]
+    use crate::base::database::Column;
     use crate::base::{
         commitment::naive_commitment::NaiveCommitment,
-        database::{owned_table_utility::*, Column, OwnedColumn},
+        database::{owned_table_utility::*, OwnedColumn},
         map::IndexMap,
         scalar::test_scalar::TestScalar,
     };
+    #[cfg(feature = "arrow")]
     use arrow::{
         array::{Int64Array, StringArray},
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
+    #[cfg(feature = "arrow")]
     use std::sync::Arc;
 
     #[test]
@@ -1151,6 +1155,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "arrow")]
     #[test]
     fn we_can_create_and_append_table_commitments_with_record_batches() {
         let schema = Arc::new(Schema::new(vec![


### PR DESCRIPTION
## Summary
- Enable the existing `ColumnCommitments` unit tests under the no-default-features test configuration.
- Enable the existing `TableCommitment` unit tests under the no-default-features test configuration.
- Keep the record batch test gated behind `arrow`, since it still depends on Arrow types.

## Why
This contributes to #560 by making existing commitment coverage count in the no-default `test` feature lane, which is useful on macOS and other environments where the default `blitzar` feature is not available.

## Coverage
Baseline from `origin/main` with `cargo llvm-cov -p proof-of-sql --no-default-features --features test --json --summary-only`:
- `column_commitments.rs`: 33/194 covered lines
- `table_commitment.rs`: 10/177 covered lines

After this change with the same coverage command:
- `column_commitments.rs`: 598/619 covered lines
- `table_commitment.rs`: 683/707 covered lines

Conservative production-code-only estimate, excluding inline test modules from the line count:
- `column_commitments.rs`: about 164/183 covered production lines
- `table_commitment.rs`: about 150/170 covered production lines


## Overlap note
I checked the current open PR file list before submitting. There are older PRs that touch nearby files, notably #1365 for a small hand-written `ColumnCommitments` coverage slice and #1345 for a narrow `TableCommitment` error-mapping test. This PR is intentionally different: it removes the `blitzar` gate from the existing full `ColumnCommitments` and `TableCommitment` unit-test modules so those tests run in the no-default `test` coverage lane. The Arrow-dependent record-batch test remains behind `arrow`.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test base::commitment`
- `cargo fmt --check`
- `git diff --check`
- `scripts/check_commits.sh`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features test --json --summary-only --output-path /tmp/sxt-proof-of-sql-branch-summary.json`

## Bounty
/claim #560

AI-assisted with OpenAI Codex; I reviewed the diff and validation before submitting.


