### PR TITLE
test: run boolean expression tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnRef, ColumnType,
             OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
@@ -11,7 +11,6 @@ use crate::{
     },
     sql::{
         proof::{
-            exercise_verification,
             mock_verification_builder::{run_verify_for_each_row, MockVerificationBuilder},
             FinalRoundBuilder, FirstRoundBuilder, VerifiableQueryResult,
         },
@@ -40,7 +39,7 @@ fn we_can_prove_a_simple_and_query() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
         table_exec(
@@ -60,8 +59,8 @@ fn we_can_prove_a_simple_and_query() {
             ),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -80,7 +79,7 @@ fn we_can_prove_a_simple_and_query_with_128_bits() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
         table_exec(
@@ -100,8 +99,8 @@ fn we_can_prove_a_simple_and_query_with_128_bits() {
             ),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -135,7 +134,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -160,8 +159,8 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 equal(column(&t, "c", &accessor), const_bigint(filter_val2)),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
+        let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+            VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
             .unwrap()
@@ -209,7 +208,7 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_first_round_evaluate()
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let and_expr: DynProofExpr = and(
         equal(column(&t, "b", &accessor), const_int128(1)),
         equal(column(&t, "d", &accessor), const_varchar("t")),
@@ -338,7 +337,7 @@ fn we_cannot_and_mismatching_types() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let lhs = Box::new(column(&t, "a", &accessor));
     let rhs = Box::new(column(&t, "b", &accessor));
     let and_err = AndExpr::try_new(lhs.clone(), rhs.clone()).unwrap_err();

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -35,7 +35,7 @@ mod placeholder_expr_test;
 
 mod and_expr;
 pub(crate) use and_expr::AndExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod and_expr_test;
 
 mod inequality_expr;
@@ -45,12 +45,12 @@ mod inequality_expr_test;
 
 mod or_expr;
 pub(crate) use or_expr::OrExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod or_expr_test;
 
 mod not_expr;
 pub(crate) use not_expr::NotExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod not_expr_test;
 
 mod numerical_util;

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
             TableRef, TableTestAccessor, TestAccessor,
@@ -8,7 +8,7 @@ use crate::{
         scalar::test_scalar::TestScalar,
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::VerifiableQueryResult,
         proof_exprs::{not_expr::NotExpr, test_utility::*, DynProofExpr, ProofExpr},
         proof_plans::test_utility::*,
         AnalyzeError,
@@ -31,7 +31,7 @@ fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
         table_exec(
@@ -44,8 +44,8 @@ fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {
         ),
         not(equal(column(&t, "b", &accessor), const_bigint(1))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -74,7 +74,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -97,8 +97,8 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             )),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
+        let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+            VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
             .unwrap()
@@ -139,7 +139,7 @@ fn we_can_compute_the_correct_output_of_a_not_expr_using_first_round_evaluate() 
         borrowed_bigint("b", [0, 1], &alloc),
         borrowed_varchar("d", ["alfa", "gama"], &alloc),
     ]);
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let t = TableRef::new("sxt", "t");
     accessor.add_table(t.clone(), data.clone(), 0);
     let not_expr: DynProofExpr = not(equal(column(&t, "b", &accessor), const_int128(1)));
@@ -154,7 +154,7 @@ fn we_cannot_not_nonbool_type() {
     let data = table([borrowed_smallint("a", [1_i16, 2, 3, 4], &alloc)]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let expr = Box::new(column(&t, "a", &accessor));
     let not_err = NotExpr::try_new(expr.clone()).unwrap_err();
     assert!(matches!(

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -1,13 +1,13 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
             TableRef, TableTestAccessor, TestAccessor,
         },
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::VerifiableQueryResult,
         proof_exprs::{or_expr::OrExpr, test_utility::*, DynProofExpr, ProofExpr},
         proof_plans::test_utility::*,
         AnalyzeError,
@@ -30,7 +30,7 @@ fn we_can_prove_a_simple_or_query() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
         table_exec(
@@ -46,8 +46,8 @@ fn we_can_prove_a_simple_or_query() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -65,7 +65,7 @@ fn we_can_prove_a_simple_or_query_with_variable_integer_types() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
         table_exec(
@@ -81,8 +81,8 @@ fn we_can_prove_a_simple_or_query_with_variable_integer_types() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -101,7 +101,7 @@ fn we_can_prove_an_or_query_where_both_lhs_and_rhs_are_true() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
         table_exec(
@@ -118,8 +118,8 @@ fn we_can_prove_an_or_query_where_both_lhs_and_rhs_are_true() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -153,7 +153,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -178,8 +178,8 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 equal(column(&t, "c", &accessor), const_bigint(filter_val2)),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
+        let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+            VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
             .unwrap()
@@ -225,7 +225,7 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_first_round_evaluate() 
         borrowed_bigint("c", [0, 2, 2, 0], &alloc),
         borrowed_varchar("d", ["ab", "t", "g", "efg"], &alloc),
     ]);
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let t = TableRef::new("sxt", "t");
     accessor.add_table(t.clone(), data.clone(), 0);
     let and_expr: DynProofExpr = or(
@@ -246,7 +246,7 @@ fn we_cannot_or_mismatching_types() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let lhs = Box::new(column(&t, "a", &accessor));
     let rhs = Box::new(column(&t, "b", &accessor));
     let and_err = OrExpr::try_new(lhs.clone(), rhs.clone()).unwrap_err();


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`. The helper did not complete locally; see the testing note below.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The `and`, `or`, and `not` proof-expression tests can run without the `blitzar` feature when they use the naive evaluation proof backend. Keeping these tests available in no-default-features builds makes the proof-expression coverage easier to exercise on machines without the `blitzar` backend.

# What changes are included in this PR?

- Enable the `and_expr_test`, `or_expr_test`, and `not_expr_test` modules under `cfg(test)` instead of requiring `feature = "blitzar"`.
- Switch the affected tests to `NaiveEvaluationProof` accessors and verifiable query results.
- Keep the existing boolean-expression assertions and verification coverage intact.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql sql::proof_exprs --no-default-features --features test`
- `LLVM_COV=/Library/Developer/CommandLineTools/usr/bin/llvm-cov LLVM_PROFDATA=/Library/Developer/CommandLineTools/usr/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --no-default-features --features test --json --summary-only --output-path target/coverage2-summary.json --no-clean -- sql::proof_exprs`
- `rustfmt --check crates/proof-of-sql/src/sql/proof_exprs/mod.rs crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs`
- `git diff --check`
- `source scripts/check_commits.sh`

I also ran `source scripts/run_ci_checks.sh`; on this macOS checkout it failed before Cargo execution because the extracted workflow entries retained the literal `run:` prefix, so the shell attempted to execute `run:` as a command.