### PR TITLE
feat(sql): add nullable column proof support

### DIFF
--- a/crates/proof-of-sql-planner/src/aggregate.rs
+++ b/crates/proof-of-sql-planner/src/aggregate.rs
@@ -1,4 +1,4 @@
-use super::{PlannerError, PlannerResult};
+use super::{PlannerError, PlannerResult, SchemaFields};
 use crate::expr_to_proof_expr;
 use datafusion::{
     logical_expr::{
@@ -7,11 +7,7 @@ use datafusion::{
     },
     physical_plan,
 };
-use proof_of_sql::{
-    base::database::{ColumnType, LiteralValue},
-    sql::proof_exprs::DynProofExpr,
-};
-use sqlparser::ast::Ident;
+use proof_of_sql::{base::database::LiteralValue, sql::proof_exprs::DynProofExpr};
 
 /// An aggregate function we support
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -25,9 +21,9 @@ pub enum AggregateFunc {
 /// Convert an [`AggregateFunction`] to a [`DynProofExpr`]
 ///
 /// TODO: Some moderate changes are necessary once we upgrade `DataFusion` to 46.0.0
-pub(crate) fn aggregate_function_to_proof_expr(
+pub(crate) fn aggregate_function_to_proof_expr<S: SchemaFields + ?Sized>(
     function: &AggregateFunction,
-    schema: &[(Ident, ColumnType)],
+    schema: &S,
 ) -> PlannerResult<(AggregateFunc, DynProofExpr)> {
     match function {
         AggregateFunction {
@@ -65,6 +61,7 @@ mod tests {
     use super::*;
     use crate::df_util::*;
     use proof_of_sql::base::database::{ColumnRef, ColumnType, TableRef};
+    use sqlparser::ast::Ident;
 
     // AggregateFunction to DynProofExpr
     #[test]

--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -1,5 +1,4 @@
 use super::table_reference_to_table_ref;
-use crate::schema_to_column_fields;
 use alloc::sync::Arc;
 use arrow::datatypes::{Field, Schema};
 use core::any::Any;
@@ -49,8 +48,7 @@ impl<A: SchemaAccessor> ContextProvider for PoSqlContextProvider<A> {
     ) -> Result<Arc<dyn TableSource>, DataFusionError> {
         let table_ref = table_reference_to_table_ref(&name)
             .map_err(|err| DataFusionError::External(Box::new(err)))?;
-        let schema = self.accessor.lookup_schema(&table_ref);
-        let column_fields = schema_to_column_fields(schema);
+        let column_fields = self.accessor.lookup_schema_fields(&table_ref);
         Ok(Arc::new(PoSqlTableSource::new(column_fields)) as Arc<dyn TableSource>)
     }
     fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>> {
@@ -95,7 +93,7 @@ impl PoSqlTableSource {
                     Field::new(
                         column_field.name().value.as_str(),
                         (&column_field.data_type()).into(),
-                        false,
+                        column_field.is_nullable(),
                     )
                 })
                 .collect::<Vec<_>>(),

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -1,16 +1,13 @@
 use super::{
     column_to_column_ref, placeholder_to_placeholder_expr, scalar_value_to_literal_value,
-    PlannerError, PlannerResult,
+    PlannerError, PlannerResult, SchemaFields,
 };
 use datafusion::logical_expr::{
     expr::{Alias, Cast, Placeholder},
     BinaryExpr, Expr, Operator,
 };
 use indexmap::IndexSet;
-use proof_of_sql::{
-    base::database::ColumnType,
-    sql::{proof_exprs::DynProofExpr, scale_cast_binary_op},
-};
+use proof_of_sql::sql::{proof_exprs::DynProofExpr, scale_cast_binary_op};
 use sqlparser::ast::Ident;
 
 /// Recursively extract all column identifiers referenced in an expression
@@ -26,7 +23,9 @@ pub(crate) fn get_column_idents_from_expr(expr: &Expr) -> IndexSet<Ident> {
             left_idents.extend(get_column_idents_from_expr(right));
             left_idents
         }
-        Expr::Not(inner) => get_column_idents_from_expr(inner),
+        Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) | Expr::IsTrue(inner) => {
+            get_column_idents_from_expr(inner)
+        }
         Expr::Alias(Alias { expr, .. }) | Expr::Cast(Cast { expr, .. }) => {
             get_column_idents_from_expr(expr)
         }
@@ -44,11 +43,11 @@ pub(crate) fn get_column_idents_from_expr(expr: &Expr) -> IndexSet<Ident> {
     clippy::missing_panics_doc,
     reason = "Output of comparisons is always boolean"
 )]
-fn binary_expr_to_proof_expr(
+fn binary_expr_to_proof_expr<S: SchemaFields + ?Sized>(
     left: &Expr,
     right: &Expr,
     op: Operator,
-    schema: &[(Ident, ColumnType)],
+    schema: &S,
 ) -> PlannerResult<DynProofExpr> {
     let left_proof_expr = expr_to_proof_expr(left, schema)?;
     let right_proof_expr = expr_to_proof_expr(right, schema)?;
@@ -123,9 +122,9 @@ fn binary_expr_to_proof_expr(
 ///
 /// # Panics
 /// The function should not panic if Proof of SQL is working correctly
-pub fn expr_to_proof_expr(
+pub fn expr_to_proof_expr<S: SchemaFields + ?Sized>(
     expr: &Expr,
-    schema: &[(Ident, ColumnType)],
+    schema: &S,
 ) -> PlannerResult<DynProofExpr> {
     match expr {
         Expr::Alias(Alias { expr, .. }) => expr_to_proof_expr(expr, schema),
@@ -141,6 +140,11 @@ pub fn expr_to_proof_expr(
             let proof_expr = expr_to_proof_expr(expr, schema)?;
             Ok(DynProofExpr::try_new_not(proof_expr)?)
         }
+        Expr::IsNull(expr) => Ok(DynProofExpr::new_is_null(expr_to_proof_expr(expr, schema)?)),
+        Expr::IsNotNull(expr) => Ok(DynProofExpr::new_is_not_null(expr_to_proof_expr(
+            expr, schema,
+        )?)),
+        Expr::IsTrue(expr) => Ok(DynProofExpr::new_is_true(expr_to_proof_expr(expr, schema)?)),
         Expr::Cast(cast) => {
             match &*cast.expr {
                 // handle cases such as `$1::int`
@@ -183,7 +187,7 @@ mod tests {
         logical_expr::{expr::Placeholder, Cast},
     };
     use proof_of_sql::base::{
-        database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+        database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef},
         math::decimal::Precision,
     };
 
@@ -631,7 +635,7 @@ mod tests {
     fn we_can_convert_literal_expr_to_proof_expr() {
         let expr = Expr::Literal(ScalarValue::Int32(Some(1)));
         assert_eq!(
-            expr_to_proof_expr(&expr, &Vec::new()).unwrap(),
+            expr_to_proof_expr(&expr, &Vec::<ColumnField>::new()).unwrap(),
             DynProofExpr::new_literal(LiteralValue::Int(1))
         );
     }
@@ -659,7 +663,7 @@ mod tests {
             Box::new(Expr::Literal(ScalarValue::Boolean(Some(true)))),
             DataType::Int32,
         ));
-        let expression = expr_to_proof_expr(&expr, &Vec::new()).unwrap();
+        let expression = expr_to_proof_expr(&expr, &Vec::<ColumnField>::new()).unwrap();
         assert_eq!(
             expression,
             DynProofExpr::try_new_cast(
@@ -677,7 +681,7 @@ mod tests {
             Box::new(Expr::Literal(ScalarValue::UInt64(Some(100)))),
             DataType::Int16,
         ));
-        let expression = expr_to_proof_expr(&expr, &Vec::new()).unwrap_err();
+        let expression = expr_to_proof_expr(&expr, &Vec::<ColumnField>::new()).unwrap_err();
         assert!(matches!(
             expression,
             PlannerError::UnsupportedDataType { data_type: _ }
@@ -691,7 +695,7 @@ mod tests {
             Box::new(Expr::Literal(ScalarValue::Boolean(Some(true)))),
             DataType::UInt16,
         ));
-        let expression = expr_to_proof_expr(&expr, &Vec::new()).unwrap_err();
+        let expression = expr_to_proof_expr(&expr, &Vec::<ColumnField>::new()).unwrap_err();
         assert!(matches!(
             expression,
             PlannerError::UnsupportedDataType { data_type: _ }
@@ -706,7 +710,7 @@ mod tests {
             Box::new(Expr::Literal(ScalarValue::Int16(Some(100)))),
             DataType::Boolean,
         ));
-        let expression = expr_to_proof_expr(&expr, &Vec::new()).unwrap_err();
+        let expression = expr_to_proof_expr(&expr, &Vec::<ColumnField>::new()).unwrap_err();
         assert!(matches!(
             expression,
             PlannerError::AnalyzeError { source: _ }
@@ -720,7 +724,7 @@ mod tests {
             id: "$1".to_string(),
             data_type: Some(DataType::Int32),
         });
-        let expression = expr_to_proof_expr(&expr, &Vec::new()).unwrap();
+        let expression = expr_to_proof_expr(&expr, &Vec::<ColumnField>::new()).unwrap();
         assert_eq!(
             expression,
             DynProofExpr::try_new_placeholder(1, ColumnType::Int).unwrap()
@@ -737,7 +741,7 @@ mod tests {
             })),
             DataType::Int32,
         ));
-        let expression = expr_to_proof_expr(&expr, &Vec::new()).unwrap();
+        let expression = expr_to_proof_expr(&expr, &Vec::<ColumnField>::new()).unwrap();
         assert_eq!(
             expression,
             DynProofExpr::try_new_placeholder(1, ColumnType::Int).unwrap()
@@ -752,7 +756,7 @@ mod tests {
             Column::new(None::<TableReference>, "column"),
         );
         assert!(matches!(
-            expr_to_proof_expr(&expr, &Vec::new()),
+            expr_to_proof_expr(&expr, &Vec::<ColumnField>::new()),
             Err(PlannerError::UnsupportedLogicalExpression { .. })
         ));
     }
@@ -761,7 +765,7 @@ mod tests {
     fn we_can_get_proof_expr_for_timestamps_of_different_scale() {
         let lhs = Expr::Literal(ScalarValue::TimestampSecond(Some(1), None));
         let rhs = Expr::Literal(ScalarValue::TimestampNanosecond(Some(1), None));
-        binary_expr_to_proof_expr(&lhs, &rhs, Operator::Gt, &Vec::new()).unwrap();
+        binary_expr_to_proof_expr(&lhs, &rhs, Operator::Gt, &Vec::<ColumnField>::new()).unwrap();
     }
 
     // get_column_idents_from_expr tests

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -23,9 +23,15 @@ pub(crate) fn get_column_idents_from_expr(expr: &Expr) -> IndexSet<Ident> {
             left_idents.extend(get_column_idents_from_expr(right));
             left_idents
         }
-        Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) | Expr::IsTrue(inner) => {
-            get_column_idents_from_expr(inner)
-        }
+        Expr::Not(inner)
+        | Expr::IsNull(inner)
+        | Expr::IsNotNull(inner)
+        | Expr::IsTrue(inner)
+        | Expr::IsFalse(inner)
+        | Expr::IsUnknown(inner)
+        | Expr::IsNotTrue(inner)
+        | Expr::IsNotFalse(inner)
+        | Expr::IsNotUnknown(inner) => get_column_idents_from_expr(inner),
         Expr::Alias(Alias { expr, .. }) | Expr::Cast(Cast { expr, .. }) => {
             get_column_idents_from_expr(expr)
         }
@@ -145,6 +151,19 @@ pub fn expr_to_proof_expr<S: SchemaFields + ?Sized>(
             expr, schema,
         )?)),
         Expr::IsTrue(expr) => Ok(DynProofExpr::new_is_true(expr_to_proof_expr(expr, schema)?)),
+        Expr::IsFalse(expr) => Ok(DynProofExpr::new_is_true(DynProofExpr::try_new_not(
+            expr_to_proof_expr(expr, schema)?,
+        )?)),
+        Expr::IsUnknown(expr) => Ok(DynProofExpr::new_is_null(expr_to_proof_expr(expr, schema)?)),
+        Expr::IsNotTrue(expr) => Ok(DynProofExpr::try_new_not(DynProofExpr::new_is_true(
+            expr_to_proof_expr(expr, schema)?,
+        ))?),
+        Expr::IsNotFalse(expr) => Ok(DynProofExpr::try_new_not(DynProofExpr::new_is_true(
+            DynProofExpr::try_new_not(expr_to_proof_expr(expr, schema)?)?,
+        ))?),
+        Expr::IsNotUnknown(expr) => Ok(DynProofExpr::new_is_not_null(expr_to_proof_expr(
+            expr, schema,
+        )?)),
         Expr::Cast(cast) => {
             match &*cast.expr {
                 // handle cases such as `$1::int`

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -23,8 +23,8 @@ pub use plan::logical_plan_to_proof_plan;
 mod uppercase_column_visitor;
 pub use uppercase_column_visitor::{statement_with_uppercase_identifiers, uppercase_identifier};
 mod util;
-pub use util::column_fields_to_schema;
+pub use util::{column_fields_to_schema, SchemaFields};
 pub(crate) use util::{
     column_to_column_ref, placeholder_to_placeholder_expr, scalar_value_to_literal_value,
-    schema_to_column_fields, table_reference_to_table_ref,
+    table_reference_to_table_ref,
 };

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1,6 +1,6 @@
 use super::{
     aggregate_function_to_proof_expr, expr_to_proof_expr, get_column_idents_from_expr,
-    table_reference_to_table_ref, AggregateFunc, PlannerError, PlannerResult,
+    table_reference_to_table_ref, AggregateFunc, PlannerError, PlannerResult, SchemaFields,
 };
 use alloc::vec::Vec;
 use datafusion::{
@@ -13,7 +13,10 @@ use datafusion::{
 };
 use indexmap::{IndexMap, IndexSet};
 use proof_of_sql::{
-    base::database::{ColumnField, ColumnRef, ColumnType, LiteralValue, SchemaAccessor, TableRef},
+    base::database::{
+        value_column_id_from_presence, ColumnRef, ColumnType, LiteralValue, SchemaAccessor,
+        TableRef,
+    },
     sql::{
         proof::ProofPlan,
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr},
@@ -31,7 +34,7 @@ use proof_of_sql::{
 fn get_aliased_dyn_proof_exprs(
     table_ref: &TableRef,
     projection: &[usize],
-    input_schema: &[(Ident, ColumnType)],
+    input_schema: &impl SchemaFields,
     output_schema: &DFSchema,
 ) -> PlannerResult<Vec<AliasedDynProofExpr>> {
     projection
@@ -41,14 +44,23 @@ fn get_aliased_dyn_proof_exprs(
             |(output_index, input_index)| -> PlannerResult<AliasedDynProofExpr> {
                 // Get output column name / alias
                 let alias: Ident = output_schema.field(output_index).name().as_str().into();
-                let (input_column_name, data_type) = input_schema
-                    .get(*input_index)
+                let input_field = input_schema
+                    .field_at(*input_index)
                     .ok_or(PlannerError::ColumnNotFound)?;
-                let expr = DynProofExpr::new_column(ColumnRef::new(
-                    table_ref.clone(),
-                    input_column_name.clone(),
-                    *data_type,
-                ));
+                let input_column_name = input_field.name();
+                let expr = DynProofExpr::new_column(if input_field.is_nullable() {
+                    ColumnRef::new_nullable(
+                        table_ref.clone(),
+                        input_column_name,
+                        input_field.data_type(),
+                    )
+                } else {
+                    ColumnRef::new(
+                        table_ref.clone(),
+                        input_column_name,
+                        input_field.data_type(),
+                    )
+                });
                 Ok(AliasedDynProofExpr { expr, alias })
             },
         )
@@ -59,11 +71,11 @@ fn get_aliased_dyn_proof_exprs(
 fn table_scan_get_required_columns(
     projection: &[usize],
     filters: &[Expr],
-    input_schema: &[(Ident, ColumnType)],
+    input_schema: &impl SchemaFields,
 ) -> IndexSet<Ident> {
     projection
         .iter()
-        .filter_map(|&i| input_schema.get(i).map(|(ident, _)| ident.clone()))
+        .filter_map(|&i| input_schema.field_at(i).map(|field| field.name()))
         .chain(filters.iter().flat_map(get_column_idents_from_expr))
         .collect()
 }
@@ -79,15 +91,15 @@ fn table_scan_to_proof_plan(
 ) -> PlannerResult<DynProofPlan> {
     // Check if the table exists
     let table_ref = table_reference_to_table_ref(table_name)?;
-    let input_schema = schemas.lookup_schema(&table_ref);
+    let input_schema = schemas.lookup_schema_fields(&table_ref);
     // Filter for only the fields we use
     let input_column_fields = projection
         .iter()
         .map(|i| {
-            let (ident, column_type) = input_schema
+            input_schema
                 .get(*i)
-                .expect("Projection index out of bounds");
-            ColumnField::new(ident.clone(), *column_type)
+                .expect("Projection index out of bounds")
+                .clone()
         })
         .collect::<Vec<_>>();
     Ok(DynProofPlan::new_table(table_ref, input_column_fields))
@@ -106,15 +118,15 @@ fn table_scan_to_filter(
 ) -> PlannerResult<DynProofPlan> {
     // Check if the table exists
     let table_ref = table_reference_to_table_ref(table_name)?;
-    let input_schema = schemas.lookup_schema(&table_ref);
+    let input_schema = schemas.lookup_schema_fields(&table_ref);
     // Get aliased expressions
     let aliased_dyn_proof_exprs =
         get_aliased_dyn_proof_exprs(&table_ref, projection, &input_schema, projected_schema)?;
     let required_columns = table_scan_get_required_columns(projection, filters, &input_schema);
     let input_column_fields = input_schema
         .iter()
-        .filter(|(ident, _)| required_columns.contains(ident))
-        .map(|(ident, column_type)| ColumnField::new(ident.clone(), *column_type))
+        .filter(|field| required_columns.contains(&field.name()))
+        .cloned()
         .collect::<Vec<_>>();
     let table_exec = DynProofPlan::new_table(table_ref, input_column_fields);
     let filter_proof_exprs = filters
@@ -137,11 +149,7 @@ fn projection_to_proof_plan(
     schemas: &impl SchemaAccessor,
 ) -> PlannerResult<DynProofPlan> {
     let input_plan = logical_plan_to_proof_plan(input, schemas)?;
-    let input_schema = input_plan
-        .get_column_result_fields()
-        .iter()
-        .map(|field| (field.name(), field.data_type()))
-        .collect::<Vec<_>>();
+    let input_schema = input_plan.get_column_result_fields();
     let aliased_exprs = expr
         .iter()
         .zip(output_schema.fields().iter())
@@ -172,11 +180,7 @@ fn aggregate_to_proof_plan(
     alias_map: &IndexMap<String, String>,
 ) -> PlannerResult<DynProofPlan> {
     let input_plan = logical_plan_to_proof_plan(input, schemas)?;
-    let input_schema = input_plan
-        .get_column_result_fields()
-        .iter()
-        .map(|field| (field.name(), field.data_type()))
-        .collect::<Vec<_>>();
+    let input_schema = input_plan.get_column_result_fields();
     let dummy_table_ref = TableRef::from_names(None, "");
     // We keep an extra alias just in case there is no count in the aggregate expr list
     let mut inner_aliases = 0..=(group_expr.len() + aggr_expr.len());
@@ -434,23 +438,28 @@ pub fn logical_plan_to_proof_plan(
             input, predicate, ..
         }) => {
             let input_plan = logical_plan_to_proof_plan(input, schema_accessor)?;
-            let input_schema = input_plan
-                .get_column_result_fields()
-                .iter()
-                .map(|field| (field.name(), field.data_type()))
-                .collect::<Vec<_>>();
+            let input_schema = input_plan.get_column_result_fields();
             let filter_proof_expr = expr_to_proof_expr(predicate, &input_schema)?;
             let aliased_exprs = input_plan
                 .get_column_result_fields()
                 .iter()
+                .filter(|field| value_column_id_from_presence(&field.name()).is_none())
                 .map(|field| -> PlannerResult<AliasedDynProofExpr> {
                     let alias = field.name();
                     Ok(AliasedDynProofExpr {
-                        expr: DynProofExpr::new_column(ColumnRef::new(
-                            TableRef::from_names(None, "__filter_input__"), // Dummy table ref
-                            alias.clone(),
-                            field.data_type(),
-                        )),
+                        expr: DynProofExpr::new_column(if field.is_nullable() {
+                            ColumnRef::new_nullable(
+                                TableRef::from_names(None, "__filter_input__"), // Dummy table ref
+                                alias.clone(),
+                                field.data_type(),
+                            )
+                        } else {
+                            ColumnRef::new(
+                                TableRef::from_names(None, "__filter_input__"), // Dummy table ref
+                                alias.clone(),
+                                field.data_type(),
+                            )
+                        }),
                         alias,
                     })
                 })

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -15,6 +15,58 @@ use proof_of_sql::{
 };
 use sqlparser::ast::Ident;
 
+/// Read-only access to planner schema fields.
+pub trait SchemaFields {
+    /// Return the field at the provided position.
+    fn field_at(&self, index: usize) -> Option<ColumnField>;
+
+    /// Find a field by identifier.
+    fn find_field(&self, ident: &Ident) -> Option<ColumnField>;
+}
+
+impl SchemaFields for [ColumnField] {
+    fn field_at(&self, index: usize) -> Option<ColumnField> {
+        self.get(index).cloned()
+    }
+
+    fn find_field(&self, ident: &Ident) -> Option<ColumnField> {
+        self.iter().find(|field| field.name() == *ident).cloned()
+    }
+}
+
+impl SchemaFields for Vec<ColumnField> {
+    fn field_at(&self, index: usize) -> Option<ColumnField> {
+        self.as_slice().field_at(index)
+    }
+
+    fn find_field(&self, ident: &Ident) -> Option<ColumnField> {
+        self.as_slice().find_field(ident)
+    }
+}
+
+impl SchemaFields for [(Ident, ColumnType)] {
+    fn field_at(&self, index: usize) -> Option<ColumnField> {
+        self.get(index)
+            .map(|(name, column_type)| ColumnField::new(name.clone(), *column_type))
+    }
+
+    fn find_field(&self, ident: &Ident) -> Option<ColumnField> {
+        self.iter()
+            .find(|(name, _)| name == ident)
+            .map(|(name, column_type)| ColumnField::new(name.clone(), *column_type))
+    }
+}
+
+impl SchemaFields for Vec<(Ident, ColumnType)> {
+    fn field_at(&self, index: usize) -> Option<ColumnField> {
+        self.as_slice().field_at(index)
+    }
+
+    fn find_field(&self, ident: &Ident) -> Option<ColumnField> {
+        self.as_slice().find_field(ident)
+    }
+}
+
 /// Parse a placeholder string of the form "$1", "$2", etc. into a `usize`.
 fn parse_placeholder_id(s: &str) -> Option<usize> {
     s.strip_prefix('$')
@@ -111,9 +163,9 @@ pub(crate) fn scalar_value_to_literal_value(value: ScalarValue) -> PlannerResult
 ///
 /// Note that the table name must be provided in the column which resolved logical plans do
 /// Otherwise we error out
-pub(crate) fn column_to_column_ref(
+pub(crate) fn column_to_column_ref<S: SchemaFields + ?Sized>(
     column: &Column,
-    schema: &[(Ident, ColumnType)],
+    schema: &S,
 ) -> PlannerResult<ColumnRef> {
     let table_ref = column
         .relation
@@ -122,12 +174,14 @@ pub(crate) fn column_to_column_ref(
         .transpose()?
         .unwrap_or_else(|| TableRef::from_names(None, ""));
     let ident: Ident = column.name.as_str().into();
-    let column_type = schema
-        .iter()
-        .find(|(i, _t)| *i == ident)
-        .ok_or(PlannerError::ColumnNotFound)?
-        .1;
-    Ok(ColumnRef::new(table_ref, ident, column_type))
+    let field = schema
+        .find_field(&ident)
+        .ok_or(PlannerError::ColumnNotFound)?;
+    Ok(if field.is_nullable() {
+        ColumnRef::new_nullable(table_ref, ident, field.data_type())
+    } else {
+        ColumnRef::new(table_ref, ident, field.data_type())
+    })
 }
 
 /// Convert a Vec<ColumnField> to a Schema
@@ -139,7 +193,11 @@ pub fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
             .map(|column_field| {
                 //TODO: Make columns nullable
                 let data_type = (&column_field.data_type()).into();
-                Field::new(column_field.name().value.as_str(), data_type, false)
+                Field::new(
+                    column_field.name().value.as_str(),
+                    data_type,
+                    column_field.is_nullable(),
+                )
             })
             .collect::<Vec<_>>(),
     )
@@ -148,6 +206,7 @@ pub fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
 /// Convert a [`DFSchema`] to a Vec<ColumnField>
 ///
 /// Note that this returns an error if any column has an unsupported `DataType`
+#[cfg(test)]
 pub(crate) fn schema_to_column_fields(schema: Vec<(Ident, ColumnType)>) -> Vec<ColumnField> {
     schema
         .into_iter()

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -175,6 +175,14 @@ fn test_nullable_column_queries() {
     let sql = "
         select score + bonus as total from nullable_scores where score + bonus = 12;
         select score is null as score_missing from nullable_scores;
+        select flag or guard as flag_or_guard, flag and guard as flag_and_guard from nullable_flags;
+        select
+            flag is false as flag_false,
+            flag is not true as flag_not_true,
+            flag is not false as flag_not_false,
+            flag is unknown as flag_unknown,
+            flag is not unknown as flag_known
+        from nullable_flags;
     ";
     let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
         TableRef::from_names(None, "nullable_scores") => table(
@@ -182,6 +190,13 @@ fn test_nullable_column_queries() {
                 borrowed_bigint("score", [5_i64, 0, 9, 5, 0], &alloc),
                 borrowed_boolean("score__presence", [true, false, true, true, false], &alloc),
                 borrowed_bigint("bonus", [7_i64, 0, 1, 7, 0], &alloc),
+            ]
+        ),
+        TableRef::from_names(None, "nullable_flags") => table(
+            vec![
+                borrowed_boolean("flag", [true, false, false, true], &alloc),
+                borrowed_boolean("flag__presence", [true, true, false, false], &alloc),
+                borrowed_boolean("guard", [false, false, false, true], &alloc),
             ]
         )
     };
@@ -191,6 +206,19 @@ fn test_nullable_column_queries() {
             boolean("total__presence", [true, true]),
         ]),
         owned_table([boolean("score_missing", [false, true, false, false, true])]),
+        owned_table([
+            boolean("flag_or_guard", [true, false, false, true]),
+            boolean("flag_or_guard__presence", [true, true, false, true]),
+            boolean("flag_and_guard", [false, false, false, true]),
+            boolean("flag_and_guard__presence", [true, true, true, false]),
+        ]),
+        owned_table([
+            boolean("flag_false", [false, true, false, false]),
+            boolean("flag_not_true", [false, true, true, true]),
+            boolean("flag_not_false", [true, false, true, true]),
+            boolean("flag_unknown", [false, false, true, true]),
+            boolean("flag_known", [true, true, false, false]),
+        ]),
     ];
 
     let public_parameters = PublicParameters::test_rand(5, &mut test_rng());

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -235,6 +235,87 @@ fn test_nullable_column_queries() {
     );
 }
 
+#[test]
+fn test_nullable_select_star_filter_queries() {
+    let alloc = Bump::new();
+    let sql = "
+        select * from nullable_addends where a + b = 2;
+        select * from nullable_addends where a + b = 4;
+        select * from nullable_addends where a + b = 3;
+        select * from nullable_addends where a + b = 0;
+        select * from nullable_addends where a = 1 or b = 1;
+    ";
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "nullable_addends") => table(
+            vec![
+                borrowed_bigint("a", [1_i64, 1, 0, 0, 2, 2, 0], &alloc),
+                borrowed_boolean(
+                    "a__presence",
+                    [true, true, false, false, true, true, false],
+                    &alloc,
+                ),
+                borrowed_bigint("b", [1_i64, 0, 1, 0, 2, 0, 2], &alloc),
+                borrowed_boolean(
+                    "b__presence",
+                    [true, false, true, false, true, false, true],
+                    &alloc,
+                ),
+                borrowed_bigint("c", [101_i64, 102, 103, 104, 105, 106, 107], &alloc),
+            ]
+        )
+    };
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        owned_table([
+            bigint("a", [1_i64]),
+            boolean("a__presence", [true]),
+            bigint("b", [1_i64]),
+            boolean("b__presence", [true]),
+            bigint("c", [101_i64]),
+        ]),
+        owned_table([
+            bigint("a", [2_i64]),
+            boolean("a__presence", [true]),
+            bigint("b", [2_i64]),
+            boolean("b__presence", [true]),
+            bigint("c", [105_i64]),
+        ]),
+        owned_table([
+            bigint("a", core::iter::empty::<i64>()),
+            boolean("a__presence", core::iter::empty::<bool>()),
+            bigint("b", core::iter::empty::<i64>()),
+            boolean("b__presence", core::iter::empty::<bool>()),
+            bigint("c", core::iter::empty::<i64>()),
+        ]),
+        owned_table([
+            bigint("a", core::iter::empty::<i64>()),
+            boolean("a__presence", core::iter::empty::<bool>()),
+            bigint("b", core::iter::empty::<i64>()),
+            boolean("b__presence", core::iter::empty::<bool>()),
+            bigint("c", core::iter::empty::<i64>()),
+        ]),
+        owned_table([
+            bigint("a", [1_i64, 1, 0]),
+            boolean("a__presence", [true, true, false]),
+            bigint("b", [1_i64, 0, 1]),
+            boolean("b__presence", [true, false, true]),
+            bigint("c", [101_i64, 102, 103]),
+        ]),
+    ];
+
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}
+
 /// Test complex filter queries with nested filters using subqueries
 #[test]
 fn test_complex_filter_queries() {

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -169,6 +169,44 @@ fn test_simple_filter_queries() {
     );
 }
 
+#[test]
+fn test_nullable_column_queries() {
+    let alloc = Bump::new();
+    let sql = "
+        select score + bonus as total from nullable_scores where score + bonus = 12;
+        select score is null as score_missing from nullable_scores;
+    ";
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "nullable_scores") => table(
+            vec![
+                borrowed_bigint("score", [5_i64, 0, 9, 5, 0], &alloc),
+                borrowed_boolean("score__presence", [true, false, true, true, false], &alloc),
+                borrowed_bigint("bonus", [7_i64, 0, 1, 7, 0], &alloc),
+            ]
+        )
+    };
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        owned_table([
+            decimal75("total", 20, 0, [12_i128, 12]),
+            boolean("total__presence", [true, true]),
+        ]),
+        owned_table([boolean("score_missing", [false, true, false, false, true])]),
+    ];
+
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}
+
 /// Test complex filter queries with nested filters using subqueries
 #[test]
 fn test_complex_filter_queries() {

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -77,7 +77,7 @@ impl From<&ColumnField> for Field {
         Field::new(
             column_field.name().value.as_str(),
             (&column_field.data_type()).into(),
-            false,
+            column_field.is_nullable(),
         )
     }
 }

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -148,6 +148,10 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
     /// - `Decimal256Array` when converting from `DataType::Decimal256` if precision is less than or equal to 75.
     /// - `StringArray` when converting from `DataType::Utf8`.
     fn try_from(value: &ArrayRef) -> Result<Self, Self::Error> {
+        if value.null_count() != 0 {
+            return Err(OwnedArrowConversionError::NullNotSupportedYet);
+        }
+
         match &value.data_type() {
             // Arrow uses a bit-packed representation for booleans.
             // Hence we need to unpack the bits to get the actual boolean values.

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -8,7 +8,7 @@ use alloc::sync::Arc;
 use arrow::{
     array::{
         ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
-        StringArray,
+        StringArray, TimestampSecondArray, UInt8Array,
     },
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
@@ -99,6 +99,34 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
         OwnedColumn::<TestScalar>::try_from(array_ref),
         Err(OwnedArrowConversionError::UnsupportedType { .. })
     ));
+}
+
+#[test]
+fn we_reject_arrow_arrays_with_nulls_when_converting_to_owned_columns() {
+    let arrays: Vec<ArrayRef> = vec![
+        Arc::new(BooleanArray::from(vec![Some(true), None, Some(false)])),
+        Arc::new(UInt8Array::from(vec![Some(1_u8), None, Some(3)])),
+        Arc::new(Int64Array::from(vec![Some(1_i64), None, Some(3)])),
+        Arc::new(
+            Decimal128Array::from(vec![Some(1_i128), None, Some(3)])
+                .with_precision_and_scale(38, 0)
+                .unwrap(),
+        ),
+        Arc::new(StringArray::from(vec![Some("a"), None, Some("c")])),
+        Arc::new(LargeBinaryArray::from(vec![
+            Some(b"a".as_slice()),
+            None,
+            Some(b"c".as_slice()),
+        ])),
+        Arc::new(TimestampSecondArray::from(vec![Some(1_i64), None, Some(3)])),
+    ];
+
+    for array in arrays {
+        assert!(matches!(
+            OwnedColumn::<TestScalar>::try_from(array),
+            Err(OwnedArrowConversionError::NullNotSupportedYet)
+        ));
+    }
 }
 
 fn we_can_convert_between_owned_table_and_record_batch_impl(

--- a/crates/proof-of-sql/src/base/database/accessor.rs
+++ b/crates/proof-of-sql/src/base/database/accessor.rs
@@ -1,6 +1,6 @@
 use crate::base::{
     commitment::Commitment,
-    database::{Column, ColumnType, Table, TableOptions, TableRef},
+    database::{Column, ColumnField, ColumnType, Table, TableOptions, TableRef},
     map::{IndexMap, IndexSet},
     scalar::Scalar,
 };
@@ -126,6 +126,14 @@ pub trait SchemaAccessor {
     /// Precondition 2: `table_ref` and `column_id` must always be lowercase.
     fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType>;
 
+    /// Lookup the column's field metadata in the specified table.
+    ///
+    /// Implementations that track nullability should override this method.
+    fn lookup_column_field(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnField> {
+        self.lookup_column(table_ref, column_id)
+            .map(|column_type| ColumnField::new(column_id.clone(), column_type))
+    }
+
     /// Lookup all the column names and their data types in the specified table
     ///
     /// Return:
@@ -134,6 +142,16 @@ pub trait SchemaAccessor {
     /// Precondition 1: the table must exist and be tamperproof.
     /// Precondition 2: `table_name` must be lowercase.
     fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)>;
+
+    /// Lookup all the column fields in the specified table.
+    ///
+    /// Implementations that track nullability should override this method.
+    fn lookup_schema_fields(&self, table_ref: &TableRef) -> Vec<ColumnField> {
+        self.lookup_schema(table_ref)
+            .into_iter()
+            .map(|(name, column_type)| ColumnField::new(name, column_type))
+            .collect()
+    }
 }
 
 /// The simplest implementation of `SchemaAccessor`.

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -53,3 +53,34 @@ impl ColumnField {
         self.nullable
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_field_defaults_to_non_nullable() {
+        let field = ColumnField::new("score".into(), ColumnType::BigInt);
+
+        assert!(!field.is_nullable());
+    }
+
+    #[test]
+    fn column_field_can_be_explicitly_nullable() {
+        let field = ColumnField::new_nullable("score".into(), ColumnType::BigInt);
+
+        assert!(field.is_nullable());
+    }
+
+    #[test]
+    fn column_field_serde_is_backward_compatible_without_nullable_flag() {
+        let field: ColumnField = serde_json::from_str(
+            r#"{"name":{"value":"score","quote_style":null},"data_type":"BigInt"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(field.name(), Ident::new("score"));
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+        assert!(!field.is_nullable());
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -10,13 +10,29 @@ use sqlparser::ast::Ident;
 pub struct ColumnField {
     name: Ident,
     data_type: ColumnType,
+    #[serde(default)]
+    nullable: bool,
 }
 
 impl ColumnField {
     /// Create a new `ColumnField` from a name and a type
     #[must_use]
     pub fn new(name: Ident, data_type: ColumnType) -> ColumnField {
-        ColumnField { name, data_type }
+        ColumnField {
+            name,
+            data_type,
+            nullable: false,
+        }
+    }
+
+    /// Create a new nullable `ColumnField` from a name and a type.
+    #[must_use]
+    pub fn new_nullable(name: Ident, data_type: ColumnType) -> ColumnField {
+        ColumnField {
+            name,
+            data_type,
+            nullable: true,
+        }
     }
 
     /// Returns the name of the column
@@ -29,5 +45,11 @@ impl ColumnField {
     #[must_use]
     pub fn data_type(&self) -> ColumnType {
         self.data_type
+    }
+
+    /// Returns whether the column is nullable.
+    #[must_use]
+    pub fn is_nullable(&self) -> bool {
+        self.nullable
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -8,6 +8,8 @@ pub struct ColumnRef {
     column_id: Ident,
     table_ref: TableRef,
     column_type: ColumnType,
+    #[serde(default)]
+    nullable: bool,
 }
 
 impl ColumnRef {
@@ -18,6 +20,18 @@ impl ColumnRef {
             column_id,
             table_ref,
             column_type,
+            nullable: false,
+        }
+    }
+
+    /// Create a new nullable `ColumnRef` from a table, column identifier and column type.
+    #[must_use]
+    pub fn new_nullable(table_ref: TableRef, column_id: Ident, column_type: ColumnType) -> Self {
+        Self {
+            column_id,
+            table_ref,
+            column_type,
+            nullable: true,
         }
     }
 
@@ -37,5 +51,11 @@ impl ColumnRef {
     #[must_use]
     pub fn column_type(&self) -> &ColumnType {
         &self.column_type
+    }
+
+    /// Returns whether the referenced column is nullable.
+    #[must_use]
+    pub fn is_nullable(&self) -> bool {
+        self.nullable
     }
 }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -74,6 +74,13 @@ pub mod arrow_schema_utility;
 mod owned_column;
 pub use owned_column::OwnedColumn;
 
+mod nullable_column;
+pub use nullable_column::{
+    NullableColumn, NullableColumnError, NullableColumnResult, NullableOwnedColumn,
+};
+#[cfg(test)]
+mod nullable_column_proof_test;
+
 mod owned_column_error;
 pub(crate) use owned_column_error::ColumnCoercionError;
 pub use owned_column_error::{OwnedColumnError, OwnedColumnResult};

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -76,7 +76,9 @@ pub use owned_column::OwnedColumn;
 
 mod nullable_column;
 pub use nullable_column::{
-    NullableColumn, NullableColumnError, NullableColumnResult, NullableOwnedColumn,
+    logical_column_fields_from_physical_schema, physical_column_fields_from_logical_schema,
+    presence_column_id, value_column_id_from_presence, NullableColumn, NullableColumnError,
+    NullableColumnResult, NullableOwnedColumn, PRESENCE_COLUMN_SUFFIX,
 };
 #[cfg(test)]
 mod nullable_column_proof_test;

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -1,0 +1,653 @@
+use super::{Column, ColumnOperationError, ColumnOperationResult, ColumnType, OwnedColumn};
+use crate::base::{
+    database::OwnedColumnResult,
+    math::permutation::{Permutation, PermutationError},
+    scalar::Scalar,
+};
+use alloc::{string::String, vec::Vec};
+use bumpalo::Bump;
+use snafu::Snafu;
+use sqlparser::ast::Ident;
+
+/// Errors from operations related to nullable columns.
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum NullableColumnError {
+    /// The value column and presence column have different lengths.
+    #[snafu(display(
+        "Value and presence columns have different lengths: {values_len} != {presence_len}"
+    ))]
+    PresenceLengthMismatch {
+        /// The length of the values column.
+        values_len: usize,
+        /// The length of the presence column.
+        presence_len: usize,
+    },
+}
+
+/// Result type for operations related to nullable columns.
+pub type NullableColumnResult<T> = core::result::Result<T, NullableColumnError>;
+
+/// An owned column with optional nullability metadata.
+///
+/// `presence == None` means the column is non-nullable. `presence == Some(mask)` means each row is
+/// present when the corresponding mask entry is true, and null otherwise. The value column remains
+/// the physical representation used by existing column operations and commitments.
+#[derive(Debug, PartialEq, Clone, Eq)]
+pub struct NullableOwnedColumn<S: Scalar> {
+    values: OwnedColumn<S>,
+    presence: Option<Vec<bool>>,
+}
+
+impl<S: Scalar> NullableOwnedColumn<S> {
+    /// Create a nullable owned column from a physical value column and optional presence mask.
+    pub fn try_new(
+        values: OwnedColumn<S>,
+        presence: Option<Vec<bool>>,
+    ) -> NullableColumnResult<Self> {
+        check_presence_len(values.len(), presence.as_deref())?;
+        Ok(Self { values, presence })
+    }
+
+    /// Create a non-nullable wrapper around an owned column.
+    #[must_use]
+    pub fn non_nullable(values: OwnedColumn<S>) -> Self {
+        Self {
+            values,
+            presence: None,
+        }
+    }
+
+    /// Convert logical optional scalars to a nullable owned column.
+    ///
+    /// Null entries are represented by `S::ZERO` before conversion to the target physical type. If
+    /// all entries are present, the returned column is non-nullable.
+    pub fn try_from_option_scalars(
+        option_scalars: &[Option<S>],
+        column_type: ColumnType,
+    ) -> OwnedColumnResult<Self> {
+        let mut saw_null = false;
+        let scalars = option_scalars
+            .iter()
+            .map(|scalar| {
+                scalar.unwrap_or_else(|| {
+                    saw_null = true;
+                    S::ZERO
+                })
+            })
+            .collect::<Vec<_>>();
+        let values = OwnedColumn::try_from_scalars(&scalars, column_type)?;
+        Ok(if saw_null {
+            Self {
+                values,
+                presence: Some(option_scalars.iter().map(Option::is_some).collect()),
+            }
+        } else {
+            Self::non_nullable(values)
+        })
+    }
+
+    /// Return the physical value column.
+    #[must_use]
+    pub fn values(&self) -> &OwnedColumn<S> {
+        &self.values
+    }
+
+    /// Return the optional presence mask.
+    #[must_use]
+    pub fn presence(&self) -> Option<&[bool]> {
+        self.presence.as_deref()
+    }
+
+    /// Split this nullable column into the physical value column and optional presence mask.
+    #[must_use]
+    pub fn into_inner(self) -> (OwnedColumn<S>, Option<Vec<bool>>) {
+        (self.values, self.presence)
+    }
+
+    /// Return the physical value column with a name suitable for an [`OwnedTable`].
+    #[must_use]
+    pub fn value_owned_column(&self, name: impl Into<Ident>) -> (Ident, OwnedColumn<S>) {
+        (name.into(), self.values.clone())
+    }
+
+    /// Return the physical presence column with a name suitable for an [`OwnedTable`].
+    ///
+    /// Returns `None` when this column is non-nullable.
+    #[must_use]
+    pub fn presence_owned_column(&self, name: impl Into<Ident>) -> Option<(Ident, OwnedColumn<S>)> {
+        self.presence
+            .as_ref()
+            .map(|presence| (name.into(), OwnedColumn::Boolean(presence.clone())))
+    }
+
+    /// Return true when this column has a presence mask.
+    #[must_use]
+    pub fn is_nullable(&self) -> bool {
+        self.presence.is_some()
+    }
+
+    /// Return the physical column type.
+    #[must_use]
+    pub fn column_type(&self) -> ColumnType {
+        self.values.column_type()
+    }
+
+    /// Return the number of rows.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Return true if the column contains no rows.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Return the column with its entries permuted.
+    pub fn try_permute(&self, permutation: &Permutation) -> Result<Self, PermutationError> {
+        Ok(Self {
+            values: self.values.try_permute(permutation)?,
+            presence: self
+                .presence
+                .as_ref()
+                .map(|presence| permutation.try_apply(presence))
+                .transpose()?,
+        })
+    }
+
+    /// Return the sliced column.
+    #[must_use]
+    pub fn slice(&self, start: usize, end: usize) -> Self {
+        Self {
+            values: self.values.slice(start, end),
+            presence: self
+                .presence
+                .as_ref()
+                .map(|presence| presence[start..end].to_vec()),
+        }
+    }
+
+    /// Borrow this nullable owned column.
+    pub fn as_column<'a>(&'a self, alloc: &'a Bump) -> NullableColumn<'a, S> {
+        NullableColumn {
+            values: Column::from_owned_column(&self.values, alloc),
+            presence: self.presence(),
+        }
+    }
+
+    /// Element-wise NOT operation on the value column. Presence is propagated unchanged.
+    pub fn element_wise_not(&self) -> ColumnOperationResult<Self> {
+        let values =
+            replace_null_rows_with(&self.values, self.presence(), NullRowReplacement::Zero)
+                .element_wise_not()?;
+        Ok(Self {
+            values: canonicalize_null_rows(values, self.presence()),
+            presence: self.presence.clone(),
+        })
+    }
+
+    /// Element-wise AND operation. Presence is the conjunction of operand presences.
+    pub fn element_wise_and(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.try_binary_op(rhs, OwnedColumn::element_wise_and, NullRowReplacement::Zero)
+    }
+
+    /// Element-wise OR operation. Presence is the conjunction of operand presences.
+    pub fn element_wise_or(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.try_binary_op(rhs, OwnedColumn::element_wise_or, NullRowReplacement::Zero)
+    }
+
+    /// Element-wise equality check. Presence is the conjunction of operand presences.
+    pub fn element_wise_eq(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.try_binary_op(rhs, OwnedColumn::element_wise_eq, NullRowReplacement::Zero)
+    }
+
+    /// Element-wise less-than check. Presence is the conjunction of operand presences.
+    pub fn element_wise_lt(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.try_binary_op(rhs, OwnedColumn::element_wise_lt, NullRowReplacement::Zero)
+    }
+
+    /// Element-wise greater-than check. Presence is the conjunction of operand presences.
+    pub fn element_wise_gt(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.try_binary_op(rhs, OwnedColumn::element_wise_gt, NullRowReplacement::Zero)
+    }
+
+    /// Element-wise addition. Presence is the conjunction of operand presences.
+    pub fn element_wise_add(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.try_binary_op(rhs, OwnedColumn::element_wise_add, NullRowReplacement::Zero)
+    }
+
+    /// Element-wise subtraction. Presence is the conjunction of operand presences.
+    pub fn element_wise_sub(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.try_binary_op(rhs, OwnedColumn::element_wise_sub, NullRowReplacement::Zero)
+    }
+
+    /// Element-wise multiplication. Presence is the conjunction of operand presences.
+    pub fn element_wise_mul(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.try_binary_op(rhs, OwnedColumn::element_wise_mul, NullRowReplacement::Zero)
+    }
+
+    /// Element-wise division. Presence is the conjunction of operand presences.
+    pub fn element_wise_div(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.try_binary_op(rhs, OwnedColumn::element_wise_div, NullRowReplacement::One)
+    }
+
+    fn try_binary_op(
+        &self,
+        rhs: &Self,
+        op: impl Fn(&OwnedColumn<S>, &OwnedColumn<S>) -> ColumnOperationResult<OwnedColumn<S>>,
+        rhs_null_replacement: NullRowReplacement,
+    ) -> ColumnOperationResult<Self> {
+        if self.len() != rhs.len() {
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
+        }
+        let presence = combine_presence(self.presence(), rhs.presence());
+        let lhs_values =
+            replace_null_rows_with(&self.values, presence.as_deref(), NullRowReplacement::Zero);
+        let rhs_values =
+            replace_null_rows_with(&rhs.values, presence.as_deref(), rhs_null_replacement);
+        let values = op(&lhs_values, &rhs_values)?;
+        Ok(Self {
+            values: canonicalize_null_rows(values, presence.as_deref()),
+            presence,
+        })
+    }
+}
+
+impl<'a, S: Scalar> TryFrom<NullableColumn<'a, S>> for NullableOwnedColumn<S> {
+    type Error = NullableColumnError;
+
+    fn try_from(value: NullableColumn<'a, S>) -> NullableColumnResult<Self> {
+        Self::try_new(
+            OwnedColumn::from(&value.values),
+            value.presence.map(<[bool]>::to_vec),
+        )
+    }
+}
+
+/// A borrowed column with optional nullability metadata.
+///
+/// `presence == None` means the column is non-nullable. `presence == Some(mask)` means each row is
+/// present when the corresponding mask entry is true, and null otherwise.
+#[derive(Debug, PartialEq, Clone, Copy, Eq)]
+pub struct NullableColumn<'a, S: Scalar> {
+    values: Column<'a, S>,
+    presence: Option<&'a [bool]>,
+}
+
+impl<'a, S: Scalar> NullableColumn<'a, S> {
+    /// Create a nullable borrowed column from a physical value column and optional presence mask.
+    pub fn try_new(
+        values: Column<'a, S>,
+        presence: Option<&'a [bool]>,
+    ) -> NullableColumnResult<Self> {
+        check_presence_len(values.len(), presence)?;
+        Ok(Self { values, presence })
+    }
+
+    /// Create a non-nullable wrapper around a borrowed column.
+    #[must_use]
+    pub fn non_nullable(values: Column<'a, S>) -> Self {
+        Self {
+            values,
+            presence: None,
+        }
+    }
+
+    /// Return the physical value column.
+    #[must_use]
+    pub fn values(&self) -> Column<'a, S> {
+        self.values
+    }
+
+    /// Return the optional presence mask.
+    #[must_use]
+    pub fn presence(&self) -> Option<&'a [bool]> {
+        self.presence
+    }
+
+    /// Return true when this column has a presence mask.
+    #[must_use]
+    pub fn is_nullable(&self) -> bool {
+        self.presence.is_some()
+    }
+
+    /// Return the physical column type.
+    #[must_use]
+    pub fn column_type(&self) -> ColumnType {
+        self.values.column_type()
+    }
+
+    /// Return the number of rows.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Return true if the column contains no rows.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+fn check_presence_len(values_len: usize, presence: Option<&[bool]>) -> NullableColumnResult<()> {
+    if let Some(presence) = presence {
+        if presence.len() != values_len {
+            return Err(NullableColumnError::PresenceLengthMismatch {
+                values_len,
+                presence_len: presence.len(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn combine_presence(lhs: Option<&[bool]>, rhs: Option<&[bool]>) -> Option<Vec<bool>> {
+    match (lhs, rhs) {
+        (None, None) => None,
+        (Some(lhs), None) => Some(lhs.to_vec()),
+        (None, Some(rhs)) => Some(rhs.to_vec()),
+        (Some(lhs), Some(rhs)) => Some(
+            lhs.iter()
+                .zip(rhs.iter())
+                .map(|(left, right)| *left && *right)
+                .collect(),
+        ),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum NullRowReplacement {
+    Zero,
+    One,
+}
+
+fn replace_null_rows_with<S: Scalar>(
+    column: &OwnedColumn<S>,
+    presence: Option<&[bool]>,
+    replacement: NullRowReplacement,
+) -> OwnedColumn<S> {
+    let Some(presence) = presence else {
+        return column.clone();
+    };
+    let mut column = column.clone();
+    replace_absent_rows(&mut column, presence, replacement);
+    column
+}
+
+fn canonicalize_null_rows<S: Scalar>(
+    mut column: OwnedColumn<S>,
+    presence: Option<&[bool]>,
+) -> OwnedColumn<S> {
+    if let Some(presence) = presence {
+        replace_absent_rows(&mut column, presence, NullRowReplacement::Zero);
+    }
+    column
+}
+
+fn replace_absent_rows<S: Scalar>(
+    column: &mut OwnedColumn<S>,
+    presence: &[bool],
+    replacement: NullRowReplacement,
+) {
+    match column {
+        OwnedColumn::Boolean(values) => {
+            replace_absent_values(
+                values,
+                presence,
+                matches!(replacement, NullRowReplacement::One),
+            );
+        }
+        OwnedColumn::Uint8(values) => replace_absent_values(
+            values,
+            presence,
+            match replacement {
+                NullRowReplacement::Zero => 0,
+                NullRowReplacement::One => 1,
+            },
+        ),
+        OwnedColumn::TinyInt(values) => replace_absent_values(
+            values,
+            presence,
+            match replacement {
+                NullRowReplacement::Zero => 0,
+                NullRowReplacement::One => 1,
+            },
+        ),
+        OwnedColumn::SmallInt(values) => replace_absent_values(
+            values,
+            presence,
+            match replacement {
+                NullRowReplacement::Zero => 0,
+                NullRowReplacement::One => 1,
+            },
+        ),
+        OwnedColumn::Int(values) => replace_absent_values(
+            values,
+            presence,
+            match replacement {
+                NullRowReplacement::Zero => 0,
+                NullRowReplacement::One => 1,
+            },
+        ),
+        OwnedColumn::BigInt(values) | OwnedColumn::TimestampTZ(_, _, values) => {
+            replace_absent_values(
+                values,
+                presence,
+                match replacement {
+                    NullRowReplacement::Zero => 0,
+                    NullRowReplacement::One => 1,
+                },
+            );
+        }
+        OwnedColumn::Int128(values) => replace_absent_values(
+            values,
+            presence,
+            match replacement {
+                NullRowReplacement::Zero => 0,
+                NullRowReplacement::One => 1,
+            },
+        ),
+        OwnedColumn::Decimal75(_, _, values) | OwnedColumn::Scalar(values) => {
+            replace_absent_values(
+                values,
+                presence,
+                match replacement {
+                    NullRowReplacement::Zero => S::ZERO,
+                    NullRowReplacement::One => S::ONE,
+                },
+            );
+        }
+        OwnedColumn::VarChar(values) => replace_absent_values(values, presence, String::new()),
+        OwnedColumn::VarBinary(values) => replace_absent_values(values, presence, Vec::new()),
+    }
+}
+
+fn replace_absent_values<T: Clone>(values: &mut [T], presence: &[bool], replacement: T) {
+    for (value, present) in values.iter_mut().zip(presence.iter()) {
+        if !present {
+            *value = replacement.clone();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{math::permutation::Permutation, scalar::test_scalar::TestScalar};
+    use alloc::vec;
+
+    #[test]
+    fn nullable_owned_column_rejects_mismatched_presence_length() {
+        let err = NullableOwnedColumn::<TestScalar>::try_new(
+            OwnedColumn::BigInt(vec![1, 2, 3]),
+            Some(vec![true, false]),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            NullableColumnError::PresenceLengthMismatch {
+                values_len: 3,
+                presence_len: 2
+            }
+        );
+    }
+
+    #[test]
+    fn nullable_owned_column_converts_option_scalars() {
+        let option_scalars = [Some(1), None, Some(3)]
+            .iter()
+            .map(|value| value.map(TestScalar::from))
+            .collect::<Vec<_>>();
+
+        let column =
+            NullableOwnedColumn::try_from_option_scalars(&option_scalars, ColumnType::BigInt)
+                .unwrap();
+
+        assert_eq!(column.values(), &OwnedColumn::BigInt(vec![1, 0, 3]));
+        assert_eq!(column.presence(), Some([true, false, true].as_slice()));
+    }
+
+    #[test]
+    fn nullable_owned_column_without_nulls_omits_presence_mask() {
+        let option_scalars = [Some(1), Some(2), Some(3)]
+            .iter()
+            .map(|value| value.map(TestScalar::from))
+            .collect::<Vec<_>>();
+
+        let column =
+            NullableOwnedColumn::try_from_option_scalars(&option_scalars, ColumnType::BigInt)
+                .unwrap();
+
+        assert_eq!(column.values(), &OwnedColumn::BigInt(vec![1, 2, 3]));
+        assert_eq!(column.presence(), None);
+    }
+
+    #[test]
+    fn nullable_binary_operations_propagate_one_presence_mask() {
+        let lhs = NullableOwnedColumn::<TestScalar>::try_new(
+            OwnedColumn::BigInt(vec![5, 0, 9]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+        let rhs = NullableOwnedColumn::non_nullable(OwnedColumn::BigInt(vec![7, 12, 1]));
+
+        let result = lhs.element_wise_add(&rhs).unwrap();
+
+        assert_eq!(result.values(), &OwnedColumn::BigInt(vec![12, 0, 10]));
+        assert_eq!(result.presence(), Some([true, false, true].as_slice()));
+    }
+
+    #[test]
+    fn nullable_binary_operations_conjoin_two_presence_masks() {
+        let lhs = NullableOwnedColumn::<TestScalar>::try_new(
+            OwnedColumn::BigInt(vec![5, 0, 9, 2]),
+            Some(vec![true, false, true, true]),
+        )
+        .unwrap();
+        let rhs = NullableOwnedColumn::try_new(
+            OwnedColumn::BigInt(vec![7, 12, 0, 3]),
+            Some(vec![true, true, false, true]),
+        )
+        .unwrap();
+
+        let result = lhs.element_wise_add(&rhs).unwrap();
+
+        assert_eq!(result.values(), &OwnedColumn::BigInt(vec![12, 0, 0, 5]));
+        assert_eq!(
+            result.presence(),
+            Some([true, false, false, true].as_slice())
+        );
+    }
+
+    #[test]
+    fn nullable_division_ignores_division_by_zero_on_null_rows() {
+        let lhs =
+            NullableOwnedColumn::<TestScalar>::non_nullable(OwnedColumn::BigInt(vec![10, 20, 30]));
+        let rhs = NullableOwnedColumn::try_new(
+            OwnedColumn::BigInt(vec![2, 0, 5]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+
+        let result = lhs.element_wise_div(&rhs).unwrap();
+
+        assert_eq!(result.values(), &OwnedColumn::BigInt(vec![5, 0, 6]));
+        assert_eq!(result.presence(), Some([true, false, true].as_slice()));
+    }
+
+    #[test]
+    fn nullable_comparisons_return_nullable_boolean_columns() {
+        let lhs = NullableOwnedColumn::<TestScalar>::try_new(
+            OwnedColumn::BigInt(vec![5, 0, 9]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+        let rhs = NullableOwnedColumn::non_nullable(OwnedColumn::BigInt(vec![5, 0, 1]));
+
+        let result = lhs.element_wise_gt(&rhs).unwrap();
+
+        assert_eq!(
+            result.values(),
+            &OwnedColumn::Boolean(vec![false, false, true])
+        );
+        assert_eq!(result.presence(), Some([true, false, true].as_slice()));
+    }
+
+    #[test]
+    fn nullable_not_preserves_presence_mask() {
+        let column = NullableOwnedColumn::<TestScalar>::try_new(
+            OwnedColumn::Boolean(vec![true, false, true]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+
+        let result = column.element_wise_not().unwrap();
+
+        assert_eq!(
+            result.values(),
+            &OwnedColumn::Boolean(vec![false, false, false])
+        );
+        assert_eq!(result.presence(), Some([true, false, true].as_slice()));
+    }
+
+    #[test]
+    fn nullable_slice_and_permute_keep_values_and_presence_aligned() {
+        let column = NullableOwnedColumn::<TestScalar>::try_new(
+            OwnedColumn::BigInt(vec![5, 0, 9, 2]),
+            Some(vec![true, false, true, true]),
+        )
+        .unwrap();
+
+        let sliced = column.slice(1, 4);
+        assert_eq!(sliced.values(), &OwnedColumn::BigInt(vec![0, 9, 2]));
+        assert_eq!(sliced.presence(), Some([false, true, true].as_slice()));
+
+        let permutation = Permutation::try_new(vec![2, 0, 1]).unwrap();
+        let permuted = sliced.try_permute(&permutation).unwrap();
+        assert_eq!(permuted.values(), &OwnedColumn::BigInt(vec![2, 0, 9]));
+        assert_eq!(permuted.presence(), Some([true, false, true].as_slice()));
+    }
+
+    #[test]
+    fn borrowed_and_owned_nullable_columns_round_trip() {
+        let alloc = Bump::new();
+        let owned = NullableOwnedColumn::<TestScalar>::try_new(
+            OwnedColumn::BigInt(vec![5, 0, 9]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+
+        let borrowed = owned.as_column(&alloc);
+        assert_eq!(borrowed.values(), Column::BigInt(&[5, 0, 9]));
+        assert_eq!(borrowed.presence(), Some([true, false, true].as_slice()));
+
+        let round_trip = NullableOwnedColumn::try_from(borrowed).unwrap();
+        assert_eq!(round_trip, owned);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -6,7 +6,11 @@ use crate::base::{
     math::permutation::{Permutation, PermutationError},
     scalar::Scalar,
 };
-use alloc::{format, string::String, vec::Vec};
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use bumpalo::Bump;
 use snafu::Snafu;
 use sqlparser::ast::Ident;
@@ -259,14 +263,14 @@ impl<S: Scalar> NullableOwnedColumn<S> {
         })
     }
 
-    /// Element-wise AND operation. Presence is the conjunction of operand presences.
+    /// Element-wise SQL `AND` operation with three-valued null semantics.
     pub fn element_wise_and(&self, rhs: &Self) -> ColumnOperationResult<Self> {
-        self.try_binary_op(rhs, OwnedColumn::element_wise_and, NullRowReplacement::Zero)
+        self.try_boolean_op(rhs, SqlBooleanOp::And)
     }
 
-    /// Element-wise OR operation. Presence is the conjunction of operand presences.
+    /// Element-wise SQL `OR` operation with three-valued null semantics.
     pub fn element_wise_or(&self, rhs: &Self) -> ColumnOperationResult<Self> {
-        self.try_binary_op(rhs, OwnedColumn::element_wise_or, NullRowReplacement::Zero)
+        self.try_boolean_op(rhs, SqlBooleanOp::Or)
     }
 
     /// Element-wise equality check. Presence is the conjunction of operand presences.
@@ -324,6 +328,45 @@ impl<S: Scalar> NullableOwnedColumn<S> {
         let values = op(&lhs_values, &rhs_values)?;
         Ok(Self {
             values: canonicalize_null_rows(values, presence.as_deref()),
+            presence,
+        })
+    }
+
+    fn try_boolean_op(&self, rhs: &Self, op: SqlBooleanOp) -> ColumnOperationResult<Self> {
+        if self.len() != rhs.len() {
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
+        }
+        let (OwnedColumn::Boolean(lhs_values), OwnedColumn::Boolean(rhs_values)) =
+            (&self.values, &rhs.values)
+        else {
+            return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
+                operator: op.operator_name().to_string(),
+                left_type: self.column_type(),
+                right_type: rhs.column_type(),
+            });
+        };
+
+        let values = lhs_values
+            .iter()
+            .zip(rhs_values.iter())
+            .map(|(lhs, rhs)| match op {
+                SqlBooleanOp::And => *lhs && *rhs,
+                SqlBooleanOp::Or => *lhs || *rhs,
+            })
+            .collect();
+        let presence = match op {
+            SqlBooleanOp::And => {
+                sql_and_presence(lhs_values, self.presence(), rhs_values, rhs.presence())
+            }
+            SqlBooleanOp::Or => {
+                sql_or_presence(lhs_values, self.presence(), rhs_values, rhs.presence())
+            }
+        };
+        Ok(Self {
+            values: OwnedColumn::Boolean(values),
             presence,
         })
     }
@@ -436,6 +479,95 @@ fn combine_presence(lhs: Option<&[bool]>, rhs: Option<&[bool]>) -> Option<Vec<bo
 enum NullRowReplacement {
     Zero,
     One,
+}
+
+#[derive(Clone, Copy)]
+enum SqlBooleanOp {
+    And,
+    Or,
+}
+
+impl SqlBooleanOp {
+    fn operator_name(self) -> &'static str {
+        match self {
+            SqlBooleanOp::And => "AND",
+            SqlBooleanOp::Or => "OR",
+        }
+    }
+}
+
+fn sql_and_presence(
+    lhs_values: &[bool],
+    lhs_presence: Option<&[bool]>,
+    rhs_values: &[bool],
+    rhs_presence: Option<&[bool]>,
+) -> Option<Vec<bool>> {
+    match (lhs_presence, rhs_presence) {
+        (None, None) => None,
+        (Some(lhs_presence), None) => Some(
+            lhs_presence
+                .iter()
+                .zip(rhs_values.iter())
+                .map(|(lhs_present, rhs_value)| *lhs_present || !*rhs_value)
+                .collect(),
+        ),
+        (None, Some(rhs_presence)) => Some(
+            lhs_values
+                .iter()
+                .zip(rhs_presence.iter())
+                .map(|(lhs_value, rhs_present)| *rhs_present || !*lhs_value)
+                .collect(),
+        ),
+        (Some(lhs_presence), Some(rhs_presence)) => Some(
+            lhs_values
+                .iter()
+                .zip(lhs_presence.iter())
+                .zip(rhs_values.iter().zip(rhs_presence.iter()))
+                .map(|((lhs_value, lhs_present), (rhs_value, rhs_present))| {
+                    (*lhs_present && *rhs_present)
+                        || (*lhs_present && !*lhs_value)
+                        || (*rhs_present && !*rhs_value)
+                })
+                .collect(),
+        ),
+    }
+}
+
+fn sql_or_presence(
+    lhs_values: &[bool],
+    lhs_presence: Option<&[bool]>,
+    rhs_values: &[bool],
+    rhs_presence: Option<&[bool]>,
+) -> Option<Vec<bool>> {
+    match (lhs_presence, rhs_presence) {
+        (None, None) => None,
+        (Some(lhs_presence), None) => Some(
+            lhs_presence
+                .iter()
+                .zip(rhs_values.iter())
+                .map(|(lhs_present, rhs_value)| *lhs_present || *rhs_value)
+                .collect(),
+        ),
+        (None, Some(rhs_presence)) => Some(
+            lhs_values
+                .iter()
+                .zip(rhs_presence.iter())
+                .map(|(lhs_value, rhs_present)| *rhs_present || *lhs_value)
+                .collect(),
+        ),
+        (Some(lhs_presence), Some(rhs_presence)) => Some(
+            lhs_values
+                .iter()
+                .zip(lhs_presence.iter())
+                .zip(rhs_values.iter().zip(rhs_presence.iter()))
+                .map(|((lhs_value, lhs_present), (rhs_value, rhs_present))| {
+                    (*lhs_present && *rhs_present)
+                        || (*lhs_present && *lhs_value)
+                        || (*rhs_present && *rhs_value)
+                })
+                .collect(),
+        ),
+    }
 }
 
 fn replace_null_rows_with<S: Scalar>(
@@ -686,6 +818,52 @@ mod tests {
             &OwnedColumn::Boolean(vec![false, false, false])
         );
         assert_eq!(result.presence(), Some([true, false, true].as_slice()));
+    }
+
+    #[test]
+    fn nullable_boolean_and_or_use_sql_three_valued_logic() {
+        let lhs = NullableOwnedColumn::<TestScalar>::try_new(
+            OwnedColumn::Boolean(vec![
+                false, false, false, true, true, true, false, false, false,
+            ]),
+            Some(vec![
+                true, true, true, true, true, true, false, false, false,
+            ]),
+        )
+        .unwrap();
+        let rhs = NullableOwnedColumn::try_new(
+            OwnedColumn::Boolean(vec![
+                false, true, false, false, true, false, false, true, false,
+            ]),
+            Some(vec![
+                true, true, false, true, true, false, true, true, false,
+            ]),
+        )
+        .unwrap();
+
+        let and_result = lhs.element_wise_and(&rhs).unwrap();
+        assert_eq!(
+            and_result.values(),
+            &OwnedColumn::Boolean(vec![
+                false, false, false, false, true, false, false, false, false,
+            ])
+        );
+        assert_eq!(
+            and_result.presence(),
+            Some([true, true, true, true, true, false, true, false, false].as_slice())
+        );
+
+        let or_result = lhs.element_wise_or(&rhs).unwrap();
+        assert_eq!(
+            or_result.values(),
+            &OwnedColumn::Boolean(vec![
+                false, true, false, true, true, true, false, true, false,
+            ])
+        );
+        assert_eq!(
+            or_result.presence(),
+            Some([true, true, false, true, true, true, false, true, false].as_slice())
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -1,13 +1,85 @@
-use super::{Column, ColumnOperationError, ColumnOperationResult, ColumnType, OwnedColumn};
+use super::{
+    Column, ColumnField, ColumnOperationError, ColumnOperationResult, ColumnType, OwnedColumn,
+};
 use crate::base::{
     database::OwnedColumnResult,
     math::permutation::{Permutation, PermutationError},
     scalar::Scalar,
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{format, string::String, vec::Vec};
 use bumpalo::Bump;
 use snafu::Snafu;
 use sqlparser::ast::Ident;
+
+/// Suffix used for the physical boolean presence column backing a nullable value column.
+pub const PRESENCE_COLUMN_SUFFIX: &str = "__presence";
+
+/// Return the physical presence-column identifier for a logical nullable column.
+#[must_use]
+pub fn presence_column_id(column_id: &Ident) -> Ident {
+    Ident::new(format!("{}{}", column_id.value, PRESENCE_COLUMN_SUFFIX))
+}
+
+/// Return the logical value-column identifier if `column_id` is a physical presence column.
+#[must_use]
+pub fn value_column_id_from_presence(column_id: &Ident) -> Option<Ident> {
+    column_id
+        .value
+        .strip_suffix(PRESENCE_COLUMN_SUFFIX)
+        .map(Ident::new)
+}
+
+/// Convert a physical value/presence schema to a logical schema with nullable fields.
+#[must_use]
+pub fn logical_column_fields_from_physical_schema(
+    schema: impl IntoIterator<Item = (Ident, ColumnType)>,
+) -> Vec<ColumnField> {
+    let schema = schema.into_iter().collect::<Vec<_>>();
+    schema
+        .iter()
+        .filter_map(|(name, column_type)| {
+            if let Some(value_id) = value_column_id_from_presence(name) {
+                if *column_type == ColumnType::Boolean
+                    && schema
+                        .iter()
+                        .any(|(candidate_name, _)| *candidate_name == value_id)
+                {
+                    return None;
+                }
+            }
+            let presence_id = presence_column_id(name);
+            let is_nullable = schema.iter().any(|(candidate_name, candidate_type)| {
+                *candidate_name == presence_id && *candidate_type == ColumnType::Boolean
+            });
+            Some(if is_nullable {
+                ColumnField::new_nullable(name.clone(), *column_type)
+            } else {
+                ColumnField::new(name.clone(), *column_type)
+            })
+        })
+        .collect()
+}
+
+/// Convert a logical schema to the physical value/presence schema used by proofs.
+#[must_use]
+pub fn physical_column_fields_from_logical_schema(
+    schema: impl IntoIterator<Item = ColumnField>,
+) -> Vec<ColumnField> {
+    schema
+        .into_iter()
+        .flat_map(|field| {
+            let mut fields = Vec::with_capacity(if field.is_nullable() { 2 } else { 1 });
+            fields.push(field.clone());
+            if field.is_nullable() {
+                fields.push(ColumnField::new(
+                    presence_column_id(&field.name()),
+                    ColumnType::Boolean,
+                ));
+            }
+            fields
+        })
+        .collect()
+}
 
 /// Errors from operations related to nullable columns.
 #[derive(Snafu, Debug, PartialEq, Eq)]

--- a/crates/proof-of-sql/src/base/database/nullable_column_proof_test.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column_proof_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    owned_table_utility::*, ColumnType, NullableOwnedColumn, OwnedColumn, OwnedTableTestAccessor,
-    TableRef,
+    owned_table_utility::*, presence_column_id, ColumnField, ColumnRef, ColumnType,
+    NullableOwnedColumn, OwnedColumn, OwnedTableTestAccessor, TableRef,
 };
 use crate::{
     base::{
@@ -8,7 +8,9 @@ use crate::{
         scalar::test_scalar::TestScalar,
     },
     sql::{
-        proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::test_utility::*,
+        proof::VerifiableQueryResult,
+        proof_exprs::{test_utility::*, DynProofExpr},
+        proof_plans::test_utility::*,
     },
 };
 use alloc::vec::Vec;
@@ -189,6 +191,83 @@ fn we_can_prove_nullable_bigint_addition_with_presence_columns() {
             bigint("sum_value", [12_i64, 12]),
             boolean("score_present", [true, true]),
             boolean("sum_present", [true, true]),
+        ])
+    );
+}
+
+#[test]
+fn we_can_prove_nullable_expressions_through_projection_and_filter() {
+    let nullable_score = nullable_bigint([Some(5_i64), None, Some(9), Some(5), None]);
+    let bonus = NullableOwnedColumn::<TestScalar>::non_nullable(OwnedColumn::BigInt(vec![
+        7_i64, 0, 1, 7, 0,
+    ]));
+    let t = TableRef::new("sxt", "nullable_scores");
+    let score_presence = presence_column_id(&"score".into());
+    let data = owned_table([
+        nullable_score.value_owned_column("score"),
+        nullable_score
+            .presence_owned_column(score_presence.clone())
+            .unwrap(),
+        bonus.value_owned_column("bonus"),
+    ]);
+    let accessor =
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
+    let score = DynProofExpr::new_column(ColumnRef::new_nullable(
+        t.clone(),
+        "score".into(),
+        ColumnType::BigInt,
+    ));
+    let bonus = DynProofExpr::new_column(ColumnRef::new(
+        t.clone(),
+        "bonus".into(),
+        ColumnType::BigInt,
+    ));
+    let total = add(score.clone(), bonus.clone());
+    let table_scan = table_exec(
+        t.clone(),
+        vec![
+            ColumnField::new_nullable("score".into(), ColumnType::BigInt),
+            ColumnField::new("bonus".into(), ColumnType::BigInt),
+        ],
+    );
+    let projection_plan = projection(
+        vec![
+            aliased_plan(total.clone(), "total"),
+            aliased_plan(DynProofExpr::new_is_null(score.clone()), "score_is_null"),
+        ],
+        table_scan.clone(),
+    );
+    let projection_table =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&projection_plan, &accessor, &(), &[])
+            .unwrap()
+            .verify(&projection_plan, &accessor, &(), &[])
+            .unwrap()
+            .table;
+    assert_eq!(
+        projection_table,
+        owned_table([
+            decimal75("total", 20, 0, [12_i128, 0, 10, 12, 0]),
+            boolean("total__presence", [true, false, true, true, false]),
+            boolean("score_is_null", [false, true, false, false, true]),
+        ])
+    );
+
+    let filter_plan = filter(
+        vec![aliased_plan(total.clone(), "total")],
+        table_scan,
+        equal(total, const_decimal75(20, 0, 12_i128)),
+    );
+    let filtered_table =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&filter_plan, &accessor, &(), &[])
+            .unwrap()
+            .verify(&filter_plan, &accessor, &(), &[])
+            .unwrap()
+            .table;
+    assert_eq!(
+        filtered_table,
+        owned_table([
+            decimal75("total", 20, 0, [12_i128, 12]),
+            boolean("total__presence", [true, true]),
         ])
     );
 }

--- a/crates/proof-of-sql/src/base/database/nullable_column_proof_test.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column_proof_test.rs
@@ -1,0 +1,202 @@
+use super::{
+    owned_table_utility::*, ColumnType, NullableOwnedColumn, OwnedColumn, OwnedTableTestAccessor,
+    TableRef,
+};
+use crate::{
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof, math::decimal::Precision,
+        scalar::test_scalar::TestScalar,
+    },
+    sql::{
+        proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::test_utility::*,
+    },
+};
+use alloc::vec::Vec;
+
+#[test]
+#[expect(clippy::too_many_lines)]
+fn we_can_prove_nullable_bigint_addition_with_presence_columns() {
+    let nullable_score = nullable_bigint([Some(5_i64), None, Some(9), Some(5), None]);
+    let bonus_values = vec![7_i64, 12, 1, 7, 6];
+    let bonus =
+        NullableOwnedColumn::<TestScalar>::non_nullable(OwnedColumn::BigInt(bonus_values.clone()));
+    let nullable_sum = nullable_score.element_wise_add(&bonus).unwrap();
+
+    assert_eq!(
+        nullable_sum.values(),
+        &OwnedColumn::BigInt(vec![12, 0, 10, 12, 0])
+    );
+    assert_eq!(
+        nullable_sum.presence(),
+        Some([true, false, true, true, false].as_slice())
+    );
+
+    let data = owned_table([
+        nullable_score.value_owned_column("score_value"),
+        nullable_score
+            .presence_owned_column("score_present")
+            .unwrap(),
+        bonus.value_owned_column("bonus_value"),
+        nullable_sum.value_owned_column("sum_value"),
+        nullable_sum.presence_owned_column("sum_present").unwrap(),
+    ]);
+    let t = TableRef::new("sxt", "nullable_scores");
+    let accessor =
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
+
+    let score_plus_bonus = add(
+        column(&t, "score_value", &accessor),
+        column(&t, "bonus_value", &accessor),
+    );
+    let sum_value_as_decimal = cast(
+        column(&t, "sum_value", &accessor),
+        ColumnType::Decimal75(Precision::new(20).unwrap(), 0),
+    );
+    let where_clause = and(
+        column(&t, "score_present", &accessor),
+        and(
+            equal(
+                column(&t, "score_present", &accessor),
+                column(&t, "sum_present", &accessor),
+            ),
+            and(
+                equal(score_plus_bonus.clone(), sum_value_as_decimal),
+                equal(score_plus_bonus.clone(), const_decimal75(20, 0, 12_i128)),
+            ),
+        ),
+    );
+    let plan = filter(
+        vec![
+            aliased_plan(score_plus_bonus, "score_plus_bonus"),
+            col_expr_plan(&t, "sum_value", &accessor),
+            col_expr_plan(&t, "score_present", &accessor),
+            col_expr_plan(&t, "sum_present", &accessor),
+        ],
+        table_exec(
+            t.clone(),
+            vec![
+                column_field("score_value", ColumnType::BigInt),
+                column_field("score_present", ColumnType::Boolean),
+                column_field("bonus_value", ColumnType::BigInt),
+                column_field("sum_value", ColumnType::BigInt),
+                column_field("sum_present", ColumnType::Boolean),
+            ],
+        ),
+        where_clause,
+    );
+
+    let mismatched_presence_plan = filter(
+        vec![
+            col_expr_plan(&t, "score_present", &accessor),
+            col_expr_plan(&t, "sum_present", &accessor),
+        ],
+        table_exec(
+            t.clone(),
+            vec![
+                column_field("score_value", ColumnType::BigInt),
+                column_field("score_present", ColumnType::Boolean),
+                column_field("bonus_value", ColumnType::BigInt),
+                column_field("sum_value", ColumnType::BigInt),
+                column_field("sum_present", ColumnType::Boolean),
+            ],
+        ),
+        not(equal(
+            column(&t, "score_present", &accessor),
+            column(&t, "sum_present", &accessor),
+        )),
+    );
+    let mismatched_presence_res = VerifiableQueryResult::<NaiveEvaluationProof>::new(
+        &mismatched_presence_plan,
+        &accessor,
+        &(),
+        &[],
+    )
+    .unwrap();
+    let mismatched_presence_table = mismatched_presence_res
+        .verify(&mismatched_presence_plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+    assert_eq!(
+        mismatched_presence_table,
+        owned_table([
+            boolean("score_present", core::iter::empty::<bool>()),
+            boolean("sum_present", core::iter::empty::<bool>()),
+        ])
+    );
+
+    let tampered_sum = NullableOwnedColumn::<TestScalar>::try_new(
+        OwnedColumn::BigInt(vec![12, 0, 10, 13, 0]),
+        nullable_sum.presence().map(<[bool]>::to_vec),
+    )
+    .unwrap();
+    let tampered_sum_accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        t.clone(),
+        owned_table([
+            nullable_score.value_owned_column("score_value"),
+            nullable_score
+                .presence_owned_column("score_present")
+                .unwrap(),
+            bonus.value_owned_column("bonus_value"),
+            tampered_sum.value_owned_column("sum_value"),
+            tampered_sum.presence_owned_column("sum_present").unwrap(),
+        ]),
+        0,
+        (),
+    );
+    let tampered_sum_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+    assert!(tampered_sum_res
+        .verify(&plan, &tampered_sum_accessor, &(), &[])
+        .is_err());
+
+    let tampered_sum_presence = NullableOwnedColumn::<TestScalar>::try_new(
+        OwnedColumn::BigInt(vec![12, 0, 10, 0, 0]),
+        Some(vec![true, false, true, false, false]),
+    )
+    .unwrap();
+    let tampered_presence_accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        t.clone(),
+        owned_table([
+            nullable_score.value_owned_column("score_value"),
+            nullable_score
+                .presence_owned_column("score_present")
+                .unwrap(),
+            bonus.value_owned_column("bonus_value"),
+            tampered_sum_presence.value_owned_column("sum_value"),
+            tampered_sum_presence
+                .presence_owned_column("sum_present")
+                .unwrap(),
+        ]),
+        0,
+        (),
+    );
+    let tampered_presence_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+    assert!(tampered_presence_res
+        .verify(&plan, &tampered_presence_accessor, &(), &[])
+        .is_err());
+
+    let verified_table =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[])
+            .unwrap()
+            .verify(&plan, &accessor, &(), &[])
+            .unwrap()
+            .table;
+    assert_eq!(
+        verified_table,
+        owned_table([
+            decimal75("score_plus_bonus", 20, 0, [12_i128, 12]),
+            bigint("sum_value", [12_i64, 12]),
+            boolean("score_present", [true, true]),
+            boolean("sum_present", [true, true]),
+        ])
+    );
+}
+
+fn nullable_bigint<const N: usize>(values: [Option<i64>; N]) -> NullableOwnedColumn<TestScalar> {
+    let values = values
+        .into_iter()
+        .map(|value| value.map(TestScalar::from))
+        .collect::<Vec<_>>();
+    NullableOwnedColumn::try_from_option_scalars(&values, ColumnType::BigInt).unwrap()
+}

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -1,6 +1,7 @@
 use super::{
-    Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedColumn,
-    OwnedTable, SchemaAccessor, TableRef, TestAccessor,
+    logical_column_fields_from_physical_schema, Column, ColumnField, ColumnType,
+    CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedColumn, OwnedTable, SchemaAccessor,
+    TableRef, TestAccessor,
 };
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
@@ -189,6 +190,16 @@ impl<CP: CommitmentEvaluationProof> SchemaAccessor for OwnedTableTestAccessor<'_
             .iter()
             .map(|(id, col)| (id.clone(), col.column_type()))
             .collect()
+    }
+
+    fn lookup_column_field(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnField> {
+        self.lookup_schema_fields(table_ref)
+            .into_iter()
+            .find(|field| field.name() == *column_id)
+    }
+
+    fn lookup_schema_fields(&self, table_ref: &TableRef) -> Vec<ColumnField> {
+        logical_column_fields_from_physical_schema(self.lookup_schema(table_ref))
     }
 }
 

--- a/crates/proof-of-sql/src/base/database/table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor.rs
@@ -1,6 +1,7 @@
 use super::{
-    Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor, Table,
-    TableRef, TestAccessor,
+    logical_column_fields_from_physical_schema, Column, ColumnField, ColumnType,
+    CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor, Table, TableRef,
+    TestAccessor,
 };
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
@@ -145,6 +146,16 @@ impl<CP: CommitmentEvaluationProof> SchemaAccessor for TableTestAccessor<'_, CP>
             .iter()
             .map(|(id, col)| (id.clone(), col.column_type()))
             .collect()
+    }
+
+    fn lookup_column_field(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnField> {
+        self.lookup_schema_fields(table_ref)
+            .into_iter()
+            .find(|field| field.name() == *column_id)
+    }
+
+    fn lookup_schema_fields(&self, table_ref: &TableRef) -> Vec<ColumnField> {
+        logical_column_fields_from_physical_schema(self.lookup_schema(table_ref))
     }
 }
 

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -78,6 +78,9 @@ impl EVMDynProofExpr {
             DynProofExpr::Placeholder(placeholder_expr) => Ok(Self::Placeholder(
                 EVMPlaceholderExpr::from_proof_expr(placeholder_expr),
             )),
+            DynProofExpr::IsNull(_) | DynProofExpr::IsNotNull(_) | DynProofExpr::IsTrue(_) => {
+                Err(EVMProofPlanError::NotSupported)
+            }
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -1,8 +1,13 @@
-use super::{add_subtract_columns, DecimalProofExpr, DynProofExpr, ProofExpr};
+use super::{
+    add_subtract_columns, final_round_evaluate_nullable_presence,
+    first_round_evaluate_nullable_presence, verifier_evaluate_nullable_presence, DecimalProofExpr,
+    DynProofExpr, NullableColumnEvaluation, ProofExpr,
+};
 use crate::{
     base::{
         database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table,
+            try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue,
+            NullableColumn, Table,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -54,6 +59,10 @@ impl ProofExpr for AddExpr {
     fn data_type(&self) -> ColumnType {
         try_add_subtract_column_types(self.lhs.data_type(), self.rhs.data_type())
             .expect("Failed to add/subtract column types")
+    }
+
+    fn is_nullable(&self) -> bool {
+        self.lhs.is_nullable() || self.rhs.is_nullable()
     }
 
     fn first_round_evaluate<'a, S: Scalar>(
@@ -108,6 +117,74 @@ impl ProofExpr for AddExpr {
             .rhs
             .verifier_evaluate(builder, accessor, chi_eval, params)?;
         Ok(lhs_eval + rhs_eval)
+    }
+
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let res = add_subtract_columns(lhs_column.values(), rhs_column.values(), alloc, false);
+        let values = Column::Decimal75(self.precision(), self.scale(), res);
+        let presence = first_round_evaluate_nullable_presence(
+            table.num_rows(),
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let res = add_subtract_columns(lhs_column.values(), rhs_column.values(), alloc, false);
+        let values = Column::Decimal75(self.precision(), self.scale(), res);
+        let presence = final_round_evaluate_nullable_presence(
+            builder,
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let lhs = self
+            .lhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let rhs = self
+            .rhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let presence_eval =
+            verifier_evaluate_nullable_presence(builder, lhs.presence_eval(), rhs.presence_eval())?;
+        Ok(NullableColumnEvaluation::new(
+            lhs.value_eval() + rhs.value_eval(),
+            presence_eval,
+        ))
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -1,7 +1,7 @@
 use super::{
-    final_round_evaluate_boolean_and, final_round_evaluate_nullable_presence,
-    first_round_evaluate_boolean_and, first_round_evaluate_nullable_presence,
-    verifier_evaluate_boolean_and, verifier_evaluate_nullable_presence, DynProofExpr,
+    final_round_evaluate_boolean_and, final_round_evaluate_nullable_boolean_and_presence,
+    first_round_evaluate_boolean_and, first_round_evaluate_nullable_boolean_and_presence,
+    verifier_evaluate_boolean_and, verifier_evaluate_nullable_boolean_and_presence, DynProofExpr,
     NullableColumnEvaluation, ProofExpr,
 };
 use crate::{
@@ -158,10 +158,12 @@ impl ProofExpr for AndExpr {
             lhs,
             rhs,
         ));
-        let presence = first_round_evaluate_nullable_presence(
+        let presence = first_round_evaluate_nullable_boolean_and_presence(
             table.num_rows(),
             alloc,
+            lhs,
             lhs_column.presence(),
+            rhs,
             rhs_column.presence(),
         );
         Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
@@ -189,10 +191,12 @@ impl ProofExpr for AndExpr {
             .as_boolean()
             .expect("rhs is not boolean");
         let values = Column::Boolean(final_round_evaluate_boolean_and(builder, alloc, lhs, rhs));
-        let presence = final_round_evaluate_nullable_presence(
+        let presence = final_round_evaluate_nullable_boolean_and_presence(
             builder,
             alloc,
+            lhs,
             lhs_column.presence(),
+            rhs,
             rhs_column.presence(),
         );
         Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
@@ -213,8 +217,14 @@ impl ProofExpr for AndExpr {
             .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
         let value_eval =
             verifier_evaluate_boolean_and(builder, lhs.value_eval(), rhs.value_eval())?;
-        let presence_eval =
-            verifier_evaluate_nullable_presence(builder, lhs.presence_eval(), rhs.presence_eval())?;
+        let presence_eval = verifier_evaluate_nullable_boolean_and_presence(
+            builder,
+            chi_eval,
+            lhs.value_eval(),
+            lhs.presence_eval(),
+            rhs.value_eval(),
+            rhs.presence_eval(),
+        )?;
         Ok(NullableColumnEvaluation::new(value_eval, presence_eval))
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -1,18 +1,25 @@
-use super::{DynProofExpr, ProofExpr};
+use super::{
+    final_round_evaluate_boolean_and, final_round_evaluate_nullable_presence,
+    first_round_evaluate_boolean_and, first_round_evaluate_nullable_presence,
+    verifier_evaluate_boolean_and, verifier_evaluate_nullable_presence, DynProofExpr,
+    NullableColumnEvaluation, ProofExpr,
+};
 use crate::{
     base::{
-        database::{can_and_or_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            can_and_or_types, Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
-        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        proof::{FinalRoundBuilder, VerificationBuilder},
         AnalyzeError, AnalyzeResult,
     },
     utils::log,
 };
-use alloc::{boxed::Box, string::ToString, vec};
+use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
@@ -66,8 +73,12 @@ impl ProofExpr for AndExpr {
         let rhs_column: Column<'a, S> = self.rhs.first_round_evaluate(alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        let result =
-            Column::Boolean(alloc.alloc_slice_fill_with(table.num_rows(), |i| lhs[i] && rhs[i]));
+        let result = Column::Boolean(first_round_evaluate_boolean_and(
+            table.num_rows(),
+            alloc,
+            lhs,
+            rhs,
+        ));
 
         log::log_memory_usage("End");
 
@@ -92,21 +103,7 @@ impl ProofExpr for AndExpr {
             .final_round_evaluate(builder, alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        let n = lhs.len();
-        assert_eq!(n, rhs.len());
-
-        // lhs_and_rhs
-        let lhs_and_rhs: &[bool] = alloc.alloc_slice_fill_with(n, |i| lhs[i] && rhs[i]);
-        builder.produce_intermediate_mle(lhs_and_rhs);
-
-        // subpolynomial: lhs_and_rhs - lhs * rhs
-        builder.produce_sumcheck_subpolynomial(
-            SumcheckSubpolynomialType::Identity,
-            vec![
-                (S::one(), vec![Box::new(lhs_and_rhs)]),
-                (-S::one(), vec![Box::new(lhs), Box::new(rhs)]),
-            ],
-        );
+        let lhs_and_rhs = final_round_evaluate_boolean_and(builder, alloc, lhs, rhs);
         let result = Column::Boolean(lhs_and_rhs);
 
         log::log_memory_usage("End");
@@ -128,18 +125,97 @@ impl ProofExpr for AndExpr {
             .rhs
             .verifier_evaluate(builder, accessor, chi_eval, params)?;
 
-        // lhs_and_rhs
-        let lhs_and_rhs = builder.try_consume_final_round_mle_evaluation()?;
+        verifier_evaluate_boolean_and(builder, lhs, rhs)
+    }
 
-        // subpolynomial: lhs_and_rhs - lhs * rhs
-        builder.try_produce_sumcheck_subpolynomial_evaluation(
-            SumcheckSubpolynomialType::Identity,
-            lhs_and_rhs - lhs * rhs,
-            2,
-        )?;
+    fn is_nullable(&self) -> bool {
+        self.lhs.is_nullable() || self.rhs.is_nullable()
+    }
 
-        // selection
-        Ok(lhs_and_rhs)
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let lhs = lhs_column
+            .values()
+            .as_boolean()
+            .expect("lhs is not boolean");
+        let rhs = rhs_column
+            .values()
+            .as_boolean()
+            .expect("rhs is not boolean");
+        let values = Column::Boolean(first_round_evaluate_boolean_and(
+            table.num_rows(),
+            alloc,
+            lhs,
+            rhs,
+        ));
+        let presence = first_round_evaluate_nullable_presence(
+            table.num_rows(),
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let lhs = lhs_column
+            .values()
+            .as_boolean()
+            .expect("lhs is not boolean");
+        let rhs = rhs_column
+            .values()
+            .as_boolean()
+            .expect("rhs is not boolean");
+        let values = Column::Boolean(final_round_evaluate_boolean_and(builder, alloc, lhs, rhs));
+        let presence = final_round_evaluate_nullable_presence(
+            builder,
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let lhs = self
+            .lhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let rhs = self
+            .rhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let value_eval =
+            verifier_evaluate_boolean_and(builder, lhs.value_eval(), rhs.value_eval())?;
+        let presence_eval =
+            verifier_evaluate_nullable_presence(builder, lhs.presence_eval(), rhs.presence_eval())?;
+        Ok(NullableColumnEvaluation::new(value_eval, presence_eval))
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -1,7 +1,9 @@
-use super::{numerical_util::cast_column, DynProofExpr, ProofExpr};
+use super::{numerical_util::cast_column, DynProofExpr, NullableColumnEvaluation, ProofExpr};
 use crate::{
     base::{
-        database::{try_cast_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            try_cast_types, Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -51,6 +53,10 @@ impl ProofExpr for CastExpr {
         self.to_type
     }
 
+    fn is_nullable(&self) -> bool {
+        self.from_expr.is_nullable()
+    }
+
     fn first_round_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
@@ -93,6 +99,56 @@ impl ProofExpr for CastExpr {
     ) -> Result<S, ProofError> {
         self.from_expr
             .verifier_evaluate(builder, accessor, chi_eval, params)
+    }
+
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let uncasted_result = self
+            .from_expr
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let values = cast_column(
+            alloc,
+            uncasted_result.values(),
+            self.from_expr.data_type(),
+            self.to_type,
+        );
+        Ok(NullableColumn::try_new(values, uncasted_result.presence())
+            .expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let uncasted_result = self
+            .from_expr
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let values = cast_column(
+            alloc,
+            uncasted_result.values(),
+            self.from_expr.data_type(),
+            self.to_type,
+        );
+        Ok(NullableColumn::try_new(values, uncasted_result.presence())
+            .expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        self.from_expr
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -1,7 +1,10 @@
-use super::ProofExpr;
+use super::{NullableColumnEvaluation, ProofExpr};
 use crate::{
     base::{
-        database::{Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            presence_column_id, Column, ColumnField, ColumnRef, ColumnType, LiteralValue,
+            NullableColumn, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -41,7 +44,11 @@ impl ColumnExpr {
     /// Wrap the column output name and its type within the [`ColumnField`]
     #[must_use]
     pub fn get_column_field(&self) -> ColumnField {
-        ColumnField::new(self.column_ref.column_id(), *self.column_ref.column_type())
+        if self.column_ref.is_nullable() {
+            ColumnField::new_nullable(self.column_ref.column_id(), *self.column_ref.column_type())
+        } else {
+            ColumnField::new(self.column_ref.column_id(), *self.column_ref.column_type())
+        }
     }
 
     /// Get the column identifier
@@ -62,12 +69,35 @@ impl ColumnExpr {
             .get(&self.column_ref.column_id())
             .expect("Column not found")
     }
+
+    /// Fetch the value column and optional physical presence column.
+    #[must_use]
+    pub fn fetch_nullable_column<'a, S: Scalar>(
+        &self,
+        table: &Table<'a, S>,
+    ) -> NullableColumn<'a, S> {
+        let values = self.fetch_column(table);
+        let presence = self.column_ref.is_nullable().then(|| {
+            let presence_id = presence_column_id(&self.column_ref.column_id());
+            table
+                .inner_table()
+                .get(&presence_id)
+                .expect("Presence column not found")
+                .as_boolean()
+                .expect("Presence column is not boolean")
+        });
+        NullableColumn::try_new(values, presence).expect("presence length should match values")
+    }
 }
 
 impl ProofExpr for ColumnExpr {
     /// Get the data type of the expression
     fn data_type(&self) -> ColumnType {
         *self.get_column_reference().column_type()
+    }
+
+    fn is_nullable(&self) -> bool {
+        self.column_ref.is_nullable()
     }
 
     /// Evaluate the column expression and
@@ -109,10 +139,63 @@ impl ProofExpr for ColumnExpr {
             })?)
     }
 
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        _alloc: &'a Bump,
+        table: &Table<'a, S>,
+        _params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        Ok(self.fetch_nullable_column(table))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        _builder: &mut FinalRoundBuilder<'a, S>,
+        _alloc: &'a Bump,
+        table: &Table<'a, S>,
+        _params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        Ok(self.fetch_nullable_column(table))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        _builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        _chi_eval: S,
+        _params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let value_eval =
+            *accessor
+                .get(&self.column_ref.column_id())
+                .ok_or(ProofError::VerificationError {
+                    error: "Column Not Found",
+                })?;
+        let presence_eval = if self.column_ref.is_nullable() {
+            Some(
+                *accessor
+                    .get(&presence_column_id(&self.column_ref.column_id()))
+                    .ok_or(ProofError::VerificationError {
+                        error: "Presence Column Not Found",
+                    })?,
+            )
+        } else {
+            None
+        };
+        Ok(NullableColumnEvaluation::new(value_eval, presence_eval))
+    }
+
     /// Insert in the [`IndexSet`] `columns` all the column
     /// references in the `BoolExpr` or forwards the call to some
     /// subsequent `bool_expr`
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         columns.insert(self.column_ref.clone());
+        if self.column_ref.is_nullable() {
+            columns.insert(ColumnRef::new(
+                self.column_ref.table_ref(),
+                presence_column_id(&self.column_ref.column_id()),
+                ColumnType::Boolean,
+            ));
+        }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -1,16 +1,18 @@
 use super::{
-    AddExpr, AndExpr, CastExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr, MultiplyExpr,
-    NotExpr, OrExpr, PlaceholderExpr, ProofExpr, ScalingCastExpr, SubtractExpr,
+    AddExpr, AndExpr, CastExpr, ColumnExpr, EqualsExpr, InequalityExpr, IsNotNullExpr, IsNullExpr,
+    IsTrueExpr, LiteralExpr, MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ProofExpr,
+    ScalingCastExpr, SubtractExpr,
 };
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
         proof::{FinalRoundBuilder, VerificationBuilder},
+        proof_exprs::NullableColumnEvaluation,
         AnalyzeResult,
     },
 };
@@ -50,6 +52,12 @@ pub enum DynProofExpr {
     Cast(CastExpr),
     /// Provable expression for casting numeric expressions to decimal expressions
     ScalingCast(ScalingCastExpr),
+    /// Provable SQL `IS NULL` expression
+    IsNull(IsNullExpr),
+    /// Provable SQL `IS NOT NULL` expression
+    IsNotNull(IsNotNullExpr),
+    /// Provable SQL `IS TRUE` expression
+    IsTrue(IsTrueExpr),
 }
 impl DynProofExpr {
     /// Create column expression
@@ -120,5 +128,23 @@ impl DynProofExpr {
         to_datatype: ColumnType,
     ) -> AnalyzeResult<Self> {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
+    }
+
+    /// Create a new SQL `IS NULL` expression.
+    #[must_use]
+    pub fn new_is_null(expr: DynProofExpr) -> Self {
+        Self::IsNull(IsNullExpr::new(Box::new(expr)))
+    }
+
+    /// Create a new SQL `IS NOT NULL` expression.
+    #[must_use]
+    pub fn new_is_not_null(expr: DynProofExpr) -> Self {
+        Self::IsNotNull(IsNotNullExpr::new(Box::new(expr)))
+    }
+
+    /// Create a new SQL `IS TRUE` expression.
+    #[must_use]
+    pub fn new_is_true(expr: DynProofExpr) -> Self {
+        Self::IsTrue(IsTrueExpr::new(Box::new(expr)))
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -1,7 +1,13 @@
-use super::{add_subtract_columns, DynProofExpr, ProofExpr};
+use super::{
+    add_subtract_columns, final_round_evaluate_nullable_presence,
+    first_round_evaluate_nullable_presence, verifier_evaluate_nullable_presence, DynProofExpr,
+    NullableColumnEvaluation, ProofExpr,
+};
 use crate::{
     base::{
-        database::{try_equals_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            try_equals_types, Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -52,6 +58,10 @@ impl EqualsExpr {
 impl ProofExpr for EqualsExpr {
     fn data_type(&self) -> ColumnType {
         ColumnType::Boolean
+    }
+
+    fn is_nullable(&self) -> bool {
+        self.lhs.is_nullable() || self.rhs.is_nullable()
     }
 
     #[tracing::instrument(name = "EqualsExpr::first_round_evaluate", level = "debug", skip_all)]
@@ -120,6 +130,83 @@ impl ProofExpr for EqualsExpr {
             .rhs
             .verifier_evaluate(builder, accessor, chi_eval, params)?;
         verifier_evaluate_equals_zero(builder, lhs_eval - rhs_eval, chi_eval)
+    }
+
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let res = add_subtract_columns(lhs_column.values(), rhs_column.values(), alloc, true);
+        let values = Column::Boolean(first_round_evaluate_equals_zero(
+            table.num_rows(),
+            alloc,
+            res,
+        ));
+        let presence = first_round_evaluate_nullable_presence(
+            table.num_rows(),
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let scale_and_subtract_res =
+            add_subtract_columns(lhs_column.values(), rhs_column.values(), alloc, true);
+        let values = Column::Boolean(final_round_evaluate_equals_zero(
+            table.num_rows(),
+            builder,
+            alloc,
+            scale_and_subtract_res,
+        ));
+        let presence = final_round_evaluate_nullable_presence(
+            builder,
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let lhs = self
+            .lhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let rhs = self
+            .rhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let value_eval =
+            verifier_evaluate_equals_zero(builder, lhs.value_eval() - rhs.value_eval(), chi_eval)?;
+        let presence_eval =
+            verifier_evaluate_nullable_presence(builder, lhs.presence_eval(), rhs.presence_eval())?;
+        Ok(NullableColumnEvaluation::new(value_eval, presence_eval))
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -1,7 +1,14 @@
-use super::{add_subtract_columns, DynProofExpr, ProofExpr};
+use super::{
+    add_subtract_columns, final_round_evaluate_nullable_presence,
+    first_round_evaluate_nullable_presence, verifier_evaluate_nullable_presence, DynProofExpr,
+    NullableColumnEvaluation, ProofExpr,
+};
 use crate::{
     base::{
-        database::{try_inequality_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            try_inequality_types, Column, ColumnRef, ColumnType, LiteralValue, NullableColumn,
+            Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -64,6 +71,10 @@ impl InequalityExpr {
 impl ProofExpr for InequalityExpr {
     fn data_type(&self) -> ColumnType {
         ColumnType::Boolean
+    }
+
+    fn is_nullable(&self) -> bool {
+        self.lhs.is_nullable() || self.rhs.is_nullable()
     }
 
     #[tracing::instrument(
@@ -151,6 +162,85 @@ impl ProofExpr for InequalityExpr {
 
         // sign(diff) == -1
         verifier_evaluate_sign(builder, diff_eval, chi_eval, None)
+    }
+
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let diff = if self.is_lt {
+            add_subtract_columns(lhs_column.values(), rhs_column.values(), alloc, true)
+        } else {
+            add_subtract_columns(rhs_column.values(), lhs_column.values(), alloc, true)
+        };
+        let values = Column::Boolean(first_round_evaluate_sign(table.num_rows(), alloc, diff));
+        let presence = first_round_evaluate_nullable_presence(
+            table.num_rows(),
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let diff = if self.is_lt {
+            add_subtract_columns(lhs_column.values(), rhs_column.values(), alloc, true)
+        } else {
+            add_subtract_columns(rhs_column.values(), lhs_column.values(), alloc, true)
+        };
+        let values = Column::Boolean(final_round_evaluate_sign(builder, alloc, diff));
+        let presence = final_round_evaluate_nullable_presence(
+            builder,
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let lhs = self
+            .lhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let rhs = self
+            .rhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let diff_eval = if self.is_lt {
+            lhs.value_eval() - rhs.value_eval()
+        } else {
+            rhs.value_eval() - lhs.value_eval()
+        };
+        let value_eval = verifier_evaluate_sign(builder, diff_eval, chi_eval, None)?;
+        let presence_eval =
+            verifier_evaluate_nullable_presence(builder, lhs.presence_eval(), rhs.presence_eval())?;
+        Ok(NullableColumnEvaluation::new(value_eval, presence_eval))
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/is_null_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/is_null_expr.rs
@@ -1,0 +1,222 @@
+use super::{DynProofExpr, ProofExpr};
+use crate::{
+    base::{
+        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        map::{IndexMap, IndexSet},
+        proof::{PlaceholderResult, ProofError},
+        scalar::Scalar,
+    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
+
+/// Provable SQL `IS NULL` expression.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IsNullExpr {
+    expr: Box<DynProofExpr>,
+}
+
+impl IsNullExpr {
+    /// Create a SQL `IS NULL` expression.
+    #[must_use]
+    pub fn new(expr: Box<DynProofExpr>) -> Self {
+        Self { expr }
+    }
+}
+
+impl ProofExpr for IsNullExpr {
+    fn data_type(&self) -> ColumnType {
+        ColumnType::Boolean
+    }
+
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let input = self
+            .expr
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        Ok(Column::Boolean(match input.presence() {
+            None => alloc.alloc_slice_fill_copy(input.len(), false),
+            Some(presence) => alloc.alloc_slice_fill_with(input.len(), |i| !presence[i]),
+        }))
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let input = self
+            .expr
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        Ok(Column::Boolean(match input.presence() {
+            None => alloc.alloc_slice_fill_copy(input.len(), false),
+            Some(presence) => alloc.alloc_slice_fill_with(input.len(), |i| !presence[i]),
+        }))
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<S, ProofError> {
+        let input = self
+            .expr
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        Ok(input
+            .presence_eval()
+            .map_or_else(S::zero, |presence| chi_eval - presence))
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.expr.get_column_references(columns);
+    }
+}
+
+/// Provable SQL `IS NOT NULL` expression.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IsNotNullExpr {
+    expr: Box<DynProofExpr>,
+}
+
+impl IsNotNullExpr {
+    /// Create a SQL `IS NOT NULL` expression.
+    #[must_use]
+    pub fn new(expr: Box<DynProofExpr>) -> Self {
+        Self { expr }
+    }
+}
+
+impl ProofExpr for IsNotNullExpr {
+    fn data_type(&self) -> ColumnType {
+        ColumnType::Boolean
+    }
+
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let input = self
+            .expr
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        Ok(Column::Boolean(match input.presence() {
+            None => alloc.alloc_slice_fill_copy(input.len(), true),
+            Some(presence) => presence,
+        }))
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let input = self
+            .expr
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        Ok(Column::Boolean(match input.presence() {
+            None => alloc.alloc_slice_fill_copy(input.len(), true),
+            Some(presence) => presence,
+        }))
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<S, ProofError> {
+        let input = self
+            .expr
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        Ok(input.presence_eval().unwrap_or(chi_eval))
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.expr.get_column_references(columns);
+    }
+}
+
+/// Provable SQL `IS TRUE` expression.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IsTrueExpr {
+    expr: Box<DynProofExpr>,
+}
+
+impl IsTrueExpr {
+    /// Create a SQL `IS TRUE` expression.
+    #[must_use]
+    pub fn new(expr: Box<DynProofExpr>) -> Self {
+        Self { expr }
+    }
+}
+
+impl ProofExpr for IsTrueExpr {
+    fn data_type(&self) -> ColumnType {
+        ColumnType::Boolean
+    }
+
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let input = self
+            .expr
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        Ok(Column::Boolean(
+            super::first_round_evaluate_nullable_boolean_is_true(alloc, input),
+        ))
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let input = self
+            .expr
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        Ok(Column::Boolean(
+            super::final_round_evaluate_nullable_boolean_is_true(builder, alloc, input),
+        ))
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<S, ProofError> {
+        let input = self
+            .expr
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        super::verifier_evaluate_nullable_boolean_is_true(
+            builder,
+            input.value_eval(),
+            input.presence_eval(),
+        )
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.expr.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -1,11 +1,18 @@
 //! This module proves provable expressions.
 mod proof_expr;
 pub(crate) use proof_expr::{
-    final_round_evaluate_boolean_and, final_round_evaluate_nullable_boolean_is_true,
-    final_round_evaluate_nullable_presence, first_round_evaluate_boolean_and,
-    first_round_evaluate_nullable_boolean_is_true, first_round_evaluate_nullable_presence,
-    verifier_evaluate_boolean_and, verifier_evaluate_nullable_boolean_is_true,
-    verifier_evaluate_nullable_presence, DecimalProofExpr,
+    final_round_evaluate_boolean_and, final_round_evaluate_boolean_or,
+    final_round_evaluate_nullable_boolean_and_presence,
+    final_round_evaluate_nullable_boolean_is_true,
+    final_round_evaluate_nullable_boolean_or_presence, final_round_evaluate_nullable_presence,
+    first_round_evaluate_boolean_and, first_round_evaluate_boolean_or,
+    first_round_evaluate_nullable_boolean_and_presence,
+    first_round_evaluate_nullable_boolean_is_true,
+    first_round_evaluate_nullable_boolean_or_presence, first_round_evaluate_nullable_presence,
+    verifier_evaluate_boolean_and, verifier_evaluate_boolean_or,
+    verifier_evaluate_nullable_boolean_and_presence, verifier_evaluate_nullable_boolean_is_true,
+    verifier_evaluate_nullable_boolean_or_presence, verifier_evaluate_nullable_presence,
+    DecimalProofExpr,
 };
 pub use proof_expr::{NullableColumnEvaluation, ProofExpr};
 #[cfg(all(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -1,7 +1,13 @@
 //! This module proves provable expressions.
 mod proof_expr;
-pub(crate) use proof_expr::DecimalProofExpr;
-pub use proof_expr::ProofExpr;
+pub(crate) use proof_expr::{
+    final_round_evaluate_boolean_and, final_round_evaluate_nullable_boolean_is_true,
+    final_round_evaluate_nullable_presence, first_round_evaluate_boolean_and,
+    first_round_evaluate_nullable_boolean_is_true, first_round_evaluate_nullable_presence,
+    verifier_evaluate_boolean_and, verifier_evaluate_nullable_boolean_is_true,
+    verifier_evaluate_nullable_presence, DecimalProofExpr,
+};
+pub use proof_expr::{NullableColumnEvaluation, ProofExpr};
 #[cfg(all(test, feature = "blitzar"))]
 mod proof_expr_test;
 
@@ -62,6 +68,9 @@ mod equals_expr;
 pub(crate) use equals_expr::EqualsExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod equals_expr_test;
+
+mod is_null_expr;
+pub(crate) use is_null_expr::{IsNotNullExpr, IsNullExpr, IsTrueExpr};
 
 mod table_expr;
 pub use table_expr::TableExpr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -1,7 +1,14 @@
-use super::{DecimalProofExpr, DynProofExpr, ProofExpr};
+use super::{
+    final_round_evaluate_nullable_presence, first_round_evaluate_nullable_presence,
+    verifier_evaluate_nullable_presence, DecimalProofExpr, DynProofExpr, NullableColumnEvaluation,
+    ProofExpr,
+};
 use crate::{
     base::{
-        database::{try_multiply_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            try_multiply_column_types, Column, ColumnRef, ColumnType, LiteralValue, NullableColumn,
+            Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -53,6 +60,10 @@ impl ProofExpr for MultiplyExpr {
     fn data_type(&self) -> ColumnType {
         try_multiply_column_types(self.lhs.data_type(), self.rhs.data_type())
             .expect("Failed to multiply column types")
+    }
+
+    fn is_nullable(&self) -> bool {
+        self.lhs.is_nullable() || self.rhs.is_nullable()
     }
 
     fn first_round_evaluate<'a, S: Scalar>(
@@ -129,6 +140,90 @@ impl ProofExpr for MultiplyExpr {
 
         // selection
         Ok(lhs_times_rhs)
+    }
+
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let res = multiply_columns(&lhs_column.values(), &rhs_column.values(), alloc);
+        let values = Column::Decimal75(self.precision(), self.scale(), res);
+        let presence = first_round_evaluate_nullable_presence(
+            table.num_rows(),
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+
+        let lhs_times_rhs = multiply_columns(&lhs_column.values(), &rhs_column.values(), alloc);
+        builder.produce_intermediate_mle(lhs_times_rhs);
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(lhs_times_rhs)]),
+                (
+                    -S::one(),
+                    vec![Box::new(lhs_column.values()), Box::new(rhs_column.values())],
+                ),
+            ],
+        );
+        let values = Column::Decimal75(self.precision(), self.scale(), lhs_times_rhs);
+        let presence = final_round_evaluate_nullable_presence(
+            builder,
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let lhs = self
+            .lhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let rhs = self
+            .rhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+
+        let lhs_times_rhs = builder.try_consume_final_round_mle_evaluation()?;
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            lhs_times_rhs - lhs.value_eval() * rhs.value_eval(),
+            2,
+        )?;
+        let presence_eval =
+            verifier_evaluate_nullable_presence(builder, lhs.presence_eval(), rhs.presence_eval())?;
+        Ok(NullableColumnEvaluation::new(lhs_times_rhs, presence_eval))
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -1,7 +1,9 @@
-use super::{DynProofExpr, ProofExpr};
+use super::{DynProofExpr, NullableColumnEvaluation, ProofExpr};
 use crate::{
     base::{
-        database::{can_not_type, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            can_not_type, Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -93,6 +95,63 @@ impl ProofExpr for NotExpr {
             .expr
             .verifier_evaluate(builder, accessor, chi_eval, params)?;
         Ok(chi_eval - eval)
+    }
+
+    fn is_nullable(&self) -> bool {
+        self.expr.is_nullable()
+    }
+
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let expr_column = self
+            .expr
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let expr = expr_column
+            .values()
+            .as_boolean()
+            .expect("expr is not boolean");
+        let values = Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]));
+        Ok(NullableColumn::try_new(values, expr_column.presence())
+            .expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let expr_column = self
+            .expr
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let expr = expr_column
+            .values()
+            .as_boolean()
+            .expect("expr is not boolean");
+        let values = Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]));
+        Ok(NullableColumn::try_new(values, expr_column.presence())
+            .expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let eval = self
+            .expr
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        Ok(NullableColumnEvaluation::new(
+            chi_eval - eval.value_eval(),
+            eval.presence_eval(),
+        ))
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -1,6 +1,8 @@
 use super::{
-    final_round_evaluate_nullable_presence, first_round_evaluate_nullable_presence,
-    verifier_evaluate_nullable_presence, DynProofExpr, NullableColumnEvaluation, ProofExpr,
+    final_round_evaluate_boolean_or, final_round_evaluate_nullable_boolean_or_presence,
+    first_round_evaluate_boolean_or, first_round_evaluate_nullable_boolean_or_presence,
+    verifier_evaluate_boolean_or, verifier_evaluate_nullable_boolean_or_presence, DynProofExpr,
+    NullableColumnEvaluation, ProofExpr,
 };
 use crate::{
     base::{
@@ -12,12 +14,12 @@ use crate::{
         scalar::Scalar,
     },
     sql::{
-        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        proof::{FinalRoundBuilder, VerificationBuilder},
         AnalyzeError, AnalyzeResult,
     },
     utils::log,
 };
-use alloc::{boxed::Box, string::ToString, vec};
+use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
@@ -71,7 +73,12 @@ impl ProofExpr for OrExpr {
         let rhs_column: Column<'a, S> = self.rhs.first_round_evaluate(alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        let result = Column::Boolean(first_round_evaluate_or(table.num_rows(), alloc, lhs, rhs));
+        let result = Column::Boolean(first_round_evaluate_boolean_or(
+            table.num_rows(),
+            alloc,
+            lhs,
+            rhs,
+        ));
 
         log::log_memory_usage("End");
 
@@ -96,7 +103,7 @@ impl ProofExpr for OrExpr {
             .final_round_evaluate(builder, alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        let result = Column::Boolean(final_round_evaluate_or(builder, alloc, lhs, rhs));
+        let result = Column::Boolean(final_round_evaluate_boolean_or(builder, alloc, lhs, rhs));
 
         log::log_memory_usage("End");
 
@@ -117,7 +124,7 @@ impl ProofExpr for OrExpr {
             .rhs
             .verifier_evaluate(builder, accessor, chi_eval, params)?;
 
-        verifier_evaluate_or(builder, &lhs, &rhs)
+        verifier_evaluate_boolean_or(builder, lhs, rhs)
     }
 
     fn is_nullable(&self) -> bool {
@@ -144,11 +151,18 @@ impl ProofExpr for OrExpr {
             .values()
             .as_boolean()
             .expect("rhs is not boolean");
-        let values = Column::Boolean(first_round_evaluate_or(table.num_rows(), alloc, lhs, rhs));
-        let presence = first_round_evaluate_nullable_presence(
+        let values = Column::Boolean(first_round_evaluate_boolean_or(
             table.num_rows(),
             alloc,
+            lhs,
+            rhs,
+        ));
+        let presence = first_round_evaluate_nullable_boolean_or_presence(
+            table.num_rows(),
+            alloc,
+            lhs,
             lhs_column.presence(),
+            rhs,
             rhs_column.presence(),
         );
         Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
@@ -175,11 +189,13 @@ impl ProofExpr for OrExpr {
             .values()
             .as_boolean()
             .expect("rhs is not boolean");
-        let values = Column::Boolean(final_round_evaluate_or(builder, alloc, lhs, rhs));
-        let presence = final_round_evaluate_nullable_presence(
+        let values = Column::Boolean(final_round_evaluate_boolean_or(builder, alloc, lhs, rhs));
+        let presence = final_round_evaluate_nullable_boolean_or_presence(
             builder,
             alloc,
+            lhs,
             lhs_column.presence(),
+            rhs,
             rhs_column.presence(),
         );
         Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
@@ -198,9 +214,14 @@ impl ProofExpr for OrExpr {
         let rhs = self
             .rhs
             .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
-        let value_eval = verifier_evaluate_or(builder, &lhs.value_eval(), &rhs.value_eval())?;
-        let presence_eval =
-            verifier_evaluate_nullable_presence(builder, lhs.presence_eval(), rhs.presence_eval())?;
+        let value_eval = verifier_evaluate_boolean_or(builder, lhs.value_eval(), rhs.value_eval())?;
+        let presence_eval = verifier_evaluate_nullable_boolean_or_presence(
+            builder,
+            lhs.value_eval(),
+            lhs.presence_eval(),
+            rhs.value_eval(),
+            rhs.presence_eval(),
+        )?;
         Ok(NullableColumnEvaluation::new(value_eval, presence_eval))
     }
 
@@ -208,68 +229,4 @@ impl ProofExpr for OrExpr {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }
-}
-
-#[expect(
-    clippy::missing_panics_doc,
-    reason = "table_length matches lhs and rhs lengths, ensuring no panic occurs"
-)]
-pub fn first_round_evaluate_or<'a>(
-    table_length: usize,
-    alloc: &'a Bump,
-    lhs: &[bool],
-    rhs: &[bool],
-) -> &'a [bool] {
-    assert_eq!(table_length, lhs.len());
-    assert_eq!(table_length, rhs.len());
-    alloc.alloc_slice_fill_with(table_length, |i| lhs[i] || rhs[i])
-}
-
-#[expect(
-    clippy::missing_panics_doc,
-    reason = "lhs and rhs are guaranteed to have the same length, ensuring no panic occurs"
-)]
-pub fn final_round_evaluate_or<'a, S: Scalar>(
-    builder: &mut FinalRoundBuilder<'a, S>,
-    alloc: &'a Bump,
-    lhs: &'a [bool],
-    rhs: &'a [bool],
-) -> &'a [bool] {
-    let n = lhs.len();
-    assert_eq!(n, rhs.len());
-
-    // lhs_and_rhs
-    let lhs_and_rhs: &[_] = alloc.alloc_slice_fill_with(n, |i| lhs[i] && rhs[i]);
-    builder.produce_intermediate_mle(lhs_and_rhs);
-
-    // subpolynomial: lhs_and_rhs - lhs * rhs
-    builder.produce_sumcheck_subpolynomial(
-        SumcheckSubpolynomialType::Identity,
-        vec![
-            (S::one(), vec![Box::new(lhs_and_rhs)]),
-            (-S::one(), vec![Box::new(lhs), Box::new(rhs)]),
-        ],
-    );
-
-    // selection
-    alloc.alloc_slice_fill_with(n, |i| lhs[i] || rhs[i])
-}
-
-pub fn verifier_evaluate_or<S: Scalar>(
-    builder: &mut impl VerificationBuilder<S>,
-    lhs: &S,
-    rhs: &S,
-) -> Result<S, ProofError> {
-    // lhs_and_rhs
-    let lhs_and_rhs = builder.try_consume_final_round_mle_evaluation()?;
-
-    // subpolynomial: lhs_and_rhs - lhs * rhs
-    builder.try_produce_sumcheck_subpolynomial_evaluation(
-        SumcheckSubpolynomialType::Identity,
-        lhs_and_rhs - *lhs * *rhs,
-        2,
-    )?;
-
-    // selection
-    Ok(*lhs + *rhs - lhs_and_rhs)
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -1,7 +1,12 @@
-use super::{DynProofExpr, ProofExpr};
+use super::{
+    final_round_evaluate_nullable_presence, first_round_evaluate_nullable_presence,
+    verifier_evaluate_nullable_presence, DynProofExpr, NullableColumnEvaluation, ProofExpr,
+};
 use crate::{
     base::{
-        database::{can_and_or_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            can_and_or_types, Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -113,6 +118,90 @@ impl ProofExpr for OrExpr {
             .verifier_evaluate(builder, accessor, chi_eval, params)?;
 
         verifier_evaluate_or(builder, &lhs, &rhs)
+    }
+
+    fn is_nullable(&self) -> bool {
+        self.lhs.is_nullable() || self.rhs.is_nullable()
+    }
+
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let lhs = lhs_column
+            .values()
+            .as_boolean()
+            .expect("lhs is not boolean");
+        let rhs = rhs_column
+            .values()
+            .as_boolean()
+            .expect("rhs is not boolean");
+        let values = Column::Boolean(first_round_evaluate_or(table.num_rows(), alloc, lhs, rhs));
+        let presence = first_round_evaluate_nullable_presence(
+            table.num_rows(),
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let lhs = lhs_column
+            .values()
+            .as_boolean()
+            .expect("lhs is not boolean");
+        let rhs = rhs_column
+            .values()
+            .as_boolean()
+            .expect("rhs is not boolean");
+        let values = Column::Boolean(final_round_evaluate_or(builder, alloc, lhs, rhs));
+        let presence = final_round_evaluate_nullable_presence(
+            builder,
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let lhs = self
+            .lhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let rhs = self
+            .rhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let value_eval = verifier_evaluate_or(builder, &lhs.value_eval(), &rhs.value_eval())?;
+        let presence_eval =
+            verifier_evaluate_nullable_presence(builder, lhs.presence_eval(), rhs.presence_eval())?;
+        Ok(NullableColumnEvaluation::new(value_eval, presence_eval))
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,16 +1,59 @@
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table},
         map::{IndexMap, IndexSet},
         math::decimal::Precision,
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    sql::proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
+use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use core::fmt::Debug;
 use sqlparser::ast::Ident;
+
+/// Evaluations of a nullable expression at a verifier point.
+///
+/// `presence_eval == None` means the expression is non-nullable. `Some(eval)` is the MLE
+/// evaluation of the boolean presence column where `true` means the row is present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NullableColumnEvaluation<S: Scalar> {
+    value_eval: S,
+    presence_eval: Option<S>,
+}
+
+impl<S: Scalar> NullableColumnEvaluation<S> {
+    /// Create a non-nullable evaluation.
+    #[must_use]
+    pub fn non_nullable(value_eval: S) -> Self {
+        Self {
+            value_eval,
+            presence_eval: None,
+        }
+    }
+
+    /// Create an evaluation with optional presence.
+    #[must_use]
+    pub fn new(value_eval: S, presence_eval: Option<S>) -> Self {
+        Self {
+            value_eval,
+            presence_eval,
+        }
+    }
+
+    /// Return the value-column evaluation.
+    #[must_use]
+    pub fn value_eval(&self) -> S {
+        self.value_eval
+    }
+
+    /// Return the optional presence-column evaluation.
+    #[must_use]
+    pub fn presence_eval(&self) -> Option<S> {
+        self.presence_eval
+    }
+}
 
 /// Provable AST column expression that evaluates to a `Column`
 #[enum_dispatch::enum_dispatch(DynProofExpr)]
@@ -49,10 +92,195 @@ pub trait ProofExpr: Debug + Send + Sync {
         params: &[LiteralValue],
     ) -> Result<S, ProofError>;
 
+    /// Return whether this expression can evaluate to SQL NULL.
+    fn is_nullable(&self) -> bool {
+        false
+    }
+
+    /// Evaluate the expression and carry optional row-presence metadata.
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        Ok(NullableColumn::non_nullable(
+            self.first_round_evaluate(alloc, table, params)?,
+        ))
+    }
+
+    /// Evaluate the expression, add proof components, and carry optional row-presence metadata.
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        Ok(NullableColumn::non_nullable(
+            self.final_round_evaluate(builder, alloc, table, params)?,
+        ))
+    }
+
+    /// Verify the expression's value and optional presence evaluation.
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        Ok(NullableColumnEvaluation::non_nullable(
+            self.verifier_evaluate(builder, accessor, chi_eval, params)?,
+        ))
+    }
+
     /// Insert in the [`IndexSet`] `columns` all the column
     /// references in the `BoolExpr` or forwards the call to some
     /// subsequent `bool_expr`
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>);
+}
+
+/// Evaluate a boolean AND without producing proof data.
+pub(crate) fn first_round_evaluate_boolean_and<'a>(
+    table_length: usize,
+    alloc: &'a Bump,
+    lhs: &'a [bool],
+    rhs: &'a [bool],
+) -> &'a [bool] {
+    assert_eq!(table_length, lhs.len());
+    assert_eq!(table_length, rhs.len());
+    alloc.alloc_slice_fill_with(table_length, |i| lhs[i] && rhs[i])
+}
+
+/// Evaluate and prove a boolean AND.
+pub(crate) fn final_round_evaluate_boolean_and<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    lhs: &'a [bool],
+    rhs: &'a [bool],
+) -> &'a [bool] {
+    let n = lhs.len();
+    assert_eq!(n, rhs.len());
+
+    let lhs_and_rhs: &'a [bool] = alloc.alloc_slice_fill_with(n, |i| lhs[i] && rhs[i]);
+    builder.produce_intermediate_mle(lhs_and_rhs);
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (S::one(), vec![Box::new(lhs_and_rhs)]),
+            (-S::one(), vec![Box::new(lhs), Box::new(rhs)]),
+        ],
+    );
+    lhs_and_rhs
+}
+
+/// Verify a boolean AND.
+pub(crate) fn verifier_evaluate_boolean_and<S: Scalar>(
+    builder: &mut impl VerificationBuilder<S>,
+    lhs: S,
+    rhs: S,
+) -> Result<S, ProofError> {
+    let lhs_and_rhs = builder.try_consume_final_round_mle_evaluation()?;
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        lhs_and_rhs - lhs * rhs,
+        2,
+    )?;
+    Ok(lhs_and_rhs)
+}
+
+/// Combine optional presence masks using SQL binary-expression nullability rules.
+#[must_use]
+pub(crate) fn first_round_evaluate_nullable_presence<'a>(
+    table_length: usize,
+    alloc: &'a Bump,
+    lhs: Option<&'a [bool]>,
+    rhs: Option<&'a [bool]>,
+) -> Option<&'a [bool]> {
+    match (lhs, rhs) {
+        (None, None) => None,
+        (Some(lhs), None) => Some(lhs),
+        (None, Some(rhs)) => Some(rhs),
+        (Some(lhs), Some(rhs)) => Some(first_round_evaluate_boolean_and(
+            table_length,
+            alloc,
+            lhs,
+            rhs,
+        )),
+    }
+}
+
+/// Combine optional presence masks and prove the conjunction when both sides are nullable.
+pub(crate) fn final_round_evaluate_nullable_presence<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    lhs: Option<&'a [bool]>,
+    rhs: Option<&'a [bool]>,
+) -> Option<&'a [bool]> {
+    match (lhs, rhs) {
+        (None, None) => None,
+        (Some(lhs), None) => Some(lhs),
+        (None, Some(rhs)) => Some(rhs),
+        (Some(lhs), Some(rhs)) => Some(final_round_evaluate_boolean_and(builder, alloc, lhs, rhs)),
+    }
+}
+
+/// Verify optional presence-mask conjunction.
+pub(crate) fn verifier_evaluate_nullable_presence<S: Scalar>(
+    builder: &mut impl VerificationBuilder<S>,
+    lhs: Option<S>,
+    rhs: Option<S>,
+) -> Result<Option<S>, ProofError> {
+    match (lhs, rhs) {
+        (None, None) => Ok(None),
+        (Some(lhs), None) => Ok(Some(lhs)),
+        (None, Some(rhs)) => Ok(Some(rhs)),
+        (Some(lhs), Some(rhs)) => Ok(Some(verifier_evaluate_boolean_and(builder, lhs, rhs)?)),
+    }
+}
+
+/// Evaluate a nullable boolean as SQL `IS TRUE`, which is what `WHERE` clauses select.
+pub(crate) fn first_round_evaluate_nullable_boolean_is_true<'a, S: Scalar>(
+    alloc: &'a Bump,
+    column: NullableColumn<'a, S>,
+) -> &'a [bool] {
+    let values = column
+        .values()
+        .as_boolean()
+        .expect("expression is not boolean");
+    match column.presence() {
+        None => values,
+        Some(presence) => first_round_evaluate_boolean_and(column.len(), alloc, values, presence),
+    }
+}
+
+/// Evaluate and prove nullable boolean `IS TRUE`.
+pub(crate) fn final_round_evaluate_nullable_boolean_is_true<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    column: NullableColumn<'a, S>,
+) -> &'a [bool] {
+    let values = column
+        .values()
+        .as_boolean()
+        .expect("expression is not boolean");
+    match column.presence() {
+        None => values,
+        Some(presence) => final_round_evaluate_boolean_and(builder, alloc, values, presence),
+    }
+}
+
+/// Verify nullable boolean `IS TRUE`.
+pub(crate) fn verifier_evaluate_nullable_boolean_is_true<S: Scalar>(
+    builder: &mut impl VerificationBuilder<S>,
+    value_eval: S,
+    presence_eval: Option<S>,
+) -> Result<S, ProofError> {
+    match presence_eval {
+        None => Ok(value_eval),
+        Some(presence_eval) => verifier_evaluate_boolean_and(builder, value_eval, presence_eval),
+    }
 }
 
 /// A trait for `ProofExpr`s that always return a decimal type

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -190,6 +190,51 @@ pub(crate) fn verifier_evaluate_boolean_and<S: Scalar>(
     Ok(lhs_and_rhs)
 }
 
+/// Evaluate a boolean OR without producing proof data.
+pub(crate) fn first_round_evaluate_boolean_or<'a>(
+    table_length: usize,
+    alloc: &'a Bump,
+    lhs: &'a [bool],
+    rhs: &'a [bool],
+) -> &'a [bool] {
+    assert_eq!(table_length, lhs.len());
+    assert_eq!(table_length, rhs.len());
+    alloc.alloc_slice_fill_with(table_length, |i| lhs[i] || rhs[i])
+}
+
+/// Evaluate and prove a boolean OR.
+pub(crate) fn final_round_evaluate_boolean_or<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    lhs: &'a [bool],
+    rhs: &'a [bool],
+) -> &'a [bool] {
+    let n = lhs.len();
+    assert_eq!(n, rhs.len());
+
+    let _ = final_round_evaluate_boolean_and(builder, alloc, lhs, rhs);
+    alloc.alloc_slice_fill_with(n, |i| lhs[i] || rhs[i])
+}
+
+/// Verify a boolean OR.
+pub(crate) fn verifier_evaluate_boolean_or<S: Scalar>(
+    builder: &mut impl VerificationBuilder<S>,
+    lhs: S,
+    rhs: S,
+) -> Result<S, ProofError> {
+    let lhs_and_rhs = verifier_evaluate_boolean_and(builder, lhs, rhs)?;
+    Ok(lhs + rhs - lhs_and_rhs)
+}
+
+fn first_round_evaluate_boolean_not<'a>(
+    table_length: usize,
+    alloc: &'a Bump,
+    values: &'a [bool],
+) -> &'a [bool] {
+    assert_eq!(table_length, values.len());
+    alloc.alloc_slice_fill_with(table_length, |i| !values[i])
+}
+
 /// Combine optional presence masks using SQL binary-expression nullability rules.
 #[must_use]
 pub(crate) fn first_round_evaluate_nullable_presence<'a>(
@@ -237,6 +282,281 @@ pub(crate) fn verifier_evaluate_nullable_presence<S: Scalar>(
         (Some(lhs), None) => Ok(Some(lhs)),
         (None, Some(rhs)) => Ok(Some(rhs)),
         (Some(lhs), Some(rhs)) => Ok(Some(verifier_evaluate_boolean_and(builder, lhs, rhs)?)),
+    }
+}
+
+/// Compute SQL three-valued `AND` result presence for nullable boolean operands.
+#[must_use]
+pub(crate) fn first_round_evaluate_nullable_boolean_and_presence<'a>(
+    table_length: usize,
+    alloc: &'a Bump,
+    lhs_values: &'a [bool],
+    lhs_presence: Option<&'a [bool]>,
+    rhs_values: &'a [bool],
+    rhs_presence: Option<&'a [bool]>,
+) -> Option<&'a [bool]> {
+    match (lhs_presence, rhs_presence) {
+        (None, None) => None,
+        (Some(lhs_presence), None) => {
+            let rhs_false = first_round_evaluate_boolean_not(table_length, alloc, rhs_values);
+            Some(first_round_evaluate_boolean_or(
+                table_length,
+                alloc,
+                lhs_presence,
+                rhs_false,
+            ))
+        }
+        (None, Some(rhs_presence)) => {
+            let lhs_false = first_round_evaluate_boolean_not(table_length, alloc, lhs_values);
+            Some(first_round_evaluate_boolean_or(
+                table_length,
+                alloc,
+                rhs_presence,
+                lhs_false,
+            ))
+        }
+        (Some(lhs_presence), Some(rhs_presence)) => {
+            let both_present =
+                first_round_evaluate_boolean_and(table_length, alloc, lhs_presence, rhs_presence);
+            let lhs_false = first_round_evaluate_boolean_not(table_length, alloc, lhs_values);
+            let lhs_false_present =
+                first_round_evaluate_boolean_and(table_length, alloc, lhs_presence, lhs_false);
+            let rhs_false = first_round_evaluate_boolean_not(table_length, alloc, rhs_values);
+            let rhs_false_present =
+                first_round_evaluate_boolean_and(table_length, alloc, rhs_presence, rhs_false);
+            let left = first_round_evaluate_boolean_or(
+                table_length,
+                alloc,
+                both_present,
+                lhs_false_present,
+            );
+            Some(first_round_evaluate_boolean_or(
+                table_length,
+                alloc,
+                left,
+                rhs_false_present,
+            ))
+        }
+    }
+}
+
+/// Compute SQL three-valued `OR` result presence for nullable boolean operands.
+#[must_use]
+pub(crate) fn first_round_evaluate_nullable_boolean_or_presence<'a>(
+    table_length: usize,
+    alloc: &'a Bump,
+    lhs_values: &'a [bool],
+    lhs_presence: Option<&'a [bool]>,
+    rhs_values: &'a [bool],
+    rhs_presence: Option<&'a [bool]>,
+) -> Option<&'a [bool]> {
+    match (lhs_presence, rhs_presence) {
+        (None, None) => None,
+        (Some(lhs_presence), None) => Some(first_round_evaluate_boolean_or(
+            table_length,
+            alloc,
+            lhs_presence,
+            rhs_values,
+        )),
+        (None, Some(rhs_presence)) => Some(first_round_evaluate_boolean_or(
+            table_length,
+            alloc,
+            rhs_presence,
+            lhs_values,
+        )),
+        (Some(lhs_presence), Some(rhs_presence)) => {
+            let both_present =
+                first_round_evaluate_boolean_and(table_length, alloc, lhs_presence, rhs_presence);
+            let lhs_true_present =
+                first_round_evaluate_boolean_and(table_length, alloc, lhs_presence, lhs_values);
+            let rhs_true_present =
+                first_round_evaluate_boolean_and(table_length, alloc, rhs_presence, rhs_values);
+            let left = first_round_evaluate_boolean_or(
+                table_length,
+                alloc,
+                both_present,
+                lhs_true_present,
+            );
+            Some(first_round_evaluate_boolean_or(
+                table_length,
+                alloc,
+                left,
+                rhs_true_present,
+            ))
+        }
+    }
+}
+
+/// Compute and prove SQL three-valued `AND` result presence for nullable boolean operands.
+pub(crate) fn final_round_evaluate_nullable_boolean_and_presence<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    lhs_values: &'a [bool],
+    lhs_presence: Option<&'a [bool]>,
+    rhs_values: &'a [bool],
+    rhs_presence: Option<&'a [bool]>,
+) -> Option<&'a [bool]> {
+    match (lhs_presence, rhs_presence) {
+        (None, None) => None,
+        (Some(lhs_presence), None) => {
+            let rhs_false = first_round_evaluate_boolean_not(lhs_presence.len(), alloc, rhs_values);
+            Some(final_round_evaluate_boolean_or(
+                builder,
+                alloc,
+                lhs_presence,
+                rhs_false,
+            ))
+        }
+        (None, Some(rhs_presence)) => {
+            let lhs_false = first_round_evaluate_boolean_not(rhs_presence.len(), alloc, lhs_values);
+            Some(final_round_evaluate_boolean_or(
+                builder,
+                alloc,
+                rhs_presence,
+                lhs_false,
+            ))
+        }
+        (Some(lhs_presence), Some(rhs_presence)) => {
+            let both_present =
+                final_round_evaluate_boolean_and(builder, alloc, lhs_presence, rhs_presence);
+            let lhs_false = first_round_evaluate_boolean_not(lhs_presence.len(), alloc, lhs_values);
+            let lhs_false_present =
+                final_round_evaluate_boolean_and(builder, alloc, lhs_presence, lhs_false);
+            let rhs_false = first_round_evaluate_boolean_not(rhs_presence.len(), alloc, rhs_values);
+            let rhs_false_present =
+                final_round_evaluate_boolean_and(builder, alloc, rhs_presence, rhs_false);
+            let left =
+                final_round_evaluate_boolean_or(builder, alloc, both_present, lhs_false_present);
+            Some(final_round_evaluate_boolean_or(
+                builder,
+                alloc,
+                left,
+                rhs_false_present,
+            ))
+        }
+    }
+}
+
+/// Compute and prove SQL three-valued `OR` result presence for nullable boolean operands.
+pub(crate) fn final_round_evaluate_nullable_boolean_or_presence<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    lhs_values: &'a [bool],
+    lhs_presence: Option<&'a [bool]>,
+    rhs_values: &'a [bool],
+    rhs_presence: Option<&'a [bool]>,
+) -> Option<&'a [bool]> {
+    match (lhs_presence, rhs_presence) {
+        (None, None) => None,
+        (Some(lhs_presence), None) => Some(final_round_evaluate_boolean_or(
+            builder,
+            alloc,
+            lhs_presence,
+            rhs_values,
+        )),
+        (None, Some(rhs_presence)) => Some(final_round_evaluate_boolean_or(
+            builder,
+            alloc,
+            rhs_presence,
+            lhs_values,
+        )),
+        (Some(lhs_presence), Some(rhs_presence)) => {
+            let both_present =
+                final_round_evaluate_boolean_and(builder, alloc, lhs_presence, rhs_presence);
+            let lhs_true_present =
+                final_round_evaluate_boolean_and(builder, alloc, lhs_presence, lhs_values);
+            let rhs_true_present =
+                final_round_evaluate_boolean_and(builder, alloc, rhs_presence, rhs_values);
+            let left =
+                final_round_evaluate_boolean_or(builder, alloc, both_present, lhs_true_present);
+            Some(final_round_evaluate_boolean_or(
+                builder,
+                alloc,
+                left,
+                rhs_true_present,
+            ))
+        }
+    }
+}
+
+/// Verify SQL three-valued `AND` result presence for nullable boolean operands.
+pub(crate) fn verifier_evaluate_nullable_boolean_and_presence<S: Scalar>(
+    builder: &mut impl VerificationBuilder<S>,
+    chi_eval: S,
+    lhs_value_eval: S,
+    lhs_presence_eval: Option<S>,
+    rhs_value_eval: S,
+    rhs_presence_eval: Option<S>,
+) -> Result<Option<S>, ProofError> {
+    match (lhs_presence_eval, rhs_presence_eval) {
+        (None, None) => Ok(None),
+        (Some(lhs_presence_eval), None) => Ok(Some(verifier_evaluate_boolean_or(
+            builder,
+            lhs_presence_eval,
+            chi_eval - rhs_value_eval,
+        )?)),
+        (None, Some(rhs_presence_eval)) => Ok(Some(verifier_evaluate_boolean_or(
+            builder,
+            rhs_presence_eval,
+            chi_eval - lhs_value_eval,
+        )?)),
+        (Some(lhs_presence_eval), Some(rhs_presence_eval)) => {
+            let both_present =
+                verifier_evaluate_boolean_and(builder, lhs_presence_eval, rhs_presence_eval)?;
+            let lhs_false_present = verifier_evaluate_boolean_and(
+                builder,
+                lhs_presence_eval,
+                chi_eval - lhs_value_eval,
+            )?;
+            let rhs_false_present = verifier_evaluate_boolean_and(
+                builder,
+                rhs_presence_eval,
+                chi_eval - rhs_value_eval,
+            )?;
+            let left = verifier_evaluate_boolean_or(builder, both_present, lhs_false_present)?;
+            Ok(Some(verifier_evaluate_boolean_or(
+                builder,
+                left,
+                rhs_false_present,
+            )?))
+        }
+    }
+}
+
+/// Verify SQL three-valued `OR` result presence for nullable boolean operands.
+pub(crate) fn verifier_evaluate_nullable_boolean_or_presence<S: Scalar>(
+    builder: &mut impl VerificationBuilder<S>,
+    lhs_value_eval: S,
+    lhs_presence_eval: Option<S>,
+    rhs_value_eval: S,
+    rhs_presence_eval: Option<S>,
+) -> Result<Option<S>, ProofError> {
+    match (lhs_presence_eval, rhs_presence_eval) {
+        (None, None) => Ok(None),
+        (Some(lhs_presence_eval), None) => Ok(Some(verifier_evaluate_boolean_or(
+            builder,
+            lhs_presence_eval,
+            rhs_value_eval,
+        )?)),
+        (None, Some(rhs_presence_eval)) => Ok(Some(verifier_evaluate_boolean_or(
+            builder,
+            rhs_presence_eval,
+            lhs_value_eval,
+        )?)),
+        (Some(lhs_presence_eval), Some(rhs_presence_eval)) => {
+            let both_present =
+                verifier_evaluate_boolean_and(builder, lhs_presence_eval, rhs_presence_eval)?;
+            let lhs_true_present =
+                verifier_evaluate_boolean_and(builder, lhs_presence_eval, lhs_value_eval)?;
+            let rhs_true_present =
+                verifier_evaluate_boolean_and(builder, rhs_presence_eval, rhs_value_eval)?;
+            let left = verifier_evaluate_boolean_or(builder, both_present, lhs_true_present)?;
+            Ok(Some(verifier_evaluate_boolean_or(
+                builder,
+                left,
+                rhs_true_present,
+            )?))
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
@@ -1,10 +1,10 @@
 use super::{
     numerical_util::{cast_column_with_scaling, try_get_scaling_factor_with_precision_and_scale},
-    DynProofExpr, ProofExpr,
+    DynProofExpr, NullableColumnEvaluation, ProofExpr,
 };
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -63,6 +63,10 @@ impl ProofExpr for ScalingCastExpr {
         self.to_type
     }
 
+    fn is_nullable(&self) -> bool {
+        self.from_expr.is_nullable()
+    }
+
     fn first_round_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
@@ -104,6 +108,51 @@ impl ProofExpr for ScalingCastExpr {
         self.from_expr
             .verifier_evaluate(builder, accessor, chi_eval, params)
             .map(|unscaled_eval| S::from(self.scaling_factor) * unscaled_eval)
+    }
+
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let uncasted_result = self
+            .from_expr
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let values = cast_column_with_scaling(alloc, uncasted_result.values(), self.to_type);
+        Ok(NullableColumn::try_new(values, uncasted_result.presence())
+            .expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let uncasted_result = self
+            .from_expr
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let values = cast_column_with_scaling(alloc, uncasted_result.values(), self.to_type);
+        Ok(NullableColumn::try_new(values, uncasted_result.presence())
+            .expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let unscaled = self
+            .from_expr
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        Ok(NullableColumnEvaluation::new(
+            S::from(self.scaling_factor) * unscaled.value_eval(),
+            unscaled.presence_eval(),
+        ))
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
@@ -1,8 +1,13 @@
-use super::{add_subtract_columns, DecimalProofExpr, DynProofExpr, ProofExpr};
+use super::{
+    add_subtract_columns, final_round_evaluate_nullable_presence,
+    first_round_evaluate_nullable_presence, verifier_evaluate_nullable_presence, DecimalProofExpr,
+    DynProofExpr, NullableColumnEvaluation, ProofExpr,
+};
 use crate::{
     base::{
         database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table,
+            try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue,
+            NullableColumn, Table,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -54,6 +59,10 @@ impl ProofExpr for SubtractExpr {
     fn data_type(&self) -> ColumnType {
         try_add_subtract_column_types(self.lhs.data_type(), self.rhs.data_type())
             .expect("Failed to add/subtract column types")
+    }
+
+    fn is_nullable(&self) -> bool {
+        self.lhs.is_nullable() || self.rhs.is_nullable()
     }
 
     fn first_round_evaluate<'a, S: Scalar>(
@@ -109,6 +118,74 @@ impl ProofExpr for SubtractExpr {
             .rhs
             .verifier_evaluate(builder, accessor, chi_eval, params)?;
         Ok(lhs_eval - rhs_eval)
+    }
+
+    fn first_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .first_round_evaluate_nullable(alloc, table, params)?;
+        let res = add_subtract_columns(lhs_column.values(), rhs_column.values(), alloc, true);
+        let values = Column::Decimal75(self.precision(), self.scale(), res);
+        let presence = first_round_evaluate_nullable_presence(
+            table.num_rows(),
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn final_round_evaluate_nullable<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<NullableColumn<'a, S>> {
+        let lhs_column = self
+            .lhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let rhs_column = self
+            .rhs
+            .final_round_evaluate_nullable(builder, alloc, table, params)?;
+        let res = add_subtract_columns(lhs_column.values(), rhs_column.values(), alloc, true);
+        let values = Column::Decimal75(self.precision(), self.scale(), res);
+        let presence = final_round_evaluate_nullable_presence(
+            builder,
+            alloc,
+            lhs_column.presence(),
+            rhs_column.presence(),
+        );
+        Ok(NullableColumn::try_new(values, presence).expect("presence length should match values"))
+    }
+
+    fn verifier_evaluate_nullable<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<NullableColumnEvaluation<S>, ProofError> {
+        let lhs = self
+            .lhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let rhs = self
+            .rhs
+            .verifier_evaluate_nullable(builder, accessor, chi_eval, params)?;
+        let presence_eval =
+            verifier_evaluate_nullable_presence(builder, lhs.presence_eval(), rhs.presence_eval())?;
+        Ok(NullableColumnEvaluation::new(
+            lhs.value_eval() - rhs.value_eval(),
+            presence_eval,
+        ))
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -180,7 +180,13 @@ impl DynProofPlan {
     pub(crate) fn get_column_result_fields_as_references(&self) -> IndexSet<ColumnRef> {
         self.get_column_result_fields()
             .into_iter()
-            .map(|f| ColumnRef::new(TableRef::from_names(None, ""), f.name(), f.data_type()))
+            .map(|f| {
+                if f.is_nullable() {
+                    ColumnRef::new_nullable(TableRef::from_names(None, ""), f.name(), f.data_type())
+                } else {
+                    ColumnRef::new(TableRef::from_names(None, ""), f.name(), f.data_type())
+                }
+            })
             .collect()
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -2,8 +2,8 @@ use super::{fold_vals, DynProofPlan};
 use crate::{
     base::{
         database::{
-            filter_util::filter_columns, Column, ColumnField, ColumnRef, LiteralValue, Table,
-            TableEvaluation, TableOptions, TableRef,
+            filter_util::filter_columns, presence_column_id, Column, ColumnField, ColumnRef,
+            ColumnType, LiteralValue, Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -13,7 +13,12 @@ use crate::{
         proof::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
-        proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr},
+        proof_exprs::{
+            final_round_evaluate_nullable_boolean_is_true,
+            first_round_evaluate_nullable_boolean_is_true,
+            verifier_evaluate_nullable_boolean_is_true, AliasedDynProofExpr, DynProofExpr,
+            ProofExpr,
+        },
         proof_gadgets::{final_round_evaluate_filter, verify_evaluate_filter},
     },
     utils::log,
@@ -91,27 +96,41 @@ impl ProofPlan for FilterExec {
             .collect::<IndexMap<_, _>>();
 
         // 1. selection
-        let selection_eval =
-            self.where_clause
-                .verifier_evaluate(builder, &accessor, input_chi_eval.0, params)?;
+        let selection_eval = {
+            let where_eval = self.where_clause.verifier_evaluate_nullable(
+                builder,
+                &accessor,
+                input_chi_eval.0,
+                params,
+            )?;
+            verifier_evaluate_nullable_boolean_is_true(
+                builder,
+                where_eval.value_eval(),
+                where_eval.presence_eval(),
+            )?
+        };
         // 2. columns
-        let columns_evals = Vec::from_iter(
-            self.aliased_results
-                .iter()
-                .map(|aliased_expr| {
-                    aliased_expr.expr.verifier_evaluate(
-                        builder,
-                        &accessor,
-                        input_chi_eval.0,
-                        params,
-                    )
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-        );
+        let columns_evals = self.aliased_results.iter().try_fold(
+            Vec::new(),
+            |mut columns_evals, aliased_expr| {
+                let eval = aliased_expr.expr.verifier_evaluate_nullable(
+                    builder,
+                    &accessor,
+                    input_chi_eval.0,
+                    params,
+                )?;
+                columns_evals.push(eval.value_eval());
+                if let Some(presence_eval) = eval.presence_eval() {
+                    columns_evals.push(presence_eval);
+                }
+                Ok::<_, ProofError>(columns_evals)
+            },
+        )?;
         // 3. filtered_columns
+        let output_fields = self.get_column_result_fields();
         let filtered_columns_evals =
-            builder.try_consume_first_round_mle_evaluations(self.aliased_results.len())?;
-        assert!(filtered_columns_evals.len() == self.aliased_results.len());
+            builder.try_consume_first_round_mle_evaluations(output_fields.len())?;
+        assert!(filtered_columns_evals.len() == output_fields.len());
 
         let output_chi_eval = builder.try_consume_chi_evaluation()?;
 
@@ -135,8 +154,27 @@ impl ProofPlan for FilterExec {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         self.aliased_results
             .iter()
-            .map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+            .flat_map(|aliased_expr| {
+                let mut fields = Vec::with_capacity(if aliased_expr.expr.is_nullable() {
+                    2
+                } else {
+                    1
+                });
+                fields.push(if aliased_expr.expr.is_nullable() {
+                    ColumnField::new_nullable(
+                        aliased_expr.alias.clone(),
+                        aliased_expr.expr.data_type(),
+                    )
+                } else {
+                    ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+                });
+                if aliased_expr.expr.is_nullable() {
+                    fields.push(ColumnField::new(
+                        presence_column_id(&aliased_expr.alias),
+                        ColumnType::Boolean,
+                    ));
+                }
+                fields
             })
             .collect()
     }
@@ -166,24 +204,28 @@ impl ProverEvaluate for FilterExec {
             .first_round_evaluate(builder, alloc, table_map, params)?;
 
         // 1. selection
-        let selection_column: Column<'a, S> = self
+        let selection_column = self
             .where_clause
-            .first_round_evaluate(alloc, &input, params)?;
-        let selection = selection_column
-            .as_boolean()
-            .expect("selection is not boolean");
+            .first_round_evaluate_nullable(alloc, &input, params)?;
+        let selection = first_round_evaluate_nullable_boolean_is_true(alloc, selection_column);
         let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
-        let columns: Vec<_> = self
-            .aliased_results
-            .iter()
-            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
-                aliased_expr
+        let (column_aliases, columns) = self.aliased_results.iter().try_fold(
+            (Vec::new(), Vec::new()),
+            |(mut aliases, mut columns), aliased_expr| -> PlaceholderResult<_> {
+                let column = aliased_expr
                     .expr
-                    .first_round_evaluate(alloc, &input, params)
-            })
-            .collect::<PlaceholderResult<Vec<_>>>()?;
+                    .first_round_evaluate_nullable(alloc, &input, params)?;
+                aliases.push(aliased_expr.alias.clone());
+                columns.push(column.values());
+                if let Some(presence) = column.presence() {
+                    aliases.push(presence_column_id(&aliased_expr.alias));
+                    columns.push(Column::Boolean(presence));
+                }
+                Ok((aliases, columns))
+            },
+        )?;
 
         // Compute filtered_columns and indexes
         let (filtered_columns, _) = filter_columns(alloc, &columns, selection);
@@ -192,10 +234,7 @@ impl ProverEvaluate for FilterExec {
             builder.produce_intermediate_mle(column);
         });
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.aliased_results
-                .iter()
-                .map(|expr| expr.alias.clone())
-                .zip(filtered_columns),
+            column_aliases.into_iter().zip(filtered_columns),
             TableOptions::new(Some(output_length)),
         )
         .expect("Failed to create table from iterator");
@@ -223,24 +262,29 @@ impl ProverEvaluate for FilterExec {
             .input
             .final_round_evaluate(builder, alloc, table_map, params)?;
         // 1. selection
-        let selection_column: Column<'a, S> = self
+        let selection_column = self
             .where_clause
-            .final_round_evaluate(builder, alloc, &input, params)?;
-        let selection = selection_column
-            .as_boolean()
-            .expect("selection is not boolean");
+            .final_round_evaluate_nullable(builder, alloc, &input, params)?;
+        let selection =
+            final_round_evaluate_nullable_boolean_is_true(builder, alloc, selection_column);
         let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
-        let columns: Vec<_> = self
-            .aliased_results
-            .iter()
-            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
-                aliased_expr
+        let (column_aliases, columns) = self.aliased_results.iter().try_fold(
+            (Vec::new(), Vec::new()),
+            |(mut aliases, mut columns), aliased_expr| -> PlaceholderResult<_> {
+                let column = aliased_expr
                     .expr
-                    .final_round_evaluate(builder, alloc, &input, params)
-            })
-            .collect::<PlaceholderResult<Vec<_>>>()?;
+                    .final_round_evaluate_nullable(builder, alloc, &input, params)?;
+                aliases.push(aliased_expr.alias.clone());
+                columns.push(column.values());
+                if let Some(presence) = column.presence() {
+                    aliases.push(presence_column_id(&aliased_expr.alias));
+                    columns.push(Column::Boolean(presence));
+                }
+                Ok((aliases, columns))
+            },
+        )?;
         // Compute filtered_columns
         let (filtered_columns, result_len) = filter_columns(alloc, &columns, selection);
 
@@ -256,10 +300,7 @@ impl ProverEvaluate for FilterExec {
             result_len,
         );
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.aliased_results
-                .iter()
-                .map(|expr| expr.alias.clone())
-                .zip(filtered_columns),
+            column_aliases.into_iter().zip(filtered_columns),
             TableOptions::new(Some(output_length)),
         )
         .expect("Failed to create table from iterator");

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -2,8 +2,8 @@ use super::DynProofPlan;
 use crate::{
     base::{
         database::{
-            Column, ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableOptions,
-            TableRef,
+            presence_column_id, Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table,
+            TableEvaluation, TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
@@ -74,23 +74,49 @@ impl ProofPlan for ProjectionExec {
             .zip(input_eval.column_evals())
             .map(|(field, eval)| (field.name().clone(), *eval))
             .collect::<IndexMap<_, _>>();
-        let output_column_evals = self
-            .aliased_results
-            .iter()
-            .map(|aliased_expr| {
-                aliased_expr
-                    .expr
-                    .verifier_evaluate(builder, &current_accessor, chi.0, params)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let output_column_evals = self.aliased_results.iter().try_fold(
+            Vec::new(),
+            |mut output_column_evals, aliased_expr| {
+                let eval = aliased_expr.expr.verifier_evaluate_nullable(
+                    builder,
+                    &current_accessor,
+                    chi.0,
+                    params,
+                )?;
+                output_column_evals.push(eval.value_eval());
+                if let Some(presence_eval) = eval.presence_eval() {
+                    output_column_evals.push(presence_eval);
+                }
+                Ok::<_, ProofError>(output_column_evals)
+            },
+        )?;
         Ok(TableEvaluation::new(output_column_evals, chi))
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         self.aliased_results
             .iter()
-            .map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+            .flat_map(|aliased_expr| {
+                let mut fields = Vec::with_capacity(if aliased_expr.expr.is_nullable() {
+                    2
+                } else {
+                    1
+                });
+                fields.push(if aliased_expr.expr.is_nullable() {
+                    ColumnField::new_nullable(
+                        aliased_expr.alias.clone(),
+                        aliased_expr.expr.data_type(),
+                    )
+                } else {
+                    ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
+                });
+                if aliased_expr.expr.is_nullable() {
+                    fields.push(ColumnField::new(
+                        presence_column_id(&aliased_expr.alias),
+                        ColumnType::Boolean,
+                    ));
+                }
+                fields
             })
             .collect()
     }
@@ -124,20 +150,22 @@ impl ProverEvaluate for ProjectionExec {
             .input
             .first_round_evaluate(builder, alloc, table_map, params)?;
 
-        let cols = self
-            .aliased_results
-            .iter()
-            .map(
-                |aliased_expr| -> PlaceholderResult<(Ident, Column<'a, S>)> {
-                    Ok((
-                        aliased_expr.alias.clone(),
-                        aliased_expr
-                            .expr
-                            .first_round_evaluate(alloc, &input, params)?,
-                    ))
-                },
-            )
-            .collect::<PlaceholderResult<IndexMap<_, _>>>()?;
+        let cols = self.aliased_results.iter().try_fold(
+            IndexMap::default(),
+            |mut cols, aliased_expr| -> PlaceholderResult<_> {
+                let column = aliased_expr
+                    .expr
+                    .first_round_evaluate_nullable(alloc, &input, params)?;
+                cols.insert(aliased_expr.alias.clone(), column.values());
+                if let Some(presence) = column.presence() {
+                    cols.insert(
+                        presence_column_id(&aliased_expr.alias),
+                        Column::Boolean(presence),
+                    );
+                }
+                Ok(cols)
+            },
+        )?;
 
         let res =
             Table::<'a, S>::try_new_with_options(cols, TableOptions::new(Some(input.num_rows())))
@@ -167,20 +195,22 @@ impl ProverEvaluate for ProjectionExec {
             .final_round_evaluate(builder, alloc, table_map, params)?;
 
         // Evaluate result expressions
-        let cols = self
-            .aliased_results
-            .iter()
-            .map(
-                |aliased_expr| -> PlaceholderResult<(Ident, Column<'a, S>)> {
-                    Ok((
-                        aliased_expr.alias.clone(),
-                        aliased_expr
-                            .expr
-                            .final_round_evaluate(builder, alloc, &input, params)?,
-                    ))
-                },
-            )
-            .collect::<PlaceholderResult<IndexMap<_, _>>>()?;
+        let cols = self.aliased_results.iter().try_fold(
+            IndexMap::default(),
+            |mut cols, aliased_expr| -> PlaceholderResult<_> {
+                let column = aliased_expr
+                    .expr
+                    .final_round_evaluate_nullable(builder, alloc, &input, params)?;
+                cols.insert(aliased_expr.alias.clone(), column.values());
+                if let Some(presence) = column.presence() {
+                    cols.insert(
+                        presence_column_id(&aliased_expr.alias),
+                        Column::Boolean(presence),
+                    );
+                }
+                Ok(cols)
+            },
+        )?;
 
         let res =
             Table::<'a, S>::try_new_with_options(cols, TableOptions::new(Some(input.num_rows())))

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -1,6 +1,9 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, LiteralValue, Table, TableEvaluation, TableRef},
+        database::{
+            physical_column_fields_from_logical_schema, presence_column_id, ColumnField, ColumnRef,
+            ColumnType, LiteralValue, Table, TableEvaluation, TableRef,
+        },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -55,8 +58,8 @@ impl ProofPlan for TableExec {
         chi_eval_map: &IndexMap<TableRef, (S, usize)>,
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
-        let column_evals = self
-            .schema
+        let output_schema = self.get_column_result_fields();
+        let column_evals = output_schema
             .iter()
             .map(|field| {
                 *accessor
@@ -73,13 +76,28 @@ impl ProofPlan for TableExec {
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        self.schema.clone()
+        physical_column_fields_from_logical_schema(self.schema.clone())
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         self.schema
             .iter()
-            .map(|field| ColumnRef::new(self.table_ref.clone(), field.name(), field.data_type()))
+            .flat_map(|field| {
+                let mut refs = Vec::with_capacity(if field.is_nullable() { 2 } else { 1 });
+                refs.push(if field.is_nullable() {
+                    ColumnRef::new_nullable(self.table_ref.clone(), field.name(), field.data_type())
+                } else {
+                    ColumnRef::new(self.table_ref.clone(), field.name(), field.data_type())
+                });
+                if field.is_nullable() {
+                    refs.push(ColumnRef::new(
+                        self.table_ref.clone(),
+                        presence_column_id(&field.name()),
+                        ColumnType::Boolean,
+                    ));
+                }
+                refs
+            })
             .collect()
     }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

#183 asks for nullable column support, including support for existing operations on nullable columns, and the issue discussion specifically asks for a proof-of-concept that demonstrates a non-trivial proof involving at least one null type.

This PR implements a proof-level nullable column vertical slice using the value-column plus presence-column design discussed in the issue. A logical nullable column is represented physically as a value column plus a boolean `<column>__presence` column. Nullable expression evaluation carries both the value evaluation and optional presence evaluation through prover and verifier code, so arithmetic, predicates, filters, and projections can preserve SQL null semantics.

This includes the query shape requested in the issue discussion: nullable `A + B` inside a `WHERE` clause, with `SELECT *` results verified end to end.

/claim #183

Refs #183

# What changes are included in this PR?

- Add nullable owned/borrowed column support using value columns plus optional boolean presence masks.
- Add nullable metadata to `ColumnField` and `ColumnRef`.
- Add schema helpers that expand logical nullable fields into physical value + presence columns for proof execution.
- Add nullable proof-expression evaluation for column references, arithmetic, comparisons, casts, `NOT`, `AND`, `OR`, `IS NULL`, `IS NOT NULL`, and `IS TRUE`.
- Implement SQL three-valued boolean behavior for nullable `AND` / `OR`.
- Update `FilterExec` so `WHERE` uses `IS TRUE` semantics: only true rows pass; false and null do not.
- Update `TableExec`, `ProjectionExec`, and `FilterExec` so nullable result columns carry their presence columns through first round, final round, and verifier evaluation.
- Update planner lowering so nullable schema metadata reaches proof expressions/plans, including `IS NULL`, `IS NOT NULL`, `IS TRUE`, `IS FALSE`, `IS UNKNOWN`, and related predicates.
- Add a uniform Arrow guard so `OwnedColumn::try_from(&ArrayRef)` rejects null-bearing Arrow arrays until callers use an explicit nullable representation.
- Add proof and planner tests covering nullable arithmetic, filtering, tampered value/presence commitments, null predicates, and boolean three-valued logic.

# Proof-of-concept signal

The planner E2E tests now prove and verify nullable arithmetic through `SELECT *` filters over nullable `a` and `b` columns:

```sql
select * from nullable_addends where a + b = 2;
select * from nullable_addends where a + b = 4;
select * from nullable_addends where a + b = 3;
select * from nullable_addends where a + b = 0;
select * from nullable_addends where a = 1 or b = 1;
```

The backing table includes physical `a__presence` and `b__presence` columns, and the expected results include the filtered value and presence columns.

# Are these changes tested?

Yes. Ran locally:

```sh
cargo fmt --all --check
git diff --check origin/main...HEAD
source scripts/check_commits.sh
cargo check -p proof-of-sql --no-default-features --features test
cargo check -p proof-of-sql-planner --no-default-features
cargo test -p proof-of-sql --no-default-features --features test nullable -- --nocapture
cargo test -p proof-of-sql --no-default-features --features 'arrow test' we_reject_arrow_arrays_with_nulls_when_converting_to_owned_columns -- --nocapture
cargo test -p proof-of-sql-planner --no-default-features --test e2e_tests nullable -- --nocapture
```

Results:
- `source scripts/check_commits.sh`: 4 commits checked, 0 failures
- nullable proof/core test filter: 16 passed, 0 failed
- Arrow nullable-array rejection test: 1 passed, 0 failed
- nullable planner E2E filter: 2 passed, 0 failed

I did not run the full `source scripts/run_ci_checks.sh` locally. This branch has been validated with the focused checks above and should still go through repository CI.