### PR TITLE
test: cover ProjectionExec accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -52,6 +52,40 @@ impl ProjectionExec {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::ColumnType,
+        sql::{
+            proof_exprs::{ColumnExpr, DynProofExpr},
+            proof_plans::TableExec,
+        },
+    };
+
+    #[test]
+    fn we_can_access_projection_input_and_aliased_results() {
+        let table_ref = TableRef::new("sxt", "sxt_tab");
+        let input = DynProofPlan::Table(TableExec::new(
+            table_ref.clone(),
+            vec![ColumnField::new("a".into(), ColumnType::BigInt)],
+        ));
+        let aliased_results = vec![AliasedDynProofExpr {
+            expr: DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                table_ref,
+                Ident::new("a"),
+                ColumnType::BigInt,
+            ))),
+            alias: Ident::new("a_alias"),
+        }];
+
+        let projection = ProjectionExec::new(aliased_results.clone(), Box::new(input.clone()));
+
+        assert_eq!(projection.input(), &input);
+        assert_eq!(projection.aliased_results(), aliased_results.as_slice());
+    }
+}
+
 impl ProofPlan for ProjectionExec {
     fn verifier_evaluate<S: Scalar>(
         &self,


### PR DESCRIPTION
## Summary
- add a focused unit test for `ProjectionExec::input` and `ProjectionExec::aliased_results`
- keep the test independent of the default blitzar feature path so it can run on non-x86_64 environments

/claim #560

## Verification
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features=test we_can_access_projection_input_and_aliased_results`
- `cargo check -p proof-of-sql --no-default-features --features=test`
- `git diff --check`

Note: default-feature test runs are not available on this aarch64 runner because `blitzar-sys`/`halo2curves` require x86_64/asm.