### PR TITLE
ci: cache cargo udeps install

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -268,7 +268,12 @@ jobs:
       - name: Install nightly toolchain
         run: |
           curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install nightly
-          cargo +nightly install cargo-udeps --locked
+      - name: Install cargo-udeps
+        uses: taiki-e/cache-cargo-install-action@v3
+        env:
+          RUSTUP_TOOLCHAIN: nightly
+        with:
+          tool: cargo-udeps
       - name: Run cargo udeps
         run: cargo +nightly udeps --all-targets
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a focused CI runtime improvement for #557.

The `udeps` job currently compiles `cargo-udeps` from source every time the job runs. This changes that install to `taiki-e/cache-cargo-install-action`, which still installs `cargo-udeps` with the default locked install behavior but restores the installed binary from cache on later runs instead of recompiling it.

/claim #557

# What changes are included in this PR?

- Replaces the inline `cargo +nightly install cargo-udeps --locked` command with `taiki-e/cache-cargo-install-action@v3`.
- Keeps `RUSTUP_TOOLCHAIN=nightly` for the install because `cargo-udeps` is used through nightly.
- Leaves the actual validation command unchanged: `cargo +nightly udeps --all-targets`.

# Are these changes tested?

Local validation:
- `git diff --check`

I did not run the full CI script locally because this is a GitHub Actions-only setup/runtime change and the full workflow requires the repository CI runner environment.