### PR TITLE
ci: cache coverage workflow rust builds

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,6 +25,10 @@ jobs:
     - uses: taiki-e/install-action@cargo-llvm-cov
     - name: Clean Previous Coverage Artifacts
       run: cargo llvm-cov clean --workspace
+    - name: Setup Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: coverage
     - name: Run Tests to Generate Coverage Data (All Features)
       run: cargo llvm-cov --no-report --all-features --workspace --exclude proof-of-sql-benches --ignore-filename-regex evm_tests
     #- name: Run Tests to Generate Coverage Data (Rayon Only)


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimefdn/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

Issue #557 was clarified to include broad CI runtime improvements. The regular lint/test workflow already restores Rust cache in its Rust jobs, but the separate `CI-Code-Coverage` workflow runs the expensive `cargo llvm-cov --all-features --workspace` path without restoring Cargo/target cache first.

This PR restores `Swatinem/rust-cache` in the coverage job after `cargo llvm-cov clean --workspace` and immediately before the coverage test run. That preserves the explicit cleanup of previous coverage artifacts while still allowing Cargo dependencies and reusable build outputs to be restored for the expensive coverage command.

/claim #557

# What changes are included in this PR?

- Add `Swatinem/rust-cache@v2` to `.github/workflows/code-coverage.yml`.
- Use a coverage-specific cache key.
- Leave every coverage validation command unchanged:
  - `cargo llvm-cov clean --workspace`
  - `cargo llvm-cov --no-report --all-features --workspace --exclude proof-of-sql-benches --ignore-filename-regex evm_tests`
  - final LCOV report generation
  - Codecov upload
  - coverage threshold enforcement

# Are these changes tested?

Static/local validation:

- YAML parse of `.github/workflows/code-coverage.yml` succeeded.
- `git diff --check` passed.
- Clean commit check passed by running the project script through bash after stripping Windows CR characters from the script stream.
- Verified `Swatinem/rust-cache` latest release is available.

Limitations:

- I did not run `source scripts/run_ci_checks.sh` locally because this change is limited to GitHub Actions coverage workflow setup and the full Rust/coverage suite is the CI path being optimized.
