### PR TITLE
test: cover bool varint encoding

### DIFF
--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -154,6 +154,13 @@ fn test_regression_22() {
     assert!(i8::decode_var(&encoded).is_none());
 }
 
+#[test]
+fn we_can_encode_and_decode_bool_varints() {
+    test_encode_decode(false, [0]);
+    test_encode_decode(true, [1]);
+    assert_eq!(bool::decode_var(&[2]), None);
+}
+
 // ------------------------------------------------------------------------------
 // End of tests taken directly from integer-encoding-rs with minimal modification
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
/claim #560

## Summary
- covers bool VarInt true and false encoding/decoding
- covers bool VarInt rejection for invalid decoded values

## Verification
- cargo test -p proof-of-sql --no-default-features --features test we_can_encode_and_decode_bool_varints
- cargo fmt --check
- git diff --check
- cargo llvm-cov -p proof-of-sql --no-default-features --features test --lcov --output-path target/proof-of-sql-varint-bool.lcov -- we_can_encode_and_decode_bool_varints
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"

## Coverage
- crates/proof-of-sql/src/base/encode/varint_trait.rs bool implementation lines 136-152 covered
