### PR TITLE
test: cover evm proof plan conversions

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -1651,4 +1651,313 @@ mod tests {
         assert_eq!(evm_literal_exprs_bytes,
             "000000000000000a000000000100000002020000000300030000000400000004000000050000000000000005000000070000000000000001360000000a0000000000000000000000000000000000000000000000000000000000000007000000080a0000000000000000000000000000000000000000000000000000000000000000080000000b000000000000000109000000090000000100000000000000000000000a".to_string());
     }
+
+    #[test]
+    fn binary_evm_exprs_report_rhs_column_errors_when_converting_from_proof_exprs() {
+        let table_ref = TableRef::try_from("namespace.table").unwrap();
+        let bigint_lhs = ColumnRef::new(table_ref.clone(), "lhs".into(), ColumnType::BigInt);
+        let bigint_rhs = ColumnRef::new(table_ref.clone(), "rhs".into(), ColumnType::BigInt);
+        let bool_lhs = ColumnRef::new(table_ref.clone(), "left_flag".into(), ColumnType::Boolean);
+        let bool_rhs = ColumnRef::new(table_ref, "right_flag".into(), ColumnType::Boolean);
+
+        let bigint_refs = indexset! { bigint_lhs.clone() };
+        let bool_refs = indexset! { bool_lhs.clone() };
+
+        let lhs = DynProofExpr::new_column(bigint_lhs.clone());
+        let rhs = DynProofExpr::new_column(bigint_rhs.clone());
+        assert_eq!(
+            EVMEqualsExpr::try_from_proof_expr(
+                &EqualsExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap(),
+                &bigint_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMInequalityExpr::try_from_proof_expr(
+                &InequalityExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone()), true)
+                    .unwrap(),
+                &bigint_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMAddExpr::try_from_proof_expr(
+                &AddExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap(),
+                &bigint_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMSubtractExpr::try_from_proof_expr(
+                &SubtractExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap(),
+                &bigint_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMMultiplyExpr::try_from_proof_expr(
+                &MultiplyExpr::try_new(Box::new(lhs.clone()), Box::new(rhs)).unwrap(),
+                &bigint_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+
+        let lhs = DynProofExpr::new_column(bool_lhs.clone());
+        let rhs = DynProofExpr::new_column(bool_rhs);
+        assert_eq!(
+            EVMAndExpr::try_from_proof_expr(
+                &AndExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap(),
+                &bool_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMOrExpr::try_from_proof_expr(
+                &OrExpr::try_new(Box::new(lhs), Box::new(rhs)).unwrap(),
+                &bool_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+    }
+
+    #[test]
+    fn binary_evm_exprs_report_lhs_column_errors_when_converting_from_proof_exprs() {
+        let table_ref = TableRef::try_from("namespace.table").unwrap();
+        let bigint_lhs = ColumnRef::new(table_ref.clone(), "lhs".into(), ColumnType::BigInt);
+        let bigint_rhs = ColumnRef::new(table_ref.clone(), "rhs".into(), ColumnType::BigInt);
+        let bool_lhs = ColumnRef::new(table_ref.clone(), "left_flag".into(), ColumnType::Boolean);
+        let bool_rhs = ColumnRef::new(table_ref, "right_flag".into(), ColumnType::Boolean);
+
+        let bigint_refs = indexset! { bigint_rhs.clone() };
+        let bool_refs = indexset! { bool_rhs.clone() };
+
+        let lhs = DynProofExpr::new_column(bigint_lhs.clone());
+        let rhs = DynProofExpr::new_column(bigint_rhs.clone());
+        assert_eq!(
+            EVMInequalityExpr::try_from_proof_expr(
+                &InequalityExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone()), true)
+                    .unwrap(),
+                &bigint_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMAddExpr::try_from_proof_expr(
+                &AddExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap(),
+                &bigint_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMSubtractExpr::try_from_proof_expr(
+                &SubtractExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap(),
+                &bigint_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMMultiplyExpr::try_from_proof_expr(
+                &MultiplyExpr::try_new(Box::new(lhs), Box::new(rhs)).unwrap(),
+                &bigint_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+
+        let lhs = DynProofExpr::new_column(bool_lhs.clone());
+        let rhs = DynProofExpr::new_column(bool_rhs);
+        assert_eq!(
+            EVMAndExpr::try_from_proof_expr(
+                &AndExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap(),
+                &bool_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMOrExpr::try_from_proof_expr(
+                &OrExpr::try_new(Box::new(lhs), Box::new(rhs)).unwrap(),
+                &bool_refs,
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+    }
+
+    #[test]
+    fn unary_evm_exprs_report_nested_column_errors_when_converting_from_proof_exprs() {
+        let table_ref = TableRef::try_from("namespace.table").unwrap();
+        let bool_column = ColumnRef::new(table_ref.clone(), "flag".into(), ColumnType::Boolean);
+        let int_column = ColumnRef::new(table_ref, "amount".into(), ColumnType::Int);
+
+        assert_eq!(
+            EVMNotExpr::try_from_proof_expr(
+                &NotExpr::try_new(Box::new(DynProofExpr::new_column(bool_column))).unwrap(),
+                &indexset! {},
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMCastExpr::try_from_proof_expr(
+                &CastExpr::try_new(
+                    Box::new(DynProofExpr::new_column(int_column.clone())),
+                    ColumnType::BigInt,
+                )
+                .unwrap(),
+                &indexset! {},
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMScalingCastExpr::try_from_proof_expr(
+                &ScalingCastExpr::try_new(
+                    Box::new(DynProofExpr::new_column(int_column)),
+                    ColumnType::Decimal75(Precision::new(15).unwrap(), 2),
+                )
+                .unwrap(),
+                &indexset! {},
+            )
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+    }
+
+    #[test]
+    fn binary_evm_exprs_report_rhs_column_errors_when_converting_into_proof_exprs() {
+        let table_ref = TableRef::try_from("namespace.table").unwrap();
+        let bigint_column = ColumnRef::new(table_ref.clone(), "amount".into(), ColumnType::BigInt);
+        let bool_column = ColumnRef::new(table_ref, "flag".into(), ColumnType::Boolean);
+
+        let valid_bigint_column = EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 });
+        let missing_bigint_column = EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 });
+        let bigint_refs = indexset! { bigint_column };
+
+        assert_eq!(
+            EVMEqualsExpr::new(valid_bigint_column.clone(), missing_bigint_column.clone())
+                .try_into_proof_expr(&bigint_refs)
+                .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMInequalityExpr::new(
+                valid_bigint_column.clone(),
+                missing_bigint_column.clone(),
+                true
+            )
+            .try_into_proof_expr(&bigint_refs)
+            .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMAddExpr::new(valid_bigint_column.clone(), missing_bigint_column.clone())
+                .try_into_proof_expr(&bigint_refs)
+                .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMSubtractExpr::new(valid_bigint_column.clone(), missing_bigint_column.clone())
+                .try_into_proof_expr(&bigint_refs)
+                .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMMultiplyExpr::new(valid_bigint_column, missing_bigint_column)
+                .try_into_proof_expr(&bigint_refs)
+                .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+
+        let valid_bool_column = EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 });
+        let missing_bool_column = EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 });
+        let bool_refs = indexset! { bool_column };
+
+        assert_eq!(
+            EVMAndExpr::new(valid_bool_column.clone(), missing_bool_column.clone())
+                .try_into_proof_expr(&bool_refs)
+                .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_eq!(
+            EVMOrExpr::new(valid_bool_column, missing_bool_column)
+                .try_into_proof_expr(&bool_refs)
+                .unwrap_err(),
+            EVMProofPlanError::ColumnNotFound
+        );
+    }
+
+    #[test]
+    fn evm_exprs_report_type_errors_after_nested_evm_conversion_succeeds() {
+        let table_ref = TableRef::try_from("namespace.table").unwrap();
+        let bigint_column = ColumnRef::new(table_ref.clone(), "amount".into(), ColumnType::BigInt);
+        let bool_column = ColumnRef::new(table_ref, "flag".into(), ColumnType::Boolean);
+        let column_refs = indexset! { bigint_column, bool_column };
+        let bigint_expr = EVMDynProofExpr::Column(EVMColumnExpr { column_number: 0 });
+        let bool_expr = EVMDynProofExpr::Column(EVMColumnExpr { column_number: 1 });
+
+        assert!(matches!(
+            EVMEqualsExpr::new(bigint_expr.clone(), bool_expr.clone())
+                .try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+        assert!(matches!(
+            EVMInequalityExpr::new(bigint_expr.clone(), bool_expr.clone(), true)
+                .try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+        assert!(matches!(
+            EVMAddExpr::new(bigint_expr.clone(), bool_expr.clone())
+                .try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+        assert!(matches!(
+            EVMSubtractExpr::new(bigint_expr.clone(), bool_expr.clone())
+                .try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+        assert!(matches!(
+            EVMMultiplyExpr::new(bigint_expr.clone(), bool_expr.clone())
+                .try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+        assert!(matches!(
+            EVMAndExpr::new(bigint_expr.clone(), bool_expr.clone())
+                .try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+        assert!(matches!(
+            EVMOrExpr::new(bigint_expr.clone(), bool_expr.clone())
+                .try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+        assert!(matches!(
+            EVMNotExpr::new(bigint_expr.clone()).try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+        assert!(matches!(
+            EVMCastExpr::new(bigint_expr.clone(), ColumnType::Boolean)
+                .try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+        assert!(matches!(
+            EVMScalingCastExpr::new(
+                bigint_expr,
+                ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+                [0, 0, 0, 100],
+            )
+            .try_into_proof_expr(&column_refs),
+            Err(EVMProofPlanError::AnalyzeError { .. })
+        ));
+    }
 }

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -834,6 +834,144 @@ mod tests {
     use indexmap::IndexSet;
 
     #[test]
+    fn evm_dyn_proof_plan_dispatches_wrapper_variants() {
+        let table_ref: TableRef = "namespace.table".parse().unwrap();
+        let ident_a: Ident = "a".into();
+        let ident_b: Ident = "b".into();
+        let alias = "alias".to_string();
+        let sum_alias = "sum_b".to_string();
+        let count_alias = "count".to_string();
+
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let table_refs = indexset![table_ref.clone()];
+        let column_refs = indexset![column_ref_a.clone(), column_ref_b.clone()];
+
+        let table_plan = DynProofPlan::Table(TableExec::new(
+            table_ref.clone(),
+            vec![
+                ColumnField::new(ident_a.clone(), ColumnType::BigInt),
+                ColumnField::new(ident_b.clone(), ColumnType::BigInt),
+            ],
+        ));
+        let true_literal = DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true)));
+
+        let empty = EVMDynProofPlan::try_from_proof_plan(
+            &DynProofPlan::Empty(EmptyExec::new()),
+            &table_refs,
+            &column_refs,
+        )
+        .unwrap();
+        assert!(matches!(
+            empty
+                .try_into_proof_plan(&table_refs, &column_refs, None)
+                .unwrap(),
+            DynProofPlan::Empty(_)
+        ));
+
+        let legacy_filter_plan = DynProofPlan::LegacyFilter(LegacyFilterExec::new(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
+                alias: Ident::new(alias.clone()),
+            }],
+            TableExpr {
+                table_ref: table_ref.clone(),
+            },
+            true_literal.clone(),
+        ));
+        let legacy_filter =
+            EVMDynProofPlan::try_from_proof_plan(&legacy_filter_plan, &table_refs, &column_refs)
+                .unwrap();
+        assert!(matches!(
+            legacy_filter
+                .try_into_proof_plan(&table_refs, &column_refs, Some(&indexset![alias]))
+                .unwrap(),
+            DynProofPlan::LegacyFilter(_)
+        ));
+
+        let output_ref_a = ColumnRef::new(
+            TableRef::from_names(None, ""),
+            ident_a.clone(),
+            ColumnType::BigInt,
+        );
+        let output_ref_b = ColumnRef::new(
+            TableRef::from_names(None, ""),
+            ident_b.clone(),
+            ColumnType::BigInt,
+        );
+        let aggregate_like_group_by_exprs = vec![AliasedDynProofExpr {
+            expr: DynProofExpr::Column(ColumnExpr::new(output_ref_a)),
+            alias: ident_a.clone(),
+        }];
+        let aggregate_like_sum_expr = vec![AliasedDynProofExpr {
+            expr: DynProofExpr::Column(ColumnExpr::new(output_ref_b)),
+            alias: Ident::new(sum_alias.clone()),
+        }];
+        let aggregate_output_names = indexset![
+            ident_a.value.clone(),
+            sum_alias.clone(),
+            count_alias.clone()
+        ];
+
+        let group_by_plan = DynProofPlan::GroupBy(
+            GroupByExec::try_new(
+                vec![ColumnExpr::new(column_ref_a.clone())],
+                vec![AliasedDynProofExpr {
+                    expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
+                    alias: Ident::new(sum_alias.clone()),
+                }],
+                Ident::new(count_alias.clone()),
+                TableExpr {
+                    table_ref: table_ref.clone(),
+                },
+                true_literal.clone(),
+            )
+            .unwrap(),
+        );
+        let group_by =
+            EVMDynProofPlan::try_from_proof_plan(&group_by_plan, &table_refs, &column_refs)
+                .unwrap();
+        assert!(matches!(
+            group_by
+                .try_into_proof_plan(&table_refs, &column_refs, Some(&aggregate_output_names))
+                .unwrap(),
+            DynProofPlan::GroupBy(_)
+        ));
+
+        let union_plan = DynProofPlan::Union(
+            UnionExec::try_new(vec![table_plan.clone(), table_plan.clone()]).unwrap(),
+        );
+        let union =
+            EVMDynProofPlan::try_from_proof_plan(&union_plan, &table_refs, &column_refs).unwrap();
+        assert!(matches!(
+            union
+                .try_into_proof_plan(&table_refs, &column_refs, None)
+                .unwrap(),
+            DynProofPlan::Union(_)
+        ));
+
+        let aggregate_plan = DynProofPlan::Aggregate(
+            AggregateExec::try_new(
+                aggregate_like_group_by_exprs,
+                aggregate_like_sum_expr,
+                Ident::new(count_alias),
+                Box::new(table_plan),
+                true_literal,
+            )
+            .unwrap(),
+        );
+        let aggregate =
+            EVMDynProofPlan::try_from_proof_plan(&aggregate_plan, &table_refs, &column_refs)
+                .unwrap();
+        assert!(matches!(
+            aggregate
+                .try_into_proof_plan(&table_refs, &column_refs, Some(&aggregate_output_names))
+                .unwrap(),
+            DynProofPlan::Aggregate(_)
+        ));
+    }
+
+    #[test]
     fn we_can_put_projection_exec_in_evm() {
         let table_ref: TableRef = "namespace.table".parse().unwrap();
         let ident_a: Ident = "a".into();

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -191,3 +191,135 @@ impl ProverEvaluate for EVMProofPlan {
             .final_round_evaluate(builder, alloc, table_map, params)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{table_utility::*, ColumnField},
+            map::{indexmap, indexset},
+            scalar::test_scalar::TestScalar,
+        },
+        sql::{
+            evm_proof_plan::plans::EVMEmptyExec,
+            proof::{
+                mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder,
+                FirstRoundBuilder,
+            },
+            proof_plans::{EmptyExec, TableExec},
+        },
+    };
+    use alloc::collections::VecDeque;
+
+    fn test_table_plan() -> (TableRef, EVMProofPlan) {
+        let table_ref = TableRef::new("namespace", "table");
+        let plan = DynProofPlan::Table(TableExec::new(
+            table_ref.clone(),
+            vec![ColumnField::new("a".into(), ColumnType::BigInt)],
+        ));
+        (table_ref, EVMProofPlan::new(plan))
+    }
+
+    #[test]
+    fn evm_proof_plan_exposes_and_consumes_inner_plan() {
+        let plan = DynProofPlan::Empty(EmptyExec::new());
+        let evm_plan = EVMProofPlan::new(plan.clone());
+
+        assert_eq!(evm_plan.inner(), &plan);
+        assert_eq!(evm_plan.into_inner(), plan);
+    }
+
+    #[test]
+    fn compact_plan_rejects_invalid_table_names() {
+        let compact_plan = CompactPlan {
+            tables: vec!["too.many.parts".to_string()],
+            columns: Vec::new(),
+            output_column_names: Vec::new(),
+            plan: EVMDynProofPlan::Empty(EVMEmptyExec {}),
+        };
+
+        assert_eq!(
+            EVMProofPlan::try_from(compact_plan).unwrap_err(),
+            EVMProofPlanError::InvalidTableName
+        );
+    }
+
+    #[test]
+    fn compact_plan_rejects_columns_with_missing_table_indexes() {
+        let compact_plan = CompactPlan {
+            tables: vec![TableRef::new("namespace", "table").to_string()],
+            columns: vec![(1, "a".to_string(), ColumnType::BigInt)],
+            output_column_names: Vec::new(),
+            plan: EVMDynProofPlan::Empty(EVMEmptyExec {}),
+        };
+
+        assert_eq!(
+            EVMProofPlan::try_from(compact_plan).unwrap_err(),
+            EVMProofPlanError::TableNotFound
+        );
+    }
+
+    #[test]
+    fn evm_proof_plan_delegates_metadata_and_verifier_evaluation() {
+        let (table_ref, evm_plan) = test_table_plan();
+        let column_ref = ColumnRef::new(table_ref.clone(), "a".into(), ColumnType::BigInt);
+
+        assert_eq!(
+            evm_plan.get_column_result_fields(),
+            vec![ColumnField::new("a".into(), ColumnType::BigInt)]
+        );
+        assert_eq!(evm_plan.get_column_references(), indexset! { column_ref });
+        assert_eq!(
+            evm_plan.get_table_references(),
+            indexset! { table_ref.clone() }
+        );
+
+        let accessor = indexmap! {
+            table_ref.clone() => indexmap! {
+                "a".into() => TestScalar::from(7),
+            },
+        };
+        let chi_eval_map = indexmap! {
+            table_ref => (TestScalar::from(11), 2),
+        };
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            Vec::new(),
+            0,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        let result = evm_plan
+            .verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[])
+            .unwrap();
+
+        assert_eq!(result.column_evals(), &[TestScalar::from(7)]);
+        assert_eq!(result.chi(), (TestScalar::from(11), 2));
+    }
+
+    #[test]
+    fn evm_proof_plan_delegates_prover_evaluation_rounds() {
+        let (table_ref, evm_plan) = test_table_plan();
+        let alloc = Bump::new();
+        let input_table = table::<TestScalar>([borrowed_bigint("a", [1_i64, 2], &alloc)]);
+        let table_map = indexmap! {
+            table_ref => input_table.clone(),
+        };
+
+        let mut first_round_builder = FirstRoundBuilder::new(0);
+        let first_round_result = evm_plan
+            .first_round_evaluate(&mut first_round_builder, &alloc, &table_map, &[])
+            .unwrap();
+        assert_eq!(first_round_result, input_table);
+
+        let mut final_round_builder = FinalRoundBuilder::new(0, VecDeque::new());
+        let final_round_result = evm_plan
+            .final_round_evaluate(&mut final_round_builder, &alloc, &table_map, &[])
+            .unwrap();
+        assert_eq!(final_round_result, input_table);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary

This is a test-only coverage slice for the EVM proof plan conversion layer.

- add coverage for `EVMProofPlan` wrapper accessors, compact-plan validation, metadata delegation, verifier evaluation, and prover evaluation forwarding
- add focused EVM expression conversion tests for missing nested columns and type-checking failures after nested conversion succeeds
- add direct `EVMDynProofPlan` dispatch coverage for Empty, LegacyFilter, GroupBy, Union, and Aggregate wrapper variants

No production logic changes.

## Coverage accounting

Focused coverage command:

```bash
cargo llvm-cov -p proof-of-sql --no-default-features --features=test \
  --lcov --output-path target/llvm-cov/evm-proof-plan.lcov -- evm_proof_plan
```

Compared against a clean `upstream/main` worktree at `1bf50a63` with the same command:

| File | Baseline missed | Branch missed | Conservative newly covered original lines |
| --- | ---: | ---: | ---: |
| `crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs` | 34 | 1 | 33 |
| `crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs` | 31 | 5 | 26 |
| `crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs` | 39 | 12 | 27 |

Conservative total: 86 newly covered original lines, estimated $8.60 at $0.10/line, subject to maintainer review and final Algora accounting.

## Validation

- `cargo test -p proof-of-sql evm_proof_plan --no-default-features --features=test` -> 82 passed; 0 failed; 889 filtered out
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/evm-proof-plan.lcov -- evm_proof_plan`
- `cargo fmt --check`
- `git diff --check`
- `scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and validation before submitting.
