### PR TITLE
test: cover timestamp scale casting

### DIFF
--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -73,7 +73,10 @@ pub fn scale_cast_binary_op(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::{ColumnRef, TableRef};
+    use crate::base::{
+        database::{ColumnRef, TableRef},
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    };
 
     #[expect(non_snake_case)]
     fn COLUMN1_BOOLEAN() -> DynProofExpr {
@@ -138,6 +141,24 @@ mod tests {
                 Precision::new(25).expect("Precision is definitely valid"),
                 5,
             ),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN1_TIMESTAMP_SECOND() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN2_TIMESTAMP_MILLISECOND() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column2".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
         ))
     }
 
@@ -234,5 +255,33 @@ mod tests {
         let right = COLUMN2_DECIMAL_25_5();
         let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
         assert_eq!(proof_exprs, (left, right));
+    }
+
+    #[test]
+    fn we_can_convert_scale_cast_binary_op_upcasting_left_timestamp() {
+        let left = COLUMN1_TIMESTAMP_SECOND();
+        let right = COLUMN2_TIMESTAMP_MILLISECOND();
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+        assert_eq!(
+            proof_exprs,
+            (
+                DynProofExpr::try_new_scaling_cast(left, right.data_type()).unwrap(),
+                right
+            )
+        );
+    }
+
+    #[test]
+    fn we_can_convert_scale_cast_binary_op_upcasting_right_timestamp() {
+        let left = COLUMN2_TIMESTAMP_MILLISECOND();
+        let right = COLUMN1_TIMESTAMP_SECOND();
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+        assert_eq!(
+            proof_exprs,
+            (
+                left.clone(),
+                DynProofExpr::try_new_scaling_cast(right, left.data_type()).unwrap()
+            )
+        );
     }
 }


### PR DESCRIPTION
Summary

- add timestamp scale-cast branch coverage for `scale_cast_binary_op`
- verify both second-to-millisecond and millisecond-to-second timestamp branches
- keep the change scoped to tests only

Coverage

- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/scale-timestamp-after.lcov -- sql::scale`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/scale-left-timestamp-after.lcov -- we_can_convert_scale_cast_binary_op_upcasting_left_timestamp`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/scale-right-timestamp-after.lcov -- we_can_convert_scale_cast_binary_op_upcasting_right_timestamp`
- conservative local non-overlap estimate from the two new timestamp tests versus existing local aggregate reports: 100 newly covered lines, estimated $10.00 under #560

Tests

- `cargo test -p proof-of-sql sql::scale --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/scale-timestamp-after.lcov -- sql::scale`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/scale-left-timestamp-after.lcov -- we_can_convert_scale_cast_binary_op_upcasting_left_timestamp`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/scale-right-timestamp-after.lcov -- we_can_convert_scale_cast_binary_op_upcasting_right_timestamp`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

/claim #560