### PR TITLE
test: cover dynamic proof expression constructors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -122,3 +122,93 @@ impl DynProofExpr {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{database::TableRef, math::decimal::Precision, proof::PlaceholderError},
+        sql::AnalyzeError,
+    };
+
+    #[test]
+    fn constructors_wrap_the_expected_variants_and_types() {
+        let table_ref = TableRef::new("sxt", "t");
+        let column_ref = ColumnRef::new(table_ref, "amount".into(), ColumnType::BigInt);
+        let column_expr = DynProofExpr::new_column(column_ref.clone());
+        assert!(
+            matches!(&column_expr, DynProofExpr::Column(expr) if expr.column_ref() == &column_ref)
+        );
+        assert_eq!(column_expr.data_type(), ColumnType::BigInt);
+
+        let literal_expr = DynProofExpr::new_literal(LiteralValue::Boolean(true));
+        assert!(matches!(literal_expr, DynProofExpr::Literal(_)));
+        assert_eq!(literal_expr.data_type(), ColumnType::Boolean);
+
+        let placeholder_expr = DynProofExpr::try_new_placeholder(2, ColumnType::VarChar).unwrap();
+        assert!(matches!(&placeholder_expr, DynProofExpr::Placeholder(expr) if expr.index() == 1));
+        assert_eq!(placeholder_expr.data_type(), ColumnType::VarChar);
+    }
+
+    #[test]
+    fn boolean_constructors_reject_non_boolean_inputs() {
+        let numeric_expr = DynProofExpr::new_literal(LiteralValue::BigInt(7));
+        let boolean_expr = DynProofExpr::new_literal(LiteralValue::Boolean(true));
+
+        assert!(DynProofExpr::try_new_not(numeric_expr.clone()).is_err());
+        assert!(DynProofExpr::try_new_and(numeric_expr.clone(), boolean_expr.clone()).is_err());
+        assert!(DynProofExpr::try_new_or(boolean_expr, numeric_expr).is_err());
+    }
+
+    #[test]
+    fn comparison_and_arithmetic_constructors_wrap_valid_inputs() {
+        let lhs = DynProofExpr::new_literal(LiteralValue::BigInt(7));
+        let rhs = DynProofExpr::new_literal(LiteralValue::BigInt(11));
+
+        assert!(matches!(
+            DynProofExpr::try_new_equals(lhs.clone(), rhs.clone()).unwrap(),
+            DynProofExpr::Equals(_)
+        ));
+        assert!(matches!(
+            DynProofExpr::try_new_inequality(lhs.clone(), rhs.clone(), true).unwrap(),
+            DynProofExpr::Inequality(_)
+        ));
+        assert!(matches!(
+            DynProofExpr::try_new_add(lhs.clone(), rhs.clone()).unwrap(),
+            DynProofExpr::Add(_)
+        ));
+        assert!(matches!(
+            DynProofExpr::try_new_subtract(lhs.clone(), rhs.clone()).unwrap(),
+            DynProofExpr::Subtract(_)
+        ));
+        assert!(matches!(
+            DynProofExpr::try_new_multiply(lhs, rhs).unwrap(),
+            DynProofExpr::Multiply(_)
+        ));
+    }
+
+    #[test]
+    fn cast_constructors_wrap_valid_inputs() {
+        let bigint_expr = DynProofExpr::new_literal(LiteralValue::BigInt(7));
+        let decimal_type = ColumnType::Decimal75(Precision::new(21).unwrap(), 2);
+
+        assert!(matches!(
+            DynProofExpr::try_new_cast(bigint_expr.clone(), ColumnType::Int128).unwrap(),
+            DynProofExpr::Cast(_)
+        ));
+        assert!(matches!(
+            DynProofExpr::try_new_scaling_cast(bigint_expr, decimal_type).unwrap(),
+            DynProofExpr::ScalingCast(_)
+        ));
+    }
+
+    #[test]
+    fn placeholder_constructor_forwards_zero_id_errors() {
+        assert!(matches!(
+            DynProofExpr::try_new_placeholder(0, ColumnType::Boolean),
+            Err(AnalyzeError::PlaceholderError {
+                source: PlaceholderError::ZeroPlaceholderId
+            })
+        ));
+    }
+}


### PR DESCRIPTION
Adds focused unit coverage for `DynProofExpr` constructor helpers as part of #560.

What changed:
- covers constructor wrapping and `data_type()` behavior for column, literal, and placeholder expressions
- covers boolean constructor rejection for non-boolean inputs
- covers comparison, arithmetic, cast, and scaling cast constructors wrapping valid inputs
- covers forwarding of zero placeholder id errors

Verification:
- `cargo test --package proof-of-sql --no-default-features --features test,std sql::proof_exprs::dyn_proof_expr::tests`
- `cargo fmt --check -p proof-of-sql`
- `cargo check -p proof-of-sql --no-default-features --features test`
- `git diff --check`

Note: default-feature tests are not runnable on this aarch64 runner because upstream default `perf` dependencies require x86_64 (`blitzar-sys` and `halo2curves/asm`).

/claim #560
