### PR TITLE
test: cover comparison expression accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -620,3 +620,18 @@ fn we_cannot_equals_mismatching_types() {
         }
     ));
 }
+
+#[test]
+fn we_can_access_equals_expr_operands() {
+    let alloc = Bump::new();
+    let data = table([borrowed_bigint("a", [1_i64, 2, 3], &alloc)]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+    let lhs = Box::new(column(&t, "a", &accessor));
+    let rhs = Box::new(const_bigint(2_i64));
+
+    let equals_expr = EqualsExpr::try_new(lhs.clone(), rhs.clone()).unwrap();
+    assert_eq!(equals_expr.lhs(), lhs.as_ref());
+    assert_eq!(equals_expr.rhs(), rhs.as_ref());
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -849,3 +849,24 @@ fn we_cannot_inequality_mismatching_types() {
         }
     ));
 }
+
+#[test]
+fn we_can_access_inequality_expr_operands_and_direction() {
+    let alloc = Bump::new();
+    let data = table([borrowed_bigint("a", [1_i64, 2, 3], &alloc)]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+    let lhs = Box::new(column(&t, "a", &accessor));
+    let rhs = Box::new(const_bigint(2_i64));
+
+    let lt_expr = InequalityExpr::try_new(lhs.clone(), rhs.clone(), true).unwrap();
+    assert_eq!(lt_expr.lhs(), lhs.as_ref());
+    assert_eq!(lt_expr.rhs(), rhs.as_ref());
+    assert!(lt_expr.is_lt());
+
+    let gt_expr = InequalityExpr::try_new(lhs.clone(), rhs.clone(), false).unwrap();
+    assert_eq!(gt_expr.lhs(), lhs.as_ref());
+    assert_eq!(gt_expr.rhs(), rhs.as_ref());
+    assert!(!gt_expr.is_lt());
+}


### PR DESCRIPTION
## Summary
- add direct coverage for `EqualsExpr` operand accessors
- add direct coverage for `InequalityExpr` operand accessors and comparison direction flag

/claim #560

## Verification
- `cargo fmt --check`
- `cargo check -p proof-of-sql --no-default-features --features test`
- `git diff --check`

Note: default/blitzar test execution is unavailable in this aarch64 environment because `blitzar-sys` supports only x86_64 and `halo2curves` asm is x86_64-only.
