### PR TITLE
test: run sign tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use sign_expr::{
 mod range_check;
 #[cfg(all(test, feature = "blitzar"))]
 mod range_check_test;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod sign_expr_test;
 pub(crate) use monotonic::{
     final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic,


### PR DESCRIPTION
Summary

- run the sign proof gadget tests under the no-default `test` feature by removing the unnecessary `blitzar` module gate
- keep the change to a test-module gate only; no production behavior change

Bounty

/claim #560

Local coverage accounting

- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/sign-expr-after.lcov -- sql::proof_gadgets::sign_expr_test`
- conservative local non-overlap estimate against existing local #560 coverage reports: 107 newly covered lines
- estimated nominal amount at $0.10/line: $10.70, subject to maintainer review/final accounting

Validation

- `cargo test -p proof-of-sql sql::proof_gadgets::sign_expr_test --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/sign-expr-after.lcov -- sql::proof_gadgets::sign_expr_test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`