### PR TITLE
test: cover dynamic dory proof guards

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -6,6 +6,29 @@ use ark_std::UniformRand;
 use merlin::Transcript;
 
 #[test]
+fn unsupported_generator_offset_returns_default_dynamic_dory_proof() {
+    let public_parameters = PublicParameters::test_rand(1, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let mut transcript = Transcript::new(b"invalid_offset_dynamic_evaluation_proof");
+
+    let proof = DynamicDoryEvaluationProof::new(&mut transcript, &[], &[], 1, &&prover_setup);
+
+    assert_eq!(proof, DynamicDoryEvaluationProof::default());
+}
+
+#[test]
+fn oversized_point_returns_default_dynamic_dory_proof() {
+    let public_parameters = PublicParameters::test_rand(1, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let b_point = vec![DoryScalar::from(1); 4];
+    let mut transcript = Transcript::new(b"small_setup_dynamic_evaluation_proof");
+
+    let proof = DynamicDoryEvaluationProof::new(&mut transcript, &[], &b_point, 0, &&prover_setup);
+
+    assert_eq!(proof, DynamicDoryEvaluationProof::default());
+}
+
+#[test]
 fn test_simple_ipa() {
     let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);


### PR DESCRIPTION
## Summary
- add focused tests for unsupported dynamic Dory generator offsets returning the default proof
- add focused tests for prover setups that are too small for the point size returning the default proof
- keep this test-only with no production behavior changes

/claim #560

## Coverage
- before full no-default `test` LCOV: `dynamic_dory_commitment_evaluation_proof.rs` missed lines 54 and 60
- after focused LCOV with `returns_default_dynamic_dory_proof`: line 54 count 1, line 60 count 1
- conservative newly covered original production lines: 2 ($0.20 at $0.10/line), subject to maintainer review and final baseline

## Verification
- `cargo test -p proof-of-sql returns_default_dynamic_dory_proof --no-default-features --features=test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path /tmp/dynamic-dory-proof-guards-after.lcov -- returns_default_dynamic_dory_proof`
- `cargo fmt --check`
- `git diff --check`
- `source scripts/check_commits.sh`

AI-assisted with Codex; I reviewed the diff and local verification before submission.