### PR TITLE
test: run proof plan tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
@@ -1,18 +1,14 @@
 use super::test_utility::*;
 use crate::{
+    base::scalar::test_scalar::TestScalar,
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnType,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
-    sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-        proof_plans::AggregateExec,
-    },
+    sql::{proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::AggregateExec},
 };
 use bumpalo::Bump;
 
@@ -25,7 +21,7 @@ fn we_can_prove_aggregation_without_group_by() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = aggregate(
         vec![],
@@ -41,8 +37,8 @@ fn we_can_prove_aggregation_without_group_by() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_c", [101 + 104 + 102 + 103]),
@@ -60,7 +56,7 @@ fn we_can_prove_a_simple_aggregate_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = aggregate(
         cols_expr_plan(&t, &["a"], &accessor),
@@ -76,8 +72,8 @@ fn we_can_prove_a_simple_aggregate_with_bigint_columns() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
@@ -96,7 +92,7 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = aggregate(
         cols_expr_plan(&t, &["a"], &accessor),
@@ -118,8 +114,8 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
@@ -134,19 +130,19 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
 #[expect(clippy::too_many_lines)]
 #[test]
 fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
-    let scalar_filter_data: Vec<Curve25519Scalar> = [
+    let scalar_filter_data: Vec<TestScalar> = [
         333, 222, 222, 333, 222, 333, 333, 333, 222, 222, 222, 333, 222, 222, 222, 222, 222, 222,
         333, 333,
     ]
     .iter()
     .map(core::convert::Into::into)
     .collect();
-    let scalar_group_data: Vec<Curve25519Scalar> =
+    let scalar_group_data: Vec<TestScalar> =
         [5, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 4, 5]
             .iter()
             .map(core::convert::Into::into)
             .collect();
-    let scalar_sum_data: Vec<Curve25519Scalar> = [
+    let scalar_sum_data: Vec<TestScalar> = [
         119, 522, 100, 325, 501, 447, 759, 375, 212, 532, 459, 616, 579, 179, 695, 963, 532, 868,
         331, 830,
     ]
@@ -209,7 +205,7 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
     ]);
 
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // SELECT scalar_group, int128_group, bigint_group, sum(bigint_sum + 1) as sum_int, sum(bigint_sum - int128_sum) as sum_bigint, sum(scalar_filter) as sum_scal, count(*) as __count__
@@ -258,7 +254,7 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
         ),
     );
     assert!(expr.is_none());
-    // let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    // let res = VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     // exercise_verification(&res, &expr, &accessor, &t);
     // let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     // let expected = owned_table([
@@ -306,8 +302,8 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_int", [1406 + 927 + 637]),
@@ -328,7 +324,7 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         borrowed_bigint("b", [10, 20, 30, 40, 50], &alloc),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // Intermediate data after FilterExec: rows where b > 15
@@ -337,7 +333,7 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         borrowed_bigint("b", [20, 30, 40, 50], &alloc),
     ]);
     let mut intermediate_accessor =
-        TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+        TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     intermediate_accessor.add_table(t.clone(), intermediate_data, 0);
 
     // Create a TableExec as input
@@ -377,8 +373,8 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         const_bool(true),
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         decimal75("one_plus_double_a", 40, 0, [3, 5, 7]),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -1,7 +1,7 @@
 use super::{test_utility::*, DynProofPlan};
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType, TableRef,
             TableTestAccessor, TestAccessor,
@@ -10,7 +10,7 @@ use crate::{
     },
     sql::{
         evm_proof_plan::EVMProofPlan,
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::VerifiableQueryResult,
         proof_exprs::{test_utility::*, AddExpr, AliasedDynProofExpr, DynProofExpr},
     },
 };
@@ -24,7 +24,7 @@ fn we_can_get_fields_of_filter() {
         borrowed_bigint("b", [4, 5, 6], &alloc),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // Create a TableExec as input for FilterExec
@@ -60,7 +60,7 @@ fn we_can_correctly_filter_data_with_filter() {
         borrowed_bigint("b", [1, 2, 3, 4, 5], &alloc),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // Create a TableExec as input for FilterExec
@@ -80,8 +80,8 @@ fn we_can_correctly_filter_data_with_filter() {
         where_clause,
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected_res = owned_table([bigint("b", [3_i64, 5])]);
     assert_eq!(res, expected_res);
@@ -96,7 +96,7 @@ fn we_can_correctly_filter_with_complex_condition() {
         borrowed_int128("c", [10, 20, 30, 40, 50], &alloc),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // Create a TableExec as input for FilterExec
@@ -120,8 +120,8 @@ fn we_can_correctly_filter_with_complex_condition() {
         where_clause,
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [4_i64, 5]),
@@ -140,7 +140,7 @@ fn we_can_compose_multiple_filters() {
         borrowed_int128("c", [10, 20, 30, 40, 50], &alloc),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // Create a TableExec as input
@@ -167,8 +167,8 @@ fn we_can_compose_multiple_filters() {
         lt(column(&t, "b", &accessor), const_int128(4_i128)),
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [4_i64, 5]),
@@ -188,7 +188,7 @@ fn we_can_compose_complex_filters() {
         borrowed_int128("c", [10, 20, 30, 40, 50], &alloc),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     let intermediate_data = table([
@@ -197,7 +197,7 @@ fn we_can_compose_complex_filters() {
         borrowed_int128("c", [20, 30, 40, 50], &alloc),
     ]);
     let mut intermediate_accessor =
-        TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+        TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     intermediate_accessor.add_table(t.clone(), intermediate_data, 0);
 
     // Create a TableExec as input
@@ -237,8 +237,8 @@ fn we_can_compose_complex_filters() {
             const_int128(11_i128),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected_res = owned_table([
         decimal75("sum", 11, 0, [15, 19]), // a+b values for rows 3,4
@@ -257,7 +257,7 @@ fn we_can_have_projection_as_input_plan_for_filter() {
         borrowed_int128("c", [10, 20, 30, 40, 50], &alloc),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     let table_exec = table_exec(
@@ -342,8 +342,8 @@ fn we_can_have_projection_as_input_plan_for_filter() {
             const_int128(13_i128),
         ),
     );
-    let res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&filter, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&filter, &accessor, &(), &[]).unwrap();
     res.verify(&filter, &accessor, &(), &[]).unwrap();
     let expected_evm_proof_plan = EVMProofPlan::new(filter);
     let deserialized_evem_proof_plan: EVMProofPlan = try_standard_binary_deserialization(
@@ -351,8 +351,14 @@ fn we_can_have_projection_as_input_plan_for_filter() {
     )
     .unwrap()
     .0;
-    let res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&deserialized_evem_proof_plan, &accessor, &(), &[]).unwrap();
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(
+            &deserialized_evem_proof_plan,
+            &accessor,
+            &(),
+            &[],
+        )
+        .unwrap();
     res.verify(&deserialized_evem_proof_plan, &accessor, &(), &[])
         .unwrap();
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -1,7 +1,7 @@
 use super::{fold_columns, fold_vals};
 use crate::{
+    base::scalar::test_scalar::TestScalar,
     base::{database::Column, math::decimal::Precision},
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
 };
 use bumpalo::Bump;
 use num_traits::Zero;
@@ -9,20 +9,14 @@ use num_traits::Zero;
 #[test]
 fn we_can_fold_columns_with_scalars() {
     let expected = vec![
-        Curve25519Scalar::from(77 + 1602 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("1"),
-        Curve25519Scalar::from(77 + 2703 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("2"),
-        Curve25519Scalar::from(77 + 3805 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("3"),
-        Curve25519Scalar::from(77 + 4907 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("4"),
-        Curve25519Scalar::from(77 + 5001 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("5"),
+        TestScalar::from(77 + 1602 * 33) + TestScalar::from(10 * 33) * TestScalar::from("1"),
+        TestScalar::from(77 + 2703 * 33) + TestScalar::from(10 * 33) * TestScalar::from("2"),
+        TestScalar::from(77 + 3805 * 33) + TestScalar::from(10 * 33) * TestScalar::from("3"),
+        TestScalar::from(77 + 4907 * 33) + TestScalar::from(10 * 33) * TestScalar::from("4"),
+        TestScalar::from(77 + 5001 * 33) + TestScalar::from(10 * 33) * TestScalar::from("5"),
     ];
 
-    let str_scalars: [Curve25519Scalar; 5] =
-        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let str_scalars: [TestScalar; 5] = ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [2.into(), 3.into(), 5.into(), 7.into(), 1.into()];
     let mut columns = vec![
         Column::BigInt(&[1, 2, 3, 4, 5]),
@@ -50,23 +44,20 @@ fn we_can_fold_columns_with_scalars() {
 #[test]
 fn we_can_fold_columns_with_that_get_padded() {
     let expected = vec![
-        Curve25519Scalar::from(77 + 1602 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("1"),
-        Curve25519Scalar::from(77 + 2703 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("2"),
-        Curve25519Scalar::from(77 + 3800 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("3"),
-        Curve25519Scalar::from(77 + 4900 * 33),
-        Curve25519Scalar::from(77 + 5000 * 33),
-        Curve25519Scalar::from(77),
-        Curve25519Scalar::from(77),
-        Curve25519Scalar::from(77),
-        Curve25519Scalar::from(77),
-        Curve25519Scalar::from(77),
-        Curve25519Scalar::from(77),
+        TestScalar::from(77 + 1602 * 33) + TestScalar::from(10 * 33) * TestScalar::from("1"),
+        TestScalar::from(77 + 2703 * 33) + TestScalar::from(10 * 33) * TestScalar::from("2"),
+        TestScalar::from(77 + 3800 * 33) + TestScalar::from(10 * 33) * TestScalar::from("3"),
+        TestScalar::from(77 + 4900 * 33),
+        TestScalar::from(77 + 5000 * 33),
+        TestScalar::from(77),
+        TestScalar::from(77),
+        TestScalar::from(77),
+        TestScalar::from(77),
+        TestScalar::from(77),
+        TestScalar::from(77),
     ];
 
-    let str_scalars: [Curve25519Scalar; 3] = ["1".into(), "2".into(), "3".into()];
+    let str_scalars: [TestScalar; 3] = ["1".into(), "2".into(), "3".into()];
     let scalars = [2.into(), 3.into()];
     let mut columns = vec![
         Column::BigInt(&[1, 2, 3, 4, 5]),
@@ -93,7 +84,7 @@ fn we_can_fold_columns_with_that_get_padded() {
 #[test]
 fn we_can_fold_empty_columns() {
     let columns = vec![
-        Column::BigInt::<Curve25519Scalar>(&[]),
+        Column::BigInt::<TestScalar>(&[]),
         Column::Int128(&[]),
         Column::VarChar((&[], &[])),
         Column::Scalar(&[]),
@@ -107,17 +98,11 @@ fn we_can_fold_empty_columns() {
 
 #[test]
 fn we_can_fold_vals() {
-    assert_eq!(fold_vals(Curve25519Scalar::from(10), &[]), Zero::zero());
+    assert_eq!(fold_vals(TestScalar::from(10), &[]), Zero::zero());
     assert_eq!(
         fold_vals(
             10.into(),
-            &[
-                Curve25519Scalar::from(1),
-                2.into(),
-                3.into(),
-                4.into(),
-                5.into()
-            ]
+            &[TestScalar::from(1), 2.into(), 3.into(), 4.into(), 5.into()]
         ),
         (12345).into()
     );

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
@@ -1,15 +1,11 @@
 use super::test_utility::*;
 use crate::{
+    base::scalar::test_scalar::TestScalar,
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{owned_table_utility::*, OwnedTableTestAccessor, TableRef, TestAccessor},
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
-    sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-        proof_plans::GroupByExec,
-    },
+    sql::{proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::GroupByExec},
 };
 
 /// `select sum(c) as sum_c, count(*) as __count__ from sxt.t where b = 99`
@@ -21,7 +17,7 @@ fn we_can_prove_aggregation_without_group_by() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = group_by(
         vec![],
@@ -30,8 +26,8 @@ fn we_can_prove_aggregation_without_group_by() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_c", [101 + 104 + 102 + 103]),
@@ -49,7 +45,7 @@ fn we_can_prove_a_simple_group_by_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = group_by(
         cols_expr(&t, &["a"], &accessor),
@@ -58,8 +54,8 @@ fn we_can_prove_a_simple_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
@@ -78,7 +74,7 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = group_by(
         cols_expr(&t, &["a"], &accessor),
@@ -93,8 +89,8 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
@@ -109,19 +105,19 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
 #[expect(clippy::too_many_lines)]
 #[test]
 fn we_cannot_prove_a_complex_group_by_query_with_many_columns() {
-    let scalar_filter_data: Vec<Curve25519Scalar> = [
+    let scalar_filter_data: Vec<TestScalar> = [
         333, 222, 222, 333, 222, 333, 333, 333, 222, 222, 222, 333, 222, 222, 222, 222, 222, 222,
         333, 333,
     ]
     .iter()
     .map(core::convert::Into::into)
     .collect();
-    let scalar_group_data: Vec<Curve25519Scalar> =
+    let scalar_group_data: Vec<TestScalar> =
         [5, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 4, 5]
             .iter()
             .map(core::convert::Into::into)
             .collect();
-    let scalar_sum_data: Vec<Curve25519Scalar> = [
+    let scalar_sum_data: Vec<TestScalar> = [
         119, 522, 100, 325, 501, 447, 759, 375, 212, 532, 459, 616, 579, 179, 695, 963, 532, 868,
         331, 830,
     ]
@@ -184,7 +180,7 @@ fn we_cannot_prove_a_complex_group_by_query_with_many_columns() {
     ]);
 
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // SELECT scalar_group, int128_group, bigint_group, sum(bigint_sum + 1) as sum_int, sum(bigint_sum - int128_sum) as sum_bigint, sum(scalar_filter) as sum_scal, count(*) as __count__
@@ -218,7 +214,7 @@ fn we_cannot_prove_a_complex_group_by_query_with_many_columns() {
         ),
     );
     assert!(expr.is_none());
-    // let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
+    // let res = VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     // exercise_verification(&res, &expr, &accessor, &t);
     // let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     // let expected = owned_table([
@@ -251,8 +247,8 @@ fn we_cannot_prove_a_complex_group_by_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_int", [1406 + 927 + 637]),

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
@@ -1,5 +1,7 @@
 use super::{test_utility::*, LegacyFilterExec};
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
 use crate::{
+    base::scalar::test_scalar::TestScalar,
     base::{
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
@@ -9,16 +11,14 @@ use crate::{
         map::{indexmap, IndexMap, IndexSet},
         math::decimal::Precision,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
-            exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
-            ProverEvaluate, VerifiableQueryResult,
+            FirstRoundBuilder, ProofPlan, ProvableQueryResult, ProverEvaluate,
+            VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, LiteralExpr, TableExpr},
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
 
@@ -160,11 +160,11 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_filter() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let where_clause = equal(column(&t, "a", &accessor), const_int128(5_i128));
     let ast = legacy_filter(cols_expr_plan(&t, &["b"], &accessor), tab(&t), where_clause);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -188,7 +188,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_first_
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let expr = legacy_filter(
@@ -206,13 +206,13 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_first_
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -237,7 +237,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_first_round_evaluate() {
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let expr = legacy_filter(
@@ -255,13 +255,13 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_first_round_evaluate() {
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -286,13 +286,13 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_firs
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let expr = legacy_filter(cols_expr_plan(&t, &[], &accessor), tab(&t), where_clause);
     let fields = &[];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
@@ -317,7 +317,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_first_round_evaluate(
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let expr = legacy_filter(
@@ -335,13 +335,13 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_first_round_evaluate(
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [3, 5]),
         int128("c", [3, 5]),
         varchar("d", ["3", "5"]),
@@ -360,14 +360,15 @@ fn we_can_prove_a_filter_on_an_empty_table() {
         scalar("e", [3; 0]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = legacy_filter(
         cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),
@@ -388,15 +389,15 @@ fn we_can_prove_a_filter_with_empty_results() {
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = legacy_filter(
         cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),
@@ -417,7 +418,7 @@ fn we_can_prove_a_filter() {
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = legacy_filter(
         vec![
@@ -434,8 +435,8 @@ fn we_can_prove_a_filter() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(105)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3, 7]),

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -4,12 +4,12 @@ pub use empty_exec::EmptyExec;
 
 mod table_exec;
 pub use table_exec::TableExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod table_exec_test;
 
 mod projection_exec;
 pub(crate) use projection_exec::ProjectionExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod projection_exec_test;
 
 #[cfg(test)]
@@ -19,7 +19,7 @@ mod legacy_filter_exec;
 pub(crate) use legacy_filter_exec::LegacyFilterExec;
 #[cfg(test)]
 pub(crate) use legacy_filter_exec::OstensibleLegacyFilterExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod legacy_filter_exec_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod legacy_filter_exec_test_dishonest_prover;
@@ -32,34 +32,34 @@ mod fold_util_test;
 mod group_by_exec;
 pub(crate) use group_by_exec::GroupByExec;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod group_by_exec_test;
 
 mod filter_exec;
 pub(crate) use filter_exec::FilterExec;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod filter_exec_test;
 
 mod aggregate_exec;
 pub(crate) use aggregate_exec::AggregateExec;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod aggregate_exec_test;
 
 mod slice_exec;
 pub(crate) use slice_exec::SliceExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod slice_exec_test;
 
 mod union_exec;
 pub(crate) use union_exec::UnionExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod union_exec_test;
 
 mod sort_merge_join_exec;
 pub use sort_merge_join_exec::SortMergeJoinExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod sort_merge_join_exec_test;
 
 mod dyn_proof_plan;

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -1,5 +1,7 @@
 use super::{test_utility::*, DynProofPlan, ProjectionExec};
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
 use crate::{
+    base::scalar::test_scalar::TestScalar,
     base::{
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
@@ -8,17 +10,15 @@ use crate::{
         map::{indexmap, IndexMap, IndexSet},
         math::decimal::Precision,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
-            exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
-            ProverEvaluate, VerifiableQueryResult,
+            FirstRoundBuilder, ProofPlan, ProvableQueryResult, ProverEvaluate,
+            VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr},
         proof_plans::TableExec,
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
 
@@ -119,7 +119,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_projection() {
         bigint("b", [1_i64, 2, 3, 4, 5, 1, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let ast = projection(
         cols_expr_plan(&t, &["b"], &accessor),
@@ -131,8 +131,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -148,7 +148,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
         bigint("b", [1_i64, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let ast = projection(
         vec![
@@ -166,8 +166,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -187,14 +187,14 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
         bigint("b", [1_i64, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let intermediate_data = owned_table([
         decimal75("a", 20, 0, [8_i64, 10]),
         decimal75("b", 20, 0, [4_i64, 6]),
     ]);
     let mut intermediate_accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     intermediate_accessor.add_table(t.clone(), intermediate_data, 0);
     let ast = projection(
         vec![
@@ -228,8 +228,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
             equal(column(&t, "a", &accessor), const_int128(5)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -257,7 +257,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_fi
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr: DynProofPlan = projection(
         cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
@@ -282,13 +282,13 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_fi
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -314,7 +314,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr: DynProofPlan = projection(
         cols_expr_plan(&t, &[], &accessor),
@@ -331,7 +331,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     );
     let fields = &[];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
@@ -356,7 +356,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_first_round_evalu
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr: DynProofPlan = projection(
         vec![
@@ -389,13 +389,13 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_first_round_evalu
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [2, 3, 4, 5, 6]),
         int128("prod", [1, 4, 9, 16, 25]),
         varchar("d", ["1", "2", "3", "4", "5"]),
@@ -414,7 +414,7 @@ fn we_can_prove_a_projection_on_an_empty_table() {
         scalar("e", [3; 0]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = projection(
         vec![
@@ -437,7 +437,8 @@ fn we_can_prove_a_projection_on_an_empty_table() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         decimal75("b", 20, 0, [3; 0]),
@@ -458,7 +459,7 @@ fn we_can_prove_a_projection() {
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = projection(
         vec![
@@ -483,8 +484,8 @@ fn we_can_prove_a_projection() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [1, 2, 3, 4, 7]),

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -1,5 +1,7 @@
 use super::test_utility::*;
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
 use crate::{
+    base::scalar::test_scalar::TestScalar,
     base::{
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnType, OwnedTable,
@@ -8,16 +10,11 @@ use crate::{
         map::{indexmap, IndexMap},
         math::decimal::Precision,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{
-            exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
-            VerifiableQueryResult,
-        },
+        proof::{FirstRoundBuilder, ProvableQueryResult, ProverEvaluate, VerifiableQueryResult},
         proof_exprs::{test_utility::*, DynProofExpr},
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 
 #[test]
@@ -28,7 +25,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
     ]);
     let t: TableRef = "sxt.t".parse().unwrap();
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = slice_exec(
         projection(
             cols_expr_plan(&t, &["a", "b"], &accessor),
@@ -43,8 +40,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -61,7 +58,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(2));
     let table_plan = table_exec(
         t.clone(),
@@ -79,8 +76,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -104,7 +101,7 @@ fn we_can_get_an_empty_result_from_a_slice_on_an_empty_table_using_first_round_e
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let table_plan = table_exec(
@@ -137,13 +134,13 @@ fn we_can_get_an_empty_result_from_a_slice_on_an_empty_table_using_first_round_e
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -168,7 +165,7 @@ fn we_can_get_an_empty_result_from_a_slice_using_first_round_evaluate() {
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let table_plan = table_exec(
@@ -201,13 +198,13 @@ fn we_can_get_an_empty_result_from_a_slice_using_first_round_evaluate() {
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
         varchar("d", [""; 0]),
@@ -232,7 +229,7 @@ fn we_can_get_no_columns_from_a_slice_with_empty_input_using_first_round_evaluat
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let table_plan = table_exec(
@@ -252,7 +249,7 @@ fn we_can_get_no_columns_from_a_slice_with_empty_input_using_first_round_evaluat
     );
     let fields = &[];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
@@ -277,7 +274,7 @@ fn we_can_get_the_correct_result_from_a_slice_using_first_round_evaluate() {
     let table_map = indexmap! {
         t.clone() => data.clone()
     };
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let table_plan = table_exec(
@@ -309,13 +306,13 @@ fn we_can_get_the_correct_result_from_a_slice_using_first_round_evaluate() {
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(fields)
     .unwrap();
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("b", [5]),
         int128("c", [5]),
         varchar("d", ["5"]),
@@ -334,7 +331,7 @@ fn we_can_prove_a_slice_exec() {
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -365,8 +362,8 @@ fn we_can_prove_a_slice_exec() {
         2,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [4]),
@@ -389,7 +386,7 @@ fn we_can_prove_a_nested_slice_exec() {
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -424,8 +421,8 @@ fn we_can_prove_a_nested_slice_exec() {
         1,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [4]),
@@ -448,7 +445,7 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -483,8 +480,8 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [0; 0]),
@@ -507,7 +504,7 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -542,8 +539,8 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [0; 0]),
@@ -572,7 +569,7 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         1,
         Some(4),
     );
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+    let accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
         table_ref.clone(),
         table([
             borrowed_bigint("language_rank", [0_i64, 1, 2, 3], &alloc),
@@ -595,8 +592,8 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])
         .unwrap()
@@ -615,9 +612,10 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
 #[test]
 fn we_can_create_and_prove_a_slice_exec_on_top_of_an_empty_exec() {
     let empty_table = owned_table([]);
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let expr = slice_exec(empty_exec(), 3, Some(2));
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     assert_eq!(res, empty_table);
 }
@@ -630,7 +628,7 @@ fn we_can_prove_a_slice_exec_if_it_has_groupby_with_provable_uniqueness_as_input
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let plan = slice_exec(
         group_by(
@@ -643,9 +641,8 @@ fn we_can_prove_a_slice_exec_if_it_has_groupby_with_provable_uniqueness_as_input
         1,
         None,
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &plan, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -1,22 +1,19 @@
 use super::test_utility::*;
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
 use crate::{
     base::database::{
         owned_table_utility::*, table_utility::*, ColumnType, TableRef, TableTestAccessor,
         TestAccessor,
     },
-    sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-    },
+    sql::{proof::VerifiableQueryResult, proof_exprs::test_utility::*},
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
 
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar(
@@ -56,9 +53,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -74,7 +70,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_merge_join() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let cats = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 29, 20, 21], &alloc),
         borrowed_varchar(
@@ -134,9 +130,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
         2,
         Some(3),
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -153,7 +148,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
 #[expect(clippy::too_many_lines)]
 fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_sort_merge_joins() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let cats = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 10, 29, 20, 21], &alloc),
         borrowed_varchar(
@@ -267,9 +262,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
         ],
     );
 
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -296,7 +290,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
 #[test]
 fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar(
@@ -332,9 +326,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -353,7 +346,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
 ) {
     // Left table has no rows but right table has rows
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [0_i64; 0], &alloc),
         borrowed_varchar("name", [""; 0], &alloc),
@@ -385,9 +378,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_right);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -400,7 +392,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
     assert_eq!(res, expected_res);
 
     // Right table has no rows but left table has rows
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar(
@@ -436,9 +428,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -451,7 +442,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
     assert_eq!(res, expected_res);
 
     // Both tables have no rows
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [0_i64; 0], &alloc),
         borrowed_varchar("name", [""; 0], &alloc),
@@ -483,8 +474,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
@@ -1,12 +1,12 @@
 use super::test_utility::*;
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
 use crate::{
     base::database::{
         owned_table_utility::*, table_utility::*, ColumnField, ColumnType, TableRef,
         TableTestAccessor,
     },
-    sql::proof::{exercise_verification, VerifiableQueryResult},
+    sql::proof::VerifiableQueryResult,
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 
 #[test]
@@ -17,14 +17,14 @@ fn we_can_create_and_prove_an_empty_table_exec() {
         table_ref.clone(),
         vec![ColumnField::new("a".into(), ColumnType::BigInt)],
     );
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+    let accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
         table_ref.clone(),
         table([borrowed_bigint("a", [0_i64; 0], &alloc)]),
         0_usize,
         (),
     );
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])
         .unwrap()
@@ -45,7 +45,7 @@ fn we_can_create_and_prove_a_table_exec() {
             ColumnField::new("space_and_time".into(), ColumnType::VarChar),
         ],
     );
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+    let accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
         table_ref.clone(),
         table([
             borrowed_bigint("language_rank", [0_i64, 1, 2, 3], &alloc),
@@ -68,8 +68,8 @@ fn we_can_create_and_prove_a_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -1,5 +1,7 @@
 use super::test_utility::*;
+use crate::base::commitment::naive_evaluation_proof::NaiveEvaluationProof;
 use crate::{
+    base::scalar::test_scalar::TestScalar,
     base::{
         database::{
             owned_table_utility::*, table_utility::*, ColumnType, OwnedTable,
@@ -7,16 +9,11 @@ use crate::{
         },
         map::indexmap,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{
-            exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
-            VerifiableQueryResult,
-        },
+        proof::{FirstRoundBuilder, ProvableQueryResult, ProverEvaluate, VerifiableQueryResult},
         proof_exprs::test_utility::*,
     },
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 
 #[test]
@@ -33,7 +30,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_with_one_table() {
         varchar("b0", ["", "1", "2", "3", "4"]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let table_plan = table_exec(
         t.clone(),
@@ -55,7 +52,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
     let t0 = TableRef::new("sxt", "t0");
     let data1 = owned_table([bigint("a1", [0_i64; 0])]);
     let t1 = TableRef::new("sxt", "t1");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t0.clone(), data0, 0);
     accessor.add_table(t1.clone(), data1, 0);
     let ast = union_exec(vec![
@@ -69,7 +66,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
         ),
     ]);
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -91,7 +88,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
         borrowed_varchar("b1", ["2", "3", "4", "5", "6"], &alloc),
     ]);
     let t1 = TableRef::new("sxt", "t1");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t0.clone(), data0, 0);
     accessor.add_table(t1.clone(), data1, 0);
     let ast = union_exec(vec![
@@ -113,8 +110,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
             ],
         ),
     ]);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t0);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -165,7 +162,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
         borrowed_varchar("b6", ["8", "9", "10", "11"], &alloc),
     ]);
     let t6 = TableRef::new("sxt", "t6");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t0.clone(), data0, 0);
     accessor.add_table(t1.clone(), data1, 0);
     accessor.add_table(t2.clone(), data2, 0);
@@ -254,8 +251,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
             ],
         ),
     ]);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t0);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -296,7 +293,7 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
 
     let data_length = std::cmp::max(len_0, len_1);
 
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t0.clone(), data0, 0);
     accessor.add_table(t1.clone(), data1, 0);
     let fields = vec![
@@ -326,14 +323,14 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
         ),
     ]);
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+    let res: OwnedTable<TestScalar> = ProvableQueryResult::from(
         ast.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
             .unwrap(),
     )
     .to_owned_table(&fields)
     .unwrap();
 
-    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+    let expected: OwnedTable<TestScalar> = owned_table([
         bigint("a", [1_i64, 2, 3, 4, 5, 2, 3, 4, 5, 6]),
         varchar("b", ["1", "2", "3", "4", "5", "2", "3", "4", "5", "6"]),
     ]);


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Contributes to #560.

The core proof-plan tests can run without the `blitzar` feature when they use the naive evaluation proof backend. Enabling these tests in no-default-features builds broadens coverage for table, projection, filter, aggregation, slice, union, and sort-merge-join proof-plan behavior.

# What changes are included in this PR?

- Enable the main proof-plan test modules under `cfg(test)` instead of requiring `feature = "blitzar"`.
- Switch the affected tests from `InnerProductProof`/`Curve25519Scalar` to `NaiveEvaluationProof`/`TestScalar`.
- Keep the existing schema, first-round evaluation, query-result, composition, empty-result, aggregation, slicing, union, and join assertions intact.
- Keep the dishonest-prover legacy-filter test gated behind `feature = "blitzar"` because it is intentionally tied to that backend.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql sql::proof_plans --no-default-features --features test`
- `LLVM_COV=/Library/Developer/CommandLineTools/usr/bin/llvm-cov LLVM_PROFDATA=/Library/Developer/CommandLineTools/usr/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --no-default-features --features test --json --summary-only --output-path target/coverage7-summary.json --no-clean -- sql::proof_plans`
- `rustfmt --check crates/proof-of-sql/src/sql/proof_plans/mod.rs crates/proof-of-sql/src/sql/proof_plans/*_test.rs`
- `git diff --check`
- `source scripts/check_commits.sh`
- `source scripts/run_ci_checks.sh`

`source scripts/run_ci_checks.sh` did not reach Cargo execution in this checkout because the extracted workflow commands retained the literal `run:` prefix, for example `run: cargo check --no-default-features`, which the shell cannot execute.