### PR TITLE
test: cover polynomial sumcheck helpers

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,5 +1,10 @@
 use super::MultilinearExtension;
-use crate::base::{database::Column, scalar::test_scalar::TestScalar};
+use crate::base::{
+    database::Column,
+    math::decimal::Precision,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    scalar::test_scalar::TestScalar,
+};
 use bumpalo::Bump;
 
 #[test]
@@ -112,5 +117,111 @@ fn we_can_use_multilinear_extension_methods_for_i64_vec() {
     assert_ne!(
         MultilinearExtension::<TestScalar>::id(&slice),
         MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
+    );
+}
+
+#[test]
+fn we_can_evaluate_multilinear_extensions_at_a_point() {
+    let slice: &[i64] = &[8, 13];
+
+    assert_eq!(slice.evaluate_at_point(&[TestScalar::from(0)]), 8.into());
+    assert_eq!(slice.evaluate_at_point(&[TestScalar::from(1)]), 13.into());
+}
+
+#[test]
+fn we_can_use_multilinear_extension_methods_for_array_refs() {
+    let array = &[2_i64, 3, 4, 5];
+    let evaluation_vec: Vec<TestScalar> = vec![11.into(), 13.into(), 17.into(), 19.into()];
+
+    assert_eq!(
+        array.inner_product(&evaluation_vec),
+        (2 * 11 + 3 * 13 + 4 * 17 + 5 * 19).into()
+    );
+
+    let mut res: Vec<TestScalar> = vec![1.into(), 2.into(), 3.into(), 4.into()];
+    array.mul_add(&mut res, &10.into());
+    assert_eq!(res, vec![21.into(), 32.into(), 43.into(), 54.into()]);
+    assert_eq!(
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&array, 2),
+        vec![2.into(), 3.into(), 4.into(), 5.into()]
+    );
+    assert_eq!(MultilinearExtension::<TestScalar>::id(&array).1, 4);
+}
+
+fn assert_column_mle_methods(column: Column<'_, TestScalar>, expected: &[TestScalar]) {
+    let evaluation_vec: Vec<TestScalar> = vec![11.into(), 13.into()];
+    assert_eq!(
+        column.inner_product(&evaluation_vec),
+        expected[0] * evaluation_vec[0] + expected[1] * evaluation_vec[1]
+    );
+
+    let mut res: Vec<TestScalar> = vec![17.into(), 19.into()];
+    let multiplier = TestScalar::from(2);
+    column.mul_add(&mut res, &multiplier);
+    assert_eq!(
+        res,
+        vec![
+            TestScalar::from(17) + expected[0] * multiplier,
+            TestScalar::from(19) + expected[1] * multiplier
+        ]
+    );
+
+    assert_eq!(
+        column.to_sumcheck_term(2),
+        vec![expected[0], expected[1], 0.into(), 0.into()]
+    );
+    assert_eq!(column.id().1, 2);
+}
+
+#[test]
+fn we_can_use_multilinear_extension_methods_for_all_column_variants() {
+    let bools = [true, false];
+    assert_column_mle_methods(Column::Boolean(&bools), &[1.into(), 0.into()]);
+
+    let uint8s = [2_u8, 3];
+    assert_column_mle_methods(Column::Uint8(&uint8s), &[2.into(), 3.into()]);
+
+    let tinyints = [2_i8, 3];
+    assert_column_mle_methods(Column::TinyInt(&tinyints), &[2.into(), 3.into()]);
+
+    let smallints = [2_i16, 3];
+    assert_column_mle_methods(Column::SmallInt(&smallints), &[2.into(), 3.into()]);
+
+    let ints = [2_i32, 3];
+    assert_column_mle_methods(Column::Int(&ints), &[2.into(), 3.into()]);
+
+    let bigints = [2_i64, 3];
+    assert_column_mle_methods(Column::BigInt(&bigints), &[2.into(), 3.into()]);
+
+    let int128s = [2_i128, 3];
+    assert_column_mle_methods(Column::Int128(&int128s), &[2.into(), 3.into()]);
+
+    let scalars = [2.into(), 3.into()];
+    assert_column_mle_methods(Column::Scalar(&scalars), &[2.into(), 3.into()]);
+
+    let decimal_scalars = [2.into(), 3.into()];
+    assert_column_mle_methods(
+        Column::Decimal75(Precision::new(10).unwrap(), 2, &decimal_scalars),
+        &[2.into(), 3.into()],
+    );
+
+    let timestamps = [2_i64, 3];
+    assert_column_mle_methods(
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &timestamps),
+        &[2.into(), 3.into()],
+    );
+
+    let strings = ["alpha", "beta"];
+    let string_scalars = [5.into(), 7.into()];
+    assert_column_mle_methods(
+        Column::VarChar((&strings, &string_scalars)),
+        &[5.into(), 7.into()],
+    );
+
+    let binaries: [&[u8]; 2] = [b"alpha", b"beta"];
+    let binary_scalars = [5.into(), 7.into()];
+    assert_column_mle_methods(
+        Column::VarBinary((&binaries, &binary_scalars)),
+        &[5.into(), 7.into()],
     );
 }

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -91,7 +91,10 @@ impl<'a, S: Scalar> SumcheckSubpolynomial<'a, S> {
 
 #[cfg(test)]
 mod tests {
-    use super::{SumcheckSubpolynomial, SumcheckSubpolynomialTerm, SumcheckSubpolynomialType};
+    use super::{
+        CompositePolynomialBuilder, SumcheckSubpolynomial, SumcheckSubpolynomialTerm,
+        SumcheckSubpolynomialType,
+    };
     use crate::base::scalar::test_scalar::TestScalar;
     use alloc::boxed::Box;
 
@@ -118,5 +121,43 @@ mod tests {
         assert_eq!(coeff, TestScalar::from(15));
 
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn compose_adds_identity_terms_to_the_composite_polynomial() {
+        let fr = vec![TestScalar::from(3), TestScalar::from(4)];
+        let mle = vec![TestScalar::from(7), TestScalar::from(11)];
+        let terms: Vec<SumcheckSubpolynomialTerm<_>> =
+            vec![(TestScalar::from(2), vec![Box::new(&mle)])];
+        let subpoly = SumcheckSubpolynomial::new(SumcheckSubpolynomialType::Identity, terms);
+        let mut builder = CompositePolynomialBuilder::new(1, &fr);
+
+        assert_eq!(
+            subpoly.subpolynomial_type(),
+            SumcheckSubpolynomialType::Identity
+        );
+        subpoly.compose(&mut builder, TestScalar::from(5));
+
+        let composite = builder.make_composite_polynomial();
+        assert_eq!(composite.hypercube_sum(2), TestScalar::from(650));
+    }
+
+    #[test]
+    fn compose_adds_zero_sum_terms_to_the_composite_polynomial() {
+        let fr = vec![TestScalar::from(3), TestScalar::from(4)];
+        let mle = vec![TestScalar::from(7), TestScalar::from(11)];
+        let terms: Vec<SumcheckSubpolynomialTerm<_>> =
+            vec![(TestScalar::from(2), vec![Box::new(&mle)])];
+        let subpoly = SumcheckSubpolynomial::new(SumcheckSubpolynomialType::ZeroSum, terms);
+        let mut builder = CompositePolynomialBuilder::new(1, &fr);
+
+        assert_eq!(
+            subpoly.subpolynomial_type(),
+            SumcheckSubpolynomialType::ZeroSum
+        );
+        subpoly.compose(&mut builder, TestScalar::from(5));
+
+        let composite = builder.make_composite_polynomial();
+        assert_eq!(composite.hypercube_sum(2), TestScalar::from(180));
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- Add `MultilinearExtension` coverage for `evaluate_at_point`, array refs, and all `Column` variant delegation paths.
- Add `SumcheckSubpolynomial::compose` coverage for both `Identity` and `ZeroSum` branches.

## Coverage
Checked current open PRs and issue #560 comments for these exact files before opening this PR; I did not find an active overlapping claim.

Full no-default LCOV spot-check:
- `multilinear_extension.rs`: 66 -> 106 hit lines, 40 newly covered production lines.
- `sumcheck_subpolynomial.rs`: all previously missed production compose/type paths are now hit; conservatively counted as 13 newly covered production lines.

Conservative production coverage delta: 53 lines / $5.30 at $0.10 per line, subject to maintainer baseline review.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features=test multilinear_extension`
- `cargo test -p proof-of-sql --no-default-features --features=test sumcheck_subpolynomial`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path target/coverage-polynomial-sumcheck-lcov.info`
- `cargo fmt --check`
- `git diff --check`
- `tr -d '\r' < scripts/check_commits.sh | bash`