### PR TITLE
test: run query commitment tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -122,17 +122,20 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::{
+        commitment::naive_commitment::NaiveCommitment,
+        database::{owned_table_utility::*, OwnedColumn, OwnedTable},
+        scalar::test_scalar::TestScalar,
+    };
+
+    #[cfg(feature = "blitzar")]
     use crate::{
         base::{
-            commitment::{naive_commitment::NaiveCommitment, Bounds, ColumnBounds},
-            database::{
-                owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableTestAccessor,
-                TestAccessor,
-            },
-            scalar::test_scalar::TestScalar,
+            commitment::{Bounds, ColumnBounds},
+            database::{OwnedTableTestAccessor, TestAccessor},
         },
         proof_primitive::dory::{
             test_rng, DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup, ProverSetup,
@@ -317,6 +320,7 @@ mod tests {
     }
 
     #[expect(clippy::similar_names)]
+    #[cfg(feature = "blitzar")]
     #[test]
     fn we_can_get_query_commitments_from_accessor() {
         let public_parameters = PublicParameters::test_rand(4, &mut test_rng());


### PR DESCRIPTION
/claim #560

## Summary
- ungate the `NaiveCommitment` query commitment tests so they run under the no-default `test` feature
- keep the Dory setup/accessor test behind `feature = "blitzar"`
- add no production behavior changes

## Coverage accounting
- focused lcov: `target/llvm-cov/query-commitments-after.lcov`
- `query_commitments.rs` covered lines after this change: 156
- prior local no-default baseline covered lines for this file: 0
- conservative non-test production-code delta used for bounty accounting: 32 newly covered lines
- estimated at $0.10/line: $3.20, subject to maintainer review/final accounting

## Tests
- `cargo test -p proof-of-sql query_commitments --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/query-commitments-after.lcov -- query_commitments`
- `cargo fmt --check`
- `git diff --check HEAD~1 HEAD`
- `source scripts/check_commits.sh`

Note: default-feature local test was not run on this ARM environment because default `perf`/blitzar compilation has the known `halo2curves` asm limitation here; the Dory/blitzar test remains gated exactly as before.