### PR TITLE
test: cover verifiable query result without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -53,7 +53,7 @@ pub(crate) use sumcheck_subpolynomial::{
 
 mod verifiable_query_result;
 pub use verifiable_query_result::VerifiableQueryResult;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod verifiable_query_result_test;
 
 #[cfg(all(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::{bigint, owned_table},
             table_utility::*,
@@ -100,13 +100,14 @@ fn we_can_verify_queries_on_an_empty_table() {
         columns: 1,
         ..Default::default()
     };
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+    let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
         TableRef::new("sxt", "test"),
         owned_table([bigint("a1", [0_i64; 0])]),
         0,
         (),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let QueryData {
         verification_hash: _,
         table,


### PR DESCRIPTION
## Summary
- run the existing VerifiableQueryResult smoke test under plain `#[cfg(test)]` instead of requiring `feature = "blitzar"`
- switch that test to the no-default-compatible `NaiveEvaluationProof` fixture
- cover the public `VerifiableQueryResult::new` and `verify` wrapper paths in no-default test coverage

/claim #560

## Coverage
Baseline `/tmp/sxt-full-nodefault-test.lcov` for `crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs`:
- LF: 27
- LH: 0

After this PR, `/tmp/sxt-verifiable-query-result.lcov`:
- LF: 27
- LH: 27

Conservative claim: 27 newly covered lines * $0.10 = $2.70.

## Verification
- `cargo test -p proof-of-sql --no-default-features --features=test we_can_verify_queries_on_an_empty_table`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=test --lcov --output-path /tmp/sxt-verifiable-query-result.lcov`
- `cargo fmt --check`
- `git diff --check`