### PR TITLE
test: cover composite polynomial helpers

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -1,6 +1,7 @@
 use super::CompositePolynomial;
 use crate::base::scalar::test_scalar::TestScalar;
 use alloc::rc::Rc;
+use core::iter;
 
 #[test]
 fn test_composite_polynomial_evaluation() {
@@ -68,4 +69,45 @@ fn test_composite_polynomial_hypercube_sum() {
         sum,
         TestScalar::from(3 * ((-7) * 2 + 2 * (-8) + (-6) * 4 + 17 * 1) + 2 * (1 + 3 + (-5) + (-9)))
     );
+}
+
+#[test]
+fn test_composite_polynomial_reuses_existing_extension_indexes() {
+    let shared_extension = Rc::new(vec![TestScalar::from(1u32), TestScalar::from(2u32)]);
+    let mut prod = CompositePolynomial::new(1);
+    prod.add_product(
+        [Rc::clone(&shared_extension), Rc::clone(&shared_extension)],
+        TestScalar::from(3u32),
+    );
+    prod.add_product([Rc::clone(&shared_extension)], TestScalar::from(5u32));
+
+    assert_eq!(prod.max_multiplicands, 2);
+    assert_eq!(prod.flattened_ml_extensions.len(), 1);
+    assert!(Rc::ptr_eq(
+        &prod.flattened_ml_extensions[0],
+        &shared_extension
+    ));
+    assert_eq!(
+        prod.products,
+        vec![
+            (TestScalar::from(3u32), vec![0, 0]),
+            (TestScalar::from(5u32), vec![0])
+        ]
+    );
+}
+
+#[test]
+#[should_panic(expected = "assertion failed: !product.is_empty()")]
+fn test_composite_polynomial_rejects_empty_product() {
+    let mut prod = CompositePolynomial::new(1);
+    prod.add_product(iter::empty::<Rc<Vec<TestScalar>>>(), TestScalar::from(1u32));
+}
+
+#[test]
+fn test_composite_polynomial_annotate_trace() {
+    let extension = Rc::new(vec![TestScalar::from(1u32), TestScalar::from(2u32)]);
+    let mut prod = CompositePolynomial::new(1);
+    prod.add_product([extension], TestScalar::from(3u32));
+
+    prod.annotate_trace();
 }


### PR DESCRIPTION
## Summary
- add coverage for reusing an existing multilinear extension index when the same Rc is added repeatedly
- cover the empty-product assertion path
- exercise annotate_trace on a populated composite polynomial

/claim #560

## Validation
- cargo test -p proof-of-sql composite_polynomial --no-default-features --features=test
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh