### PR TITLE
test: cover dynamic dory commitment traits

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
@@ -108,8 +108,51 @@ mod tests {
         },
         proof_primitive::dory::{test_rng, DoryScalar, ProverSetup, PublicParameters},
     };
+    use ark_ec::pairing::PairingOutput;
     use ark_ff::UniformRand;
+    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+    use num_traits::One;
     use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn default_dynamic_dory_commitment_is_the_multiplicative_identity() {
+        assert_eq!(
+            DynamicDoryCommitment::default(),
+            DynamicDoryCommitment(PairingOutput(One::one()))
+        );
+    }
+
+    #[test]
+    fn we_can_scale_dynamic_dory_commitments_by_value_and_reference() {
+        let mut rng = StdRng::seed_from_u64(7);
+        let scalar = DoryScalar::rand(&mut rng);
+        let commitment = DynamicDoryCommitment(GT::rand(&mut rng));
+
+        assert_eq!(scalar * commitment, scalar * &commitment);
+        assert_eq!((scalar * commitment).0, commitment.0 * scalar.0);
+    }
+
+    #[test]
+    fn computing_empty_dynamic_dory_commitments_returns_empty() {
+        let public_parameters = PublicParameters::test_rand(1, &mut test_rng());
+        let setup = ProverSetup::from(&public_parameters);
+
+        let commitments = DynamicDoryCommitment::compute_commitments(&[], 0, &&setup);
+
+        assert!(commitments.is_empty());
+    }
+
+    #[test]
+    fn we_can_canonical_serialize_dynamic_dory_commitments() {
+        let mut rng = StdRng::seed_from_u64(11);
+        let commitment = DynamicDoryCommitment(GT::rand(&mut rng));
+        let mut bytes = Vec::new();
+
+        commitment.serialize_compressed(&mut bytes).unwrap();
+        let deserialized = DynamicDoryCommitment::deserialize_compressed(&bytes[..]).unwrap();
+
+        assert_eq!(deserialized, commitment);
+    }
 
     #[test]
     fn we_get_different_transcript_bytes_from_different_dynamic_dory_commitments() {


### PR DESCRIPTION
## Summary
- add focused coverage for `DynamicDoryCommitment` default identity behavior
- cover scalar multiplication by value and by reference
- cover direct empty `Commitment::compute_commitments` delegation and canonical serialization round-trip
- keep this test-only with no production behavior changes

/claim #560

## Coverage
- before full no-default `test` LCOV: `dynamic_dory_commitment.rs` missed lines 47-48, 55-57, 64-66, and 70-72
- after focused LCOV: only derive macro lines 47-48 still report as missed
- conservative newly covered original production lines: 9 ($0.90 at $0.10/line), excluding the two remaining derive macro lines and subject to maintainer review/final baseline

## Verification
- `cargo test -p proof-of-sql proof_primitive::dory::dynamic_dory_commitment::tests --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path /tmp/dynamic-dory-after.lcov -- proof_primitive::dory::dynamic_dory_commitment::tests`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

AI-assisted with Codex; I reviewed the diff and local verification before submission.