### PR TITLE
test: cover filter and fold log gadgets

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base.rs
@@ -150,3 +150,85 @@ pub(crate) fn final_round_filter_constraints<'a, S: Scalar + 'a>(
         ],
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{final_round_evaluate_filter, verify_evaluate_filter};
+    use crate::{
+        base::{
+            database::table_utility::borrowed_bigint,
+            polynomial::MultilinearExtension,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::{
+            mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
+            FirstRoundBuilder,
+        },
+        sql::proof_plans::fold_vals,
+    };
+    use bumpalo::Bump;
+    use core::convert::identity;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn we_can_verify_filter_constraints() {
+        let alloc = Bump::new();
+        let input_column = borrowed_bigint::<TestScalar>("input", [1, 2, 3], &alloc).1;
+        let filtered_column = borrowed_bigint::<TestScalar>("filtered", [1, 3], &alloc).1;
+        let selection = &[true, false, true];
+        let output_chi = &[true, true];
+        let alpha = TestScalar::TWO;
+        let beta = TestScalar::TEN;
+
+        let first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(3);
+        let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
+            FinalRoundBuilder::new(3, VecDeque::new());
+        final_round_evaluate_filter(
+            &mut final_round_builder,
+            &alloc,
+            alpha,
+            beta,
+            &[input_column.clone()],
+            selection,
+            &[filtered_column.clone()],
+            3,
+            2,
+        );
+
+        assert_eq!(final_round_builder.pcs_proof_mles().len(), 2);
+        assert_eq!(final_round_builder.num_sumcheck_subpolynomials(), 4);
+
+        let verification_builder = run_verify_for_each_row(
+            3,
+            &first_round_builder,
+            &final_round_builder,
+            Vec::new(),
+            3,
+            |verification_builder, input_chi_eval, evaluation_point| {
+                let c_fold_eval =
+                    alpha * fold_vals(beta, &[input_column.inner_product(evaluation_point)]);
+                let d_fold_eval =
+                    alpha * fold_vals(beta, &[filtered_column.inner_product(evaluation_point)]);
+                verify_evaluate_filter(
+                    verification_builder,
+                    c_fold_eval,
+                    d_fold_eval,
+                    input_chi_eval,
+                    output_chi.inner_product(evaluation_point),
+                    selection.inner_product(evaluation_point),
+                )
+                .unwrap();
+            },
+        );
+
+        assert!(verification_builder
+            .get_identity_results()
+            .iter()
+            .all(|row| row.iter().copied().all(identity)));
+        assert!(verification_builder
+            .get_zero_sum_results()
+            .iter()
+            .copied()
+            .all(identity));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
@@ -83,3 +83,116 @@ impl<S: Scalar> FoldLogExpr<S> {
         self.final_round_evaluate_with_chi(builder, alloc, columns, length, chi)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FoldLogExpr;
+    use crate::{
+        base::{
+            database::table_utility::borrowed_bigint,
+            polynomial::MultilinearExtension,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::{
+            proof::{
+                mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
+                FirstRoundBuilder,
+            },
+            proof_plans::fold_vals,
+        },
+    };
+    use bumpalo::Bump;
+    use core::convert::identity;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn we_can_verify_fold_log_expr_constraints() {
+        let alloc = Bump::new();
+        let alpha = TestScalar::TWO;
+        let beta = TestScalar::TEN;
+        let expr = FoldLogExpr::new(alpha, beta);
+        let lhs = borrowed_bigint::<TestScalar>("lhs", [1, 2, 3], &alloc).1;
+        let rhs = borrowed_bigint::<TestScalar>("rhs", [4, 5, 6], &alloc).1;
+
+        let first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(3);
+        let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
+            FinalRoundBuilder::new(3, VecDeque::new());
+        let (star, fold) = expr.final_round_evaluate(
+            &mut final_round_builder,
+            &alloc,
+            &[lhs.clone(), rhs.clone()],
+            3,
+        );
+
+        assert_eq!(star.len(), 3);
+        assert_eq!(fold.len(), 3);
+        assert_eq!(final_round_builder.pcs_proof_mles().len(), 1);
+        assert_eq!(final_round_builder.num_sumcheck_subpolynomials(), 1);
+
+        let verification_builder = run_verify_for_each_row(
+            3,
+            &first_round_builder,
+            &final_round_builder,
+            Vec::new(),
+            3,
+            |verification_builder, chi_eval, evaluation_point| {
+                let column_evals = [
+                    lhs.inner_product(evaluation_point),
+                    rhs.inner_product(evaluation_point),
+                ];
+                let (star_eval, fold_eval) = expr
+                    .verify_evaluate(verification_builder, &column_evals, chi_eval)
+                    .unwrap();
+                assert_eq!(fold_eval, alpha * fold_vals(beta, &column_evals));
+                assert_eq!(star_eval, star.inner_product(evaluation_point));
+            },
+        );
+
+        assert!(verification_builder
+            .get_identity_results()
+            .iter()
+            .all(|row| row.iter().copied().all(identity)));
+    }
+
+    #[test]
+    fn we_can_verify_fold_log_expr_with_custom_chi() {
+        let alloc = Bump::new();
+        let alpha = TestScalar::from(3);
+        let beta = TestScalar::TWO;
+        let expr = FoldLogExpr::new(alpha, beta);
+        let column = borrowed_bigint::<TestScalar>("column", [7, 8, 9], &alloc).1;
+        let chi = &[true, true, true];
+
+        let first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(3);
+        let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
+            FinalRoundBuilder::new(3, VecDeque::new());
+        expr.final_round_evaluate_with_chi(
+            &mut final_round_builder,
+            &alloc,
+            &[column.clone()],
+            3,
+            chi,
+        );
+
+        let verification_builder = run_verify_for_each_row(
+            3,
+            &first_round_builder,
+            &final_round_builder,
+            Vec::new(),
+            3,
+            |verification_builder, _chi_eval, evaluation_point| {
+                expr.verify_evaluate(
+                    verification_builder,
+                    &[column.inner_product(evaluation_point)],
+                    chi.inner_product(evaluation_point),
+                )
+                .unwrap();
+            },
+        );
+
+        assert!(verification_builder
+            .get_identity_results()
+            .iter()
+            .all(|row| row.iter().copied().all(identity)));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add verifier/prover coverage for filter_base logarithmic-derivative constraints
- add FoldLogExpr coverage for default and explicit chi final-round paths

## Validation
- cargo fmt --check
- cargo test -p proof-of-sql --no-default-features --features test sql::proof_gadgets::filter_base
- cargo test -p proof-of-sql --no-default-features --features test sql::proof_gadgets::fold_log_expr
- cargo test -p proof-of-sql --no-default-features --features arrow,test sql::proof_gadgets::filter_base
- cargo test -p proof-of-sql --no-default-features --features arrow,test sql::proof_gadgets::fold_log_expr
- cargo test -p proof-of-sql --no-default-features --features arrow,test --lib
- git diff --check