### PR TITLE
test: cover Dory offset byte conversions

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -60,3 +60,57 @@ impl OffsetToBytes<32> for [u64; 4] {
         bytemuck::cast(*self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OffsetToBytes;
+
+    #[test]
+    fn signed_offsets_shift_min_to_zero() {
+        assert_eq!(i8::MIN.offset_to_bytes(), [0]);
+        assert_eq!(i16::MIN.offset_to_bytes(), [0, 0]);
+        assert_eq!(i32::MIN.offset_to_bytes(), [0, 0, 0, 0]);
+        assert_eq!(i64::MIN.offset_to_bytes(), [0; 8]);
+        assert_eq!(i128::MIN.offset_to_bytes(), [0; 16]);
+    }
+
+    #[test]
+    fn signed_offsets_shift_across_sign_boundary() {
+        let negative_one = (-1_i32).offset_to_bytes();
+        let zero = 0_i32.offset_to_bytes();
+        let positive_one = 1_i32.offset_to_bytes();
+
+        assert_eq!(negative_one, i32::MAX.to_le_bytes());
+        assert_eq!(zero, i32::MIN.to_le_bytes());
+        assert_eq!(positive_one, i32::MIN.wrapping_add(1).to_le_bytes());
+    }
+
+    #[test]
+    fn bool_and_unsigned_offsets_use_direct_bytes() {
+        assert_eq!(false.offset_to_bytes(), [0]);
+        assert_eq!(true.offset_to_bytes(), [1]);
+        assert_eq!(
+            0x0123_4567_89ab_cdef_u64.offset_to_bytes(),
+            [0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01,]
+        );
+    }
+
+    #[test]
+    fn u64_array_offsets_concatenate_words() {
+        let words = [
+            0x0123_4567_89ab_cdef_u64,
+            0xfedc_ba98_7654_3210_u64,
+            0,
+            u64::MAX,
+        ];
+
+        assert_eq!(
+            words.offset_to_bytes(),
+            [
+                0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, 0x10, 0x32, 0x54, 0x76, 0x98, 0xba,
+                0xdc, 0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Adds focused unit coverage for the Dory `OffsetToBytes` conversions.

Covered cases:
- signed integer minimum values shift to zero bytes
- signed values around the sign boundary use the expected wrapping offset
- bool and u64 direct byte conversions
- `[u64; 4]` conversion concatenates all words into the expected byte layout

/claim #560

Verification:
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test proof_primitive::dory::offset_to_bytes::tests -- --nocapture`
- `cargo check -p proof-of-sql --no-default-features --features test`
- `git diff --check`
