### PR TITLE
test: cover database metadata accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,33 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnField, ColumnType};
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn column_field_accessors_clone_name_and_copy_type() {
+        let field = ColumnField::new(Ident::new("amount"), ColumnType::BigInt);
+
+        assert_eq!(field.name(), Ident::new("amount"));
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+
+        let mut cloned_name = field.name();
+        cloned_name.value = "mutated".into();
+        assert_eq!(field.name(), Ident::new("amount"));
+    }
+
+    #[test]
+    fn column_field_round_trips_through_serde() {
+        let field = ColumnField::new(Ident::new("description"), ColumnType::VarChar);
+
+        let serialized = serde_json::to_string(&field).unwrap();
+        let deserialized: ColumnField = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, field);
+        assert_eq!(deserialized.name(), Ident::new("description"));
+        assert_eq!(deserialized.data_type(), ColumnType::VarChar);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,48 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnRef, ColumnType, TableRef};
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn column_ref_accessors_return_owned_reference_parts() {
+        let table_ref = TableRef::new("sxt", "orders");
+        let column_ref = ColumnRef::new(table_ref.clone(), Ident::new("total"), ColumnType::Int128);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), Ident::new("total"));
+        assert_eq!(column_ref.column_type(), &ColumnType::Int128);
+
+        let cloned_table = column_ref.table_ref();
+        let mut cloned_table_name = cloned_table.table_id().clone();
+        cloned_table_name.value = "mutated".into();
+        let mut cloned_column = column_ref.column_id();
+        cloned_column.value = "mutated".into();
+
+        assert_eq!(column_ref.table_ref(), TableRef::new("sxt", "orders"));
+        assert_eq!(column_ref.column_id(), Ident::new("total"));
+    }
+
+    #[test]
+    fn column_ref_round_trips_through_serde() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("analytics", "events"),
+            Ident::new("payload"),
+            ColumnType::VarBinary,
+        );
+
+        let serialized = serde_json::to_string(&column_ref).unwrap();
+        let deserialized: ColumnRef = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, column_ref);
+        assert_eq!(
+            deserialized.table_ref(),
+            TableRef::new("analytics", "events")
+        );
+        assert_eq!(deserialized.column_id(), Ident::new("payload"));
+        assert_eq!(deserialized.column_type(), &ColumnType::VarBinary);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,29 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableEvaluation;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn table_evaluation_accessors_expose_columns_and_chi() {
+        let columns = vec![TestScalar::from(7), TestScalar::from(11)];
+        let chi = (TestScalar::from(13), 5);
+        let evaluation = TableEvaluation::new(columns.clone(), chi);
+
+        assert_eq!(evaluation.column_evals(), columns.as_slice());
+        assert_eq!(evaluation.chi_eval(), chi.0);
+        assert_eq!(evaluation.chi(), chi);
+    }
+
+    #[test]
+    fn table_evaluation_keeps_empty_column_evaluations_distinct_from_chi_length() {
+        let evaluation = TableEvaluation::<TestScalar>::new(vec![], (TestScalar::from(3), 8));
+
+        assert!(evaluation.column_evals().is_empty());
+        assert_eq!(evaluation.chi_eval(), TestScalar::from(3));
+        assert_eq!(evaluation.chi(), (TestScalar::from(3), 8));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused unit coverage for `ColumnField` accessor cloning and serde round-tripping
- add `ColumnRef` accessor/serde coverage, including cloned table/column identifier ownership
- add `TableEvaluation` accessor coverage for column evaluations and chi metadata, including an empty-column case

## Verification
- `cargo fmt --check -p proof-of-sql`
- `cargo test -p proof-of-sql --no-default-features --features test base::database::column_field::tests -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features test base::database::column_ref::tests -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features test base::database::table_evaluation::tests -- --nocapture`
- `cargo check -p proof-of-sql --no-default-features --features test`
- `git diff --check`
