### PR TITLE
test: cover database table helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -2,6 +2,7 @@ use crate::{
     base::{
         database::{owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableError},
         map::IndexMap,
+        math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::test_scalar::TestScalar,
     },
@@ -100,6 +101,60 @@ fn we_can_create_an_owned_table_with_data() {
         ]),
     );
     assert_eq!(owned_table.into_inner(), table);
+}
+
+#[test]
+fn we_can_create_an_owned_table_with_all_column_helpers() {
+    let owned_table = owned_table::<TestScalar>([
+        uint8("uint8", [1_u8, 2]),
+        tinyint("tinyint", [-1_i8, 2]),
+        smallint("smallint", [-3_i16, 4]),
+        int("int", [-5_i32, 6]),
+        decimal75("decimal75", 12, -2, [7, 8]),
+        varbinary("varbinary", [vec![1_u8, 2], vec![3, 4, 5]]),
+    ]);
+
+    assert_eq!(owned_table.num_columns(), 6);
+    assert_eq!(owned_table.num_rows(), 2);
+    assert!(!owned_table.is_empty());
+
+    let column_names = owned_table
+        .column_names()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        column_names,
+        [
+            "uint8",
+            "tinyint",
+            "smallint",
+            "int",
+            "decimal75",
+            "varbinary"
+        ]
+    );
+
+    assert_eq!(
+        owned_table.column_by_index(0),
+        Some(&OwnedColumn::Uint8(vec![1, 2]))
+    );
+    assert_eq!(
+        owned_table.column_by_index(3),
+        Some(&OwnedColumn::Int(vec![-5, 6]))
+    );
+    assert_eq!(
+        owned_table.column_by_index(4),
+        Some(&OwnedColumn::Decimal75(
+            Precision::new(12).unwrap(),
+            -2,
+            vec![TestScalar::from(7), TestScalar::from(8)]
+        ))
+    );
+    assert_eq!(
+        owned_table.inner_table().get(&Ident::new("varbinary")),
+        Some(&OwnedColumn::VarBinary(vec![vec![1, 2], vec![3, 4, 5]]))
+    );
+    assert_eq!(owned_table.column_by_index(6), None);
 }
 #[test]
 fn we_get_inequality_between_tables_with_differing_column_order() {

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -1,6 +1,7 @@
 use crate::base::{
-    database::{table_utility::*, Column, Table, TableError, TableOptions},
+    database::{table_utility::*, Column, ColumnType, Table, TableError, TableOptions},
     map::{indexmap, IndexMap},
+    math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
 };
@@ -192,6 +193,65 @@ fn we_can_create_a_table_with_data() {
     expected_table.insert(Ident::new("boolean"), Column::Boolean(boolean_data));
 
     assert_eq!(borrowed_table.into_inner(), expected_table);
+}
+
+#[test]
+fn we_can_create_a_table_with_all_borrowed_column_helpers() {
+    let alloc = Bump::new();
+
+    let table = table_with_row_count::<TestScalar>(
+        [
+            borrowed_uint8("uint8", [1_u8, 2], &alloc),
+            borrowed_tinyint("tinyint", [-1_i8, 2], &alloc),
+            borrowed_smallint("smallint", [-3_i16, 4], &alloc),
+            borrowed_int("int", [-5_i32, 6], &alloc),
+            borrowed_decimal75("decimal75", 12, -2, [7, 8], &alloc),
+        ],
+        2,
+    );
+
+    assert_eq!(table.num_columns(), 5);
+    assert_eq!(table.num_rows(), 2);
+    assert!(!table.is_empty());
+
+    let column_names = table
+        .column_names()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        column_names,
+        ["uint8", "tinyint", "smallint", "int", "decimal75"]
+    );
+
+    let column_types = table.columns().map(Column::column_type).collect::<Vec<_>>();
+    assert_eq!(
+        column_types,
+        [
+            ColumnType::Uint8,
+            ColumnType::TinyInt,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::Decimal75(Precision::new(12).unwrap(), -2),
+        ]
+    );
+
+    let expected_decimal = [TestScalar::from(7), TestScalar::from(8)];
+    assert_eq!(
+        table["decimal75"],
+        Column::Decimal75(Precision::new(12).unwrap(), -2, &expected_decimal)
+    );
+
+    let schema = table.schema();
+    assert_eq!(schema[0].name(), Ident::new("uint8"));
+    assert_eq!(schema[0].data_type(), ColumnType::Uint8);
+    assert_eq!(
+        schema[4].data_type(),
+        ColumnType::Decimal75(Precision::new(12).unwrap(), -2)
+    );
+
+    let table_with_rho = table.clone().add_rho_column(&alloc);
+    assert_eq!(table_with_rho.num_columns(), 6);
+    assert_eq!(table_with_rho.column(5), Some(&Column::Int128(&[0, 1])));
 }
 
 #[test]


### PR DESCRIPTION
/claim #560

# Rationale for this change

Add a small, non-overlapping test-only coverage slice for database table helper APIs. I checked recent open #560 PRs and did not find an active slice targeting `table_utility.rs` / `owned_table_utility.rs` helper constructors and the related `Table` / `OwnedTable` accessor paths.

# What changes are included in this PR?

- Add borrowed table helper coverage for `uint8`, `tinyint`, `smallint`, `int`, and `decimal75` columns.
- Add owned table helper coverage for `uint8`, `tinyint`, `smallint`, `int`, `decimal75`, and `varbinary` columns.
- Assert table names, column types, schema accessors, index accessors, `inner_table`, out-of-range column lookup, and `add_rho_column` behavior.

# Are these changes tested?

Yes.

- [x] `HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0.1:7890 RUSTUP_TOOLCHAIN=stable cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features=test helpers -- --nocapture`
- [x] `RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- [x] `git diff --check`
- [x] `source scripts/check_commits.sh`

Focused coverage spot-check, using the same linker override required on this machine because `.cargo/config.toml` points at unavailable `lld`:

- [x] `HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0.1:7890 RUSTUP_TOOLCHAIN=stable CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS='' cargo llvm-cov -p proof-of-sql --lib --no-default-features --features=test --lcov --output-path lcov-helpers.info -- helpers`

That focused run covered these production files from this slice:

| File | Covered lines in focused run |
| --- | ---: |
| `crates/proof-of-sql/src/base/database/owned_table_utility.rs` | 65 |
| `crates/proof-of-sql/src/base/database/table_utility.rs` | 60 |
| `crates/proof-of-sql/src/base/database/table.rs` | 50 |
| `crates/proof-of-sql/src/base/database/owned_table.rs` | 31 |
| `crates/proof-of-sql/src/base/database/column.rs` | 21 |
| `crates/proof-of-sql/src/base/database/column_field.rs` | 9 |

I did not run the full `source scripts/run_ci_checks.sh` locally because this shallow clone directory is named `sxt-proof-of-sql-shallow`, while the script searches upward for a literal `sxt-proof-of-sql/.github/workflows/lint-and-test.yml` path. The focused test, formatting, diff, commit, and coverage checks above passed.

AI-assisted with Codex; I reviewed and verified the diff before submitting.
