### PR TITLE
test: cover i256 constructor accessors

### DIFF
--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -184,6 +184,20 @@ mod tests {
     ]);
 
     #[test]
+    fn we_can_construct_i256_from_limbs() {
+        let limbs = [
+            0x0123_4567_89AB_CDEF,
+            0xFEDC_BA98_7654_3210,
+            0x0F0F_F0F0_55AA_AA55,
+            0x8000_0000_0000_0001,
+        ];
+
+        let value = I256::new(limbs);
+
+        assert_eq!(value.limbs(), limbs);
+    }
+
+    #[test]
     fn we_can_compute_the_negative_of_i256() {
         assert_eq!(ZERO.neg(), ZERO);
         assert_eq!(ONE.neg(), NEG_ONE);


### PR DESCRIPTION
## Summary
- add focused coverage for `I256::new` and the test-only `limbs()` accessor
- keep this test-only with no production behavior changes

/claim #560

## Coverage
- before focused LCOV for `base::math::i256`: `i256.rs` missed lines 34-36 and 41-43
- after focused LCOV for `base::math::i256`: 0 missed lines in `i256.rs`
- conservative newly covered original production lines: 6 ($0.60 at $0.10/line), subject to maintainer review and final baseline

## Verification
- `cargo test -p proof-of-sql base::math::i256 --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path /tmp/i256-after.lcov -- base::math::i256`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

AI-assisted with Codex; I reviewed the diff and local verification before submission.