### PR TITLE
test: cover DynProofPlan result refs

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan_test.rs
@@ -1,0 +1,33 @@
+use super::DynProofPlan;
+use crate::base::{
+    database::{ColumnField, ColumnRef, ColumnType, TableRef},
+    map::IndexSet,
+};
+
+#[test]
+fn result_fields_are_exposed_as_unqualified_column_refs() {
+    let table_ref = TableRef::new("sxt", "orders");
+    let plan = DynProofPlan::new_table(
+        table_ref,
+        vec![
+            ColumnField::new("order_id".into(), ColumnType::BigInt),
+            ColumnField::new("amount".into(), ColumnType::Int128),
+        ],
+    );
+
+    let result_refs = plan.get_column_result_fields_as_references();
+    let expected_refs = IndexSet::from_iter([
+        ColumnRef::new(
+            TableRef::from_names(None, ""),
+            "order_id".into(),
+            ColumnType::BigInt,
+        ),
+        ColumnRef::new(
+            TableRef::from_names(None, ""),
+            "amount".into(),
+            ColumnType::Int128,
+        ),
+    ]);
+
+    assert_eq!(result_refs, expected_refs);
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -64,6 +64,8 @@ mod sort_merge_join_exec_test;
 
 mod dyn_proof_plan;
 pub use dyn_proof_plan::DynProofPlan;
+#[cfg(test)]
+mod dyn_proof_plan_test;
 
 #[cfg(test)]
 mod demo_mock_plan;


### PR DESCRIPTION
Closes #560

/claim #560

## Summary
- add focused coverage for DynProofPlan::get_column_result_fields_as_references
- verify result fields become unqualified ColumnRef values with preserved names and data types

## Verification
- cargo fmt --check
- cargo test -p proof-of-sql --no-default-features --features test result_fields_are_exposed_as_unqualified_column_refs
- cargo check -p proof-of-sql --no-default-features --features test
- git diff --check