### PR TITLE
test: run proof gadget tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -196,15 +196,17 @@ impl ProofPlan for MembershipCheckTestPlan {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof,
+            scalar::test_scalar::TestScalar,
+        },
         sql::proof::VerifiableQueryResult,
     };
-    use blitzar::proof::InnerProductProof;
 
     #[test]
     fn we_can_do_minimal_membership_check() {
@@ -213,7 +215,7 @@ mod tests {
         let candidate_table = table([borrowed_bigint("c", [1, 2, 2, 1, 2], &alloc)]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -235,7 +237,7 @@ mod tests {
             )],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let actual = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .unwrap()
@@ -261,7 +263,7 @@ mod tests {
         ]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -283,7 +285,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let actual = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .unwrap()
@@ -309,7 +311,7 @@ mod tests {
         ]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -331,7 +333,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let actual = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .unwrap()
@@ -351,7 +353,7 @@ mod tests {
         let candidate_table = table([borrowed_bigint("a", [1, 2, 1, 1, 2], &alloc)]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -371,25 +373,25 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_can_do_membership_check_if_there_are_no_columns_in_the_tables() {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(5) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(4) },
         )
         .unwrap();
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -403,26 +405,26 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_can_do_membership_check_if_there_are_no_columns_in_the_tables_and_candidate_has_no_rows_either(
     ) {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(5) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -436,25 +438,25 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_cannot_do_membership_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -468,7 +470,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -485,7 +487,7 @@ mod tests {
         ]);
         let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
         let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -499,6 +501,6 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -118,23 +118,25 @@ impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof,
+            scalar::test_scalar::TestScalar,
+        },
         base::{
             database::{table_utility::*, ColumnType, TableTestAccessor},
             math::decimal::Precision,
             posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         },
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
         sql::proof::{QueryError, VerifiableQueryResult},
     };
-    use blitzar::proof::InnerProductProof;
 
     fn check_monotonic<const STRICT: bool, const ASC: bool>(
         table_ref: TableRef,
-        accessor: &TableTestAccessor<InnerProductProof>,
+        accessor: &TableTestAccessor<NaiveEvaluationProof>,
         column_name: &str,
         column_type: ColumnType,
         shall_error: bool,
@@ -143,7 +145,7 @@ mod tests {
             column: ColumnRef::new(table_ref, column_name.into(), column_type),
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, accessor, &(), &[]).unwrap();
         let res = verifiable_res.verify(&plan, accessor, &(), &[]);
         if shall_error {
             assert!(matches!(
@@ -219,7 +221,7 @@ mod tests {
     /// non-monotonic
     fn check_monotonic_for_table<const STRICT: bool, const ASC: bool>(
         table_ref: TableRef,
-        accessor: &TableTestAccessor<InnerProductProof>,
+        accessor: &TableTestAccessor<NaiveEvaluationProof>,
         shall_error: bool,
     ) {
         let precision = Precision::new(50).unwrap();
@@ -269,12 +271,16 @@ mod tests {
 
     /// Run `check_monotonic_for_table` for all possible forms of monotonicity
     fn check_all_monotonic_for_table(
-        table: Table<Curve25519Scalar>,
+        table: Table<TestScalar>,
         expected_monotonicity: &Monotonicity,
     ) {
         let table_ref: TableRef = "sxt.table".parse().unwrap();
-        let accessor =
-            TableTestAccessor::<InnerProductProof>::new_from_table(table_ref.clone(), table, 0, ());
+        let accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            table,
+            0,
+            (),
+        );
         check_monotonic_for_table::<true, true>(
             table_ref.clone(),
             &accessor,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -159,15 +159,17 @@ impl ProofPlan for PermutationCheckTestPlan {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof,
+            scalar::test_scalar::TestScalar,
+        },
         sql::proof::VerifiableQueryResult,
     };
-    use blitzar::proof::InnerProductProof;
 
     #[test]
     fn we_can_do_minimal_permutation_check() {
@@ -176,7 +178,7 @@ mod tests {
         let candidate_table = table([borrowed_bigint("c", [2, 3, 1], &alloc)]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -198,7 +200,7 @@ mod tests {
             )],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
@@ -219,7 +221,7 @@ mod tests {
         ]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -241,7 +243,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
@@ -262,7 +264,7 @@ mod tests {
         ]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -284,7 +286,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
@@ -299,7 +301,7 @@ mod tests {
         let candidate_table = table([borrowed_bigint("a", [1, 2], &alloc)]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -319,25 +321,25 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_can_do_permutation_check_if_there_are_no_columns_in_the_tables() {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(5) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(4) },
         )
         .unwrap();
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -351,26 +353,26 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_cannot_do_permutation_check_if_there_are_no_columns_in_the_tables_and_candidate_has_no_rows_either(
     ) {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(5) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -384,25 +386,25 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "The number of source columns should be greater than 0")]
     fn we_cannot_do_permutation_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
-        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let source_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
-        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+        let candidate_table = Table::<'_, TestScalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -416,7 +418,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -433,7 +435,7 @@ mod tests {
         ]);
         let source_table_ref = TableRef::new("sxt", "source_table");
         let candidate_table_ref = TableRef::new("sxt", "candidate_table");
-        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+        let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             source_table_ref.clone(),
             source_table,
             0,
@@ -447,6 +449,6 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 }


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The membership, permutation, and monotonic proof-gadget tests can run without the `blitzar` feature when they use the naive evaluation proof backend. Enabling these tests in no-default-features builds broadens coverage for shared proof-gadget verification logic.

# What changes are included in this PR?

- Enable the membership-check, permutation-check, and monotonic proof-gadget test modules under `cfg(test)` instead of requiring `feature = "blitzar"`.
- Switch the affected tests from `InnerProductProof`/`Curve25519Scalar` to `NaiveEvaluationProof`/`TestScalar`.
- Keep the existing success, panic, empty-table, mismatched-column, and monotonicity assertions intact.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql sql::proof_gadgets --no-default-features --features test`
- `LLVM_COV=/Library/Developer/CommandLineTools/usr/bin/llvm-cov LLVM_PROFDATA=/Library/Developer/CommandLineTools/usr/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --no-default-features --features test --json --summary-only --output-path target/coverage6-summary.json --no-clean -- sql::proof_gadgets`
- `rustfmt --check crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs`
- `git diff --check`
- `source scripts/check_commits.sh`
- `source scripts/run_ci_checks.sh`

`source scripts/run_ci_checks.sh` did not reach Cargo execution in this checkout because the extracted workflow commands retained the literal `run:` prefix, for example `run: cargo check --no-default-features`, which the shell cannot execute.