### PR TITLE
test: cover big decimal table parsing thresholds

### DIFF
--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,28 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn test_find_bigdecimals_ignores_non_create_table_statements() {
+        let sql = "CREATE VIEW ETHEREUM.BIG_DECIMALS AS SELECT 1 AS VALUE;";
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert!(bigdecimals.is_empty());
+    }
+
+    #[test]
+    fn test_find_bigdecimals_requires_precision_scale_and_precision_threshold() {
+        let sql = "CREATE TABLE IF NOT EXISTS ANALYTICS.AMOUNTS(
+            THRESHOLD DECIMAL(38, 2),
+            OVERSIZED DECIMAL(39, 2),
+            PRECISION_ONLY DECIMAL(80),
+            UNBOUNDED DECIMAL
+        );";
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(
+            bigdecimals.get("ANALYTICS.AMOUNTS").unwrap(),
+            &[("OVERSIZED".to_string(), 39, 2)]
+        );
+    }
 }


### PR DESCRIPTION
Addresses #560

## Summary
- Add coverage that `find_bigdecimals` ignores non-`CREATE TABLE` statements.
- Cover the explicit precision/scale threshold behavior for `DECIMAL`, including ignored threshold, precision-only, and unbounded decimal forms.

/claim #560

## Validation
- `PATH=/Users/jakehatchett/.cargo/bin:$PATH cargo test -p proof-of-sql --no-default-features --features std find_bigdecimals`
- `PATH=/Users/jakehatchett/.cargo/bin:$PATH cargo fmt --all -- --check`
- `git diff --check`

## Disclosure
- Prepared with AI assistance in Codex.
