### PR TITLE
test: reduce more example Dory setup sizes

### DIFF
--- a/crates/proof-of-sql-planner/examples/countries/main.rs
+++ b/crates/proof-of-sql-planner/examples/countries/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 4;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"7a1b3c8d2e4f9g6h5i0j7k2l8m3n9o1p";
 

--- a/crates/proof-of-sql-planner/examples/dinosaurs/main.rs
+++ b/crates/proof-of-sql-planner/examples/dinosaurs/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"262a6aa18b5c43d589677c13dd33e6dc";
 

--- a/crates/proof-of-sql-planner/examples/rockets/main.rs
+++ b/crates/proof-of-sql-planner/examples/rockets/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"7a1b3c8d2e4f9g6h5i0j7k2l8m3n9o1p";
 

--- a/crates/proof-of-sql-planner/examples/vehicles/main.rs
+++ b/crates/proof-of-sql-planner/examples/vehicles/main.rs
@@ -30,7 +30,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"97b13c8che4f9g4050jjkk2l5m3nbo1p";
 


### PR DESCRIPTION
/claim #557

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a separate, incremental test/example runtime improvement for #557. I checked the current open #557 PRs and avoided the files touched by #1638, planner e2e setup caching, Dory evaluation/commitment/inner-product test reductions, setup tests, and CI workflow changes.

The changed planner examples still used `DORY_SETUP_MAX_NU = 8` even though their CSV table sizes are much smaller. Each file documents that `max_nu` only needs to satisfy `max table size < 2^(2*max_nu-1)`, so this trims only the generated Dory setup size while leaving the same CSV data, SQL queries, proof generation, verification, and result checks in place.

# What changes are included in this PR?

- Reduce `countries` example setup from `max_nu = 8` to `4` for a 33-row CSV payload.
- Reduce `dinosaurs`, `rockets`, and `vehicles` examples from `max_nu = 8` to `3` for 9, 27, and 10-row CSV payloads.

# Timing evidence

Warm local debug example runs on aarch64 macOS using `cargo run -q -p proof-of-sql-planner --example <name> --no-default-features`:

| Example | Before | After |
| --- | ---: | ---: |
| dinosaurs | 37.46s | 14.55s |
| vehicles | 39.58s | 16.83s |
| countries | 49.01s | 28.57s |
| rockets | 40.74s | 19.40s |

# Are these changes tested?

Yes.

- `cargo run -q -p proof-of-sql-planner --example dinosaurs --no-default-features`
- `cargo run -q -p proof-of-sql-planner --example vehicles --no-default-features`
- `cargo run -q -p proof-of-sql-planner --example countries --no-default-features`
- `cargo run -q -p proof-of-sql-planner --example rockets --no-default-features`
- `cargo check -p proof-of-sql-planner --example dinosaurs --example vehicles --example countries --example rockets --no-default-features`
- `rustfmt --check --edition 2021 --config imports_granularity=Crate,group_imports=One` on the changed files
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: `cargo fmt --check` is blocked locally because the repo-selected rustup toolchain does not have `cargo-fmt` installed, so I verified the changed files directly with the installed `rustfmt` binary.
