### PR TITLE
test: run accessor tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -108,12 +108,12 @@ pub use test_accessor::TestAccessor;
 
 mod owned_table_test_accessor;
 pub use owned_table_test_accessor::OwnedTableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod owned_table_test_accessor_test;
 
 mod table_test_accessor;
 pub use table_test_accessor::TableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod table_test_accessor_test;
 
 /// Module providing utilities for filtering columns based on selection vectors.


### PR DESCRIPTION
Summary

- run the base database table accessor tests under the no-default `test` feature by removing unnecessary `blitzar` module gates
- keep the change to test-module gates only; no production behavior change

Bounty

/claim #560

Local coverage accounting

- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/accessor-after.lcov -- test_accessor_test`
- conservative local non-overlap estimate against existing local #560 coverage reports: 381 newly covered lines
- estimated nominal amount at $0.10/line: $38.10, subject to maintainer review/final accounting

Validation

- `cargo test -p proof-of-sql test_accessor_test --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/accessor-after.lcov -- test_accessor_test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`