### PR TITLE
refactor: add explicit string scalar hashing

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -279,7 +279,7 @@ impl ArrayRefExt for ArrayRef {
                     let scals = if let Some(scals) = precomputed_scals {
                         &scals[range.start..range.end]
                     } else {
-                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S { vals[i].into() })
+                        alloc.alloc_slice_fill_with(vals.len(), |i| S::from_str_via_hash(vals[i]))
                     };
 
                     Ok(Column::VarChar((vals, scals)))
@@ -430,7 +430,10 @@ mod tests {
         let array: ArrayRef = Arc::new(StringArray::from(vec!["hello", "world", "test"]));
         let result = array.to_column::<TestScalar>(&alloc, &(1..3), None);
         let expected_vals = vec!["world", "test"];
-        let expected_scals: Vec<TestScalar> = expected_vals.iter().map(|&v| v.into()).collect();
+        let expected_scals: Vec<TestScalar> = expected_vals
+            .iter()
+            .map(|&v| TestScalar::from_str_via_hash(v))
+            .collect();
 
         assert_eq!(
             result.unwrap(),
@@ -463,7 +466,7 @@ mod tests {
         let array: ArrayRef = Arc::new(StringArray::from(vec!["hello", "world", "test"]));
         let precomputed_scals: Vec<DoryScalar> = ["hello", "world", "test"]
             .iter()
-            .map(|&v| v.into())
+            .map(|&v| DoryScalar::from_str_via_hash(v))
             .collect();
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), Some(&precomputed_scals));
         let expected_vals = vec!["world", "test"];
@@ -1007,7 +1010,10 @@ mod tests {
     fn we_can_convert_valid_string_array_refs_into_valid_columns() {
         let alloc = Bump::new();
         let data = vec!["ab", "-f34"];
-        let scals: Vec<_> = data.iter().map(core::convert::Into::into).collect();
+        let scals: Vec<_> = data
+            .iter()
+            .map(|&v| DoryScalar::from_str_via_hash(v))
+            .collect();
         let array: ArrayRef = Arc::new(arrow::array::StringArray::from(data.clone()));
         assert_eq!(
             array
@@ -1141,7 +1147,10 @@ mod tests {
     {
         let alloc = Bump::new();
         let data = ["ab", "-f34", "ehfh43"];
-        let scals: Vec<_> = data.iter().map(core::convert::Into::into).collect();
+        let scals: Vec<_> = data
+            .iter()
+            .map(|&v| DoryScalar::from_str_via_hash(v))
+            .collect();
 
         let array: ArrayRef = Arc::new(arrow::array::StringArray::from(data.to_vec()));
         assert_eq!(
@@ -1176,7 +1185,10 @@ mod tests {
     fn we_can_convert_valid_string_array_refs_into_valid_columns_using_precomputed_scalars() {
         let alloc = Bump::new();
         let data = vec!["ab", "-f34"];
-        let scals: Vec<_> = data.iter().map(core::convert::Into::into).collect();
+        let scals: Vec<_> = data
+            .iter()
+            .map(|&v| TestScalar::from_str_via_hash(v))
+            .collect();
         let array: ArrayRef = Arc::new(arrow::array::StringArray::from(data.clone()));
         assert_eq!(
             array

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -128,7 +128,7 @@ mod tests {
         )
         .unwrap();
 
-        let b_scals = ["1".into(), "2".into(), "3".into()];
+        let b_scals = ["1", "2", "3"].map(TestScalar::from_str_via_hash);
 
         let columns = [
             (&"a".into(), &Column::<TestScalar>::BigInt(&[1, 2, 3])),
@@ -161,7 +161,7 @@ mod tests {
         )
         .unwrap();
 
-        let b_scals2 = ["4".into(), "5".into(), "6".into()];
+        let b_scals2 = ["4", "5", "6"].map(TestScalar::from_str_via_hash);
 
         let columns2 = [
             (&"a".into(), &Column::<TestScalar>::BigInt(&[4, 5, 6])),

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -162,7 +162,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
             OwnedColumn::VarChar(strings) => CommittableColumn::VarChar(
                 strings
                     .iter()
-                    .map(Into::<S>::into)
+                    .map(|s| S::from_str_via_hash(s))
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),
@@ -807,7 +807,12 @@ mod tests {
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
-            CommittableColumn::VarChar(strings.map(TestScalar::from).map(<[u64; 4]>::from).into())
+            CommittableColumn::VarChar(
+                strings
+                    .map(|s| TestScalar::from_str_via_hash(&s))
+                    .map(<[u64; 4]>::from)
+                    .into()
+            )
         );
     }
 

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -1167,7 +1167,7 @@ mod tests {
         )
         .unwrap();
 
-        let b_scals = ["1".into(), "2".into(), "3".into()];
+        let b_scals = ["1", "2", "3"].map(TestScalar::from_str_via_hash);
 
         let columns = [
             (&"a".into(), &Column::<TestScalar>::BigInt(&[1, 2, 3])),
@@ -1199,7 +1199,7 @@ mod tests {
         )
         .unwrap();
 
-        let b_scals2 = ["4".into(), "5".into(), "6".into()];
+        let b_scals2 = ["4", "5", "6"].map(TestScalar::from_str_via_hash);
 
         let columns2 = [
             (&"a".into(), &Column::<TestScalar>::BigInt(&[4, 5, 6])),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -139,7 +139,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, S::from(string)),
+                alloc.alloc_slice_fill_copy(length, S::from_str_via_hash(string)),
             )),
             LiteralValue::VarBinary(bytes) => {
                 // Convert the bytes to a slice of bytes references
@@ -177,7 +177,10 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
             OwnedColumn::VarChar(col) => {
-                let scalars = col.iter().map(S::from).collect::<Vec<_>>();
+                let scalars = col
+                    .iter()
+                    .map(|s| S::from_str_via_hash(s))
+                    .collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)
@@ -460,7 +463,10 @@ mod tests {
             "Spațiu și Timp",
             "Spazju u Ħin",
         ];
-        let scalars = strs.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strs
+            .iter()
+            .map(|&s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let owned_col = OwnedColumn::VarChar(
             strs.iter()
                 .map(ToString::to_string)

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -138,14 +138,17 @@ mod tests {
         assert_eq!(result, Column::Scalar(&expected_scalars));
 
         let strings = vec!["a", "b", "c"];
-        let scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strings
+            .iter()
+            .map(|&s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let column: Column<TestScalar> = Column::VarChar((&strings, &scalars));
         let indexes = [2, 1, 1];
         let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
         let expected_strings = vec!["c", "b", "b"];
         let expected_scalars = expected_strings
             .iter()
-            .map(TestScalar::from)
+            .map(|&s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         assert_eq!(
             result,

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -165,13 +165,16 @@ mod tests {
 
         // Varchar
         let strings = vec!["a", "b", "c"];
-        let scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strings
+            .iter()
+            .map(|&s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let column: Column<TestScalar> = Column::VarChar((&strings, &scalars));
         let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
         let doubled_strings = vec!["a", "b", "c", "a", "b", "c"];
         let doubled_scalars = doubled_strings
             .iter()
-            .map(TestScalar::from)
+            .map(|&s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         assert_eq!(
             result,
@@ -189,13 +192,16 @@ mod tests {
 
         // Varchar
         let strings = vec!["a", "b", "c"];
-        let scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strings
+            .iter()
+            .map(|&s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let column: Column<TestScalar> = Column::VarChar((&strings, &scalars));
         let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
         let doubled_strings = vec!["a", "a", "b", "b", "c", "c"];
         let doubled_scalars = doubled_strings
             .iter()
-            .map(TestScalar::from)
+            .map(|&s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         assert_eq!(
             result,

--- a/crates/proof-of-sql/src/base/database/columnar_value.rs
+++ b/crates/proof-of-sql/src/base/database/columnar_value.rs
@@ -66,7 +66,6 @@ impl<'a, S: Scalar> ColumnarValue<'a, S> {
 mod tests {
     use super::*;
     use crate::base::scalar::test_scalar::TestScalar;
-    use core::convert::Into;
 
     #[test]
     fn we_can_get_column_type_of_columnar_values() {
@@ -114,7 +113,10 @@ mod tests {
         );
 
         let strings = ["a", "b", "c"];
-        let scalars: Vec<TestScalar> = strings.iter().map(Into::into).collect();
+        let scalars: Vec<TestScalar> = strings
+            .iter()
+            .map(|&s| TestScalar::from_str_via_hash(s))
+            .collect();
         let columnar_value =
             ColumnarValue::Column(Column::<TestScalar>::VarChar((&strings, &scalars)));
         let res = columnar_value.into_column(0, &bump);

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,14 +1,14 @@
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
-    scalar::test_scalar::TestScalar,
+    scalar::{test_scalar::TestScalar, Scalar},
 };
 use bumpalo::Bump;
 
 #[test]
 fn we_can_filter_columns() {
     let selection = vec![true, false, true, false, true];
-    let str_scalars: [TestScalar; 5] = ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let str_scalars: [TestScalar; 5] = ["1", "2", "3", "4", "5"].map(TestScalar::from_str_via_hash);
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![
@@ -26,7 +26,10 @@ fn we_can_filter_columns() {
         vec![
             Column::BigInt(&[1, 3, 5]),
             Column::Int128(&[1, 3, 5]),
-            Column::VarChar((&["1", "3", "5"], &["1".into(), "3".into(), "5".into()])),
+            Column::VarChar((
+                &["1", "3", "5"],
+                &["1", "3", "5"].map(TestScalar::from_str_via_hash),
+            )),
             Column::Scalar(&[1.into(), 3.into(), 5.into()]),
             Column::Decimal75(
                 Precision::new(75).unwrap(),
@@ -39,7 +42,7 @@ fn we_can_filter_columns() {
 #[test]
 fn we_can_filter_columns_with_empty_result() {
     let selection = vec![false, false, false, false, false];
-    let str_scalars: [TestScalar; 5] = ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let str_scalars: [TestScalar; 5] = ["1", "2", "3", "4", "5"].map(TestScalar::from_str_via_hash);
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         database::{group_by_util::*, Column},
-        scalar::test_scalar::TestScalar,
+        scalar::{test_scalar::TestScalar, Scalar},
     },
     proof_primitive::dory::DoryScalar,
 };
@@ -162,7 +162,10 @@ fn we_can_aggregate_columns() {
     let selection = &[
         false, true, true, true, true, true, true, true, true, true, true, true,
     ];
-    let scals_b: Vec<TestScalar> = slice_b.iter().map(core::convert::Into::into).collect();
+    let scals_b: Vec<TestScalar> = slice_b
+        .iter()
+        .map(|&s| TestScalar::from_str_via_hash(s))
+        .collect();
     let scals_d: Vec<TestScalar> = slice_d.iter().map(core::convert::Into::into).collect();
     let column_a = Column::BigInt(slice_a);
     let column_b = Column::VarChar((slice_b, &scals_b));
@@ -183,12 +186,12 @@ fn we_can_aggregate_columns() {
     )
     .expect("Aggregation should succeed");
     let scals_res = [
-        TestScalar::from("Cat"),
-        TestScalar::from("Dog"),
-        TestScalar::from("Cat"),
-        TestScalar::from("Dog"),
-        TestScalar::from("Cat"),
-        TestScalar::from("Dog"),
+        TestScalar::from_str_via_hash("Cat"),
+        TestScalar::from_str_via_hash("Dog"),
+        TestScalar::from_str_via_hash("Cat"),
+        TestScalar::from_str_via_hash("Dog"),
+        TestScalar::from_str_via_hash("Cat"),
+        TestScalar::from_str_via_hash("Dog"),
     ];
     let expected_group_by_result = &[
         Column::BigInt(&[1, 1, 2, 2, 3, 3]),

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -81,7 +81,7 @@ impl LiteralValue {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar(str) => str.into(),
+            Self::VarChar(str) => S::from_str_via_hash(str),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         database::{order_by_util::*, Column, ColumnType, TableOperationError},
-        scalar::test_scalar::TestScalar,
+        scalar::{test_scalar::TestScalar, Scalar},
     },
     proof_primitive::dory::DoryScalar,
 };
@@ -50,7 +50,10 @@ fn we_can_compare_indexes_by_columns_for_mixed_columns() {
     let slice_a = &["55", "44", "66", "66", "66", "77", "66", "66", "66", "66"];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];
     let slice_c = &[11, 55, 11, 44, 77, 11, 22, 55, 11, 22];
-    let scals_a: Vec<TestScalar> = slice_a.iter().map(core::convert::Into::into).collect();
+    let scals_a: Vec<TestScalar> = slice_a
+        .iter()
+        .map(|&s| TestScalar::from_str_via_hash(s))
+        .collect();
     let column_a = Column::VarChar((slice_a, &scals_a));
     let column_b = Column::Int128(slice_b);
     let column_c = Column::BigInt(slice_c);

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -10,7 +10,7 @@ use crate::base::{
     },
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::Scalar,
-    slice_ops::{inner_product_ref_cast, inner_product_with_bytes},
+    slice_ops::{inner_product_ref_cast, inner_product_with_bytes, inner_product_with_strings},
 };
 use alloc::{
     string::{String, ToString},
@@ -65,7 +65,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {
                 inner_product_ref_cast(col, vec)
             }
-            OwnedColumn::VarChar(col) => inner_product_ref_cast(col, vec),
+            OwnedColumn::VarChar(col) => inner_product_with_strings(col, vec),
             OwnedColumn::VarBinary(col) => inner_product_with_bytes(col, vec),
             OwnedColumn::Int128(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => {
@@ -514,7 +514,10 @@ mod test {
             "ቦታ እና ጊዜ",
             "სივრცე და დრო",
         ];
-        let scalars = strs.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strs
+            .iter()
+            .map(|&s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let col: Column<'_, TestScalar> = Column::VarChar((&strs, &scalars));
         let owned_col: OwnedColumn<TestScalar> = (&col).into();
         assert_eq!(
@@ -581,7 +584,7 @@ mod test {
     fn we_cannot_convert_scalars_to_owned_columns_if_varchar() {
         let scalars = ["a", "b", "c", "d", "e"]
             .iter()
-            .map(TestScalar::from)
+            .map(|&s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         let column_type = ColumnType::VarChar;
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
@@ -659,7 +662,7 @@ mod test {
     fn we_cannot_convert_option_scalars_to_owned_columns_if_varchar() {
         let option_scalars = ["a", "b", "c", "d", "e"]
             .iter()
-            .map(|s| Some(TestScalar::from(*s)))
+            .map(|&s| Some(TestScalar::from_str_via_hash(s)))
             .collect::<Vec<_>>();
         let column_type = ColumnType::VarChar;
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
     map::IndexMap,
-    scalar::ScalarExt,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
@@ -108,7 +108,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
                 let scals: &mut [_] = self
                     .alloc
-                    .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
+                    .alloc_slice_fill_iter(col.iter().map(|s| CP::Scalar::from_str_via_hash(s)));
                 Column::VarChar((col, scals))
             }
             OwnedColumn::VarBinary(col) => {

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -9,7 +9,7 @@ use crate::base::{
     },
     database::{owned_table_utility::*, TableRef},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::test_scalar::TestScalar,
+    scalar::{test_scalar::TestScalar, Scalar},
 };
 
 #[test]
@@ -78,7 +78,7 @@ fn we_can_access_the_columns_of_a_table() {
     let col_slice: Vec<_> = vec!["a", "bc", "d", "e"];
     let col_scalars: Vec<_> = ["a", "bc", "d", "e"]
         .iter()
-        .map(core::convert::Into::into)
+        .map(|&s| TestScalar::from_str_via_hash(s))
         .collect();
     match accessor.get_column(&table_ref_2, &"varchar".into()) {
         Column::VarChar((col, scals)) => {

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -2,7 +2,7 @@ use crate::base::{
     database::{table_utility::*, Column, Table, TableError, TableOptions},
     map::{indexmap, IndexMap},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::test_scalar::TestScalar,
+    scalar::{test_scalar::TestScalar, Scalar},
 };
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
@@ -176,7 +176,10 @@ fn we_can_create_a_table_with_data() {
         .map(|&s| alloc.alloc_str(s) as &str)
         .collect();
     let varchar_str_slice = alloc.alloc_slice_clone(&varchar_data);
-    let varchar_scalars: Vec<TestScalar> = varchar_data.iter().map(Into::into).collect();
+    let varchar_scalars: Vec<TestScalar> = varchar_data
+        .iter()
+        .map(|&s| TestScalar::from_str_via_hash(s))
+        .collect();
     let varchar_scalars_slice = alloc.alloc_slice_clone(&varchar_scalars);
     expected_table.insert(
         Ident::new("varchar"),

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -9,7 +9,7 @@ use crate::base::{
     },
     database::{table_utility::*, TableRef},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::test_scalar::TestScalar,
+    scalar::{test_scalar::TestScalar, Scalar},
 };
 use bumpalo::Bump;
 
@@ -91,7 +91,7 @@ fn we_can_access_the_columns_of_a_table() {
     let col_slice: Vec<_> = vec!["a", "bc", "d", "e"];
     let col_scalars: Vec<_> = ["a", "bc", "d", "e"]
         .iter()
-        .map(core::convert::Into::into)
+        .map(|&s| TestScalar::from_str_via_hash(s))
         .collect();
     match accessor.get_column(&table_ref_2, &"varchar".into()) {
         Column::VarChar((col, scals)) => {

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -288,7 +288,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
         })
         .collect();
     let alloc_strings = alloc.alloc_slice_clone(&strings);
-    let scalars: Vec<S> = strings.iter().map(|s| (*s).into()).collect();
+    let scalars: Vec<S> = strings.iter().map(|s| S::from_str_via_hash(s)).collect();
     let alloc_scalars = alloc.alloc_slice_copy(&scalars);
     (name.into(), Column::VarChar((alloc_strings, alloc_scalars)))
 }

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -268,7 +268,7 @@ mod tests {
         let strings = vec!["a", "b", "c"];
         let scalars = strings
             .iter()
-            .map(|s| TestScalar::from(*s))
+            .map(|&s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         let col0: Column<TestScalar> = Column::VarChar((&strings, &scalars));
         let col1: Column<TestScalar> = Column::VarChar((&strings, &scalars));

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -1,9 +1,5 @@
 use crate::base::scalar::{Scalar, ScalarConversionError, ScalarExt};
-use alloc::{
-    format,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{format, string::ToString, vec::Vec};
 use ark_ff::{AdditiveGroup, BigInteger, Field, Fp, Fp256, MontBackend, MontConfig, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bnum::types::U256;
@@ -138,17 +134,6 @@ impl<T: MontConfig<4>> From<&[u8]> for MontScalar<T> {
     }
 }
 
-/// Implements `From<T>` for [`MontScalar`] for string-like types by hashing the bytes.
-macro_rules! impl_from_for_mont_scalar_for_string {
-    ($tt:ty) => {
-        impl<T: MontConfig<4>> From<$tt> for MontScalar<T> {
-            fn from(x: $tt) -> Self {
-                x.as_bytes().into()
-            }
-        }
-    };
-}
-
 impl_from_for_mont_scalar_for_type_supported_by_from!(bool);
 impl_from_for_mont_scalar_for_type_supported_by_from!(u8);
 impl_from_for_mont_scalar_for_type_supported_by_from!(u16);
@@ -160,8 +145,6 @@ impl_from_for_mont_scalar_for_type_supported_by_from!(i16);
 impl_from_for_mont_scalar_for_type_supported_by_from!(i32);
 impl_from_for_mont_scalar_for_type_supported_by_from!(i64);
 impl_from_for_mont_scalar_for_type_supported_by_from!(i128);
-impl_from_for_mont_scalar_for_string!(&str);
-impl_from_for_mont_scalar_for_string!(String);
 
 impl<F: MontConfig<4>, T> From<&T> for MontScalar<F>
 where

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,10 +1,10 @@
 #![expect(clippy::module_inception)]
 
 use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
-use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
+use tiny_keccak::Hasher;
 
 /// A trait for the scalar field used in Proof of SQL.
 pub trait Scalar:
@@ -13,7 +13,6 @@ pub trait Scalar:
     + core::fmt::Display
     + PartialEq
     + Default
-    + for<'a> From<&'a str>
     + Sync
     + Send
     + num_traits::One
@@ -52,9 +51,7 @@ pub trait Scalar:
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
-    + for<'a> core::convert::From<&'a String>
     + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>
@@ -85,4 +82,26 @@ pub trait Scalar:
     const MAX_BITS: u8;
     /// A U256 representation of the largest signed value in the field.
     const MAX_SIGNED_U256: U256;
+
+    /// Convert a string to a `Scalar` by hashing its bytes.
+    ///
+    /// This is different from parsing a numeric string. It maps arbitrary text
+    /// into the scalar field using the same masked Keccak hash used for byte
+    /// slices.
+    #[must_use]
+    fn from_str_via_hash(val: &str) -> Self {
+        if val.is_empty() {
+            return Self::ZERO;
+        }
+
+        let mut hasher = tiny_keccak::Keccak::v256();
+        hasher.update(val.as_bytes());
+        let mut hashed_bytes = [0u8; 32];
+        hasher.finalize(&mut hashed_bytes);
+        let hashed_val =
+            U256::from_le_slice(&hashed_bytes).expect("32 bytes => guaranteed to parse as U256");
+        let masked_val = hashed_val & Self::CHALLENGE_MASK;
+        let value_as_limbs: [u64; 4] = masked_val.into();
+        Self::from(value_as_limbs)
+    }
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -85,6 +85,11 @@ mod tests {
     }
 
     #[test]
+    fn we_can_get_zero_from_an_empty_string() {
+        assert_eq!(TestScalar::from_str_via_hash(""), TestScalar::ZERO);
+    }
+
+    #[test]
     fn we_can_get_scalar_from_hashed_bytes() {
         // Raw bytes of test string "abc" with 31st byte zeroed out:
         let expected: [u8; 32] = [
@@ -107,6 +112,14 @@ mod tests {
         assert_eq!(
             scalar_from_bytes, scalar_from_ref,
             "The masked keccak v256 of 'abc' must match"
+        );
+    }
+
+    #[test]
+    fn we_can_get_scalar_from_a_hashed_string() {
+        assert_eq!(
+            TestScalar::from_str_via_hash("abc"),
+            TestScalar::from_byte_slice_via_hash(b"abc")
         );
     }
 

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -2,7 +2,7 @@ use crate::base::{
     if_rayon,
     scalar::{Scalar, ScalarExt},
 };
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::{iter::Sum, ops::Mul};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
@@ -38,5 +38,13 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
     if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
         .zip(b)
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
+        .sum()
+}
+
+/// Cannot use blanket impls for `String` because strings are hashed into scalars.
+pub fn inner_product_with_strings<S: Scalar>(a: &[String], b: &[S]) -> S {
+    if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
+        .zip(b)
+        .map(|(lhs_string, &rhs)| S::from_str_via_hash(lhs_string) * rhs)
         .sum()
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -101,7 +101,7 @@ mod tests {
         base::{
             commitment::{Commitment, NumColumnsMismatch, VecCommitmentExt},
             database::{Column, OwnedColumn},
-            scalar::test_scalar_constants,
+            scalar::{test_scalar_constants, Scalar},
         },
         proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };
@@ -149,11 +149,12 @@ mod tests {
                 + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * DoryScalar::from(column_a[2]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_b[0].clone()).0
+            Pairing::pairing(Gamma_1[0], Gamma_2[0])
+                * DoryScalar::from_str_via_hash(&column_b[0]).0
                 + Pairing::pairing(Gamma_1[1], Gamma_2[0])
-                    * DoryScalar::from(column_b[1].clone()).0
+                    * DoryScalar::from_str_via_hash(&column_b[1]).0
                 + Pairing::pairing(Gamma_1[2], Gamma_2[0])
-                    * DoryScalar::from(column_b[2].clone()).0,
+                    * DoryScalar::from_str_via_hash(&column_b[2]).0,
         );
 
         assert_eq!(commitments, expected_commitments);
@@ -195,15 +196,16 @@ mod tests {
                 + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * DoryScalar::from(column_a[4]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_b[0].clone()).0
+            Pairing::pairing(Gamma_1[0], Gamma_2[0])
+                * DoryScalar::from_str_via_hash(&column_b[0]).0
                 + Pairing::pairing(Gamma_1[1], Gamma_2[0])
-                    * DoryScalar::from(column_b[1].clone()).0
+                    * DoryScalar::from_str_via_hash(&column_b[1]).0
                 + Pairing::pairing(Gamma_1[2], Gamma_2[0])
-                    * DoryScalar::from(column_b[2].clone()).0
+                    * DoryScalar::from_str_via_hash(&column_b[2]).0
                 + Pairing::pairing(Gamma_1[3], Gamma_2[0])
-                    * DoryScalar::from(column_b[3].clone()).0
+                    * DoryScalar::from_str_via_hash(&column_b[3]).0
                 + Pairing::pairing(Gamma_1[0], Gamma_2[1])
-                    * DoryScalar::from(column_b[4].clone()).0,
+                    * DoryScalar::from_str_via_hash(&column_b[4]).0,
         );
 
         assert_eq!(commitments, expected_commitments);
@@ -283,18 +285,20 @@ mod tests {
                 + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * DoryScalar::from(column_a[2]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_b[0].clone()).0
+            Pairing::pairing(Gamma_1[0], Gamma_2[0])
+                * DoryScalar::from_str_via_hash(&column_b[0]).0
                 + Pairing::pairing(Gamma_1[1], Gamma_2[0])
-                    * DoryScalar::from(column_b[1].clone()).0
+                    * DoryScalar::from_str_via_hash(&column_b[1]).0
                 + Pairing::pairing(Gamma_1[2], Gamma_2[0])
-                    * DoryScalar::from(column_b[2].clone()).0,
+                    * DoryScalar::from_str_via_hash(&column_b[2]).0,
         );
         expected_commitments[2] = DoryCommitment(
-            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_c[0].clone()).0
+            Pairing::pairing(Gamma_1[0], Gamma_2[0])
+                * DoryScalar::from_str_via_hash(&column_c[0]).0
                 + Pairing::pairing(Gamma_1[1], Gamma_2[0])
-                    * DoryScalar::from(column_c[1].clone()).0
+                    * DoryScalar::from_str_via_hash(&column_c[1]).0
                 + Pairing::pairing(Gamma_1[2], Gamma_2[0])
-                    * DoryScalar::from(column_c[2].clone()).0,
+                    * DoryScalar::from_str_via_hash(&column_c[2]).0,
         );
         expected_commitments[3] = DoryCommitment(
             Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_d[0]).0
@@ -342,15 +346,16 @@ mod tests {
                 + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * DoryScalar::from(column_a[4]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_b[0].clone()).0
+            Pairing::pairing(Gamma_1[0], Gamma_2[0])
+                * DoryScalar::from_str_via_hash(&column_b[0]).0
                 + Pairing::pairing(Gamma_1[1], Gamma_2[0])
-                    * DoryScalar::from(column_b[1].clone()).0
+                    * DoryScalar::from_str_via_hash(&column_b[1]).0
                 + Pairing::pairing(Gamma_1[2], Gamma_2[0])
-                    * DoryScalar::from(column_b[2].clone()).0
+                    * DoryScalar::from_str_via_hash(&column_b[2]).0
                 + Pairing::pairing(Gamma_1[3], Gamma_2[0])
-                    * DoryScalar::from(column_b[3].clone()).0
+                    * DoryScalar::from_str_via_hash(&column_b[3]).0
                 + Pairing::pairing(Gamma_1[0], Gamma_2[1])
-                    * DoryScalar::from(column_b[4].clone()).0,
+                    * DoryScalar::from_str_via_hash(&column_b[4]).0,
         );
 
         assert_eq!(commitments, expected_commitments);
@@ -436,9 +441,10 @@ mod tests {
                 + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * DoryScalar::from(column_a[4]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(Gamma_1[3], Gamma_2[0]) * DoryScalar::from(column_b[3].clone()).0
+            Pairing::pairing(Gamma_1[3], Gamma_2[0])
+                * DoryScalar::from_str_via_hash(&column_b[3]).0
                 + Pairing::pairing(Gamma_1[0], Gamma_2[1])
-                    * DoryScalar::from(column_b[4].clone()).0,
+                    * DoryScalar::from_str_via_hash(&column_b[4]).0,
         );
 
         assert_eq!(commitments, expected_commitments);

--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
@@ -370,9 +370,12 @@ fn the_one_scalar_is_the_multiplicative_identity() {
 
 #[test]
 fn the_empty_string_will_be_mapped_to_the_zero_scalar() {
-    assert_eq!(Curve25519Scalar::from(""), Curve25519Scalar::zero());
     assert_eq!(
-        Curve25519Scalar::from(<&str>::default()),
+        Curve25519Scalar::from_str_via_hash(""),
+        Curve25519Scalar::zero()
+    );
+    assert_eq!(
+        Curve25519Scalar::from_str_via_hash(<&str>::default()),
         Curve25519Scalar::zero()
     );
 }
@@ -380,8 +383,14 @@ fn the_empty_string_will_be_mapped_to_the_zero_scalar() {
 #[test]
 fn two_different_strings_map_to_different_scalars() {
     let s = "abc12";
-    assert_ne!(Curve25519Scalar::from(s), Curve25519Scalar::zero());
-    assert_ne!(Curve25519Scalar::from(s), Curve25519Scalar::from("abc123"));
+    assert_ne!(
+        Curve25519Scalar::from_str_via_hash(s),
+        Curve25519Scalar::zero()
+    );
+    assert_ne!(
+        Curve25519Scalar::from_str_via_hash(s),
+        Curve25519Scalar::from_str_via_hash("abc123")
+    );
 }
 
 #[test]
@@ -416,7 +425,7 @@ fn strings_of_arbitrary_size_map_to_different_scalars() {
             i,
             "testing string to scalar".repeat(dist.sample(&mut rng))
         );
-        assert!(prev_scalars.insert(Curve25519Scalar::from(s.as_str())));
+        assert!(prev_scalars.insert(Curve25519Scalar::from_str_via_hash(s.as_str())));
     }
 }
 
@@ -446,7 +455,8 @@ fn the_string_hash_implementation_uses_the_full_range_of_bits() {
         let mut bset = IndexSet::default();
 
         loop {
-            let s: Curve25519Scalar = dist.sample(&mut rng).to_string().as_str().into();
+            let sampled = dist.sample(&mut rng).to_string();
+            let s = Curve25519Scalar::from_str_via_hash(sampled.as_str());
             let bytes = s.to_bytes_le(); //Note: this is the only spot that these tests are different from the to_curve25519_scalar tests.
 
             let is_ith_bit_set = bytes[i / 8] & (1 << (i % 8)) != 0;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -117,7 +117,12 @@ impl ProvableQueryResult {
                         decode_and_convert::<S, S>(&self.data[offset..])
                     }
 
-                    ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
+                    ColumnType::VarChar => {
+                        let (raw_str, used) =
+                            decode_and_convert::<&str, &str>(&self.data[offset..])?;
+                        let x = S::from_str_via_hash(raw_str);
+                        Ok((x, used))
+                    }
                     ColumnType::VarBinary => {
                         let (raw_bytes, used) =
                             decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -288,7 +288,7 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_mixed_data_types() {
     let values3 = ["abc", "de"];
     let scalars3 = values3
         .iter()
-        .map(|v| TestScalar::from(*v))
+        .map(|&v| TestScalar::from_str_via_hash(v))
         .collect::<Vec<_>>();
     let values4 = [TestScalar::from(10), TestScalar::MAX_SIGNED];
 

--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -125,7 +125,9 @@ pub fn decode_multiple_elements<'a, T: ProvableResultElement<'a>>(
 mod tests {
 
     use super::*;
-    use crate::proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar;
+    use crate::{
+        base::scalar::Scalar, proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+    };
     use rand::{
         distributions::{Distribution, Uniform},
         rngs::StdRng,
@@ -230,10 +232,10 @@ mod tests {
         let value = "test string";
         let mut out = vec![0_u8; value.required_bytes()];
         value.encode(&mut out[..]);
-        let (decoded_value, read_bytes) =
-            decode_and_convert::<&str, Curve25519Scalar>(&out[..]).unwrap();
+        let (decoded_str, read_bytes) = <&str>::decode(&out[..]).unwrap();
+        let decoded_value = Curve25519Scalar::from_str_via_hash(decoded_str);
         assert_eq!(read_bytes, out.len());
-        assert_eq!(decoded_value, value.into());
+        assert_eq!(decoded_value, Curve25519Scalar::from_str_via_hash(value));
     }
 
     #[test]
@@ -311,10 +313,13 @@ mod tests {
             assert_eq!(read_bytes, out.len());
             assert_eq!(decoded_value, str_slice);
 
-            let (decoded_value, read_bytes) =
-                decode_and_convert::<&str, Curve25519Scalar>(&out[..]).unwrap();
+            let (decoded_str, read_bytes) = <&str>::decode(&out[..]).unwrap();
+            let decoded_value = Curve25519Scalar::from_str_via_hash(decoded_str);
             assert_eq!(read_bytes, out.len());
-            assert_eq!(decoded_value, str_slice.into());
+            assert_eq!(
+                decoded_value,
+                Curve25519Scalar::from_str_via_hash(str_slice)
+            );
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -1,6 +1,6 @@
 use super::{fold_columns, fold_vals};
 use crate::{
-    base::{database::Column, math::decimal::Precision},
+    base::{database::Column, math::decimal::Precision, scalar::Scalar},
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
 };
 use bumpalo::Bump;
@@ -10,19 +10,19 @@ use num_traits::Zero;
 fn we_can_fold_columns_with_scalars() {
     let expected = vec![
         Curve25519Scalar::from(77 + 1602 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("1"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("1"),
         Curve25519Scalar::from(77 + 2703 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("2"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("2"),
         Curve25519Scalar::from(77 + 3805 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("3"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("3"),
         Curve25519Scalar::from(77 + 4907 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("4"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("4"),
         Curve25519Scalar::from(77 + 5001 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("5"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("5"),
     ];
 
     let str_scalars: [Curve25519Scalar; 5] =
-        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+        ["1", "2", "3", "4", "5"].map(Curve25519Scalar::from_str_via_hash);
     let scalars = [2.into(), 3.into(), 5.into(), 7.into(), 1.into()];
     let mut columns = vec![
         Column::BigInt(&[1, 2, 3, 4, 5]),
@@ -51,11 +51,11 @@ fn we_can_fold_columns_with_scalars() {
 fn we_can_fold_columns_with_that_get_padded() {
     let expected = vec![
         Curve25519Scalar::from(77 + 1602 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("1"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("1"),
         Curve25519Scalar::from(77 + 2703 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("2"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("2"),
         Curve25519Scalar::from(77 + 3800 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("3"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("3"),
         Curve25519Scalar::from(77 + 4900 * 33),
         Curve25519Scalar::from(77 + 5000 * 33),
         Curve25519Scalar::from(77),
@@ -66,7 +66,8 @@ fn we_can_fold_columns_with_that_get_padded() {
         Curve25519Scalar::from(77),
     ];
 
-    let str_scalars: [Curve25519Scalar; 3] = ["1".into(), "2".into(), "3".into()];
+    let str_scalars: [Curve25519Scalar; 3] =
+        ["1", "2", "3"].map(Curve25519Scalar::from_str_via_hash);
     let scalars = [2.into(), 3.into()];
     let mut columns = vec![
         Column::BigInt(&[1, 2, 3, 4, 5]),


### PR DESCRIPTION
## Summary
- remove string From bounds from Scalar
- remove string From impls from MontScalar
- add explicit Scalar::from_str_via_hash for hashed string conversion
- update varchar/string call sites and tests to use explicit hashing

Part of #228
/claim #228

## Tests
- cargo check -p proof-of-sql --no-default-features --features test,arrow
- cargo test -p proof-of-sql --no-default-features --features test,arrow --lib --no-run
- cargo test -p proof-of-sql --no-default-features --features test,arrow we_can_get_scalar_from_a_hashed_string --lib
- cargo test -p proof-of-sql --no-default-features --features test,arrow we_can_convert_utf8_array_normal_range --lib
- cargo test -p proof-of-sql --no-default-features --features test,arrow we_can_filter_columns --lib
- cargo test -p proof-of-sql --no-default-features --features test,arrow we_can_convert_a_provable_result_to_a_final_result_with_mixed_data_types --lib
