### PR TITLE
test: cover mont scalar serialization

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -52,3 +52,44 @@ fn we_can_bound_modulus_using_max_bits() {
     assert!(modulus_of_i_max_bits <= modulus_of_test_scalar);
     assert!(modulus_of_i_max_bits_plus_1 > modulus_of_test_scalar);
 }
+
+#[test]
+fn we_can_format_test_scalar_values() {
+    assert_eq!(
+        "0000000000000000000000000000000000000000000000000000000000ABC123",
+        format!("{}", TestScalar::from(0x00AB_C123_u64))
+    );
+    assert_eq!(
+        "1000000000000000000000000000000014DEF9DEA2F79CD65812631A5C4A12CA",
+        format!("{}", TestScalar::from(-0x00AB_C123_i64))
+    );
+    assert_eq!(
+        "+0000000000000000000000000000000000000000000000000000000000ABC123",
+        format!("{:+}", TestScalar::from(0x00AB_C123_u64))
+    );
+    assert_eq!(
+        "-0x0000...C123",
+        format!("{:+#}", TestScalar::from(-0x00AB_C123_i64))
+    );
+}
+
+#[test]
+fn we_can_serialize_test_scalar_limbs() {
+    let scalar = TestScalar::from(0x00AB_C123_u64);
+    let serialized = serde_json::to_string(&scalar).unwrap();
+
+    assert_eq!(serialized, "[0,0,0,11256099]");
+    assert_eq!(
+        serde_json::from_str::<TestScalar>(&serialized).unwrap(),
+        scalar
+    );
+}
+
+#[test]
+fn we_can_convert_test_scalar_with_little_endian_bytes() {
+    let bytes = [0x23, 0xC1, 0xAB, 0x00, 0x34, 0x12];
+    let scalar = TestScalar::from_le_bytes_mod_order(&bytes);
+
+    assert_eq!(&scalar.to_bytes_le()[..bytes.len()], bytes);
+    assert_eq!(TestScalar::from_bigint([0x1234_00AB_C123, 0, 0, 0]), scalar);
+}


### PR DESCRIPTION
## Summary
- add TestScalar coverage for signed and alternate formatting modes
- verify serde limb order and round-trip behavior
- verify little-endian byte conversion and from_bigint equivalence

## Tests
- cargo test -p proof-of-sql --no-default-features --features test mont_scalar
- cargo fmt --check
- git diff --check origin/main..HEAD
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"

/claim #560