### PR TITLE
test: cover placeholder and verification helpers

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -1,5 +1,6 @@
 use super::{SumcheckMleEvaluations, VerificationBuilderImpl};
 use crate::{
+    base::{bit::BitDistribution, map::IndexMap, proof::ProofSizeMismatch},
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::{SumcheckSubpolynomialType, VerificationBuilder},
 };
@@ -26,6 +27,7 @@ fn an_empty_sumcheck_polynomial_evaluates_to_zero() {
 #[test]
 fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations() {
     let mle_evaluations = SumcheckMleEvaluations {
+        random_evaluation: Curve25519Scalar::from(7u64),
         ..Default::default()
     };
     let subpolynomial_multipliers = [
@@ -39,11 +41,11 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
         VecDeque::new(),
         Vec::new(),
         Vec::new(),
-        1,
+        2,
     );
     builder
         .try_produce_sumcheck_subpolynomial_evaluation(
-            SumcheckSubpolynomialType::ZeroSum,
+            SumcheckSubpolynomialType::Identity,
             Curve25519Scalar::from(2u64),
             1,
         )
@@ -55,9 +57,172 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
             1,
         )
         .unwrap();
-    let expected_sumcheck_evaluation = subpolynomial_multipliers[0] * Curve25519Scalar::from(2u64)
-        + subpolynomial_multipliers[1] * Curve25519Scalar::from(3u64);
+    let expected_sumcheck_evaluation =
+        subpolynomial_multipliers[0] * Curve25519Scalar::from(2u64) * Curve25519Scalar::from(7u64)
+            + subpolynomial_multipliers[1] * Curve25519Scalar::from(3u64);
     assert_eq!(builder.sumcheck_evaluation(), expected_sumcheck_evaluation);
+}
+
+#[test]
+fn we_can_consume_verification_builder_inputs_in_order() {
+    let mut chi_evaluations = IndexMap::default();
+    let chi_eval = Curve25519Scalar::from(11u64);
+    chi_evaluations.insert(4, chi_eval);
+    let mut rho_evaluations = IndexMap::default();
+    let rho_eval = Curve25519Scalar::from(13u64);
+    rho_evaluations.insert(6, rho_eval);
+    let first_round = [Curve25519Scalar::from(21u64), Curve25519Scalar::from(22u64)];
+    let final_round = [Curve25519Scalar::from(31u64), Curve25519Scalar::from(32u64)];
+    let bit_distribution = BitDistribution::new::<Curve25519Scalar, _>(&[1u64, 2, 3]);
+    let bit_distributions = [bit_distribution.clone()];
+    let mle_evaluations = SumcheckMleEvaluations {
+        chi_evaluations,
+        rho_evaluations,
+        singleton_chi_evaluation: Curve25519Scalar::from(3u64),
+        first_round_pcs_proof_evaluations: &first_round,
+        final_round_pcs_proof_evaluations: &final_round,
+        rho_256_evaluation: Some(Curve25519Scalar::from(5u64)),
+        ..Default::default()
+    };
+    let mut builder = VerificationBuilderImpl::new(
+        mle_evaluations,
+        &bit_distributions,
+        &[][..],
+        VecDeque::new(),
+        vec![4],
+        vec![6],
+        0,
+    );
+
+    assert_eq!(builder.try_consume_chi_evaluation().unwrap(), (chi_eval, 4));
+    assert_eq!(builder.try_consume_rho_evaluation().unwrap(), rho_eval);
+    assert_eq!(
+        builder.try_consume_first_round_mle_evaluations(2).unwrap(),
+        first_round
+    );
+    assert_eq!(
+        builder.try_consume_final_round_mle_evaluations(2).unwrap(),
+        final_round
+    );
+    assert_eq!(
+        builder.try_consume_bit_distribution().unwrap(),
+        bit_distribution
+    );
+    assert_eq!(
+        builder.singleton_chi_evaluation(),
+        Curve25519Scalar::from(3u64)
+    );
+    assert_eq!(
+        builder.rho_256_evaluation(),
+        Some(Curve25519Scalar::from(5u64))
+    );
+    assert_eq!(builder.sumcheck_evaluation(), Curve25519Scalar::zero());
+}
+
+#[test]
+fn we_reject_missing_verification_builder_inputs() {
+    let mut builder = VerificationBuilderImpl::<Curve25519Scalar>::new(
+        SumcheckMleEvaluations::default(),
+        &[][..],
+        &[][..],
+        VecDeque::new(),
+        Vec::new(),
+        Vec::new(),
+        0,
+    );
+    assert!(matches!(
+        builder.try_consume_chi_evaluation(),
+        Err(ProofSizeMismatch::TooFewChiLengths)
+    ));
+    assert!(matches!(
+        builder.try_consume_rho_evaluation(),
+        Err(ProofSizeMismatch::TooFewRhoLengths)
+    ));
+    assert!(matches!(
+        builder.try_consume_first_round_mle_evaluation(),
+        Err(ProofSizeMismatch::TooFewMLEEvaluations)
+    ));
+    assert!(matches!(
+        builder.try_consume_final_round_mle_evaluation(),
+        Err(ProofSizeMismatch::TooFewMLEEvaluations)
+    ));
+    assert!(matches!(
+        builder.try_consume_bit_distribution(),
+        Err(ProofSizeMismatch::TooFewBitDistributions)
+    ));
+    assert!(matches!(
+        builder.try_consume_post_result_challenge(),
+        Err(ProofSizeMismatch::PostResultCountMismatch)
+    ));
+    assert!(matches!(
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::ZeroSum,
+            Curve25519Scalar::from(1u64),
+            0,
+        ),
+        Err(ProofSizeMismatch::ConstraintCountMismatch)
+    ));
+}
+
+#[test]
+fn we_reject_missing_chi_and_rho_length_evaluations() {
+    let mut builder = VerificationBuilderImpl::<Curve25519Scalar>::new(
+        SumcheckMleEvaluations::default(),
+        &[][..],
+        &[][..],
+        VecDeque::new(),
+        vec![4],
+        vec![6],
+        0,
+    );
+    assert!(matches!(
+        builder.try_consume_chi_evaluation(),
+        Err(ProofSizeMismatch::ChiLengthNotFound)
+    ));
+    assert!(matches!(
+        builder.try_consume_rho_evaluation(),
+        Err(ProofSizeMismatch::RhoLengthNotFound)
+    ));
+}
+
+#[test]
+fn we_reject_sumcheck_subpolynomials_that_exceed_the_builder_size() {
+    let subpolynomial_multipliers = [Curve25519Scalar::from(1u64)];
+    let mut builder = VerificationBuilderImpl::new(
+        SumcheckMleEvaluations::default(),
+        &[][..],
+        &subpolynomial_multipliers,
+        VecDeque::new(),
+        Vec::new(),
+        Vec::new(),
+        0,
+    );
+    assert!(matches!(
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            Curve25519Scalar::from(1u64),
+            0,
+        ),
+        Err(ProofSizeMismatch::SumcheckProofTooSmall)
+    ));
+
+    let mut builder = VerificationBuilderImpl::new(
+        SumcheckMleEvaluations::default(),
+        &[][..],
+        &subpolynomial_multipliers,
+        VecDeque::new(),
+        Vec::new(),
+        Vec::new(),
+        0,
+    );
+    assert!(matches!(
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::ZeroSum,
+            Curve25519Scalar::from(1u64),
+            1,
+        ),
+        Err(ProofSizeMismatch::SumcheckProofTooSmall)
+    ));
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
@@ -151,6 +151,11 @@ impl ProofExpr for PlaceholderExpr {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        base::{map::indexmap, scalar::test_scalar::TestScalar},
+        sql::proof::{SumcheckMleEvaluations, VerificationBuilderImpl},
+    };
+    use alloc::collections::VecDeque;
     // new
     #[test]
     fn we_cannot_create_a_placeholder_with_zero_id() {
@@ -204,5 +209,77 @@ mod tests {
         let params = vec![LiteralValue::Boolean(true)];
         let res = placeholder_expr.interpolate(&params);
         assert_eq!(res.unwrap(), &LiteralValue::Boolean(true));
+    }
+
+    #[test]
+    fn we_can_evaluate_placeholder_in_the_first_round() {
+        let alloc = Bump::new();
+        let table_values = [10_i64, 20_i64, 30_i64];
+        let table = Table::try_new(indexmap! {
+            "a".into() => Column::BigInt::<TestScalar>(&table_values),
+        })
+        .unwrap();
+        let placeholder_expr = PlaceholderExpr::try_new(1, ColumnType::BigInt).unwrap();
+        let params = [LiteralValue::BigInt(42)];
+        let evaluated = placeholder_expr
+            .first_round_evaluate(&alloc, &table, &params)
+            .unwrap();
+        let expected_values = [42_i64, 42, 42];
+
+        assert_eq!(evaluated, Column::BigInt(&expected_values));
+    }
+
+    #[test]
+    fn we_can_evaluate_placeholder_in_the_final_round() {
+        let alloc = Bump::new();
+        let table_values = [true, false];
+        let table = Table::try_new(indexmap! {
+            "a".into() => Column::Boolean::<TestScalar>(&table_values),
+        })
+        .unwrap();
+        let placeholder_expr = PlaceholderExpr::try_new(1, ColumnType::Boolean).unwrap();
+        let params = [LiteralValue::Boolean(true)];
+        let mut builder = FinalRoundBuilder::<TestScalar>::new(2, VecDeque::new());
+        let evaluated = placeholder_expr
+            .final_round_evaluate(&mut builder, &alloc, &table, &params)
+            .unwrap();
+        let expected_values = [true, true];
+
+        assert_eq!(evaluated, Column::Boolean(&expected_values));
+    }
+
+    #[test]
+    fn we_can_evaluate_placeholder_for_the_verifier() {
+        let placeholder_expr = PlaceholderExpr::try_new(1, ColumnType::BigInt).unwrap();
+        let params = [LiteralValue::BigInt(7)];
+        let mut builder = VerificationBuilderImpl::<TestScalar>::new(
+            SumcheckMleEvaluations::default(),
+            &[][..],
+            &[][..],
+            VecDeque::new(),
+            Vec::new(),
+            Vec::new(),
+            0,
+        );
+        let evaluated = placeholder_expr
+            .verifier_evaluate(
+                &mut builder,
+                &IndexMap::default(),
+                TestScalar::from(3),
+                &params,
+            )
+            .unwrap();
+
+        assert_eq!(evaluated, TestScalar::from(21));
+    }
+
+    #[test]
+    fn placeholders_do_not_reference_table_columns() {
+        let placeholder_expr = PlaceholderExpr::try_new(1, ColumnType::Boolean).unwrap();
+        let mut columns = IndexSet::default();
+
+        placeholder_expr.get_column_references(&mut columns);
+
+        assert!(columns.is_empty());
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add direct no-default tests for `VerificationBuilderImpl` input consumption, accessor behavior, and proof-size mismatch branches
- add no-default placeholder tests for first-round, final-round, verifier evaluation, and column-reference behavior
- keep the patch test-only and scoped to the two helper surfaces

## Coverage
Final local LCOV: `/tmp/sxt-posql-placeholder-verification-final.lcov`

| File | Before | After | Notes |
| --- | ---: | ---: | --- |
| `crates/proof-of-sql/src/sql/proof/verification_builder.rs` | 61/146 | 146/146 | covers the remaining consumption/accessor/error branches |
| `crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs` | 71/110 | 161/164 | includes new no-default placeholder behavior tests |

Conservative original production-code delta: 119 newly covered lines, estimated $11.90 at $0.10/line if accepted.

## Validation
- `cargo test -p proof-of-sql sql::proof::verification_builder_test --no-default-features --features=test`
- `cargo test -p proof-of-sql sql::proof_exprs::placeholder_expr::tests --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path /tmp/sxt-posql-placeholder-verification-final.lcov` (968 passed)
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

AI-assisted with Codex; I reviewed the diff and validation before submitting.