### PR TITLE
test: cover table utility helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -99,6 +99,8 @@ pub use table::{Table, TableOptions};
 #[cfg(test)]
 mod table_test;
 pub mod table_utility;
+#[cfg(test)]
+mod table_utility_test;
 
 mod table_evaluation;
 pub use table_evaluation::TableEvaluation;

--- a/crates/proof-of-sql/src/base/database/table_utility_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility_test.rs
@@ -1,0 +1,50 @@
+use super::{
+    table_utility::{
+        borrowed_decimal75, borrowed_int, borrowed_smallint, borrowed_tinyint, borrowed_uint8,
+        table,
+    },
+    Column,
+};
+use crate::base::{math::decimal::Precision, scalar::test_scalar::TestScalar};
+use bumpalo::Bump;
+
+#[test]
+fn we_can_build_small_integer_helper_columns() {
+    let alloc = Bump::new();
+
+    let table = table::<TestScalar>([
+        borrowed_uint8("uint8_col", [1_u8, 2, 3], &alloc),
+        borrowed_tinyint("tinyint_col", [-1_i8, 0, 1], &alloc),
+        borrowed_smallint("smallint_col", [-2_i16, 0, 2], &alloc),
+        borrowed_int("int_col", [-3_i32, 0, 3], &alloc),
+    ]);
+
+    assert_eq!(table.num_rows(), 3);
+    assert_eq!(table["uint8_col"], Column::Uint8(&[1, 2, 3]));
+    assert_eq!(table["tinyint_col"], Column::TinyInt(&[-1, 0, 1]));
+    assert_eq!(table["smallint_col"], Column::SmallInt(&[-2, 0, 2]));
+    assert_eq!(table["int_col"], Column::Int(&[-3, 0, 3]));
+}
+
+#[test]
+fn we_can_build_decimal75_helper_columns() {
+    let alloc = Bump::new();
+    let table = table::<TestScalar>([borrowed_decimal75(
+        "decimal_col",
+        12,
+        -2,
+        [10, -20, 30],
+        &alloc,
+    )]);
+    let expected = [
+        TestScalar::from(10),
+        TestScalar::from(-20),
+        TestScalar::from(30),
+    ];
+
+    assert_eq!(table.num_rows(), 3);
+    assert_eq!(
+        table["decimal_col"],
+        Column::Decimal75(Precision::new(12).unwrap(), -2, &expected)
+    );
+}


### PR DESCRIPTION
/claim #560

## Summary

- Add direct tests for `table_utility` helper constructors that were still uncovered by the no-default `test` feature coverage run.
- Cover the small integer helpers: `borrowed_uint8`, `borrowed_tinyint`, `borrowed_smallint`, and `borrowed_int`.
- Cover `borrowed_decimal75`, including precision/scale and scalar backing values.

## Coverage

Baseline scan on `upstream/main` with:

```text
cargo llvm-cov -p proof-of-sql --no-default-features --features=test --summary-only
```

`base/database/table_utility.rs` before this PR:

```text
Lines: 134, Missed Lines: 54, Cover: 59.70%
```

After this PR, the same scoped coverage run reports:

```text
base/database/table_utility.rs ... Lines: 134, Missed Lines: 0, Cover: 100.00%
```

Conservative bounty accounting: 54 newly covered production lines / USD 5.40 at USD 0.10 per line.

## Tests

- `cargo fmt --check`
- Linux/WSL: `source scripts/run_ci_checks.sh`
  - Passed the extracted non-test, non-udeps, non-examples CI commands:
    `cargo check --no-default-features`,
    `cargo check --all-targets`,
    `cargo check --all-targets --all-features`,
    `cargo check -p proof-of-sql --no-default-features`
- `cargo test -p proof-of-sql --no-default-features --features test table_utility`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --summary-only`
- `git diff --check`
- `source scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and validation before submitting.
