### PR TITLE
test: cover HyperKZG Nova engine behavior

### DIFF
--- a/crates/proof-of-sql/src/base/math/mod.rs
+++ b/crates/proof-of-sql/src/base/math/mod.rs
@@ -11,3 +11,28 @@ mod big_decimal_ext;
 pub use big_decimal_ext::BigDecimalExt;
 /// Module providing permutation utilities for reordering data in proof computations.
 pub(crate) mod permutation;
+
+/// Returns whether `value` is a multiple of `rhs`, matching the standard
+/// integer `is_multiple_of` zero-divisor semantics without requiring the
+/// unstable library feature on this toolchain.
+#[inline]
+pub(crate) const fn is_multiple_of(value: usize, rhs: usize) -> bool {
+    if rhs == 0 {
+        value == 0
+    } else {
+        value % rhs == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_multiple_of;
+
+    #[test]
+    fn is_multiple_of_matches_zero_divisor_semantics() {
+        assert!(is_multiple_of(0, 0));
+        assert!(!is_multiple_of(1, 0));
+        assert!(is_multiple_of(6, 3));
+        assert!(!is_multiple_of(7, 3));
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/interpolate.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate.rs
@@ -62,7 +62,7 @@ where
                 );
 
         // This handles the (-1)^(d-i) sign.
-        if (degree - i).is_multiple_of(2) {
+        if crate::base::math::is_multiple_of(degree - i, 2) {
             sum += new_term;
         } else {
             sum -= new_term;

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -3,7 +3,7 @@ use super::{
     pairings, DynamicDoryCommitment, G1Affine, ProverSetup,
 };
 use crate::{
-    base::{commitment::CommittableColumn, if_rayon, slice_ops::slice_cast},
+    base::{commitment::CommittableColumn, if_rayon, math::is_multiple_of, slice_ops::slice_cast},
     proof_primitive::dynamic_matrix_utils::matrix_structure::row_and_column_from_index,
     utils::log,
 };
@@ -66,9 +66,7 @@ pub(super) fn compute_dynamic_dory_commitments(
     let all_sub_commits: Vec<G1Affine> = slice_cast(&blitzar_sub_commits);
     let signed_sub_commits = signed_commits(&all_sub_commits, committable_columns);
     assert!(
-        signed_sub_commits
-            .len()
-            .is_multiple_of(committable_columns.len()),
+        is_multiple_of(signed_sub_commits.len(), committable_columns.len()),
         "Invalid number of sub commits"
     );
     let num_commits = signed_sub_commits.len() / committable_columns.len();

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -1,6 +1,7 @@
 use super::{blitzar_metadata_table::min_as_f, G1Affine, G1Projective};
 use crate::{
-    base::commitment::CommittableColumn, proof_primitive::dory::offset_to_bytes::OffsetToBytes,
+    base::{commitment::CommittableColumn, math::is_multiple_of},
+    proof_primitive::dory::offset_to_bytes::OffsetToBytes,
     utils::log,
 };
 use alloc::{vec, vec::Vec};
@@ -218,7 +219,7 @@ fn offset_column(
                     0
                 };
 
-                let last_value = if total_length.is_multiple_of(num_matrix_commitment_columns) {
+                let last_value = if is_multiple_of(total_length, num_matrix_commitment_columns) {
                     num_matrix_commitment_columns
                 } else {
                     total_length % num_matrix_commitment_columns

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
@@ -57,3 +57,63 @@ pub fn nova_commitment_key_to_hyperkzg_public_setup(
 ) -> HyperKZGPublicSetupOwned {
     slice_ops::slice_cast_with(setup.ck(), convert_g1_affine_from_halo2_to_ark)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::hyperkzg::convert_g1_affine_from_ark_to_halo2;
+    use ff::Field;
+    use nova_snark::{
+        provider::{
+            bn256_grumpkin::bn256::Scalar as NovaScalar,
+            hyperkzg::{Commitment as NovaCommitment, CommitmentEngine},
+        },
+        traits::{commitment::CommitmentEngineTrait, TranscriptEngineTrait},
+    };
+
+    #[test]
+    fn commitment_key_conversion_preserves_nova_points() {
+        let commitment_key: CommitmentKey<HyperKZGEngine> =
+            CommitmentEngine::setup(b"nova-engine-test", 4);
+
+        let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&commitment_key);
+
+        assert_eq!(public_setup.len(), commitment_key.ck().len());
+        for (ark_point, halo2_point) in public_setup.iter().zip(commitment_key.ck()) {
+            assert_eq!(convert_g1_affine_from_ark_to_halo2(ark_point), *halo2_point);
+        }
+    }
+
+    #[test]
+    fn transcript_engine_absorbs_commitments_and_squeezes_scalars() {
+        let commitment_key: CommitmentKey<HyperKZGEngine> =
+            CommitmentEngine::setup(b"nova-transcript-test", 1);
+        let zero_commitment = NovaCommitment::<HyperKZGEngine>::default();
+        let nonzero_commitment =
+            CommitmentEngine::commit(&commitment_key, &[NovaScalar::ONE], &NovaScalar::ZERO);
+
+        let mut zero_transcript =
+            <Keccak256Transcript as TranscriptEngineTrait<HyperKZGEngine>>::new(b"ignored-label");
+        zero_transcript.dom_sep(b"ignored-domain-separator");
+        zero_transcript.absorb(b"ignored-absorb-label", &zero_commitment);
+
+        let mut matching_transcript =
+            <Keccak256Transcript as TranscriptEngineTrait<HyperKZGEngine>>::new(b"different-label");
+        matching_transcript.absorb(b"different-absorb-label", &zero_commitment);
+
+        let mut nonzero_transcript =
+            <Keccak256Transcript as TranscriptEngineTrait<HyperKZGEngine>>::new(b"ignored-label");
+        nonzero_transcript.absorb(b"ignored-absorb-label", &nonzero_commitment);
+
+        let zero_challenge = zero_transcript.squeeze(b"ignored-squeeze-label").unwrap();
+        let matching_challenge = matching_transcript
+            .squeeze(b"different-squeeze-label")
+            .unwrap();
+        let nonzero_challenge = nonzero_transcript
+            .squeeze(b"ignored-squeeze-label")
+            .unwrap();
+
+        assert_eq!(zero_challenge, matching_challenge);
+        assert_ne!(zero_challenge, nonzero_challenge);
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -1,5 +1,6 @@
 use crate::{
     base::{
+        math::is_multiple_of,
         polynomial::interpolate_evaluations_to_reverse_coefficients,
         proof::{ProofError, Transcript},
         scalar::Scalar,
@@ -69,7 +70,7 @@ impl<S: Scalar> SumcheckProof<S> {
         log::log_memory_usage("Start");
 
         let coefficients_len = self.coefficients.len();
-        if !coefficients_len.is_multiple_of(num_variables) {
+        if !is_multiple_of(coefficients_len, num_variables) {
             return Err(ProofError::VerificationError {
                 error: "invalid proof size",
             });


### PR DESCRIPTION
/claim #560

## Summary
- Add focused tests for `nova_commitment_key_to_hyperkzg_public_setup` preserving Nova commitment-key points.
- Cover the HyperKZG Nova transcript engine absorbing zero/nonzero commitments and producing matching/different challenges as expected.
- Replace unstable integer `is_multiple_of` calls with a crate-local helper that preserves the documented zero-divisor semantics, so the focused tests run on the configured toolchain.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql --no-default-features --features hyperkzg_proof proof_primitive::hyperkzg::nova_engine::tests`
- `cargo test -p proof-of-sql --no-default-features --features hyperkzg_proof base::math::tests::is_multiple_of_matches_zero_divisor_semantics`

AI-assisted with Codex; I reviewed and verified the diff before submitting.