### PR TITLE
test: reuse dory setup in planner e2e tests

### DIFF
--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -1,4 +1,6 @@
 //! In this file we run end-to-end tests for Proof of SQL.
+use std::{ptr, sync::OnceLock};
+
 use ark_std::test_rng;
 use bumpalo::Bump;
 use datafusion::config::ConfigOptions;
@@ -19,6 +21,22 @@ use proof_of_sql::{
 };
 use proof_of_sql_planner::sql_to_proof_plans;
 use sqlparser::{dialect::GenericDialect, parser::Parser};
+
+static DYNAMIC_DORY_PUBLIC_PARAMETERS: OnceLock<PublicParameters> = OnceLock::new();
+static DYNAMIC_DORY_PROVER_SETUP: OnceLock<ProverSetup<'static>> = OnceLock::new();
+static DYNAMIC_DORY_VERIFIER_SETUP: OnceLock<VerifierSetup> = OnceLock::new();
+
+fn dynamic_dory_public_parameters() -> &'static PublicParameters {
+    DYNAMIC_DORY_PUBLIC_PARAMETERS.get_or_init(|| PublicParameters::test_rand(5, &mut test_rng()))
+}
+
+fn dynamic_dory_test_setup() -> (&'static ProverSetup<'static>, &'static VerifierSetup) {
+    let public_parameters = dynamic_dory_public_parameters();
+    (
+        DYNAMIC_DORY_PROVER_SETUP.get_or_init(|| ProverSetup::from(public_parameters)),
+        DYNAMIC_DORY_VERIFIER_SETUP.get_or_init(|| VerifierSetup::from(public_parameters)),
+    )
+}
 
 /// Get a new `TableTestAccessor` with the provided tables
 fn new_test_accessor<'a, CP: CommitmentEvaluationProof>(
@@ -63,17 +81,14 @@ fn posql_end_to_end_test<'a, CP: CommitmentEvaluationProof>(
 /// Empty SQL should return no plans
 #[test]
 fn test_empty_sql() {
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         "",
         &indexmap! {},
         &[],
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -100,17 +115,14 @@ fn test_tableless_queries() {
         owned_table([varchar("name", ["Katy"]), bigint("age", [0_i64])]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[
             LiteralValue::VarChar("Katy".to_string()),
             LiteralValue::BigInt(0),
@@ -154,17 +166,14 @@ fn test_simple_filter_queries() {
         ]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[LiteralValue::VarChar("Katy".to_string())],
     );
 }
@@ -212,16 +221,14 @@ fn test_complex_filter_queries() {
         ]),
     ];
 
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[LiteralValue::VarChar("Buddy".to_string())],
     );
 }
@@ -256,17 +263,14 @@ fn test_projection() {
         ]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[LiteralValue::Boolean(true)],
     );
 }
@@ -289,17 +293,14 @@ fn test_projection_scaling() {
     let expected_results: Vec<OwnedTable<DoryScalar>> =
         vec![owned_table([decimal75("res", 7, 2, [15, 26, 37, 48])])];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -326,17 +327,14 @@ fn test_slicing_limit() {
         int("price", [1200, 800]),
     ])];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -415,17 +413,14 @@ fn test_group_by() {
         owned_table([bigint("COUNT(*)", [5_i64])]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[LiteralValue::BigInt(2)],
     );
 }
@@ -467,17 +462,14 @@ fn test_coin() {
         bigint("num_transactions", [5_i64]),
     ])];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[LiteralValue::VarChar("0x2".to_string())],
     );
 }
@@ -518,16 +510,13 @@ fn test_join() {
         owned_table([decimal75("product", 21, 0, [14, 24, 40, 50])]),
         owned_table([decimal75("sum_result", 11, 0, [11, 15, 14])]),
     ];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -619,16 +608,13 @@ JOIN (
             ],
         ),
     ])];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -664,16 +650,13 @@ fn test_union() {
             "Chocolate",
         ],
     )])];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -694,16 +677,22 @@ fn test_implicit_casts() {
         boolean("compared", [true, true, false, false]),
         decimal75("product", 14, 1, [300, 800, 30, 8]),
     ])];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_test_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
         &[],
     );
+}
+
+#[test]
+fn test_dynamic_dory_setup_is_reused() {
+    let (first_prover_setup, first_verifier_setup) = dynamic_dory_test_setup();
+    let (second_prover_setup, second_verifier_setup) = dynamic_dory_test_setup();
+
+    assert!(ptr::eq(first_prover_setup, second_prover_setup));
+    assert!(ptr::eq(first_verifier_setup, second_verifier_setup));
 }

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -690,9 +690,12 @@ fn test_implicit_casts() {
 
 #[test]
 fn test_dynamic_dory_setup_is_reused() {
+    let first_public_parameters = dynamic_dory_public_parameters();
     let (first_prover_setup, first_verifier_setup) = dynamic_dory_test_setup();
+    let second_public_parameters = dynamic_dory_public_parameters();
     let (second_prover_setup, second_verifier_setup) = dynamic_dory_test_setup();
 
+    assert!(ptr::eq(first_public_parameters, second_public_parameters));
     assert!(ptr::eq(first_prover_setup, second_prover_setup));
     assert!(ptr::eq(first_verifier_setup, second_verifier_setup));
 }


### PR DESCRIPTION
Fixes #557

## Summary

- Cache the planner e2e tests' shared Dynamic Dory public parameters, prover setup, and verifier setup with `OnceLock`.
- Replace repeated per-test `PublicParameters::test_rand(5)` / setup construction with the shared helper.
- Add a regression test that verifies repeated calls reuse the same cached public parameters, prover setup, and verifier setup by pointer identity.

This keeps the proof/query assertions unchanged while reducing repeated Dory setup work in `crates/proof-of-sql-planner/tests/e2e_tests.rs` from 13 generated setups to one shared setup.

## Test plan

- `git diff --check`
- `cargo fmt --check`
- `BLITZAR_BACKEND=cpu cargo check -p proof-of-sql-planner --all-targets --all-features`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql-planner --test e2e_tests --all-features -- --nocapture`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql-planner --all-features`

The planner checks and tests pass on the final pushed head (`9bf4e30`). The EVM tests remain ignored because they require `forge`; unrelated warnings in `crates/proof-of-sql` are outside this PR.

/claim #557