### PR TITLE
test: cover LegacyFilterExec accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_accessor_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_accessor_test.rs
@@ -1,0 +1,28 @@
+use super::LegacyFilterExec;
+use crate::{
+    base::database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+    sql::proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, LiteralExpr},
+};
+use sqlparser::ast::Ident;
+
+#[test]
+fn we_can_access_legacy_filter_exec_components() {
+    let table_ref = TableRef::new("sxt", "legacy_filter_accessor_tab");
+    let table = tab(&table_ref);
+    let aliased_results = vec![aliased_plan(
+        DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+            table_ref.clone(),
+            Ident::new("result_col"),
+            ColumnType::BigInt,
+        ))),
+        "result_col",
+    )];
+    let where_clause = DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true)));
+
+    let provable_ast =
+        LegacyFilterExec::new(aliased_results.clone(), table.clone(), where_clause.clone());
+
+    assert_eq!(provable_ast.aliased_results(), aliased_results.as_slice());
+    assert_eq!(provable_ast.table(), &table);
+    assert_eq!(provable_ast.where_clause(), &where_clause);
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -19,6 +19,8 @@ mod legacy_filter_exec;
 pub(crate) use legacy_filter_exec::LegacyFilterExec;
 #[cfg(test)]
 pub(crate) use legacy_filter_exec::OstensibleLegacyFilterExec;
+#[cfg(test)]
+mod legacy_filter_exec_accessor_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod legacy_filter_exec_test;
 #[cfg(all(test, feature = "blitzar"))]


### PR DESCRIPTION
## Summary
- add a lightweight unit test covering `LegacyFilterExec` accessor methods
- register the accessor test outside the `blitzar`-gated test module so it can run with the no-default test feature set

/claim #560

## Verification
- `cargo fmt`
- `cargo test -p proof-of-sql we_can_access_legacy_filter_exec_components --no-default-features --features test -- --nocapture`
- `cargo check -p proof-of-sql --no-default-features --features test`
- `git diff --check`
