### PR TITLE
test: cover aliased proof expr serde

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr_test.rs
@@ -1,0 +1,17 @@
+use super::{AliasedDynProofExpr, DynProofExpr};
+use crate::base::database::LiteralValue;
+use sqlparser::ast::Ident;
+
+#[test]
+fn aliased_dyn_proof_expr_round_trips_through_serde() {
+    let aliased_expr = AliasedDynProofExpr {
+        expr: DynProofExpr::new_literal(LiteralValue::Int(42)),
+        alias: Ident::new("answer"),
+    };
+
+    let serialized = serde_json::to_string(&aliased_expr).unwrap();
+    let deserialized: AliasedDynProofExpr = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(deserialized, aliased_expr);
+    assert_eq!(deserialized.alias.value, "answer");
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -7,6 +7,8 @@ mod proof_expr_test;
 
 mod aliased_dyn_proof_expr;
 pub use aliased_dyn_proof_expr::AliasedDynProofExpr;
+#[cfg(test)]
+mod aliased_dyn_proof_expr_test;
 
 mod add_expr;
 pub(crate) use add_expr::AddExpr;


### PR DESCRIPTION
## Summary
- add focused coverage for `AliasedDynProofExpr` serde round-tripping
- verify aliases and wrapped dynamic literal expressions survive serialization/deserialization intact

## Tests
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test aliased_dyn_proof_expr_round_trips_through_serde -- --nocapture`
- `cargo check -p proof-of-sql --no-default-features --features test`

Note: full default-feature tests were not run on this aarch64 environment because existing default `blitzar`/asm dependencies are x86_64-specific here.

/claim #560
