### PR TITLE
test: cover HyperKZG setup deserialization errors

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
@@ -121,6 +121,15 @@ pub fn load_small_setup_for_testing() -> (
 #[cfg(all(test, feature = "std"))]
 mod std_tests {
     use super::*;
+    use std::io::{Error, ErrorKind, Read};
+
+    struct FailingReader;
+
+    impl Read for FailingReader {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(Error::new(ErrorKind::UnexpectedEof, "forced read failure"))
+        }
+    }
 
     #[test]
     fn we_can_deserialize_empty_setup_from_slice() {
@@ -161,6 +170,28 @@ mod std_tests {
                 .unwrap()
                 .len(),
             4,
+        );
+    }
+
+    #[test]
+    fn we_reject_truncated_compressed_setup_from_slice() {
+        let bytes = include_bytes!("test_ppot_0080_02.bin");
+        let truncated = &bytes[..bytes.len() - 1];
+
+        assert!(
+            deserialize_flat_compressed_hyperkzg_public_setup_from_slice(truncated, Validate::Yes)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn we_propagate_reader_errors_when_deserializing_setup() {
+        assert!(
+            deserialize_flat_compressed_hyperkzg_public_setup_from_reader(
+                FailingReader,
+                Validate::Yes
+            )
+            .is_err()
         );
     }
 }


### PR DESCRIPTION
/claim #560

Contributes to #560

## Summary
- Add focused coverage for HyperKZG public setup deserialization failure paths.
- Assert truncated compressed setup bytes are rejected instead of silently producing a partial setup.
- Assert reader I/O errors are propagated through the reader-based setup deserializer.

This is a small, test-only #560 coverage slice in `public_setup.rs`. I checked current open PRs for HyperKZG/public setup overlap; #1624 covers HyperKZG column commitments, while this covers setup deserialization error paths.

## Demo
https://github.com/digzrow-coder/sxt-proof-of-sql/releases/download/pr-1625-demo-20260515/pr-1625-hyperkzg-setup-errors-demo.mp4

## Bounty / Coverage Accounting
- Bounty terms: $0.10 per newly covered production line, subject to maintainer/Algora accounting.
- Changed file: `crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs`
- Patch size: 31 added test lines, 0 production-line changes.
- Covered behavior: truncated compressed setup slice rejection and reader error propagation in the HyperKZG public setup deserialization path.
- Exact rewarded covered-line count is left to the maintainer coverage baseline, but this PR is intentionally scoped to previously untested error paths rather than broad/noisy test churn.

## Verification
- `cargo +stable-x86_64-pc-windows-gnu test -p proof-of-sql --no-default-features --features=test proof_primitive::hyperkzg::public_setup::std_tests`: 6 passed, 0 failed
- Previous local verification: `cargo check -p proof-of-sql --no-default-features --features=test`: passed
- Previous local verification: `rustfmt --check crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs`: passed
- Previous local verification: `git diff --check`: passed

Note: full `cargo fmt --check` on this Windows/GNU setup reports an unrelated import-order diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`, so I verified formatting on the touched file directly to avoid unrelated churn. Invoking the default MSVC toolchain on this machine fails before tests because `link.exe` is not installed; the GNU command above is the validation target used for this PR.

AI-assisted with OpenAI Codex; I reviewed the diff, proof asset, and validation output before posting.