### PR TITLE
test: run column commitment tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -349,7 +349,7 @@ impl<C> FromIterator<(Ident, ColumnCommitmentMetadata, C)> for ColumnCommitments
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{


### PR DESCRIPTION
/claim #560

## Summary
- ungate the `NaiveCommitment` column commitment tests so they run under the no-default `test` feature
- cover column commitment construction, duplicate identifier handling, iteration, append/extend, add, and subtract paths without requiring blitzar
- add no production behavior changes

## Coverage accounting
- focused lcov: `target/llvm-cov/column-commitments-after.lcov`
- `column_commitments.rs` covered lines after this change: 589
- prior local no-default baseline covered lines for this file: 31
- conservative non-test production-code covered lines after this change: 164
- conservative non-test production-code covered lines in prior local baseline: 31
- conservative production-code delta used for bounty accounting: 133 newly covered lines
- estimated at $0.10/line: $13.30, subject to maintainer review/final accounting

## Tests
- `cargo test -p proof-of-sql column_commitments --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/column-commitments-after.lcov -- column_commitments`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

Note: default-feature local test was not run on this ARM environment because default `perf`/blitzar compilation has the known `halo2curves` asm limitation here.