### PR TITLE
test: cover multiply proof expr without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -138,3 +138,140 @@ impl ProofExpr for MultiplyExpr {
 }
 
 impl DecimalProofExpr for MultiplyExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{table_utility::*, TableRef},
+            math::decimal::Precision,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::mock_verification_builder::MockVerificationBuilder,
+    };
+    use alloc::{collections::VecDeque, vec, vec::Vec};
+
+    fn literal(value: LiteralValue) -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_literal(value))
+    }
+
+    fn column_ref(name: &str) -> ColumnRef {
+        ColumnRef::new(TableRef::new("sxt", "t"), name.into(), ColumnType::BigInt)
+    }
+
+    fn column(name: &str) -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_column(column_ref(name)))
+    }
+
+    fn scalar_values(values: impl IntoIterator<Item = u64>) -> Vec<TestScalar> {
+        values.into_iter().map(TestScalar::from).collect()
+    }
+
+    fn assert_decimal_column(
+        column: Column<TestScalar>,
+        precision: Precision,
+        scale: i8,
+        expected: impl IntoIterator<Item = u64>,
+    ) {
+        match column {
+            Column::Decimal75(actual_precision, actual_scale, values) => {
+                assert_eq!(actual_precision, precision);
+                assert_eq!(actual_scale, scale);
+                assert_eq!(values, scalar_values(expected).as_slice());
+            }
+            other => panic!("expected decimal column, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn we_can_create_a_multiply_expr_and_read_its_metadata() {
+        let expr = MultiplyExpr::try_new(
+            literal(LiteralValue::SmallInt(2)),
+            literal(LiteralValue::Int(3)),
+        )
+        .unwrap();
+
+        assert!(matches!(expr.lhs(), DynProofExpr::Literal(_)));
+        assert!(matches!(expr.rhs(), DynProofExpr::Literal(_)));
+        assert_eq!(
+            expr.data_type(),
+            ColumnType::Decimal75(Precision::new(16).unwrap(), 0)
+        );
+    }
+
+    #[test]
+    fn we_cannot_create_a_multiply_expr_for_non_numeric_types() {
+        let error = MultiplyExpr::try_new(
+            literal(LiteralValue::VarChar("abc".to_string())),
+            literal(LiteralValue::BigInt(3)),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, AnalyzeError::DataTypeMismatch { .. }));
+    }
+
+    #[test]
+    fn we_can_evaluate_multiply_expr_in_prover_rounds() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_bigint("a", [2_i64, 3, 4], &alloc),
+            borrowed_bigint("b", [5_i64, 6, 7], &alloc),
+        ]);
+        let expr = MultiplyExpr::try_new(column("a"), column("b")).unwrap();
+
+        let first_round = expr.first_round_evaluate(&alloc, &table, &[]).unwrap();
+        assert_decimal_column(first_round, expr.precision(), expr.scale(), [10, 18, 28]);
+
+        let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+        let final_round = expr
+            .final_round_evaluate(&mut builder, &alloc, &table, &[])
+            .unwrap();
+        assert_decimal_column(final_round, expr.precision(), expr.scale(), [10, 18, 28]);
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+    }
+
+    #[test]
+    fn we_can_verify_multiply_expr_and_record_identity_constraint() {
+        let expr = MultiplyExpr::try_new(
+            literal(LiteralValue::BigInt(2)),
+            literal(LiteralValue::BigInt(3)),
+        )
+        .unwrap();
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            vec![scalar_values([6])],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let result = expr
+            .verifier_evaluate(&mut builder, &IndexMap::default(), TestScalar::ONE, &[])
+            .unwrap();
+
+        assert_eq!(result, TestScalar::from(6_u64));
+        assert_eq!(builder.get_identity_results(), vec![vec![true]]);
+    }
+
+    #[test]
+    fn we_collect_column_references_from_both_operands() {
+        let left_ref = column_ref("a");
+        let right_ref = column_ref("b");
+        let expr = MultiplyExpr::try_new(
+            Box::new(DynProofExpr::new_column(left_ref.clone())),
+            Box::new(DynProofExpr::new_column(right_ref.clone())),
+        )
+        .unwrap();
+        let mut refs = IndexSet::default();
+
+        expr.get_column_references(&mut refs);
+
+        assert_eq!(refs.len(), 2);
+        assert!(refs.contains(&left_ref));
+        assert!(refs.contains(&right_ref));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add no-default-feature unit coverage for `MultiplyExpr` in `multiply_expr.rs`.
- Cover constructor metadata, non-numeric type rejection, prover first/final round evaluation, verifier identity constraint recording, and column reference collection.
- Keep the change test-only with no production logic changes and no `blitzar` feature dependency.

## This claim account
This PR is the latest Algora claim for this account. For maintainer reward accounting, this account has three small, non-overlapping test-only #560 PRs open:

| PR | Target slice | Conservative newly covered original lines | Est. at $0.10/line |
| --- | --- | ---: | ---: |
| #1495 | `DemoMockPlan` no-default test coverage | 41 | $4.10 |
| #1532 | EVM proof plan conversion coverage | 86 | $8.60 |
| #1537 | `MultiplyExpr` no-default test coverage | 66 | $6.60 |

Conservative total across the account's current #560 submissions: 193 newly covered original lines / $19.30, subject to maintainer review and final Algora accounting.

## #1537 coverage accounting
- Baseline: clean `upstream/main` at `1bf50a63`, focused no-default coverage for `multiply_expr.rs`: 80 original trackable lines, 13 covered, 67 missed.
- Branch focused coverage: 80 original trackable lines, 79 covered, only original line 128 missed.
- Conservative delta for this PR: 66 newly covered original source lines = $6.60 at $0.10/line.

## Validation
- `cargo test -p proof-of-sql multiply_expr --no-default-features --features=test` -> 8 passed, 0 failed.
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/llvm-cov/multiply-expr.lcov -- multiply_expr` -> 8 passed, report saved.
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `scripts/check_commits.sh`

AI-assisted with OpenAI Codex; diff reviewed and verified locally.