### PR TITLE
test: cover rayon cfg macro

### DIFF
--- a/crates/proof-of-sql/src/base/rayon_cfg.rs
+++ b/crates/proof-of-sql/src/base/rayon_cfg.rs
@@ -11,3 +11,20 @@ macro_rules! if_rayon {
     }};
 }
 pub(crate) use if_rayon;
+
+#[cfg(test)]
+mod tests {
+    use super::if_rayon;
+
+    #[cfg(not(feature = "rayon"))]
+    #[test]
+    fn if_rayon_uses_else_value_without_rayon_feature() {
+        assert_eq!(if_rayon!(panic!("rayon branch should not run"), 7), 7);
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn if_rayon_uses_rayon_value_with_rayon_feature() {
+        assert_eq!(if_rayon!(11, panic!("else branch should not run")), 11);
+    }
+}


### PR DESCRIPTION
## Summary
- add cfg-specific unit coverage for the `if_rayon!` macro
- verify the serial branch under no-default features and the rayon branch with the `rayon` feature enabled

/claim #560

Payout address: 0xbb29837c5302E242CED1595d7BB8bA3ae7450362 on Arbitrum One USDC.

## Tests
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features "std test" if_rayon_uses_else_value_without_rayon_feature`
- `cargo test -p proof-of-sql --no-default-features --features "std test rayon" if_rayon_uses_rayon_value_with_rayon_feature`
- `git diff --check`
