### PR TITLE
test: cover ref into blanket conversion

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,25 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct Wrapper(u64);
+
+    impl From<&Wrapper> for u64 {
+        fn from(value: &Wrapper) -> Self {
+            value.0
+        }
+    }
+
+    #[test]
+    fn we_can_convert_from_a_reference_without_consuming_the_value() {
+        let value = Wrapper(42);
+
+        assert_eq!(RefInto::<u64>::ref_into(&value), 42);
+        assert_eq!(value, Wrapper(42));
+    }
+}


### PR DESCRIPTION
## Summary
- add focused coverage for the `RefInto` blanket implementation
- verify reference-based conversion works without consuming the source value

## Tests
- ASDF_RUST_VERSION=1.67.0 cargo +1.91.1 test -p proof-of-sql base::ref_into --no-default-features --features test
- ASDF_RUST_VERSION=1.67.0 cargo +1.91.1 fmt --check
- git diff --check

/claim #560