### PR TITLE
test: shrink dynamic Dory helper setup

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
@@ -213,11 +213,10 @@ mod tests {
 
     #[test]
     fn we_can_compute_dynamic_T_vec_prime() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-
         let a: Vec<F> = (100..109).map(Into::into).collect();
         let nu = 3;
+        let public_parameters = PublicParameters::test_rand(nu, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
         let T_vec_prime = compute_dynamic_T_vec_prime(&a, nu, &prover_setup);
 
         // 100


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimefdn/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with source scripts/run_ci_checks.sh.
- [x] I have run the clean commit check script with source scripts/check_commits.sh.
- [x] The latest changes from main have been incorporated to this PR.

# Rationale for this change

Issue #557 rewards test/CI runtime improvements. The we_can_compute_dynamic_T_vec_prime test exercises nu = 3, but it generated Dory public parameters with max_nu = 5. That builds setup data for unused levels before the test only indexes Gamma_1[3].

This PR sizes the setup to the same nu value the test actually verifies. The input vector, expected commitments, and assertions are unchanged; the test just avoids generating unused public parameter levels.

/claim #557

# What changes are included in this PR?

- Move nu = 3 before setup construction in dynamic_dory_helper.rs.
- Pass nu to PublicParameters::test_rand instead of the larger hard-coded 5.

# Are these changes tested?

Yes.

- cargo test -p proof-of-sql proof_primitive::dory::dynamic_dory_helper::tests::we_can_compute_dynamic_T_vec_prime --no-default-features --features test -- --nocapture
- cargo fmt --check
- git diff --check
- bash check_commits.sh through a CR-stripped stream

Local warmed timing on this Windows host, after the initial compile:

- main: 1.792s
- patched: 0.901s

Limitations:

- I did not run source scripts/run_ci_checks.sh because the full project CI path is not faithful on this Windows host; the focused no-default test path above is the relevant local validation.

Disclosure: prepared with AI assistance in Codex and reviewed before submission.
