### PR TITLE
test: cover column commitment metadata accessors

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -293,6 +293,28 @@ mod tests {
     }
 
     #[test]
+    fn we_can_read_metadata_accessors_and_roundtrip_serde() {
+        let metadata = ColumnCommitmentMetadata::try_new(
+            ColumnType::Int,
+            ColumnBounds::Int(Bounds::sharp(-7, 42).unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(metadata.column_type(), &ColumnType::Int);
+        assert_eq!(
+            metadata.bounds(),
+            &ColumnBounds::Int(Bounds::sharp(-7, 42).unwrap())
+        );
+
+        let serialized = serde_json::to_string(&metadata).unwrap();
+        let deserialized: ColumnCommitmentMetadata = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, metadata);
+        assert_eq!(deserialized.column_type(), metadata.column_type());
+        assert_eq!(deserialized.bounds(), metadata.bounds());
+    }
+
+    #[test]
     fn we_cannot_construct_metadata_with_type_bounds_mismatch() {
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(


### PR DESCRIPTION
## Summary
- add focused coverage for `ColumnCommitmentMetadata::column_type` and `bounds` accessors
- verify the metadata survives serde JSON round-trip while preserving accessor outputs

## Tests
- `cargo fmt --check -p proof-of-sql`
- `cargo test -p proof-of-sql --no-default-features --features test base::commitment::column_commitment_metadata::tests::we_can_read_metadata_accessors_and_roundtrip_serde -- --nocapture`
- `cargo check -p proof-of-sql --no-default-features --features test`
- `git diff --check`

Part of #560.