### PR TITLE
test: cover rho 256 evaluation

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
@@ -48,3 +48,24 @@ fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
         expected_eval
     );
 }
+
+#[test]
+fn we_can_track_the_rho_256_evaluation_for_long_evaluation_points() {
+    let zero = Curve25519Scalar::from(0u64);
+    let one = Curve25519Scalar::from(1u64);
+    let evaluation_point = [one, zero, one, zero, zero, zero, zero, zero, zero];
+    let random_scalars = evaluation_point;
+    let sumcheck_random_scalars = SumcheckRandomScalars::new(&random_scalars, 3, 9);
+
+    let evals = SumcheckMleEvaluations::new(
+        3,
+        [],
+        [],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &[],
+        &[],
+    );
+
+    assert_eq!(evals.rho_256_evaluation, Some(Curve25519Scalar::from(5u64)));
+}


### PR DESCRIPTION
/claim #560

## Summary
- add coverage for the rho_256 evaluation path in SumcheckMleEvaluations
- verify the eight-bit fold plus remaining-point mask produces the expected scalar
- keep the test narrow by using a single long evaluation point case

## Verification
- cargo test -p proof-of-sql --no-default-features --features test we_can_track_the_rho_256_evaluation_for_long_evaluation_points
- cargo fmt --check
- git diff --check
- cargo llvm-cov -p proof-of-sql --no-default-features --features test --lcov --output-path target/proof-of-sql-rho-256-evaluation.lcov -- we_can_track_the_rho_256_evaluation_for_long_evaluation_points
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"

Coverage check confirmed sumcheck_mle_evaluations.rs lines 65-69 and 71-74 are covered.