### PR TITLE
test: trim Dory evaluation setup sizes

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -19,7 +19,7 @@ fn test_simple_ipa() {
         &DoryProverPublicSetup::new(&prover_setup, 3),
         &DoryVerifierPublicSetup::new(&verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let verifier_setup = VerifierSetup::from(&public_parameters);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
@@ -41,7 +41,7 @@ fn test_random_ipa_with_length_1() {
         &DoryProverPublicSetup::new(&prover_setup, 3),
         &DoryVerifierPublicSetup::new(&verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let verifier_setup = VerifierSetup::from(&public_parameters);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
@@ -53,7 +53,7 @@ fn test_random_ipa_with_length_1() {
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let setup_setup = [(4, 4), (4, 3), (6, 2)];
+    let setup_setup = [(4, 4), (4, 3), (5, 2)];
     for setup_p in setup_setup {
         let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -30,7 +30,7 @@ fn test_random_ipa_with_length_1() {
 #[test]
 #[should_panic = "verification improperly failed"]
 fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
     let verifier_setup = VerifierSetup::from(&public_parameters);
@@ -45,7 +45,7 @@ fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let verifier_setup = VerifierSetup::from(&public_parameters);
     for length in lengths {


### PR DESCRIPTION
## Summary

/claim #557

This trims over-provisioned Dory public-parameter generation in evaluation-proof tests without changing the exercised proof cases or assertions.

- Fixed Dory evaluation tests still exercise sigma 4, 3, and 2, but the sigma 2 case only needs `max_nu = 5` for the 128-element length case, not `6`.
- Dynamic Dory evaluation tests still exercise the same length list and the too-small-verifier panic case; the largest dynamic proof path here computes `nu = 4`, so generating setup with `max_nu = 4` is sufficient instead of `6`.
- No test inputs, expected assertions, transcript checks, or negative verification checks are removed.

## Verification

Using `RUSTUP_TOOLCHAIN=stable` locally because this checkout pins Rust `1.91.1`, which was not installed on the machine.

- `RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- `git diff --check`
- `RUSTUP_TOOLCHAIN=stable CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p proof-of-sql --no-default-features --features="std test" proof_primitive::dory::dory_commitment_evaluation_proof_test`
  - `4 passed; 0 failed`
- `RUSTUP_TOOLCHAIN=stable CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p proof-of-sql --no-default-features --features="std test" proof_primitive::dory::dynamic_dory_commitment_evaluation_proof_test`
  - `5 passed; 0 failed`

Assisted by OpenAI Codex.