### PR TITLE
test: cover dory commitment helpers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -105,13 +105,31 @@ mod tests {
         },
         proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };
-    use ark_ec::pairing::Pairing;
+    use ark_ec::pairing::{Pairing, PairingOutput};
     use ark_ff::UniformRand;
+    use num_traits::One;
     use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
     fn we_have_correct_constants_for_dory_scalar() {
         test_scalar_constants::<DoryScalar>();
+    }
+
+    #[test]
+    fn we_can_get_default_dory_commitment_identity() {
+        let expected: GT = PairingOutput(One::one());
+        assert_eq!(DoryCommitment::default(), DoryCommitment(expected));
+    }
+
+    #[test]
+    fn we_can_multiply_dory_commitments_by_scalars() {
+        let mut rng = StdRng::seed_from_u64(43);
+        let scalar = DoryScalar::rand(&mut rng);
+        let commitment = DoryCommitment(GT::rand(&mut rng));
+        let expected = DoryCommitment(commitment.0 * scalar.0);
+
+        assert_eq!(scalar * commitment, expected);
+        assert_eq!(scalar * &commitment, expected);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
@@ -108,7 +108,9 @@ mod tests {
         },
         proof_primitive::dory::{test_rng, DoryScalar, ProverSetup, PublicParameters},
     };
+    use ark_ec::pairing::PairingOutput;
     use ark_ff::UniformRand;
+    use num_traits::One;
     use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
@@ -120,6 +122,26 @@ mod tests {
             commitment1.to_transcript_bytes(),
             commitment2.to_transcript_bytes()
         );
+    }
+
+    #[test]
+    fn we_can_get_default_dynamic_dory_commitment_identity() {
+        let expected: GT = PairingOutput(One::one());
+        assert_eq!(
+            DynamicDoryCommitment::default(),
+            DynamicDoryCommitment(expected)
+        );
+    }
+
+    #[test]
+    fn we_can_multiply_dynamic_dory_commitments_by_scalars() {
+        let mut rng = StdRng::seed_from_u64(43);
+        let scalar = DoryScalar::rand(&mut rng);
+        let commitment = DynamicDoryCommitment(GT::rand(&mut rng));
+        let expected = DynamicDoryCommitment(commitment.0 * scalar.0);
+
+        assert_eq!(scalar * commitment, expected);
+        assert_eq!(scalar * &commitment, expected);
     }
 
     /// Under no circumstances should this test be modified. Unless you know what you're doing.


### PR DESCRIPTION
/claim #560

## Summary
- add identity tests for DoryCommitment and DynamicDoryCommitment defaults
- add scalar multiplication tests for owned and borrowed commitment operands
- cover the helper implementations without changing production behavior

## Verification
- cargo test -p proof-of-sql --no-default-features --features test dory_commitment
- cargo fmt --check
- git diff --check
- cargo llvm-cov test -p proof-of-sql --no-default-features --features test --no-report -- dory_commitment_identity
- cargo llvm-cov test -p proof-of-sql --no-default-features --features test --no-report -- dory_commitments_by_scalars
- cargo llvm-cov report --lcov --output-path target/proof-of-sql-dory-commitment-helpers.lcov
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"

Coverage check confirmed dory_commitment.rs lines 59-61, 68-70, and 74-76 plus dynamic_dory_commitment.rs lines 55-57, 64-66, and 70-72 are covered.