### PR TITLE
test: run round builder tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -1,21 +1,25 @@
-use super::{FinalRoundBuilder, ProvableQueryResult};
-use crate::{
-    base::{
-        commitment::{Commitment, CommittableColumn},
-        database::{Column, ColumnField, ColumnType},
-    },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
-};
-use alloc::{collections::VecDeque, sync::Arc};
+use super::FinalRoundBuilder;
+#[cfg(feature = "arrow")]
+use super::ProvableQueryResult;
+#[cfg(feature = "blitzar")]
+use crate::base::commitment::{Commitment, CommittableColumn};
+#[cfg(feature = "arrow")]
+use crate::base::database::{Column, ColumnField, ColumnType};
+use crate::proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar;
+use alloc::collections::VecDeque;
+#[cfg(feature = "arrow")]
+use alloc::sync::Arc;
 #[cfg(feature = "arrow")]
 use arrow::{
     array::Int64Array,
     datatypes::{Field, Schema},
     record_batch::RecordBatch,
 };
+#[cfg(feature = "blitzar")]
 use curve25519_dalek::RistrettoPoint;
 
 #[test]
+#[cfg(feature = "blitzar")]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
@@ -35,6 +39,7 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
 }
 
 #[test]
+#[cfg(feature = "blitzar")]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder_test.rs
@@ -1,11 +1,12 @@
 use super::FirstRoundBuilder;
-use crate::{
-    base::commitment::{Commitment, CommittableColumn},
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
-};
+#[cfg(feature = "blitzar")]
+use crate::base::commitment::{Commitment, CommittableColumn};
+use crate::proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar;
+#[cfg(feature = "blitzar")]
 use curve25519_dalek::RistrettoPoint;
 
 #[test]
+#[cfg(feature = "blitzar")]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
@@ -26,6 +27,7 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
 }
 
 #[test]
+#[cfg(feature = "blitzar")]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -7,7 +7,7 @@ mod final_round_builder;
 #[cfg(test)]
 pub(crate) mod mock_verification_builder;
 pub(crate) use final_round_builder::FinalRoundBuilder;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod final_round_builder_test;
 
 mod composite_polynomial_builder;
@@ -68,7 +68,7 @@ pub(crate) use result_element_serialization::{
 
 mod first_round_builder;
 pub(crate) use first_round_builder::FirstRoundBuilder;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod first_round_builder_test;
 
 #[cfg(all(test, feature = "arrow"))]


### PR DESCRIPTION
Summary

- run the first/final round builder evaluation and challenge tests under the no-default `test` feature
- keep commitment-specific round builder tests behind `feature = "blitzar"`, because no-blitzar `RistrettoPoint::compute_commitments` is intentionally not implemented
- keep the change test-only; no production behavior change

Bounty

/claim #560

Local coverage accounting

- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/round-builder-after.lcov -- round_builder_test`
- conservative local non-overlap estimate against existing local #560 coverage reports: 60 newly covered lines
- estimated nominal amount at $0.10/line: $6.00, subject to maintainer review/final accounting

Validation

- `cargo test -p proof-of-sql round_builder_test --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/round-builder-after.lcov -- round_builder_test`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

Note

- `cargo test -p proof-of-sql round_builder_test` with default features is blocked on this ARM machine by `halo2curves` enabling `asm`, which reports: `Currently feature asm can only be enabled on x86_64 arch.`