### PR TITLE
test: run cast expression tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::{
     base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::{
                 bigint, boolean, decimal75, int, int128, owned_table, smallint, timestamptz,
@@ -16,13 +17,12 @@ use crate::{
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::VerifiableQueryResult,
         proof_exprs::{CastExpr, DynProofExpr},
         proof_plans::test_utility::{column_field, filter, table_exec},
         AnalyzeError,
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 
 #[test]
@@ -42,7 +42,7 @@ fn we_can_prove_a_simple_cast_expr() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             aliased_plan(
@@ -83,8 +83,8 @@ fn we_can_prove_a_simple_cast_expr() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -113,7 +113,7 @@ fn we_can_prove_a_simple_cast_expr_from_int_to_other_numeric_type() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             aliased_plan(
@@ -168,8 +168,8 @@ fn we_can_prove_a_simple_cast_expr_from_int_to_other_numeric_type() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -191,7 +191,7 @@ fn we_get_error_if_we_cast_uncastable_type() {
     let data = owned_table([decimal75("a", 57, 2, [1_i16, 2, 3, 4])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     assert!(matches!(
         DynProofExpr::try_new_cast(column(&t, "a", &accessor), ColumnType::BigInt),
         Err(AnalyzeError::DataTypeMismatch { .. })
@@ -204,7 +204,7 @@ fn we_cannot_cast_mismatching_types() {
     let data = table([borrowed_smallint("a", [1_i16, 2, 3, 4], &alloc)]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let lhs = Box::new(column(&t, "a", &accessor));
     let cast_err = CastExpr::try_new(lhs.clone(), ColumnType::TinyInt).unwrap_err();
     assert!(matches!(

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -76,10 +76,10 @@ mod column_expr_test;
 
 mod cast_expr;
 pub(crate) use cast_expr::CastExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod cast_expr_test;
 
 mod scaling_cast_expr;
 pub(crate) use scaling_cast_expr::ScalingCastExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod scaling_cast_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
@@ -1,5 +1,6 @@
 use crate::{
     base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::{
                 bigint, decimal75, int, int128, owned_table, smallint, timestamptz, tinyint, uint8,
@@ -10,7 +11,7 @@ use crate::{
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::VerifiableQueryResult,
         proof_exprs::{
             test_utility::{aliased_plan, column, scaling_cast},
             LiteralExpr,
@@ -18,7 +19,6 @@ use crate::{
         proof_plans::test_utility::{column_field, filter, table_exec},
     },
 };
-use blitzar::proof::InnerProductProof;
 
 #[test]
 fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
@@ -32,7 +32,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             aliased_plan(
@@ -91,8 +91,8 @@ fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -117,7 +117,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_decimal_to_decimal() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             aliased_plan(
@@ -152,8 +152,8 @@ fn we_can_prove_a_simple_scale_cast_expr_from_decimal_to_decimal() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -176,7 +176,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_timestamp_to_timestamp() {
     )]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_plan(
             scaling_cast(
@@ -194,8 +194,8 @@ fn we_can_prove_a_simple_scale_cast_expr_from_timestamp_to_timestamp() {
         ),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The cast and scaling-cast proof-expression tests can run without the `blitzar` feature when they use the naive evaluation proof backend. Enabling them in no-default-features test builds increases coverage for cast behavior across booleans, integers, decimals, and timestamps.

# What changes are included in this PR?

- Enable `cast_expr_test` and `scaling_cast_expr_test` under `cfg(test)` instead of requiring `feature = "blitzar"`.
- Switch the affected tests from `InnerProductProof` to `NaiveEvaluationProof`.
- Keep the existing query-result, cast-error, numeric scaling, decimal scaling, and timestamp scaling assertions intact.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql sql::proof_exprs --no-default-features --features test`
- `LLVM_COV=/Library/Developer/CommandLineTools/usr/bin/llvm-cov LLVM_PROFDATA=/Library/Developer/CommandLineTools/usr/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --no-default-features --features test --json --summary-only --output-path target/coverage5-summary.json --no-clean -- sql::proof_exprs`
- `rustfmt --check crates/proof-of-sql/src/sql/proof_exprs/mod.rs crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs`
- `git diff --check`
- `source scripts/check_commits.sh`
- `source scripts/run_ci_checks.sh`

`source scripts/run_ci_checks.sh` did not reach Cargo execution in this checkout because the extracted workflow commands retained the literal `run:` prefix, for example `run: cargo check --no-default-features`, which the shell cannot execute.