### PR TITLE
test: reduce more planner example Dory setup sizes

### DIFF
--- a/crates/proof-of-sql-planner/examples/census/main.rs
+++ b/crates/proof-of-sql-planner/examples/census/main.rs
@@ -36,7 +36,7 @@ use std::{fs::File, time::Instant};
 // max_nu = 15 => max table size is 0.5 billion rows
 // max_nu = 20 => max table size is 0.5 trillion rows
 // Note: we will eventually load these from a file.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 4;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"len 32 rng seed - Space and Time";
 

--- a/crates/proof-of-sql-planner/examples/plastics/main.rs
+++ b/crates/proof-of-sql-planner/examples/plastics/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"32f7f321c4ab1234d5e6f7a8b9c0d1e2";
 

--- a/crates/proof-of-sql-planner/examples/programming_books/main.rs
+++ b/crates/proof-of-sql-planner/examples/programming_books/main.rs
@@ -27,7 +27,7 @@ use rand::{rngs::StdRng, SeedableRng};
 use sqlparser::{dialect::GenericDialect, parser::Parser};
 use std::{fs::File, time::Instant};
 
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 const DORY_SEED: [u8; 32] = *b"ebab60d58dee4cc69658939b7c2a582d";
 
 /// # Panics

--- a/crates/proof-of-sql-planner/examples/stocks/main.rs
+++ b/crates/proof-of-sql-planner/examples/stocks/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The max_nu should be set such that the maximum table size is less than 2^(2*max_nu-1).
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"f9d2e8c1b7a654309cfe81d2b7a3c940";
 

--- a/crates/proof-of-sql-planner/examples/sushi/main.rs
+++ b/crates/proof-of-sql-planner/examples/sushi/main.rs
@@ -23,7 +23,7 @@ use proof_of_sql_planner::sql_to_proof_plans;
 use rand::{rngs::StdRng, SeedableRng};
 use sqlparser::{dialect::GenericDialect, parser::Parser};
 use std::{fs::File, time::Instant};
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 const DORY_SEED: [u8; 32] = *b"sushi-is-the-best-food-available";
 
 /// # Panics

--- a/crates/proof-of-sql-planner/examples/tech_gadget_prices/main.rs
+++ b/crates/proof-of-sql-planner/examples/tech_gadget_prices/main.rs
@@ -26,7 +26,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"tech-gadget-prices-dataset-seed!";
 


### PR DESCRIPTION
/claim #557

## Summary
- reduce Dory setup max_nu for six planner examples to the smallest values that cover their checked-in CSV row counts
- keep census at max_nu=4 for 52 rows and the remaining examples at max_nu=3 for <=18 rows

## Verification
- cargo fmt --check
- git diff --check
- cargo check -p proof-of-sql-planner --examples --no-default-features --features cpu-perf
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"