### PR TITLE
test: cover evm proof plan wrappers

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -191,3 +191,72 @@ impl ProverEvaluate for EVMProofPlan {
             .final_round_evaluate(builder, alloc, table_map, params)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::plans::{EVMDynProofPlan, EVMEmptyExec};
+    use super::*;
+    use crate::{
+        base::{
+            database::{ColumnType, TableRef},
+            try_standard_binary_deserialization, try_standard_binary_serialization,
+        },
+        sql::proof_plans::DynProofPlan,
+    };
+    use alloc::{string::ToString, vec};
+
+    #[test]
+    fn evm_proof_plan_exposes_and_returns_inner_plan() {
+        let plan = DynProofPlan::new_empty();
+        let evm_plan = EVMProofPlan::new(plan.clone());
+
+        assert_eq!(evm_plan.inner(), &plan);
+        assert_eq!(evm_plan.into_inner(), plan);
+    }
+
+    #[test]
+    fn empty_evm_proof_plan_roundtrips_through_compact_plan_and_binary_encoding() {
+        let evm_plan = EVMProofPlan::new(DynProofPlan::new_empty());
+        let compact = CompactPlan::try_from(&evm_plan).unwrap();
+
+        assert!(compact.tables.is_empty());
+        assert!(compact.columns.is_empty());
+        assert!(compact.output_column_names.is_empty());
+        assert!(matches!(compact.plan, EVMDynProofPlan::Empty(_)));
+
+        let decoded = EVMProofPlan::try_from(compact).unwrap();
+        assert!(matches!(decoded.inner(), DynProofPlan::Empty(_)));
+
+        let encoded = try_standard_binary_serialization(&evm_plan).unwrap();
+        let (roundtripped, bytes_read): (EVMProofPlan, _) =
+            try_standard_binary_deserialization(&encoded).unwrap();
+
+        assert_eq!(bytes_read, encoded.len());
+        assert!(matches!(roundtripped.into_inner(), DynProofPlan::Empty(_)));
+    }
+
+    #[test]
+    fn compact_plan_rejects_invalid_table_names_and_column_table_indexes() {
+        let invalid_table_name = CompactPlan {
+            tables: vec!["schema.table.extra".to_string()],
+            columns: vec![],
+            output_column_names: vec![],
+            plan: EVMDynProofPlan::Empty(EVMEmptyExec {}),
+        };
+        assert!(matches!(
+            EVMProofPlan::try_from(invalid_table_name),
+            Err(EVMProofPlanError::InvalidTableName)
+        ));
+
+        let missing_table_index = CompactPlan {
+            tables: vec![TableRef::from_names(Some("schema"), "table").to_string()],
+            columns: vec![(1, "column".to_string(), ColumnType::BigInt)],
+            output_column_names: vec![],
+            plan: EVMDynProofPlan::Empty(EVMEmptyExec {}),
+        };
+        assert!(matches!(
+            EVMProofPlan::try_from(missing_table_index),
+            Err(EVMProofPlanError::TableNotFound)
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -82,12 +82,69 @@ mod tests {
     use crate::{
         base::database::{
             owned_table_utility::{bigint, owned_table},
-            ColumnRef, ColumnType, OwnedTableTestAccessor, TableRef,
+            table_utility::{borrowed_bigint, table},
+            ColumnRef, ColumnType, OwnedTable, OwnedTableTestAccessor, TableRef,
         },
+        base::{map::indexmap, scalar::test_scalar::TestScalar},
         sql::proof::VerifiableQueryResult,
+        sql::proof::{FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate},
     };
+    use alloc::collections::VecDeque;
     #[cfg(feature = "blitzar")]
     use blitzar::proof::InnerProductProof;
+    use bumpalo::Bump;
+
+    #[test]
+    fn demo_mock_plan_reports_its_single_column_and_table_reference() {
+        let table_ref = "namespace.table_name".parse::<TableRef>().unwrap();
+        let column_ref =
+            ColumnRef::new(table_ref.clone(), "column_name".into(), ColumnType::BigInt);
+        let plan = DemoMockPlan {
+            column: column_ref.clone(),
+        };
+
+        let fields = plan.get_column_result_fields();
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name().value, "column_name");
+        assert_eq!(fields[0].data_type(), ColumnType::BigInt);
+
+        let column_refs = plan.get_column_references();
+        assert_eq!(column_refs.len(), 1);
+        assert!(column_refs.contains(&column_ref));
+
+        let table_refs = plan.get_table_references();
+        assert_eq!(table_refs.len(), 1);
+        assert!(table_refs.contains(&table_ref));
+    }
+
+    #[test]
+    fn demo_mock_plan_prover_rounds_forward_the_source_table() {
+        let alloc = Bump::new();
+        let table_ref = "namespace.table_name".parse::<TableRef>().unwrap();
+        let column_ref =
+            ColumnRef::new(table_ref.clone(), "column_name".into(), ColumnType::BigInt);
+        let plan = DemoMockPlan { column: column_ref };
+        let source_table = table::<TestScalar>([borrowed_bigint("column_name", [7, 11], &alloc)]);
+        let table_map = indexmap! { table_ref => source_table.clone() };
+
+        let mut first_round_builder = FirstRoundBuilder::new(source_table.num_rows());
+        let first_round_table = plan
+            .first_round_evaluate(&mut first_round_builder, &alloc, &table_map, &[])
+            .unwrap();
+        assert_eq!(
+            OwnedTable::from(&first_round_table),
+            OwnedTable::from(&source_table)
+        );
+
+        let mut final_round_builder = FinalRoundBuilder::new(1, VecDeque::new());
+        let final_round_table = plan
+            .final_round_evaluate(&mut final_round_builder, &alloc, &table_map, &[])
+            .unwrap();
+        assert_eq!(
+            OwnedTable::from(&final_round_table),
+            OwnedTable::from(&source_table)
+        );
+    }
 
     #[test]
     #[cfg(feature = "blitzar")]


### PR DESCRIPTION
## Summary
- add direct unit coverage for `EVMProofPlan` wrapper accessors, compact-plan roundtripping, standard binary serialization, and compact-plan error handling
- add no-blitzar unit coverage for `DemoMockPlan` result metadata, column/table references, and first/final prover forwarding

## Validation
- `rustfmt --edition 2021 --check crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs`
- `git diff --check -- crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs`

Note: local `cargo test -p proof-of-sql --no-default-features --features test --lib evm_proof_plan::proof_plan::tests -- --nocapture` was started, but the Apple Silicon local rustc process did not complete while compiling the proof-of-sql test binary. Leaving full cargo verification to CI.

/claim #560
