### PR TITLE
test: shrink Dory commitment test setup

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -12,9 +12,12 @@ use ark_ec::pairing::Pairing;
 use ark_std::test_rng;
 use num_traits::Zero;
 
+const DORY_COMMITMENT_TEST_MAX_NU: usize = 4;
+
 #[test]
 fn we_can_compute_a_dory_commitment_with_varbinary_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
 
@@ -34,7 +37,8 @@ fn we_can_compute_a_dory_commitment_with_varbinary_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_int128_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::Int128(&[0, -1, 2])], 0, &setup);
@@ -48,7 +52,8 @@ fn we_can_compute_a_dory_commitment_with_int128_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_boolean_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -66,7 +71,8 @@ fn we_can_compute_a_dory_commitment_with_boolean_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2])], 0, &setup);
@@ -80,7 +86,8 @@ fn we_can_compute_a_dory_commitment_with_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3])], 0, &setup);
@@ -95,7 +102,8 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[2, 3])], 2, &setup);
@@ -108,7 +116,8 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with_signed_data() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
@@ -121,7 +130,8 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -146,7 +156,8 @@ fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -182,7 +193,8 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1])], 5, &setup);
@@ -195,7 +207,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -220,7 +233,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns()
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -256,7 +270,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
 
 #[test]
 fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -342,7 +357,8 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
 
 #[test]
 fn we_can_compute_an_empty_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
@@ -385,7 +401,8 @@ fn we_can_compute_an_empty_dory_commitment() {
 
 #[test]
 fn test_compute_dory_commitment_when_sigma_is_zero() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 0, &setup);
@@ -401,7 +418,8 @@ fn test_compute_dory_commitment_when_sigma_is_zero() {
 
 #[test]
 fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 5, &setup);
@@ -417,7 +435,8 @@ fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -494,7 +513,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_fewer_rows_than_columns(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -570,7 +590,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -659,7 +680,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters =
+        PublicParameters::test_rand(DORY_COMMITMENT_TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(


### PR DESCRIPTION
## Summary
- reduce the Dory commitment unit-test public parameter size from `max_nu = 5` to a named `DORY_COMMITMENT_TEST_MAX_NU = 4`
- keep the same commitment inputs and expected pairing assertions
- this still covers the largest expected index used by these tests while avoiding over-provisioned setup generation in 20 tests

/claim #557

## Verification
- `cargo fmt`
- `cargo test -p proof-of-sql --no-default-features --features test proof_primitive::dory::dory_compute_commitments_test -- --nocapture` (20 passed; finished in 15.89s)
- `cargo check -p proof-of-sql --no-default-features --features test`
- `cargo fmt --check`
- `git diff --check`

Note: default-feature focused test was attempted first but is unavailable on this aarch64 runner because `halo2curves` asm and `blitzar-sys` require x86_64, matching the known local limitation from prior SxT work.