### PR TITLE
test: reduce fixed example Dory setup sizes

### DIFF
--- a/crates/proof-of-sql-planner/examples/dog_breeds/main.rs
+++ b/crates/proof-of-sql-planner/examples/dog_breeds/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"93c0d245eb104663bfdcd25e36bc3f97";
 

--- a/crates/proof-of-sql-planner/examples/hello_world/main.rs
+++ b/crates/proof-of-sql-planner/examples/hello_world/main.rs
@@ -20,6 +20,9 @@ use std::{
     io::{stdout, Write},
     time::Instant,
 };
+
+const DORY_SETUP_MAX_NU: usize = 2;
+
 /// # Panics
 ///
 /// Will panic if flushing the output fails, which can happen due to issues with the underlying output stream.
@@ -45,7 +48,7 @@ fn main() {
     let timer = start_timer("Loading data");
     // Use a fixed seed for deterministic results
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let public_parameters = PublicParameters::rand(5, &mut rng);
+    let public_parameters = PublicParameters::rand(DORY_SETUP_MAX_NU, &mut rng);
     let prover_setup = ProverSetup::from(&public_parameters);
     let verifier_setup = VerifierSetup::from(&public_parameters);
     let mut accessor =

--- a/crates/proof-of-sql-planner/examples/space/main.rs
+++ b/crates/proof-of-sql-planner/examples/space/main.rs
@@ -33,12 +33,13 @@ use std::{fs::File, time::Instant};
 // For a sampling:
 // max_nu = 3 => max table size is 32 rows
 // max_nu = 4 => max table size is 128 rows
+// max_nu = 6 => max table size is 2048 rows
 // max_nu = 8 => max table size is 32768 rows
 // max_nu = 10 => max table size is 0.5 million rows
 // max_nu = 15 => max table size is 0.5 billion rows
 // max_nu = 20 => max table size is 0.5 trillion rows
 // Note: we will eventually load these from a file.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 6;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"len 32 rng seed - Space and Time";
 

--- a/crates/proof-of-sql-planner/examples/wood_types/main.rs
+++ b/crates/proof-of-sql-planner/examples/wood_types/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"f3a8d12e6b7c4590a1f2e3d4b5c6a7b8";
 


### PR DESCRIPTION
/claim #557

## Summary
- Reduce Dory setup sizes in fixed-data planner examples to the smallest size class that still covers each dataset.
- Keep proof generation and verification paths unchanged; only the public parameter size changes.

## Timing Evidence
Warm local example binaries on aarch64 macOS, built with `-p proof-of-sql-planner` and no-default features where needed because local all-features/default perf builds can trip `halo2curves/asm` on non-x86_64:

| Example | Before | After |
| --- | ---: | ---: |
| hello_world | 13.79s | 8.19s |
| dog_breeds | 38.32s | 18.74s |
| wood_types | 32.66s | 17.06s |
| space | 46.70s | 34.49s |

## Validation
- `rustfmt --check --edition 2021 --config imports_granularity=Crate,group_imports=One` on changed files
- `cargo check -p proof-of-sql-planner --example hello_world --features="proof-of-sql/test"`
- `cargo check -p proof-of-sql-planner --example dog_breeds`
- `cargo check -p proof-of-sql-planner --example wood_types`
- `cargo check -p proof-of-sql-planner --example space`
- Ran warm binaries for all four changed examples before and after; all exited successfully.

## Notes
- Local `cargo fmt --check` is blocked because this machine does not have `rustup`/repo-toolchain rustfmt installed, so direct `rustfmt` was used for the changed files.
