### PR TITLE
test: cover sign final-round bit proof

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -6,7 +6,8 @@ use crate::{
         scalar::{test_scalar::TestScalar, Scalar},
     },
     sql::proof::{
-        FinalRoundBuilder, SumcheckMleEvaluations, SumcheckRandomScalars, VerificationBuilderImpl,
+        FinalRoundBuilder, SumcheckMleEvaluations, SumcheckRandomScalars,
+        SumcheckSubpolynomialType, VerificationBuilderImpl,
     },
 };
 use alloc::collections::VecDeque;
@@ -34,6 +35,49 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_negative_constant_colum
     let sign = final_round_evaluate_sign(&mut builder, &alloc, &data);
     assert_eq!(sign, [true; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);
+}
+
+#[test]
+fn prover_evaluation_proves_varying_bits_are_binary() {
+    let data = [0_i64, 1, 0, 1];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
+    assert_eq!(dist.num_varying_bits(), 1);
+
+    let alloc = Bump::new();
+    let data: Vec<TestScalar> = data.into_iter().map(TestScalar::from).collect();
+    let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+    let sign = final_round_evaluate_sign(&mut builder, &alloc, &data);
+
+    assert_eq!(sign, [false; 4]);
+    assert_eq!(builder.bit_distributions(), [dist]);
+    assert_eq!(builder.pcs_proof_mles().len(), 1);
+    assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+
+    let subpolynomial = &builder.sumcheck_subpolynomials()[0];
+    let terms: Vec<_> = subpolynomial.iter_mul_by(TestScalar::ONE).collect();
+    assert_eq!(terms.len(), 2);
+    assert!(terms
+        .iter()
+        .all(|(kind, _, _)| *kind == SumcheckSubpolynomialType::Identity));
+    assert_eq!(terms[0].1, TestScalar::ONE);
+    assert_eq!(terms[1].1, -TestScalar::ONE);
+
+    for row in 0..data.len() {
+        let mut basis = vec![TestScalar::ZERO; data.len()];
+        basis[row] = TestScalar::ONE;
+        assert_eq!(builder.pcs_proof_mles()[0].inner_product(&basis), data[row]);
+        let value: TestScalar = terms
+            .iter()
+            .map(|(_, coefficient, multiplicands)| {
+                let product = multiplicands
+                    .iter()
+                    .map(|mle| mle.inner_product(&basis))
+                    .product::<TestScalar>();
+                *coefficient * product
+            })
+            .sum();
+        assert_eq!(value, TestScalar::ZERO);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a focused final-round sign gadget test for a column with one varying bit. The test checks that `final_round_evaluate_sign` records the expected bit distribution, produces the intermediate MLE for that bit, and emits the identity subpolynomial proving the bit values satisfy `b - b^2 = 0`.

/claim #560

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test,blitzar prover_evaluation_proves_varying_bits_are_binary -- --nocapture` (Docker/Linux)
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --check`
- `git diff --check`