### PR TITLE
test: reduce Dory setup sizes in planner examples

### DIFF
--- a/crates/proof-of-sql-planner/examples/albums/main.rs
+++ b/crates/proof-of-sql-planner/examples/albums/main.rs
@@ -30,7 +30,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 4;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"32f7f321c4ab1234d5e6f7a8b9c0d1e2";
 

--- a/crates/proof-of-sql-planner/examples/avocado-prices/main.rs
+++ b/crates/proof-of-sql-planner/examples/avocado-prices/main.rs
@@ -37,7 +37,7 @@ use std::{fs::File, time::Instant};
 // max_nu = 15 => max table size is 0.5 billion rows
 // max_nu = 20 => max table size is 0.5 trillion rows
 // Note: we will eventually load these from a file.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 4;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"len 32 rng seed - Space and Time";
 

--- a/crates/proof-of-sql-planner/examples/books/main.rs
+++ b/crates/proof-of-sql-planner/examples/books/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"ebab60d58dee4cc69658939b7c2a582d";
 

--- a/crates/proof-of-sql-planner/examples/brands/main.rs
+++ b/crates/proof-of-sql-planner/examples/brands/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"8f3a2e1c5b9d7f0a6e4d2c8b7a9f1e3d";
 


### PR DESCRIPTION
/claim #557

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a focused example-runtime improvement for #557.

These planner examples still generated Dory setup data with `DORY_SETUP_MAX_NU = 8`, which supports table sizes below `2^(2*8-1) = 32768` rows. Their CSV payloads are much smaller:

- `albums`: 98 data rows, so `max_nu = 4` supports it because `98 < 2^(2*4-1) = 128`.
- `avocado-prices`: 36 data rows, so `max_nu = 4` supports it.
- `books`: 19 data rows, so `max_nu = 3` supports it because `19 < 2^(2*3-1) = 32`.
- `brands`: 24 data rows, so `max_nu = 3` supports it.

This keeps each example's CSV data, SQL queries, proof generation, verification, and result checks unchanged while reducing unnecessary Dory setup generation.

# What changes are included in this PR?

- Reduce `albums` setup from `max_nu = 8` to `4`.
- Reduce `avocado-prices` setup from `max_nu = 8` to `4`.
- Reduce `books` setup from `max_nu = 8` to `3`.
- Reduce `brands` setup from `max_nu = 8` to `3`.

# Are these changes tested?

Static/local validation:

- `git diff --check`
- Verified CSV data-row counts against the existing Dory setup sizing rule in each file.

Limitations:

- I could not run `cargo fmt`, `rustfmt`, or example executions locally because this machine does not have `cargo` or `rustfmt` installed. The changes are one-line constant reductions and should be covered by repository CI/example checks.