### PR TITLE
test: cover cast expression accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -99,3 +99,18 @@ impl ProofExpr for CastExpr {
         self.from_expr.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_get_cast_expr_inputs_and_target_type() {
+        let from_expr = DynProofExpr::new_literal(LiteralValue::TinyInt(7));
+        let cast_expr =
+            CastExpr::try_new(Box::new(from_expr.clone()), ColumnType::SmallInt).unwrap();
+
+        assert_eq!(cast_expr.get_from_expr(), &from_expr);
+        assert_eq!(cast_expr.to_type(), &ColumnType::SmallInt);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
@@ -110,3 +110,21 @@ impl ProofExpr for ScalingCastExpr {
         self.from_expr.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::math::decimal::Precision;
+
+    #[test]
+    fn we_can_get_scaling_cast_expr_inputs_target_type_and_factor() {
+        let from_expr = DynProofExpr::new_literal(LiteralValue::SmallInt(3));
+        let to_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 5);
+        let scaling_cast_expr =
+            ScalingCastExpr::try_new(Box::new(from_expr.clone()), to_type).unwrap();
+
+        assert_eq!(scaling_cast_expr.get_from_expr(), &from_expr);
+        assert_eq!(scaling_cast_expr.to_type(), &to_type);
+        assert_eq!(scaling_cast_expr.scaling_factor(), [100000, 0, 0, 0]);
+    }
+}


### PR DESCRIPTION
## Summary
- add focused unit coverage for `CastExpr` accessor methods
- add focused unit coverage for `ScalingCastExpr` accessor methods, including the stored scaling factor
- keep the tests in the source modules so they run without the local `blitzar` feature gate

## Tests
- `cargo fmt --check`
- `cargo test -p proof-of-sql we_can_get_cast_expr_inputs_and_target_type --no-default-features --features std,test -- --nocapture`
- `cargo test -p proof-of-sql we_can_get_scaling_cast_expr_inputs_target_type_and_factor --no-default-features --features std,test -- --nocapture`
- `cargo check -p proof-of-sql --no-default-features --features std,test`

Refs #560
