### PR TITLE
Add comparison helper coverage tests

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -1401,4 +1401,120 @@ mod test {
             matches!(try_neg_type(ColumnType::VarChar).unwrap_err(), ColumnOperationError::UnaryOperationInvalidColumnType { operator, operand_type } if operator == "negation" && operand_type == ColumnType::VarChar)
         );
     }
+
+    #[test]
+    fn we_can_determine_equality_compatibility() {
+        try_equals_types(ColumnType::VarChar, ColumnType::VarChar).unwrap();
+        try_equals_types(ColumnType::VarBinary, ColumnType::VarBinary).unwrap();
+        try_equals_types(ColumnType::Boolean, ColumnType::Boolean).unwrap();
+        try_equals_types(ColumnType::Int, ColumnType::Scalar).unwrap();
+        try_equals_types(ColumnType::Scalar, ColumnType::VarChar).unwrap();
+        try_equals_types(
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+            ColumnType::Decimal75(Precision::new(20).unwrap(), 2),
+        )
+        .unwrap();
+        try_equals_types(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::new(5)),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            try_equals_types(
+                ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+                ColumnType::Decimal75(Precision::new(10).unwrap(), 3),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_equals_types(
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    #[test]
+    fn we_can_determine_inequality_compatibility() {
+        try_inequality_types(
+            ColumnType::Decimal75(Precision::new(20).unwrap(), 2),
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+        )
+        .unwrap();
+        try_inequality_types(ColumnType::Boolean, ColumnType::Boolean).unwrap();
+        try_inequality_types(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::new(-3)),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            try_inequality_types(ColumnType::VarChar, ColumnType::VarChar),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types(
+                ColumnType::Decimal75(Precision::new(39).unwrap(), 2),
+                ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types(
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    #[test]
+    fn we_can_determine_scaled_comparison_compatibility() {
+        try_equals_types_with_scaling(
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 3),
+        )
+        .unwrap();
+        try_equals_types_with_scaling(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::new(9)),
+        )
+        .unwrap();
+        assert!(matches!(
+            try_equals_types_with_scaling(ColumnType::Boolean, ColumnType::VarChar),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+
+        try_inequality_types_with_scaling(
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 3),
+        )
+        .unwrap();
+        try_inequality_types_with_scaling(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::new(9)),
+        )
+        .unwrap();
+        assert!(matches!(
+            try_inequality_types_with_scaling(ColumnType::VarChar, ColumnType::Boolean),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types_with_scaling(
+                ColumnType::Decimal75(Precision::new(39).unwrap(), 2),
+                ColumnType::Decimal75(Precision::new(10).unwrap(), 3),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    #[test]
+    fn we_can_check_logical_operator_compatibility() {
+        assert!(can_and_or_types(ColumnType::Boolean, ColumnType::Boolean));
+        assert!(!can_and_or_types(ColumnType::Boolean, ColumnType::Int));
+        assert!(can_not_type(ColumnType::Boolean));
+        assert!(!can_not_type(ColumnType::VarChar));
+    }
 }

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -1455,6 +1455,10 @@ mod test {
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
         assert!(matches!(
+            try_inequality_types(ColumnType::VarBinary, ColumnType::VarBinary),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
             try_inequality_types(
                 ColumnType::Decimal75(Precision::new(39).unwrap(), 2),
                 ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
@@ -1499,6 +1503,10 @@ mod test {
         .unwrap();
         assert!(matches!(
             try_inequality_types_with_scaling(ColumnType::VarChar, ColumnType::Boolean),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types_with_scaling(ColumnType::VarBinary, ColumnType::VarBinary),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
         assert!(matches!(


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
