### PR TITLE
test: shrink Dory inner product setup

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_inner_product_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_inner_product_test.rs
@@ -32,12 +32,12 @@ fn we_can_prove_and_verify_a_dory_inner_product() {
 #[test]
 fn we_can_prove_and_verify_a_dory_inner_product_for_multiple_nu_values() {
     let mut rng = test_rng();
-    let max_nu = 5;
-    let pp = PublicParameters::test_rand(max_nu, &mut rng);
+    let max_test_nu = 4;
+    let pp = PublicParameters::test_rand(max_test_nu, &mut rng);
     let prover_setup = (&pp).into();
     let verifier_setup = (&pp).into();
 
-    for nu in 0..max_nu {
+    for nu in 0..=max_test_nu {
         let (v1, v2) = rand_G_vecs(nu, &mut rng);
         let prover_state = ProverState::new(v1, v2, nu);
         let verifier_state = prover_state.calculate_verifier_state(&prover_setup);

--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re_test.rs
@@ -35,12 +35,12 @@ fn we_can_prove_and_verify_an_eval_vmv_re() {
 #[test]
 fn we_can_prove_and_verify_an_eval_vmv_re_for_multiple_nu_values() {
     let mut rng = test_rng();
-    let max_nu = 5;
-    let pp = PublicParameters::test_rand(max_nu, &mut rng);
+    let max_test_nu = 4;
+    let pp = PublicParameters::test_rand(max_test_nu, &mut rng);
     let prover_setup = (&pp).into();
     let verifier_setup = (&pp).into();
 
-    for nu in 0..max_nu {
+    for nu in 0..=max_test_nu {
         let vmv = VMV::rand(nu, &mut rng);
         let prover_state = vmv.calculate_prover_state(&prover_setup);
         let verifier_state = vmv.calculate_verifier_state(&prover_setup);

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product_test.rs
@@ -35,12 +35,12 @@ fn we_can_prove_and_verify_an_extended_dory_inner_product() {
 #[test]
 fn we_can_prove_and_verify_an_extended_dory_inner_product_for_multiple_nu_values() {
     let mut rng = test_rng();
-    let max_nu = 5;
-    let pp = PublicParameters::test_rand(max_nu, &mut rng);
+    let max_test_nu = 4;
+    let pp = PublicParameters::test_rand(max_test_nu, &mut rng);
     let prover_setup = (&pp).into();
     let verifier_setup = (&pp).into();
 
-    for nu in 0..max_nu {
+    for nu in 0..=max_test_nu {
         let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
         let (v1, v2) = rand_G_vecs(nu, &mut rng);
         let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);


### PR DESCRIPTION
## Summary
- shrink the Dory public/prover setup generated by the three multi-nu inner-product style tests from max setup `5` to `4`
- keep the actual exercised `nu` cases unchanged by switching the loops from `0..5` to `0..=4`
- reduce setup generation work without removing or weakening assertions

/claim #557

## Verification
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test proof_primitive::dory::dory_inner_product_test -- --nocapture` (10 passed)
- `cargo test -p proof-of-sql --no-default-features --features test proof_primitive::dory::eval_vmv_re_test -- --nocapture` (8 passed)
- `cargo test -p proof-of-sql --no-default-features --features test proof_primitive::dory::extended_dory_inner_product_test -- --nocapture` (11 passed)
- `cargo check -p proof-of-sql --no-default-features --features test`
- `git diff --check`

Note: this is a small focused test-runtime reduction for the Dory setup-heavy tests. The explicit `nu` values remain `0, 1, 2, 3, 4`; only the generated setup capacity is reduced to the largest value the tests actually use.