### PR TITLE
test: run basic expression tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
@@ -1,14 +1,12 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, ColumnField, ColumnType, OwnedTableTestAccessor, TableRef,
         },
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-        proof_plans::test_utility::*,
+        proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::test_utility::*,
     },
 };
 
@@ -17,7 +15,7 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
     let data = owned_table([boolean("a", [true, false])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = projection(
         cols_expr_plan(&t, &["a"], &accessor),
         table_exec(
@@ -25,8 +23,8 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
             vec![ColumnField::new("a".into(), ColumnType::Boolean)],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -1,7 +1,7 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
             Table, TableRef,
@@ -9,9 +9,7 @@ use crate::{
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-        proof_plans::test_utility::*,
+        proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::test_utility::*,
     },
 };
 use bumpalo::Bump;
@@ -41,7 +39,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -59,8 +57,8 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
             const_bool(lit),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
+        let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+            VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
             .unwrap()
@@ -102,14 +100,14 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
     let expected_res = data.clone();
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -122,14 +120,14 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
     let data = owned_table([bigint("a", [123_i64])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(false),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -25,12 +25,12 @@ pub use dyn_proof_expr::DynProofExpr;
 
 mod literal_expr;
 pub(crate) use literal_expr::LiteralExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod literal_expr_test;
 
 mod placeholder_expr;
 pub(crate) use placeholder_expr::PlaceholderExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod placeholder_expr_test;
 
 mod and_expr;
@@ -71,7 +71,7 @@ pub(crate) mod test_utility;
 
 mod column_expr;
 pub use column_expr::ColumnExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod column_expr_test;
 
 mod cast_expr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
@@ -1,14 +1,14 @@
 use super::{DynProofExpr, PlaceholderExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, LiteralValue,
             OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
         },
         proof::{PlaceholderError, ProofError},
+        scalar::test_scalar::TestScalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{QueryError, VerifiableQueryResult},
         proof_exprs::test_utility::*,
@@ -52,7 +52,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -78,7 +78,8 @@ fn test_random_tables_with_given_offset(offset: usize) {
         );
         let params = vec![random_bigint_literal, random_varchar_literal];
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &params).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &params)
+                .unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &params)
             .unwrap()
@@ -118,13 +119,13 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
     let expected_res = owned_table([boolean("p1", [true])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+    let verifiable_res = VerifiableQueryResult::<NaiveEvaluationProof>::new(
         &ast,
         &accessor,
         &(),
@@ -144,13 +145,13 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
     let expected_res = owned_table([boolean("p1", [true; 0])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(false),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+    let verifiable_res = VerifiableQueryResult::<NaiveEvaluationProof>::new(
         &ast,
         &accessor,
         &(),
@@ -167,8 +168,7 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
 #[test]
 fn we_can_compute_the_correct_output_of_a_placeholder_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
-    let data: Table<Curve25519Scalar> =
-        table([borrowed_bigint("a", [123_i64, 456, 789, 1011], &alloc)]);
+    let data: Table<TestScalar> = table([borrowed_bigint("a", [123_i64, 456, 789, 1011], &alloc)]);
     let placeholder_expr: DynProofExpr =
         DynProofExpr::try_new_placeholder(1, ColumnType::BigInt).unwrap();
     let res = placeholder_expr
@@ -181,16 +181,17 @@ fn we_can_compute_the_correct_output_of_a_placeholder_expr_using_first_round_eva
 #[test]
 fn we_cannot_prove_placeholder_expr_if_interpolate_fails() {
     let alloc = Bump::new();
-    let data: Table<Curve25519Scalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
+    let data: Table<TestScalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
     let t = TableRef::new("sxt", "t");
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let accessor =
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
     assert!(matches!(
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[],),
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[],),
         Err(PlaceholderError::InvalidPlaceholderIndex { .. })
     ));
 }
@@ -198,15 +199,16 @@ fn we_cannot_prove_placeholder_expr_if_interpolate_fails() {
 #[test]
 fn we_cannot_verify_placeholder_expr_if_interpolate_fails() {
     let alloc = Bump::new();
-    let data: Table<Curve25519Scalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
+    let data: Table<TestScalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
     let t = TableRef::new("sxt", "t");
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let accessor =
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+    let verifiable_res = VerifiableQueryResult::<NaiveEvaluationProof>::new(
         &ast,
         &accessor,
         &(),
@@ -224,9 +226,10 @@ fn we_cannot_verify_placeholder_expr_if_interpolate_fails() {
 #[test]
 fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_same_valid_params() {
     let alloc = Bump::new();
-    let data: Table<Curve25519Scalar> = table([borrowed_bigint("a", [123_i64, 456], &alloc)]);
+    let data: Table<TestScalar> = table([borrowed_bigint("a", [123_i64, 456], &alloc)]);
     let t = TableRef::new("sxt", "t");
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let accessor =
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             col_expr_plan(&t, "a", &accessor),
@@ -236,7 +239,7 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+    let verifiable_res = VerifiableQueryResult::<NaiveEvaluationProof>::new(
         &ast,
         &accessor,
         &(),
@@ -247,9 +250,22 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
     )
     .unwrap();
 
+    let make_verifiable_res = || {
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(
+            &ast,
+            &accessor,
+            &(),
+            &[
+                LiteralValue::BigInt(504_i64),
+                LiteralValue::VarChar("abc".to_string()),
+            ],
+        )
+        .unwrap()
+    };
+
     // Try some wrong values
     assert!(matches!(
-        verifiable_res.clone().verify(
+        make_verifiable_res().verify(
             &ast,
             &accessor,
             &(),
@@ -262,7 +278,7 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
     ));
 
     assert!(matches!(
-        verifiable_res.clone().verify(
+        make_verifiable_res().verify(
             &ast,
             &accessor,
             &(),
@@ -275,7 +291,7 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
     ));
 
     assert!(matches!(
-        verifiable_res.clone().verify(
+        make_verifiable_res().verify(
             &ast,
             &accessor,
             &(),


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The column, literal, and placeholder proof-expression tests can run without the `blitzar` feature when they use the naive evaluation proof backend. Keeping these basic expression tests available in no-default-features builds makes proof-expression coverage easier to exercise on machines without the `blitzar` backend.

# What changes are included in this PR?

- Enable the `column_expr_test`, `literal_expr_test`, and `placeholder_expr_test` modules under `cfg(test)` instead of requiring `feature = "blitzar"`.
- Switch the affected proof/query-result tests to `NaiveEvaluationProof` accessors and verifiable query results.
- Keep the existing first-round, interpolation, and placeholder validation assertions intact.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql sql::proof_exprs --no-default-features --features test`
- `LLVM_COV=/Library/Developer/CommandLineTools/usr/bin/llvm-cov LLVM_PROFDATA=/Library/Developer/CommandLineTools/usr/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --no-default-features --features test --json --summary-only --output-path target/coverage3-summary.json --no-clean -- sql::proof_exprs`
- `rustfmt --check crates/proof-of-sql/src/sql/proof_exprs/mod.rs crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs`
- `git diff --check`
- `source scripts/check_commits.sh`
- `source scripts/run_ci_checks.sh`

`source scripts/run_ci_checks.sh` did not reach Cargo execution in this checkout because the extracted workflow commands retained the literal `run:` prefix, for example `run: cargo check --no-default-features`, which the shell cannot execute.