### PR TITLE
ci: install evm test toolchain before cache

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -329,8 +329,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install
+      - name: Install Rust EVM test toolchain
+        uses: dtolnay/rust-toolchain@1.85.0
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install Dependencies
@@ -345,7 +345,6 @@ jobs:
           version: v1.0.0
       - name: Install dependencies
         run: solidity/scripts/install_deps.sh
-      - uses: dtolnay/rust-toolchain@1.85.0
       - name: Run Rust EVM tests
         run: cargo test --package proof-of-sql --lib --all-features -- evm_tests --ignored --test-threads=1
       - name: Run Planner Rust EVM tests


### PR DESCRIPTION
Addresses #557

## Summary
- Install the Rust EVM test job's actual Rust 1.85.0 toolchain before restoring the Rust cache.
- Remove the later duplicate `dtolnay/rust-toolchain@1.85.0` step immediately before the EVM cargo tests.
- Keep the EVM test commands unchanged while making cache restore align with the toolchain used by those tests.

/claim #557

## Validation
- `git diff --check HEAD~1..HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lint-and-test.yml"); puts "yaml ok"'`
- `source scripts/check_commits.sh`

## Disclosure
- Prepared with AI assistance in Codex and reviewed before submission.
