### PR TITLE
test: run comparison expression tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -1,16 +1,15 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTable,
             OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
         },
         math::decimal::Precision,
-        scalar::Scalar,
+        scalar::{test_scalar::TestScalar, Scalar},
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::VerifiableQueryResult,
         proof_exprs::{test_utility::*, DynProofExpr, EqualsExpr, ProofExpr},
         proof_plans::test_utility::*,
         AnalyzeError,
@@ -26,7 +25,7 @@ use rand_core::SeedableRng;
 
 #[test]
 fn we_can_prove_an_equality_query_with_no_rows() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [0; 0]),
         bigint("b", [0; 0]),
         varchar("d", [""; 0]),
@@ -34,7 +33,7 @@ fn we_can_prove_an_equality_query_with_no_rows() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
         table_exec(
@@ -49,7 +48,7 @@ fn we_can_prove_an_equality_query_with_no_rows() {
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -60,7 +59,7 @@ fn we_can_prove_an_equality_query_with_no_rows() {
 
 #[test]
 fn we_can_prove_another_equality_query_with_no_rows() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [0; 0]),
         bigint("b", [0; 0]),
         varchar("d", [""; 0]),
@@ -68,7 +67,7 @@ fn we_can_prove_another_equality_query_with_no_rows() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d"], &accessor),
         table_exec(
@@ -83,7 +82,7 @@ fn we_can_prove_another_equality_query_with_no_rows() {
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -94,7 +93,7 @@ fn we_can_prove_another_equality_query_with_no_rows() {
 
 #[test]
 fn we_can_prove_a_nested_equality_query_with_no_rows() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         boolean("bool", [true; 0]),
         bigint("a", [1; 0]),
         bigint("b", [1; 0]),
@@ -103,7 +102,7 @@ fn we_can_prove_a_nested_equality_query_with_no_rows() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b", "c", "e"], &accessor),
         table_exec(
@@ -122,7 +121,7 @@ fn we_can_prove_a_nested_equality_query_with_no_rows() {
         ),
     );
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -137,7 +136,7 @@ fn we_can_prove_a_nested_equality_query_with_no_rows() {
 
 #[test]
 fn we_can_prove_an_equality_query_with_a_single_selected_row() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [123]),
         bigint("b", [0]),
         varchar("d", ["abc"]),
@@ -145,7 +144,7 @@ fn we_can_prove_an_equality_query_with_a_single_selected_row() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["d", "a"], &accessor),
         table_exec(
@@ -159,8 +158,8 @@ fn we_can_prove_an_equality_query_with_a_single_selected_row() {
         ),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -171,7 +170,7 @@ fn we_can_prove_an_equality_query_with_a_single_selected_row() {
 
 #[test]
 fn we_can_prove_another_equality_query_with_a_single_selected_row() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [123]),
         bigint("b", [123]),
         varchar("d", ["abc"]),
@@ -179,7 +178,7 @@ fn we_can_prove_another_equality_query_with_a_single_selected_row() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["d", "a"], &accessor),
         table_exec(
@@ -193,8 +192,8 @@ fn we_can_prove_another_equality_query_with_a_single_selected_row() {
         ),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -205,15 +204,15 @@ fn we_can_prove_another_equality_query_with_a_single_selected_row() {
 
 #[test]
 fn we_can_prove_an_equality_query_with_a_single_non_selected_row() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [123]),
         bigint("b", [55]),
         varchar("d", ["abc"]),
-        decimal75("e", 75, 0, [Curve25519Scalar::MAX_SIGNED]),
+        decimal75("e", 75, 0, [TestScalar::MAX_SIGNED]),
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e"], &accessor),
         table_exec(
@@ -227,8 +226,8 @@ fn we_can_prove_an_equality_query_with_a_single_non_selected_row() {
         ),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -243,7 +242,7 @@ fn we_can_prove_an_equality_query_with_a_single_non_selected_row() {
 
 #[test]
 fn we_can_prove_an_equality_query_with_multiple_rows() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [1, 2, 3, 4]),
         bigint("b", [0, 5, 0, 5]),
         varchar("c", ["t", "ghi", "jj", "f"]),
@@ -252,16 +251,16 @@ fn we_can_prove_an_equality_query_with_multiple_rows() {
             75,
             0,
             [
-                Curve25519Scalar::ZERO,
-                Curve25519Scalar::ONE,
-                Curve25519Scalar::TWO,
-                Curve25519Scalar::MAX_SIGNED,
+                TestScalar::ZERO,
+                TestScalar::ONE,
+                TestScalar::TWO,
+                TestScalar::MAX_SIGNED,
             ],
         ),
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "c", "e"], &accessor),
         table_exec(
@@ -275,8 +274,8 @@ fn we_can_prove_an_equality_query_with_multiple_rows() {
         ),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -291,7 +290,7 @@ fn we_can_prove_an_equality_query_with_multiple_rows() {
 
 #[test]
 fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         boolean("bool", [true, false, true, false]),
         bigint("a", [1, 2, 3, 4]),
         bigint("b", [1, 5, 0, 4]),
@@ -301,16 +300,16 @@ fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
             75,
             0,
             [
-                Curve25519Scalar::ZERO,
-                Curve25519Scalar::ONE,
-                Curve25519Scalar::TWO,
-                Curve25519Scalar::MAX_SIGNED,
+                TestScalar::ZERO,
+                TestScalar::ONE,
+                TestScalar::TWO,
+                TestScalar::MAX_SIGNED,
             ],
         ),
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "c", "e"], &accessor),
         table_exec(
@@ -328,8 +327,8 @@ fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -344,7 +343,7 @@ fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
 
 #[test]
 fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [1, 2, 3, 4, 5]),
         bigint("b", [123, 5, 123, 5, 0]),
         varchar("c", ["t", "ghi", "jj", "f", "abc"]),
@@ -353,17 +352,17 @@ fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
             42,
             10,
             [
-                Curve25519Scalar::ZERO,
-                Curve25519Scalar::ONE,
-                Curve25519Scalar::TWO,
-                Curve25519Scalar::from(3),
-                Curve25519Scalar::MAX_SIGNED,
+                TestScalar::ZERO,
+                TestScalar::ONE,
+                TestScalar::TWO,
+                TestScalar::from(3),
+                TestScalar::MAX_SIGNED,
             ],
         ),
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "c", "e"], &accessor),
         table_exec(
@@ -377,8 +376,8 @@ fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
         ),
         equal(column(&t, "b", &accessor), const_bigint(123_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -393,7 +392,7 @@ fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
 
 #[test]
 fn we_can_prove_an_equality_query_with_a_string_comparison() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [1, 2, 3, 4, 5, 5]),
         bigint("b", [123, 5, 123, 123, 5, 0]),
         varchar("c", ["t", "ghi", "jj", "f", "abc", "ghi"]),
@@ -402,18 +401,18 @@ fn we_can_prove_an_equality_query_with_a_string_comparison() {
             42, // precision
             10, // scale
             [
-                Curve25519Scalar::ZERO,
-                Curve25519Scalar::ONE,
-                Curve25519Scalar::TWO,
-                Curve25519Scalar::from(3),
-                Curve25519Scalar::MAX_SIGNED,
-                Curve25519Scalar::from(-1),
+                TestScalar::ZERO,
+                TestScalar::ONE,
+                TestScalar::TWO,
+                TestScalar::from(3),
+                TestScalar::MAX_SIGNED,
+                TestScalar::from(-1),
             ],
         ),
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "b", "e"], &accessor),
         table_exec(
@@ -427,8 +426,8 @@ fn we_can_prove_an_equality_query_with_a_string_comparison() {
         ),
         equal(column(&t, "c", &accessor), const_varchar("ghi")),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -465,7 +464,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -487,8 +486,8 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 const_varchar(filter_val.as_str()),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
+        let verifiable_res =
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
             .unwrap()
@@ -528,7 +527,7 @@ fn we_can_query_random_tables_using_a_non_zero_offset() {
 #[test]
 fn we_can_compute_the_correct_output_of_an_equals_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
-    let data: Table<Curve25519Scalar> = table([
+    let data: Table<TestScalar> = table([
         borrowed_bigint("a", [1, 2, 3, 4], &alloc),
         borrowed_bigint("b", [0, 5, 0, 5], &alloc),
         borrowed_varchar("c", ["t", "ghi", "jj", "f"], &alloc),
@@ -537,20 +536,20 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_first_round_evaluat
             42,
             10,
             [
-                Curve25519Scalar::ZERO,
-                Curve25519Scalar::MAX_SIGNED,
-                Curve25519Scalar::ZERO,
-                Curve25519Scalar::from(-1),
+                TestScalar::ZERO,
+                TestScalar::MAX_SIGNED,
+                TestScalar::ZERO,
+                TestScalar::from(-1),
             ],
             &alloc,
         ),
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let equals_expr: DynProofExpr = equal(
         column(&t, "e", &accessor),
-        const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ZERO),
+        const_scalar::<TestScalar, _>(TestScalar::ZERO),
     );
     let res = equals_expr
         .first_round_evaluate(&alloc, &data, &[])
@@ -562,7 +561,7 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_first_round_evaluat
 #[test]
 fn we_can_query_with_varbinary_equality() {
     // Create a table with bigint and varbinary columns
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [123, 4567]),
         varbinary("b", [[1, 2, 3].as_slice(), &[4, 5, 6, 7]]),
     ]);
@@ -570,7 +569,7 @@ fn we_can_query_with_varbinary_equality() {
     // Create table reference and accessor
     let t = TableRef::new("sxt", "table");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
 
     // Build query plan: SELECT a, b FROM table WHERE b = [4,5,6,7]
     let ast = filter(
@@ -587,7 +586,7 @@ fn we_can_query_with_varbinary_equality() {
 
     // Execute and verify query
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -608,7 +607,7 @@ fn we_cannot_equals_mismatching_types() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let lhs = Box::new(column(&t, "a", &accessor));
     let rhs = Box::new(column(&t, "b", &accessor));
     let equals_err = EqualsExpr::try_new(lhs.clone(), rhs.clone()).unwrap_err();

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -1,17 +1,16 @@
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, LiteralValue, OwnedTable,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-        scalar::{Scalar, ScalarExt},
+        scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::VerifiableQueryResult,
         proof_exprs::{inequality_expr::InequalityExpr, test_utility::*, DynProofExpr, ProofExpr},
         proof_plans::test_utility::*,
         AnalyzeError,
@@ -27,7 +26,7 @@ use rand_core::SeedableRng;
 
 #[test]
 fn we_can_compare_columns_with_small_timestamp_values_gte() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([timestamptz(
+    let data: OwnedTable<TestScalar> = owned_table([timestamptz(
         "a",
         PoSQLTimeUnit::Second,
         PoSQLTimeZone::utc(),
@@ -35,7 +34,7 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
     )]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
         table_exec(
@@ -60,7 +59,7 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
     );
 
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -76,7 +75,7 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
 
 #[test]
 fn we_can_compare_columns_with_small_timestamp_values_lte() {
-    let data: OwnedTable<Curve25519Scalar> = owned_table([timestamptz(
+    let data: OwnedTable<TestScalar> = owned_table([timestamptz(
         "a",
         PoSQLTimeUnit::Second,
         PoSQLTimeZone::utc(),
@@ -84,7 +83,7 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
     )]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
         table_exec(
@@ -108,7 +107,7 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
     );
 
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -127,7 +126,7 @@ fn we_can_compare_a_constant_column() {
     let data = owned_table([bigint("a", [123_i64, 123, 123]), bigint("b", [1_i64, 2, 3])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -139,8 +138,8 @@ fn we_can_compare_a_constant_column() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -154,7 +153,7 @@ fn we_can_compare_a_varying_column_with_constant_sign() {
     let data = owned_table([bigint("a", [123_i64, 567, 8]), bigint("b", [1_i64, 2, 3])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -166,8 +165,8 @@ fn we_can_compare_a_varying_column_with_constant_sign() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -187,7 +186,7 @@ fn we_can_compare_columns_with_extreme_values() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["bigint_b"], &accessor),
         table_exec(
@@ -214,8 +213,8 @@ fn we_can_compare_columns_with_extreme_values() {
             column(&t, "boolean", &accessor),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -226,9 +225,9 @@ fn we_can_compare_columns_with_extreme_values() {
 
 #[test]
 fn we_can_compare_columns_with_small_decimal_values_without_scale() {
-    let scalar_pos = Curve25519Scalar::pow10(38) - Curve25519Scalar::ONE;
+    let scalar_pos = TestScalar::pow10(38) - TestScalar::ONE;
     let scalar_neg = -scalar_pos;
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [123, 25]),
         bigint("b", [55, -53]),
         varchar("d", ["abc", "de"]),
@@ -236,7 +235,7 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e"], &accessor),
         table_exec(
@@ -250,8 +249,8 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
         ),
         lte(column(&t, "e", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -266,9 +265,9 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
 
 #[test]
 fn we_can_compare_columns_with_small_decimal_values_with_scale() {
-    let scalar_pos = Curve25519Scalar::pow10(38) - Curve25519Scalar::ONE;
+    let scalar_pos = TestScalar::pow10(38) - TestScalar::ONE;
     let scalar_neg = -scalar_pos;
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [123, 25]),
         bigint("b", [55, -53]),
         varchar("d", ["abc", "de"]),
@@ -277,7 +276,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e", "f"], &accessor),
         table_exec(
@@ -299,8 +298,8 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
             .unwrap(),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -316,9 +315,9 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
 
 #[test]
 fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
-    let scalar_pos = Curve25519Scalar::pow10(38) - Curve25519Scalar::ONE;
+    let scalar_pos = TestScalar::pow10(38) - TestScalar::ONE;
     let scalar_neg = -scalar_pos;
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [123, 25]),
         bigint("b", [55, -53]),
         varchar("d", ["abc", "de"]),
@@ -327,7 +326,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e", "f"], &accessor),
         table_exec(
@@ -349,8 +348,8 @@ fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
             .unwrap(),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -366,21 +365,16 @@ fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
 
 #[test]
 fn we_can_compare_columns_returning_extreme_decimal_values() {
-    let scalar_min_signed = -Curve25519Scalar::MAX_SIGNED - Curve25519Scalar::ONE;
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let scalar_min_signed = -TestScalar::MAX_SIGNED - TestScalar::ONE;
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [123, 25]),
         bigint("b", [55, -53]),
         varchar("d", ["abc", "de"]),
-        decimal75(
-            "e",
-            75,
-            0,
-            [Curve25519Scalar::MAX_SIGNED, scalar_min_signed],
-        ),
+        decimal75("e", 75, 0, [TestScalar::MAX_SIGNED, scalar_min_signed]),
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a", "d", "e"], &accessor),
         table_exec(
@@ -394,8 +388,8 @@ fn we_can_compare_columns_returning_extreme_decimal_values() {
         ),
         lte(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -410,25 +404,20 @@ fn we_can_compare_columns_returning_extreme_decimal_values() {
 
 #[test]
 fn we_cannot_compare_columns_filtering_on_extreme_decimal_values() {
-    let scalar_min_signed = -Curve25519Scalar::MAX_SIGNED - Curve25519Scalar::ONE;
-    let data: OwnedTable<Curve25519Scalar> = owned_table([
+    let scalar_min_signed = -TestScalar::MAX_SIGNED - TestScalar::ONE;
+    let data: OwnedTable<TestScalar> = owned_table([
         bigint("a", [123, 25]),
         bigint("b", [55, -53]),
         varchar("d", ["abc", "de"]),
-        decimal75(
-            "e",
-            75,
-            0,
-            [Curve25519Scalar::MAX_SIGNED, scalar_min_signed],
-        ),
+        decimal75("e", 75, 0, [TestScalar::MAX_SIGNED, scalar_min_signed]),
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     assert!(matches!(
         DynProofExpr::try_new_inequality(
             column(&t, "e", &accessor),
-            const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ONE),
+            const_scalar::<TestScalar, _>(TestScalar::ONE),
             false
         ),
         Err(AnalyzeError::DataTypeMismatch { .. })
@@ -440,7 +429,7 @@ fn we_can_compare_two_columns() {
     let data = owned_table([bigint("a", [1_i64, 5, 8]), bigint("b", [1_i64, 7, 3])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -452,8 +441,8 @@ fn we_can_compare_two_columns() {
         ),
         lte(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -470,7 +459,7 @@ fn we_can_compare_a_varying_column_with_constant_absolute_value() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -482,8 +471,8 @@ fn we_can_compare_a_varying_column_with_constant_absolute_value() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -500,7 +489,7 @@ fn we_can_compare_a_constant_column_of_negative_columns() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -512,8 +501,8 @@ fn we_can_compare_a_constant_column_of_negative_columns() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -530,7 +519,7 @@ fn we_can_compare_a_varying_column_with_negative_only_signs() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -542,8 +531,8 @@ fn we_can_compare_a_varying_column_with_negative_only_signs() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -557,7 +546,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs() {
     let data = owned_table([bigint("a", [-1_i64, 9, 0]), bigint("b", [1_i64, 2, 3])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -569,8 +558,8 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -584,7 +573,7 @@ fn we_can_compare_column_with_greater_than_or_equal() {
     let data = owned_table([bigint("a", [-1_i64, 9, 0]), bigint("b", [1_i64, 2, 3])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -596,8 +585,8 @@ fn we_can_compare_column_with_greater_than_or_equal() {
         ),
         gte(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -615,7 +604,7 @@ fn we_can_run_nested_comparison() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -631,8 +620,8 @@ fn we_can_run_nested_comparison() {
             column(&t, "boolean", &accessor),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -646,7 +635,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs_and_a_constant
     let data = owned_table([bigint("a", [-2_i64, 3, 2]), bigint("b", [1_i64, 2, 3])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -658,8 +647,8 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs_and_a_constant
         ),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -673,7 +662,7 @@ fn we_can_compare_a_constant_column_of_zeros() {
     let data = owned_table([bigint("a", [0_i64, 0, 0]), bigint("b", [1_i64, 2, 3])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -685,8 +674,8 @@ fn we_can_compare_a_constant_column_of_zeros() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -700,7 +689,7 @@ fn the_sign_can_be_0_or_1_for_a_constant_column_of_zeros() {
     let data = owned_table([bigint("a", [0_i64, 0, 0]), bigint("b", [1_i64, 2, 3])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["b"], &accessor),
         table_exec(
@@ -712,8 +701,8 @@ fn the_sign_can_be_0_or_1_for_a_constant_column_of_zeros() {
         ),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -741,7 +730,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -758,8 +747,8 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
             lte(column(&t, "a", &accessor), const_bigint(filter_val)),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
+        let verifiable_res =
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
             .unwrap()
@@ -799,7 +788,7 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_first_round_
         borrowed_bigint("a", [-1, 9, 1], &alloc),
         borrowed_bigint("b", [1, 2, 3], &alloc),
     ]);
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let t = TableRef::new("sxt", "t");
     accessor.add_table(t.clone(), data.clone(), 0);
     let lhs_expr: DynProofExpr = column(&t, "a", &accessor);
@@ -817,7 +806,7 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_first_round_
         borrowed_bigint("a", [-1, 9, 1], &alloc),
         borrowed_bigint("b", [1, 2, 3], &alloc),
     ]);
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let t = TableRef::new("sxt", "t");
     accessor.add_table(t.clone(), data.clone(), 0);
     let col_expr: DynProofExpr = column(&t, "a", &accessor);
@@ -837,7 +826,7 @@ fn we_cannot_inequality_mismatching_types() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let lhs = Box::new(column(&t, "a", &accessor));
     let rhs = Box::new(column(&t, "b", &accessor));
     let inequality_err = InequalityExpr::try_new(lhs.clone(), rhs.clone(), true).unwrap_err();

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -40,7 +40,7 @@ mod and_expr_test;
 
 mod inequality_expr;
 pub(crate) use inequality_expr::InequalityExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod inequality_expr_test;
 
 mod or_expr;
@@ -60,7 +60,7 @@ pub(crate) use numerical_util::{divide_columns, modulo_columns};
 
 mod equals_expr;
 pub(crate) use equals_expr::EqualsExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod equals_expr_test;
 
 mod table_expr;


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The equality and inequality proof-expression tests do not need the `blitzar` backend when they use the naive evaluation proof backend. Running these comparison-expression tests in no-default-features builds improves coverage for local and CI environments where the `blitzar` feature is unavailable.

# What changes are included in this PR?

- Enable `equals_expr_test` and `inequality_expr_test` under `cfg(test)` instead of requiring `feature = "blitzar"`.
- Switch the affected tests from `InnerProductProof`/`Curve25519Scalar` to `NaiveEvaluationProof`/`TestScalar`.
- Keep the existing query-result, first-round evaluation, random-table, decimal, timestamp, and type-mismatch assertions intact.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql sql::proof_exprs --no-default-features --features test`
- `LLVM_COV=/Library/Developer/CommandLineTools/usr/bin/llvm-cov LLVM_PROFDATA=/Library/Developer/CommandLineTools/usr/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --no-default-features --features test --json --summary-only --output-path target/coverage4-summary.json --no-clean -- sql::proof_exprs`
- `rustfmt --check crates/proof-of-sql/src/sql/proof_exprs/mod.rs crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs`
- `git diff --check`
- `source scripts/check_commits.sh`
- `source scripts/run_ci_checks.sh`

`source scripts/run_ci_checks.sh` did not reach Cargo execution in this checkout because the extracted workflow commands retained the literal `run:` prefix, for example `run: cargo check --no-default-features`, which the shell cannot execute.