### PR TITLE
test: cover posql time helpers

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,34 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_convert_timestamp_errors_to_strings() {
+        assert_eq!(
+            String::from(PoSQLTimestampError::InvalidTimezone {
+                timezone: "Mars/Base".to_string()
+            }),
+            "invalid timezone string: Mars/Base"
+        );
+        assert_eq!(
+            String::from(PoSQLTimestampError::InvalidTimezoneOffset),
+            "invalid timezone offset"
+        );
+        assert_eq!(
+            String::from(PoSQLTimestampError::InvalidTimeUnit {
+                error: "fortnight".to_string()
+            }),
+            "Invalid time unit"
+        );
+        assert_eq!(
+            String::from(PoSQLTimestampError::UnsupportedPrecision {
+                error: "2".to_string()
+            }),
+            "Unsupported precision for timestamp: 2"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -59,6 +59,7 @@ impl fmt::Display for PoSQLTimeUnit {
 mod time_unit_tests {
     use super::*;
     use crate::base::posql_time::PoSQLTimestampError;
+    use alloc::string::ToString;
 
     #[test]
     fn test_valid_precisions() {
@@ -80,5 +81,30 @@ mod time_unit_tests {
                 Err(PoSQLTimestampError::UnsupportedPrecision { .. })
             ));
         }
+    }
+
+    #[test]
+    fn we_can_convert_time_units_to_precision() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn we_can_display_time_units() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- covers PoSQLTimeUnit precision conversions and Display output
- covers PoSQLTimestampError to String conversion

## Verification
- cargo test -p proof-of-sql --no-default-features --features test posql_time
- cargo fmt --check
- git diff --check
- cargo llvm-cov -p proof-of-sql --no-default-features --features test --lcov --output-path target/proof-of-sql-posql.lcov
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"

## Coverage
- crates/proof-of-sql/src/base/posql_time/error.rs: 19/19 covered
- crates/proof-of-sql/src/base/posql_time/unit.rs: 54/54 covered
