### PR TITLE
test: cover EmptyExec accessors and evaluation

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec_test.rs
@@ -1,0 +1,56 @@
+use super::EmptyExec;
+use crate::{
+    base::{
+        database::{ColumnField, ColumnRef, LiteralValue, TableRef},
+        map::{IndexMap, IndexSet},
+    },
+    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+    sql::proof::{FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate},
+};
+use alloc::{collections::VecDeque, vec::Vec};
+use bumpalo::Bump;
+
+#[test]
+fn empty_exec_has_no_references_or_columns() {
+    let plan = EmptyExec::default();
+
+    assert_eq!(plan, EmptyExec::new());
+    assert_eq!(plan.get_column_result_fields(), Vec::<ColumnField>::new());
+    assert_eq!(
+        plan.get_column_references(),
+        IndexSet::<ColumnRef>::default()
+    );
+    assert_eq!(plan.get_table_references(), IndexSet::<TableRef>::default());
+}
+
+#[test]
+fn empty_exec_first_round_evaluates_to_one_empty_row() {
+    let alloc = Bump::new();
+    let plan = EmptyExec::new();
+    let mut builder = FirstRoundBuilder::new(1);
+    let table_map = IndexMap::default();
+    let params = Vec::<LiteralValue>::new();
+
+    let result = plan
+        .first_round_evaluate::<Curve25519Scalar>(&mut builder, &alloc, &table_map, &params)
+        .unwrap();
+
+    assert_eq!(result.num_rows(), 1);
+    assert_eq!(result.num_columns(), 0);
+}
+
+#[test]
+fn empty_exec_final_round_evaluates_to_one_empty_row() {
+    let alloc = Bump::new();
+    let plan = EmptyExec::new();
+    let mut builder = FinalRoundBuilder::new(1, VecDeque::new());
+    let table_map = IndexMap::default();
+    let params = Vec::<LiteralValue>::new();
+
+    let result = plan
+        .final_round_evaluate::<Curve25519Scalar>(&mut builder, &alloc, &table_map, &params)
+        .unwrap();
+
+    assert_eq!(result.num_rows(), 1);
+    assert_eq!(result.num_columns(), 0);
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -1,6 +1,8 @@
 //! This module proves provable execution plans.
 mod empty_exec;
 pub use empty_exec::EmptyExec;
+#[cfg(test)]
+mod empty_exec_test;
 
 mod table_exec;
 pub use table_exec::TableExec;


### PR DESCRIPTION
Adds focused coverage for `EmptyExec` as part of the test coverage bounty in #560.

This covers:
- `Default` / `new` construction equivalence
- empty column result fields
- empty column and table reference accessors
- first-round evaluation returning a one-row empty table
- final-round evaluation returning a one-row empty table

/claim #560

Verification run locally on aarch64:
- `cargo fmt --all`
- `cargo test -p proof-of-sql empty_exec --no-default-features --features test`
- `cargo check -p proof-of-sql --no-default-features --features test`

Note: default-feature tests/checks on this runner fail before crate testing because `blitzar-sys` and `halo2curves/asm` only support x86_64; the no-default `test` feature combination avoids those architecture-specific dependencies.