### PR TITLE
test: run table commitment tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -374,7 +374,7 @@ fn num_rows_of_columns<'a>(
     Ok(num_rows)
 }
 
-#[cfg(all(test, feature = "arrow", feature = "blitzar"))]
+#[cfg(all(test, feature = "arrow"))]
 mod tests {
     use super::*;
     use crate::base::{


### PR DESCRIPTION
/claim #560

## Summary
- relax the `table_commitment.rs` test module gate from `arrow + blitzar` to `arrow` only
- run existing `NaiveCommitment` table commitment tests under the no-default `test,arrow` feature set
- cover construction, duplicate/mixed-length errors, append/extend, add/sub, non-contiguous range handling, and record-batch append paths
- add no production behavior changes

## Coverage accounting
- baseline lcov: `target/llvm-cov/table-commitment-baseline.lcov`
- focused after lcov: `target/llvm-cov/table-commitment-after.lcov`
- `table_commitment.rs` covered lines before this change under `test,arrow`: 0
- `table_commitment.rs` covered lines after this change under `test,arrow`: 723
- conservative non-test production-code covered lines before this change: 0
- conservative non-test production-code covered lines after this change: 146
- conservative production-code delta used for bounty accounting: 146 newly covered lines
- estimated at $0.10/line: $14.60, subject to maintainer review/final accounting

## Tests
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test,arrow --lcov --output-path target/llvm-cov/table-commitment-baseline.lcov -- table_commitment`
- `cargo test -p proof-of-sql table_commitment --no-default-features --features=test,arrow`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test,arrow --lcov --output-path target/llvm-cov/table-commitment-after.lcov -- table_commitment`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

Note: default-feature local test was not run on this ARM environment because default `perf`/blitzar compilation has the known `halo2curves` asm limitation here.