### PR TITLE
test: cover posql time helpers

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,60 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::{String, ToString};
+
+    #[test]
+    fn timestamp_errors_render_stable_messages() {
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezone {
+                timezone: "MARS".to_string()
+            }
+            .to_string(),
+            "invalid timezone string: MARS"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezoneOffset.to_string(),
+            "invalid timezone offset"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimeUnit {
+                error: "fortnight".to_string()
+            }
+            .to_string(),
+            "Invalid time unit"
+        );
+        assert_eq!(
+            PoSQLTimestampError::UnsupportedPrecision {
+                error: "4".to_string()
+            }
+            .to_string(),
+            "Unsupported precision for timestamp: 4"
+        );
+    }
+
+    #[test]
+    fn timestamp_errors_convert_into_strings() {
+        let message: String = PoSQLTimestampError::UnsupportedPrecision {
+            error: "12".to_string(),
+        }
+        .into();
+
+        assert_eq!(message, "Unsupported precision for timestamp: 12");
+    }
+
+    #[test]
+    fn timestamp_errors_serde_round_trip() {
+        let error = PoSQLTimestampError::InvalidTimezone {
+            timezone: "NOT_A_ZONE".to_string(),
+        };
+
+        let serialized = serde_json::to_string(&error).unwrap();
+        let deserialized: PoSQLTimestampError = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, error);
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -104,6 +104,25 @@ mod timezone_parsing_tests {
     }
 
     #[test]
+    fn we_can_parse_positive_time_zone() {
+        let timezone_as_str: Option<Arc<str>> = Some("+05:30".into());
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+        let expected_time_zone = PoSQLTimeZone::new(19_800);
+        assert_eq!(timezone, expected_time_zone);
+    }
+
+    #[test]
+    fn we_can_parse_utc_alias_time_zones() {
+        for timezone in ["Z", "z", "UTC", "utc", "00:00", "+00:00", "0:00", "+0:00"] {
+            let timezone_as_str: Option<Arc<str>> = Some(timezone.into());
+            assert_eq!(
+                PoSQLTimeZone::try_from(&timezone_as_str),
+                Ok(PoSQLTimeZone::utc())
+            );
+        }
+    }
+
+    #[test]
     fn we_can_parse_none_time_zone() {
         let timezone = PoSQLTimeZone::try_from(&None).unwrap();
         let expected_time_zone = PoSQLTimeZone::utc();
@@ -118,5 +137,16 @@ mod timezone_parsing_tests {
             timezone_err,
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
         ));
+    }
+
+    #[test]
+    fn we_cannot_parse_invalid_offset_digits() {
+        for timezone in ["+AA:00", "+01:BB"] {
+            let timezone_as_str: Option<Arc<str>> = Some(timezone.into());
+            assert_eq!(
+                PoSQLTimeZone::try_from(&timezone_as_str),
+                Err(PoSQLTimestampError::InvalidTimezoneOffset)
+            );
+        }
     }
 }

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -59,6 +59,7 @@ impl fmt::Display for PoSQLTimeUnit {
 mod time_unit_tests {
     use super::*;
     use crate::base::posql_time::PoSQLTimestampError;
+    use alloc::string::ToString;
 
     #[test]
     fn test_valid_precisions() {
@@ -66,6 +67,31 @@ mod time_unit_tests {
         assert_eq!(PoSQLTimeUnit::try_from("3"), Ok(PoSQLTimeUnit::Millisecond));
         assert_eq!(PoSQLTimeUnit::try_from("6"), Ok(PoSQLTimeUnit::Microsecond));
         assert_eq!(PoSQLTimeUnit::try_from("9"), Ok(PoSQLTimeUnit::Nanosecond));
+    }
+
+    #[test]
+    fn time_units_convert_to_precision_digits() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn time_units_display_supported_precisions() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Contributes to #560
/claim #560

## Summary
- add focused coverage for PoSQL timestamp error display, string conversion, and serde round-trip behavior
- cover PoSQL time unit precision conversion and display output
- cover timezone UTC aliases, positive offsets, and invalid offset digit parsing

## Verification
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features "std test" posql_time`
- `git diff --check`

## Safety
- test-only changes in `crates/proof-of-sql/src/base/posql_time`
- no dependency, script, network, or runtime logic changes
- staged diff scanned for secrets and dangerous command patterns