### PR TITLE
test: cover sumcheck term optimizer

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
@@ -141,3 +141,164 @@ impl<'a, S: Scalar + 'a> IntoIterator for &'a OptimizedSumcheckTerms<'a, S> {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{SumcheckTerm, SumcheckTermOptimizer};
+    use crate::{
+        base::scalar::test_scalar::TestScalar,
+        sql::proof::SumcheckSubpolynomialType::{Identity, ZeroSum},
+    };
+    use alloc::{boxed::Box, vec, vec::Vec};
+
+    fn scalar(value: u64) -> TestScalar {
+        TestScalar::from(value)
+    }
+
+    fn term_values(term: &SumcheckTerm<'_, TestScalar>) -> Vec<Vec<TestScalar>> {
+        term.iter()
+            .map(|multiplicand| multiplicand.to_sumcheck_term(2))
+            .collect()
+    }
+
+    #[test]
+    fn new_merges_constant_only_terms() {
+        let constant_term: SumcheckTerm<'_, TestScalar> = vec![];
+        let terms = vec![
+            (Identity, scalar(2), &constant_term),
+            (Identity, scalar(3), &constant_term),
+        ];
+
+        let optimizer = SumcheckTermOptimizer::new(terms.into_iter(), 4);
+        let optimized_terms = optimizer.terms();
+        let optimized = optimized_terms.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(optimized.len(), 1);
+        assert_eq!(optimized[0].0, Identity);
+        assert_eq!(optimized[0].1, scalar(5));
+        assert!(optimized[0].2.is_empty());
+    }
+
+    #[test]
+    fn new_keeps_single_linear_term_unmerged() {
+        let linear_values = vec![scalar(1), scalar(2), scalar(3), scalar(4)];
+        let linear_term: SumcheckTerm<'_, TestScalar> = vec![Box::new(&linear_values)];
+        let terms = vec![(ZeroSum, scalar(7), &linear_term)];
+
+        let optimizer = SumcheckTermOptimizer::new(terms.into_iter(), 4);
+        let optimized_terms = optimizer.terms();
+        let optimized = optimized_terms.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(optimized.len(), 1);
+        assert_eq!(optimized[0].0, ZeroSum);
+        assert_eq!(optimized[0].1, scalar(7));
+        assert_eq!(term_values(optimized[0].2), vec![linear_values.clone()]);
+    }
+
+    #[test]
+    fn new_merges_multiple_linear_terms() {
+        let first_values = vec![scalar(1), scalar(2), scalar(3), scalar(4)];
+        let second_values = vec![scalar(5), scalar(6), scalar(7), scalar(8)];
+        let first_term: SumcheckTerm<'_, TestScalar> = vec![Box::new(&first_values)];
+        let second_term: SumcheckTerm<'_, TestScalar> = vec![Box::new(&second_values)];
+        let terms = vec![
+            (Identity, scalar(2), &first_term),
+            (Identity, scalar(3), &second_term),
+        ];
+
+        let optimizer = SumcheckTermOptimizer::new(terms.into_iter(), 4);
+        let optimized_terms = optimizer.terms();
+        let optimized = optimized_terms.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(optimized.len(), 1);
+        assert_eq!(optimized[0].0, Identity);
+        assert_eq!(optimized[0].1, scalar(1));
+        assert_eq!(
+            term_values(optimized[0].2),
+            vec![vec![scalar(17), scalar(22), scalar(27), scalar(32)]]
+        );
+    }
+
+    #[test]
+    fn new_merges_constant_and_linear_terms() {
+        let constant_term: SumcheckTerm<'_, TestScalar> = vec![];
+        let linear_values = vec![scalar(1), scalar(2), scalar(3), scalar(4)];
+        let linear_term: SumcheckTerm<'_, TestScalar> = vec![Box::new(&linear_values)];
+        let terms = vec![
+            (ZeroSum, scalar(5), &constant_term),
+            (ZeroSum, scalar(3), &linear_term),
+        ];
+
+        let optimizer = SumcheckTermOptimizer::new(terms.into_iter(), 4);
+        let optimized_terms = optimizer.terms();
+        let optimized = optimized_terms.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(optimized.len(), 1);
+        assert_eq!(optimized[0].0, ZeroSum);
+        assert_eq!(optimized[0].1, scalar(1));
+        assert_eq!(
+            term_values(optimized[0].2),
+            vec![vec![scalar(8), scalar(11), scalar(14), scalar(17)]]
+        );
+    }
+
+    #[test]
+    fn new_keeps_superlinear_terms_unmerged() {
+        let first_values = vec![scalar(1), scalar(2), scalar(3), scalar(4)];
+        let second_values = vec![scalar(5), scalar(6), scalar(7), scalar(8)];
+        let superlinear_term: SumcheckTerm<'_, TestScalar> =
+            vec![Box::new(&first_values), Box::new(&second_values)];
+        let terms = vec![(Identity, scalar(9), &superlinear_term)];
+
+        let optimizer = SumcheckTermOptimizer::new(terms.into_iter(), 4);
+        let optimized_terms = optimizer.terms();
+        let optimized = optimized_terms.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(optimized.len(), 1);
+        assert_eq!(optimized[0].0, Identity);
+        assert_eq!(optimized[0].1, scalar(9));
+        assert_eq!(
+            term_values(optimized[0].2),
+            vec![first_values.clone(), second_values.clone()]
+        );
+    }
+
+    #[test]
+    fn into_iter_yields_unmerged_terms_before_merged_terms() {
+        let constant_term: SumcheckTerm<'_, TestScalar> = vec![];
+        let linear_values = vec![scalar(1), scalar(2), scalar(3), scalar(4)];
+        let first_superlinear_values = vec![scalar(4), scalar(3), scalar(2), scalar(1)];
+        let second_superlinear_values = vec![scalar(8), scalar(7), scalar(6), scalar(5)];
+        let linear_term: SumcheckTerm<'_, TestScalar> = vec![Box::new(&linear_values)];
+        let superlinear_term: SumcheckTerm<'_, TestScalar> = vec![
+            Box::new(&first_superlinear_values),
+            Box::new(&second_superlinear_values),
+        ];
+        let terms = vec![
+            (Identity, scalar(5), &constant_term),
+            (Identity, scalar(3), &linear_term),
+            (Identity, scalar(11), &superlinear_term),
+        ];
+
+        let optimizer = SumcheckTermOptimizer::new(terms.into_iter(), 4);
+        let optimized_terms = optimizer.terms();
+        let optimized = optimized_terms.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(optimized.len(), 2);
+        assert_eq!(optimized[0].0, Identity);
+        assert_eq!(optimized[0].1, scalar(11));
+        assert_eq!(
+            term_values(optimized[0].2),
+            vec![
+                first_superlinear_values.clone(),
+                second_superlinear_values.clone(),
+            ]
+        );
+        assert_eq!(optimized[1].0, Identity);
+        assert_eq!(optimized[1].1, scalar(1));
+        assert_eq!(
+            term_values(optimized[1].2),
+            vec![vec![scalar(8), scalar(11), scalar(14), scalar(17)]]
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused unit coverage for `SumcheckTermOptimizer` in `sumcheck_term_optimizer.rs`.
- Cover constant-only merges, single-linear passthrough, multi-linear merging, constant+linear merging, superlinear passthrough, and optimized iterator ordering.

## Validation
- `cargo fmt --check -- crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test -p proof-of-sql sumcheck_term_optimizer --lib`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test -p proof-of-sql --lib --no-default-features --features test`
