### PR TITLE
test: add column type operation coverage

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -1378,6 +1378,160 @@ mod test {
     }
 
     #[test]
+    fn we_can_scale_cast_timestamp_types_to_finer_precision() {
+        let timestamp = |unit| ColumnType::TimestampTZ(unit, PoSQLTimeZone::new(0));
+
+        try_scale_cast_types(
+            timestamp(PoSQLTimeUnit::Second),
+            timestamp(PoSQLTimeUnit::Nanosecond),
+        )
+        .unwrap();
+        try_scale_cast_types(
+            timestamp(PoSQLTimeUnit::Millisecond),
+            timestamp(PoSQLTimeUnit::Microsecond),
+        )
+        .unwrap();
+        try_scale_cast_types(
+            timestamp(PoSQLTimeUnit::Nanosecond),
+            timestamp(PoSQLTimeUnit::Millisecond),
+        )
+        .unwrap_err();
+    }
+
+    #[test]
+    fn we_can_determine_exact_type_equality_compatibility() {
+        let timestamp = |unit, offset| ColumnType::TimestampTZ(unit, PoSQLTimeZone::new(offset));
+
+        try_equals_types(ColumnType::VarChar, ColumnType::VarChar).unwrap();
+        try_equals_types(ColumnType::VarBinary, ColumnType::VarBinary).unwrap();
+        try_equals_types(ColumnType::Boolean, ColumnType::Boolean).unwrap();
+        try_equals_types(ColumnType::BigInt, ColumnType::Scalar).unwrap();
+        try_equals_types(ColumnType::Scalar, ColumnType::VarChar).unwrap();
+        try_equals_types(
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+            ColumnType::Decimal75(Precision::new(12).unwrap(), 2),
+        )
+        .unwrap();
+        try_equals_types(
+            timestamp(PoSQLTimeUnit::Millisecond, 0),
+            timestamp(PoSQLTimeUnit::Millisecond, 1),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            try_equals_types(
+                ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+                ColumnType::Decimal75(Precision::new(12).unwrap(), 3),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_equals_types(ColumnType::VarChar, ColumnType::Boolean),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_equals_types(
+                timestamp(PoSQLTimeUnit::Second, 0),
+                timestamp(PoSQLTimeUnit::Millisecond, 0),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    #[test]
+    fn we_can_determine_exact_type_inequality_compatibility() {
+        let timestamp = |unit| ColumnType::TimestampTZ(unit, PoSQLTimeZone::new(0));
+
+        try_inequality_types(ColumnType::Boolean, ColumnType::Boolean).unwrap();
+        try_inequality_types(
+            ColumnType::Decimal75(Precision::new(38).unwrap(), 4),
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 4),
+        )
+        .unwrap();
+        try_inequality_types(
+            timestamp(PoSQLTimeUnit::Microsecond),
+            timestamp(PoSQLTimeUnit::Microsecond),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            try_inequality_types(ColumnType::VarChar, ColumnType::VarChar),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types(
+                ColumnType::Decimal75(Precision::new(39).unwrap(), 4),
+                ColumnType::Decimal75(Precision::new(10).unwrap(), 4),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types(
+                ColumnType::Decimal75(Precision::new(38).unwrap(), 4),
+                ColumnType::Decimal75(Precision::new(10).unwrap(), 5),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types(
+                timestamp(PoSQLTimeUnit::Second),
+                timestamp(PoSQLTimeUnit::Nanosecond),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    #[test]
+    fn we_can_determine_scaled_comparison_compatibility() {
+        let timestamp = |unit| ColumnType::TimestampTZ(unit, PoSQLTimeZone::new(0));
+
+        try_equals_types_with_scaling(
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+            ColumnType::Decimal75(Precision::new(12).unwrap(), 3),
+        )
+        .unwrap();
+        try_equals_types_with_scaling(
+            timestamp(PoSQLTimeUnit::Second),
+            timestamp(PoSQLTimeUnit::Nanosecond),
+        )
+        .unwrap();
+        try_inequality_types_with_scaling(
+            ColumnType::Decimal75(Precision::new(38).unwrap(), 2),
+            ColumnType::Decimal75(Precision::new(12).unwrap(), 3),
+        )
+        .unwrap();
+        try_inequality_types_with_scaling(
+            timestamp(PoSQLTimeUnit::Second),
+            timestamp(PoSQLTimeUnit::Nanosecond),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            try_equals_types_with_scaling(ColumnType::VarChar, ColumnType::Boolean),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types_with_scaling(ColumnType::VarChar, ColumnType::Boolean),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            try_inequality_types_with_scaling(
+                ColumnType::Decimal75(Precision::new(39).unwrap(), 2),
+                ColumnType::Decimal75(Precision::new(12).unwrap(), 3),
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    #[test]
+    fn we_can_check_boolean_logical_type_compatibility() {
+        assert!(can_and_or_types(ColumnType::Boolean, ColumnType::Boolean));
+        assert!(!can_and_or_types(ColumnType::Boolean, ColumnType::Scalar));
+        assert!(can_not_type(ColumnType::Boolean));
+        assert!(!can_not_type(ColumnType::Scalar));
+    }
+
+    #[test]
     fn we_can_try_neg_type() {
         for (input_type, precision) in [
             (ColumnType::Uint8, 3u8),


### PR DESCRIPTION
Addresses #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This improves coverage for #560 by directly exercising column type compatibility helpers that are used by expression planning but had little direct unit coverage in this module.

# What changes are included in this PR?

- Add timestamp scale-cast compatibility coverage, including downcast rejection.
- Add exact equality and inequality compatibility coverage for scalar, decimal, timestamp, boolean, binary, and string types.
- Add scaled comparison compatibility coverage for decimals and timestamps.
- Add boolean logical operator compatibility coverage for `AND`/`OR` and `NOT` helpers.

# Are these changes tested?

Yes.

- `PATH=/Users/jakehatchett/.cargo/bin:$PATH cargo fmt --all`
- `PATH=/Users/jakehatchett/.cargo/bin:$PATH cargo test -p proof-of-sql column_type_operation --no-default-features --features std`
- `source scripts/check_commits.sh`
- `git diff --check`

/claim #560
