### PR TITLE
Materialize nullable Arrow columns for proof tests

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -34,6 +34,9 @@ use arrow::{
 use snafu::Snafu;
 use sqlparser::ast::Ident;
 
+/// Suffix used for the generated validity bitmap column when nullable Arrow arrays are materialized.
+pub const NULL_PRESENCE_COLUMN_SUFFIX: &str = "__presence";
+
 #[derive(Snafu, Debug)]
 #[non_exhaustive]
 /// Errors caused by conversions between Arrow and owned types.
@@ -64,6 +67,229 @@ pub enum OwnedArrowConversionError {
         /// The underlying source error
         source: PoSQLTimestampError,
     },
+}
+
+/// Returns the generated validity bitmap identifier for a nullable column.
+#[must_use]
+pub fn null_presence_column_id(column_id: &Ident) -> Ident {
+    Ident::new(format!("{}{NULL_PRESENCE_COLUMN_SUFFIX}", column_id.value))
+}
+
+fn insert_unique_column<S: Scalar>(
+    table: &mut IndexMap<Ident, OwnedColumn<S>>,
+    identifier: Ident,
+    owned_column: OwnedColumn<S>,
+) -> Result<(), OwnedArrowConversionError> {
+    if table.insert(identifier, owned_column).is_some() {
+        Err(OwnedArrowConversionError::DuplicateIdents)
+    } else {
+        Ok(())
+    }
+}
+
+fn null_presence_column<S: Scalar>(value: &ArrayRef) -> OwnedColumn<S> {
+    OwnedColumn::Boolean(
+        (0..value.len())
+            .map(|index| value.is_valid(index))
+            .collect(),
+    )
+}
+
+#[expect(clippy::too_many_lines)]
+fn owned_column_from_nullable_array<S: Scalar>(
+    value: &ArrayRef,
+) -> Result<OwnedColumn<S>, OwnedArrowConversionError> {
+    match &value.data_type() {
+        DataType::Boolean => Ok(OwnedColumn::Boolean(
+            value
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        )),
+        DataType::UInt8 => Ok(OwnedColumn::Uint8(
+            value
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        )),
+        DataType::Int8 => Ok(OwnedColumn::TinyInt(
+            value
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        )),
+        DataType::Int16 => Ok(OwnedColumn::SmallInt(
+            value
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        )),
+        DataType::Int32 => Ok(OwnedColumn::Int(
+            value
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        )),
+        DataType::Int64 => Ok(OwnedColumn::BigInt(
+            value
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        )),
+        DataType::Decimal128(38, 0) => Ok(OwnedColumn::Int128(
+            value
+                .as_any()
+                .downcast_ref::<Decimal128Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        )),
+        DataType::Decimal256(precision, scale) if *precision <= 75 => Ok(OwnedColumn::Decimal75(
+            Precision::new(*precision).expect("precision is less than 76"),
+            *scale,
+            value
+                .as_any()
+                .downcast_ref::<Decimal256Array>()
+                .unwrap()
+                .iter()
+                .map(|value| {
+                    value
+                        .map_or(Some(S::ZERO), |value| convert_i256_to_scalar(&value))
+                        .unwrap()
+                })
+                .collect(),
+        )),
+        DataType::Utf8 => Ok(OwnedColumn::VarChar(
+            value
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default().to_string())
+                .collect(),
+        )),
+        DataType::LargeBinary => Ok(OwnedColumn::VarBinary(
+            value
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .unwrap()
+                .iter()
+                .map(|value| value.map(<[u8]>::to_vec).unwrap_or_default())
+                .collect(),
+        )),
+        DataType::Timestamp(time_unit, timezone) => match time_unit {
+            ArrowTimeUnit::Second => {
+                let array = value
+                    .as_any()
+                    .downcast_ref::<TimestampSecondArray>()
+                    .expect("This cannot fail, all Arrow TimeUnits are mapped to PoSQL TimeUnits");
+                Ok(OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Second,
+                    PoSQLTimeZone::try_from(timezone)?,
+                    array
+                        .iter()
+                        .map(|value| value.unwrap_or_default())
+                        .collect(),
+                ))
+            }
+            ArrowTimeUnit::Millisecond => {
+                let array = value
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .expect("This cannot fail, all Arrow TimeUnits are mapped to PoSQL TimeUnits");
+                Ok(OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Millisecond,
+                    PoSQLTimeZone::try_from(timezone)?,
+                    array
+                        .iter()
+                        .map(|value| value.unwrap_or_default())
+                        .collect(),
+                ))
+            }
+            ArrowTimeUnit::Microsecond => {
+                let array = value
+                    .as_any()
+                    .downcast_ref::<TimestampMicrosecondArray>()
+                    .expect("This cannot fail, all Arrow TimeUnits are mapped to PoSQL TimeUnits");
+                Ok(OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Microsecond,
+                    PoSQLTimeZone::try_from(timezone)?,
+                    array
+                        .iter()
+                        .map(|value| value.unwrap_or_default())
+                        .collect(),
+                ))
+            }
+            ArrowTimeUnit::Nanosecond => {
+                let array = value
+                    .as_any()
+                    .downcast_ref::<TimestampNanosecondArray>()
+                    .expect("This cannot fail, all Arrow TimeUnits are mapped to PoSQL TimeUnits");
+                Ok(OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Nanosecond,
+                    PoSQLTimeZone::try_from(timezone)?,
+                    array
+                        .iter()
+                        .map(|value| value.unwrap_or_default())
+                        .collect(),
+                ))
+            }
+        },
+        &data_type => Err(OwnedArrowConversionError::UnsupportedType {
+            datatype: data_type.clone(),
+        }),
+    }
+}
+
+/// Converts an Arrow [`RecordBatch`] into an [`OwnedTable`], materializing nullable arrays
+/// as a value column plus a generated boolean validity bitmap column.
+///
+/// Null value slots are canonicalized to the type's default value. Query plans can then combine the
+/// generated presence column with ordinary proof expressions to avoid treating those defaults as
+/// present user data.
+pub fn owned_table_from_record_batch_with_nulls<S: Scalar>(
+    value: RecordBatch,
+) -> Result<OwnedTable<S>, OwnedArrowConversionError> {
+    let mut table = IndexMap::default();
+
+    for (field, array_ref) in value.schema().fields().iter().zip(value.columns()) {
+        let identifier = Ident::new(field.name());
+        let owned_column = if array_ref.null_count() == 0 {
+            OwnedColumn::try_from(array_ref)?
+        } else {
+            owned_column_from_nullable_array(array_ref)?
+        };
+        insert_unique_column(&mut table, identifier.clone(), owned_column)?;
+
+        if array_ref.null_count() != 0 {
+            insert_unique_column(
+                &mut table,
+                null_presence_column_id(&identifier),
+                null_presence_column(array_ref),
+            )?;
+        }
+    }
+
+    Ok(OwnedTable::try_new(table)?)
 }
 
 /// # Panics

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -1,8 +1,17 @@
-use super::owned_and_arrow_conversions::OwnedArrowConversionError;
+use super::owned_and_arrow_conversions::{
+    null_presence_column_id, owned_table_from_record_batch_with_nulls, OwnedArrowConversionError,
+};
 use crate::base::{
-    database::{owned_table_utility::*, OwnedColumn, OwnedTable},
+    commitment::naive_evaluation_proof::NaiveEvaluationProof,
+    database::{
+        owned_table_utility::*, ColumnField, ColumnType, OwnedColumn, OwnedTable,
+        OwnedTableTestAccessor, TableRef, TestAccessor,
+    },
     map::IndexMap,
     scalar::test_scalar::TestScalar,
+};
+use crate::sql::{
+    proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::test_utility::*,
 };
 use alloc::sync::Arc;
 use arrow::{
@@ -14,6 +23,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use proptest::prelude::*;
+use sqlparser::ast::Ident;
 
 fn we_can_convert_between_owned_column_and_array_ref_impl(
     owned_column: &OwnedColumn<TestScalar>,
@@ -190,6 +200,137 @@ fn we_can_convert_between_owned_table_and_record_batch() {
             ),
         ]),
         &batch2,
+    );
+}
+
+#[test]
+fn we_can_materialize_nullable_arrow_arrays_as_value_and_presence_columns() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("score", DataType::Int64, true),
+        Field::new("flag", DataType::Boolean, true),
+        Field::new("name", DataType::Utf8, true),
+        Field::new("bonus", DataType::Int64, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![Some(5), None, Some(9)])),
+            Arc::new(BooleanArray::from(vec![Some(true), None, Some(false)])),
+            Arc::new(StringArray::from(vec![Some("ready"), None, Some("done")])),
+            Arc::new(Int64Array::from(vec![7, 7, 1])),
+        ],
+    )
+    .unwrap();
+
+    let actual = owned_table_from_record_batch_with_nulls::<TestScalar>(batch).unwrap();
+
+    assert_eq!(
+        null_presence_column_id(&Ident::new("score")),
+        "score__presence".into()
+    );
+    assert_eq!(
+        actual,
+        owned_table([
+            bigint("score", [5_i64, 0, 9]),
+            boolean("score__presence", [true, false, true]),
+            boolean("flag", [true, false, false]),
+            boolean("flag__presence", [true, false, true]),
+            varchar("name", ["ready", "", "done"]),
+            boolean("name__presence", [true, false, true]),
+            bigint("bonus", [7_i64, 7, 1]),
+        ])
+    );
+}
+
+#[test]
+fn we_get_duplicate_idents_when_nullable_arrow_presence_column_already_exists() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("score", DataType::Int64, true),
+        Field::new("score__presence", DataType::Boolean, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![Some(5), None])),
+            Arc::new(BooleanArray::from(vec![true, false])),
+        ],
+    )
+    .unwrap();
+
+    assert!(matches!(
+        owned_table_from_record_batch_with_nulls::<TestScalar>(batch),
+        Err(OwnedArrowConversionError::DuplicateIdents)
+    ));
+}
+
+#[test]
+fn we_can_prove_over_materialized_nullable_arrow_columns() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("score", DataType::Int64, true),
+        Field::new("bonus", DataType::Int64, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![
+                Some(5),
+                None,
+                Some(9),
+                Some(5),
+                None,
+            ])),
+            Arc::new(Int64Array::from(vec![7, 99, 1, 7, 6])),
+        ],
+    )
+    .unwrap();
+    let table = owned_table_from_record_batch_with_nulls::<TestScalar>(batch).unwrap();
+
+    let t = TableRef::new("sxt", "nullable_scores");
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    accessor.add_table(t.clone(), table, 0);
+
+    let score_plus_bonus = add(
+        column(&t, "score", &accessor),
+        column(&t, "bonus", &accessor),
+    );
+    let where_clause = and(
+        column(&t, "score__presence", &accessor),
+        equal(score_plus_bonus.clone(), const_decimal75(20, 0, 12_i128)),
+    );
+    let plan = filter(
+        vec![
+            aliased_plan(score_plus_bonus, "score_plus_bonus"),
+            col_expr_plan(&t, "score", &accessor),
+            col_expr_plan(&t, "score__presence", &accessor),
+        ],
+        table_exec(
+            t.clone(),
+            vec![
+                ColumnField::new("score".into(), ColumnType::BigInt),
+                ColumnField::new("score__presence".into(), ColumnType::Boolean),
+                ColumnField::new("bonus".into(), ColumnType::BigInt),
+            ],
+        ),
+        where_clause,
+    );
+
+    let verifiable_result =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+    let result = verifiable_result
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    assert_eq!(
+        result,
+        owned_table([
+            decimal75("score_plus_bonus", 20, 0, [12_i64, 12]),
+            bigint("score", [5_i64, 5]),
+            boolean("score__presence", [true, true]),
+        ])
     );
 }
 


### PR DESCRIPTION
/claim #183

## Summary
This is a focused PoC for #183. It adds a nullable Arrow RecordBatch conversion path that materializes each nullable input column as:

- the existing physical value column, with null slots canonicalized to the type default
- a generated `<column>__presence` boolean column

That gives proof plans an explicit presence bitmap they can combine with ordinary expressions while the broader nullable SQL design is still being worked through. The existing `TryFrom<RecordBatch>` behavior is left unchanged.

## Why this slice
The issue design discussion describes nullable column `c` as a value column plus a presence column. This PR lands that representation at the Arrow boundary and keeps it isolated from the larger end-to-end nullable SQL work, so maintainers can review or reuse it independently.

The added proof test starts from an Arrow batch with real null slots, materializes `score` and `score__presence`, then proves a filtered arithmetic query that only accepts present rows.

## Tests
- `cargo test -p proof-of-sql --no-default-features --features "arrow test" owned_and_arrow_conversions_test -- --nocapture`