### PR TITLE
test: cover database test accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -108,12 +108,12 @@ pub use test_accessor::TestAccessor;
 
 mod owned_table_test_accessor;
 pub use owned_table_test_accessor::OwnedTableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod owned_table_test_accessor_test;
 
 mod table_test_accessor;
 pub use table_test_accessor::TableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod table_test_accessor_test;
 
 /// Module providing utilities for filtering columns based on selection vectors.

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -9,7 +9,7 @@ use crate::base::{
     },
     database::{owned_table_utility::*, TableRef},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::test_scalar::TestScalar,
+    scalar::{test_scalar::TestScalar, ScalarExt},
 };
 
 #[test]
@@ -45,10 +45,16 @@ fn we_can_access_the_columns_of_a_table() {
     }
 
     let data2 = owned_table([
+        uint8("u8", [1_u8, 2, 3, 4]),
+        tinyint("i8", [-1_i8, 2, -3, 4]),
+        smallint("i16", [-10_i16, 20, -30, 40]),
+        int("i32", [-100_i32, 200, -300, 400]),
         bigint("a", [1, 2, 3, 4]),
         bigint("b", [4, 5, 6, 5]),
         int128("c128", [1, 2, 3, 4]),
+        decimal75("decimal", 12, 2, [10, 20, 30, 40]),
         varchar("varchar", ["a", "bc", "d", "e"]),
+        varbinary("bytes", [vec![1_u8, 2], vec![3], vec![], vec![4, 5, 6]]),
         scalar("scalar", [1, 2, 3, 4]),
         boolean("boolean", [true, false, true, false]),
         timestamptz(
@@ -70,8 +76,45 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     }
 
+    match accessor.get_column(&table_ref_2, &"u8".into()) {
+        Column::Uint8(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"i8".into()) {
+        Column::TinyInt(col) => assert_eq!(col.to_vec(), vec![-1, 2, -3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"i16".into()) {
+        Column::SmallInt(col) => assert_eq!(col.to_vec(), vec![-10, 20, -30, 40]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"i32".into()) {
+        Column::Int(col) => assert_eq!(col.to_vec(), vec![-100, 200, -300, 400]),
+        _ => panic!("Invalid column type"),
+    }
+
     match accessor.get_column(&table_ref_2, &"c128".into()) {
         Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"decimal".into()) {
+        Column::Decimal75(precision, scale, col) => {
+            assert_eq!(precision.value(), 12);
+            assert_eq!(scale, 2);
+            assert_eq!(
+                col.to_vec(),
+                vec![
+                    TestScalar::from(10),
+                    TestScalar::from(20),
+                    TestScalar::from(30),
+                    TestScalar::from(40)
+                ]
+            );
+        }
         _ => panic!("Invalid column type"),
     }
 
@@ -84,6 +127,19 @@ fn we_can_access_the_columns_of_a_table() {
         Column::VarChar((col, scals)) => {
             assert_eq!(col.to_vec(), col_slice);
             assert_eq!(scals.to_vec(), col_scalars);
+        }
+        _ => panic!("Invalid column type"),
+    }
+
+    let byte_columns: Vec<&[u8]> = vec![&[1, 2], &[3], &[], &[4, 5, 6]];
+    let byte_scalars: Vec<_> = byte_columns
+        .iter()
+        .map(|bytes| TestScalar::from_byte_slice_via_hash(bytes))
+        .collect();
+    match accessor.get_column(&table_ref_2, &"bytes".into()) {
+        Column::VarBinary((col, scals)) => {
+            assert_eq!(col.to_vec(), byte_columns);
+            assert_eq!(scals.to_vec(), byte_scalars);
         }
         _ => panic!("Invalid column type"),
     }


### PR DESCRIPTION
## Summary
- /claim #560
- enable the owned/table test accessor test modules for the no-default `features=test` coverage build
- extend `OwnedTableTestAccessor` coverage across additional owned column variants: uint8, tinyint, smallint, int, decimal75, and varbinary

## Coverage accounting
- Focused local LCOV for `owned_table_test_accessor.rs`: 100/117 lines
- Focused local LCOV for `table_test_accessor.rs`: 72/88 lines
- Local estimate: +172 previously uncovered production lines in the no-default `features=test` coverage path, approximately $17.20 at $0.10/line
- Final bounty accounting is up to maintainers / the issue workflow

## Validation
- `RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
- `RUSTUP_TOOLCHAIN=stable cargo test -p proof-of-sql --no-default-features --features test base::database::owned_table_test_accessor_test --lib`
- `RUSTUP_TOOLCHAIN=stable cargo test -p proof-of-sql --no-default-features --features test base::database::table_test_accessor_test --lib`
- `RUSTUP_TOOLCHAIN=stable cargo llvm-cov -p proof-of-sql --no-default-features --features test --lcov --output-path /tmp/sxt-test-accessor-after.lcov --lib -- base::database::owned_table_test_accessor_test base::database::table_test_accessor_test`
- `RUSTUP_TOOLCHAIN=stable cargo test -p proof-of-sql --no-default-features --features test --lib`

AI-assisted implementation, manually reviewed and validated locally.