### PR TITLE
test: add coverage for small helper modules

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,17 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnField, ColumnType};
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn column_field_exposes_name_and_data_type() {
+        let field = ColumnField::new(Ident::new("total"), ColumnType::BigInt);
+
+        assert_eq!(field.name(), Ident::new("total"));
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,24 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableEvaluation;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn table_evaluation_returns_column_and_chi_values() {
+        let evaluation = TableEvaluation::new(
+            vec![TestScalar::from(3_u64), TestScalar::from(5_u64)],
+            (TestScalar::from(11_u64), 2),
+        );
+
+        assert_eq!(
+            evaluation.column_evals(),
+            &[TestScalar::from(3_u64), TestScalar::from(5_u64)]
+        );
+        assert_eq!(evaluation.chi_eval(), TestScalar::from(11_u64));
+        assert_eq!(evaluation.chi(), (TestScalar::from(11_u64), 2));
+    }
+}

--- a/crates/proof-of-sql/src/base/map.rs
+++ b/crates/proof-of-sql/src/base/map.rs
@@ -18,3 +18,31 @@ macro_rules! indexset {
 #[cfg(test)]
 pub(crate) use indexmap;
 pub(crate) use indexset;
+
+#[cfg(test)]
+mod tests {
+    use super::{IndexMap, IndexSet};
+
+    #[test]
+    fn indexmap_macro_uses_ahash_builder_and_preserves_insertion_order() {
+        let map: IndexMap<&str, i32> = super::indexmap! {
+            "alpha" => 1,
+            "beta" => 2,
+        };
+
+        assert_eq!(map.get("alpha"), Some(&1));
+        assert_eq!(
+            map.keys().copied().collect::<alloc::vec::Vec<_>>(),
+            alloc::vec!["alpha", "beta"]
+        );
+    }
+
+    #[test]
+    fn indexset_macro_deduplicates_values() {
+        let set: IndexSet<&str> = super::indexset!("alpha", "beta", "alpha");
+
+        assert!(set.contains("alpha"));
+        assert!(set.contains("beta"));
+        assert_eq!(set.len(), 2);
+    }
+}

--- a/crates/proof-of-sql/src/base/rayon_cfg.rs
+++ b/crates/proof-of-sql/src/base/rayon_cfg.rs
@@ -11,3 +11,17 @@ macro_rules! if_rayon {
     }};
 }
 pub(crate) use if_rayon;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn if_rayon_selects_the_active_branch() {
+        let value = super::if_rayon!(1, 2);
+
+        #[cfg(feature = "rayon")]
+        assert_eq!(value, 1);
+
+        #[cfg(not(feature = "rayon"))]
+        assert_eq!(value, 2);
+    }
+}

--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,24 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+
+    struct Counter(usize);
+
+    impl From<&Counter> for usize {
+        fn from(value: &Counter) -> Self {
+            value.0
+        }
+    }
+
+    #[test]
+    fn ref_into_uses_reference_based_conversion() {
+        let counter = Counter(7);
+        let converted: usize = counter.ref_into();
+
+        assert_eq!(converted, 7);
+    }
+}


### PR DESCRIPTION
/attempt #560
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This PR contributes to issue #560 by adding focused coverage for a few small helper modules in `base`.
The changes are intentionally narrow and low-risk: they verify simple helper behavior without changing runtime logic.

# What changes are included in this PR?

- add unit tests for `base::map` helper macros
- add a unit test for `base::rayon_cfg::if_rayon!`
- add small behavior tests for `RefInto`, `ColumnField`, and `TableEvaluation`

# Are these changes tested?

Yes.

I ran the following targeted tests on Apple Silicon with an alternative feature set compatible with this environment:

- `cargo test -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel" map -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel" rayon_cfg -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel" ref_into -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel" column_field -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel" table_evaluation -- --nocapture`

/claim #560
