### PR TITLE
test: cover small proof helper branches

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,8 +1,12 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    dory_commitment_evaluation_proof::DoryError, test_rng, DoryCommitment, DoryEvaluationProof,
+    DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup, ProverSetup, PublicParameters,
+    VerifierSetup,
 };
-use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
+use crate::base::{
+    commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof},
+    scalar::Scalar,
+};
 use ark_std::UniformRand;
 use merlin::Transcript;
 
@@ -91,4 +95,82 @@ fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
     let encoded = postcard::to_allocvec(&proof).unwrap();
     let decoded: DoryEvaluationProof = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(decoded, proof);
+}
+
+#[test]
+fn new_returns_default_for_unsupported_generators_offset() {
+    let mut rng = test_rng();
+    let public_parameters = PublicParameters::test_rand(2, &mut rng);
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let a = [DoryScalar::rand(&mut rng)];
+    let b_point = [DoryScalar::rand(&mut rng)];
+    let mut transcript = Transcript::new(b"evaluation_proof");
+
+    let proof = DoryEvaluationProof::new(
+        &mut transcript,
+        &a,
+        &b_point,
+        1,
+        &DoryProverPublicSetup::new(&prover_setup, 1),
+    );
+
+    assert_eq!(proof, DoryEvaluationProof::default());
+}
+
+#[test]
+fn new_returns_default_when_the_prover_setup_is_too_small() {
+    let mut rng = test_rng();
+    let public_parameters = PublicParameters::test_rand(0, &mut rng);
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let a = [DoryScalar::rand(&mut rng)];
+    let b_point = [
+        DoryScalar::rand(&mut rng),
+        DoryScalar::rand(&mut rng),
+        DoryScalar::rand(&mut rng),
+    ];
+    let mut transcript = Transcript::new(b"evaluation_proof");
+
+    let proof = DoryEvaluationProof::new(
+        &mut transcript,
+        &a,
+        &b_point,
+        0,
+        &DoryProverPublicSetup::new(&prover_setup, 1),
+    );
+
+    assert_eq!(proof, DoryEvaluationProof::default());
+}
+
+#[test]
+fn verify_batched_proof_reports_small_verifier_setup() {
+    let mut rng = test_rng();
+    let public_parameters = PublicParameters::test_rand(0, &mut rng);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let b_point = [
+        DoryScalar::rand(&mut rng),
+        DoryScalar::rand(&mut rng),
+        DoryScalar::rand(&mut rng),
+    ];
+    let mut transcript = Transcript::new(b"evaluation_proof");
+
+    let err = DoryEvaluationProof::default()
+        .verify_batched_proof(
+            &mut transcript,
+            &[DoryCommitment::default()],
+            &[DoryScalar::ONE],
+            &[DoryScalar::ONE],
+            &b_point,
+            0,
+            1,
+            &DoryVerifierPublicSetup::new(&verifier_setup, 1),
+        )
+        .unwrap_err();
+
+    match err {
+        DoryError::SmallSetup { actual, required } => {
+            assert_eq!(actual, 0);
+            assert_eq!(required, 2);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -47,6 +47,30 @@ fn we_can_compute_a_dory_commitment_with_int128_values() {
 }
 
 #[test]
+fn we_can_compute_dory_commitments_with_byte_integer_columns() {
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let res = compute_dory_commitments(
+        &[
+            CommittableColumn::Uint8(&[1, 2]),
+            CommittableColumn::TinyInt(&[-3, 4]),
+        ],
+        0,
+        &setup,
+    );
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
+    let expected_uint8: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(1_u8)
+        + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(2_u8);
+    let expected_tinyint: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(-3_i8)
+        + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(4_i8);
+
+    assert_eq!(res[0].0, expected_uint8);
+    assert_eq!(res[1].0, expected_tinyint);
+}
+
+#[test]
 fn we_can_compute_a_dory_commitment_with_boolean_values() {
     let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -59,6 +59,42 @@ fn test_random_ipa_with_various_lengths() {
 }
 
 #[test]
+fn new_returns_default_for_unsupported_generators_offset() {
+    let mut rng = test_rng();
+    let public_parameters = PublicParameters::test_rand(4, &mut rng);
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let a = core::iter::repeat_with(|| DoryScalar::rand(&mut rng))
+        .take(8)
+        .collect::<Vec<_>>();
+    let b_point = core::iter::repeat_with(|| DoryScalar::rand(&mut rng))
+        .take(3)
+        .collect::<Vec<_>>();
+    let mut transcript = Transcript::new(b"evaluation_proof");
+
+    let proof = DynamicDoryEvaluationProof::new(&mut transcript, &a, &b_point, 1, &&prover_setup);
+
+    assert_eq!(proof, DynamicDoryEvaluationProof::default());
+}
+
+#[test]
+fn new_returns_default_when_the_prover_setup_is_too_small() {
+    let mut rng = test_rng();
+    let public_parameters = PublicParameters::test_rand(1, &mut rng);
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let a = core::iter::repeat_with(|| DoryScalar::rand(&mut rng))
+        .take(8)
+        .collect::<Vec<_>>();
+    let b_point = core::iter::repeat_with(|| DoryScalar::rand(&mut rng))
+        .take(8)
+        .collect::<Vec<_>>();
+    let mut transcript = Transcript::new(b"evaluation_proof");
+
+    let proof = DynamicDoryEvaluationProof::new(&mut transcript, &a, &b_point, 0, &&prover_setup);
+
+    assert_eq!(proof, DynamicDoryEvaluationProof::default());
+}
+
+#[test]
 fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
     let mut rng = test_rng();
     let public_parameters = PublicParameters::test_rand(4, &mut rng);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -107,3 +107,19 @@ pub(super) fn compute_dynamic_dory_commitments(
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{test_rng, PublicParameters};
+
+    #[test]
+    fn empty_column_commitment_impl_returns_default_commitment() {
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
+        let setup = ProverSetup::from(&public_parameters);
+
+        let commitment = compute_dory_commitment(&CommittableColumn::BigInt(&[]), 7, &setup);
+
+        assert_eq!(commitment, DynamicDoryCommitment(GT::zero()));
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs
@@ -62,4 +62,13 @@ mod tests {
             commitment2.to_transcript_bytes()
         );
     }
+
+    #[cfg(not(feature = "blitzar"))]
+    #[test]
+    #[should_panic(expected = "not implemented")]
+    fn compute_commitments_panics_without_blitzar() {
+        let columns: &[CommittableColumn] = &[];
+
+        let _ = RistrettoPoint::compute_commitments(columns, 0, &());
+    }
 }

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
@@ -86,6 +86,19 @@ fn test_create_verify_proof() {
     assert!(subclaim.is_err());
 }
 
+#[test]
+fn verify_without_evaluation_rejects_invalid_proof_size() {
+    let proof = SumcheckProof {
+        coefficients: vec![Curve25519Scalar::from(1_u64), Curve25519Scalar::from(2_u64)],
+    };
+    let mut transcript = Transcript::new(b"sumchecktest");
+
+    let subclaim =
+        proof.verify_without_evaluation(&mut transcript, 3, &Curve25519Scalar::from(3_u64));
+
+    assert!(subclaim.is_err());
+}
+
 fn random_product(
     nv: usize,
     num_multiplicands: usize,

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -78,3 +78,60 @@ pub(crate) trait DecimalProofExpr: ProofExpr {
         self.data_type().scale().expect("Scale should be valid")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestDecimalProofExpr(ColumnType);
+
+    impl ProofExpr for TestDecimalProofExpr {
+        fn data_type(&self) -> ColumnType {
+            self.0
+        }
+
+        fn first_round_evaluate<'a, S: Scalar>(
+            &self,
+            _alloc: &'a Bump,
+            _table: &Table<'a, S>,
+            _params: &[LiteralValue],
+        ) -> PlaceholderResult<Column<'a, S>> {
+            unreachable!()
+        }
+
+        fn final_round_evaluate<'a, S: Scalar>(
+            &self,
+            _builder: &mut FinalRoundBuilder<'a, S>,
+            _alloc: &'a Bump,
+            _table: &Table<'a, S>,
+            _params: &[LiteralValue],
+        ) -> PlaceholderResult<Column<'a, S>> {
+            unreachable!()
+        }
+
+        fn verifier_evaluate<S: Scalar>(
+            &self,
+            _builder: &mut impl VerificationBuilder<S>,
+            _accessor: &IndexMap<Ident, S>,
+            _chi_eval: S,
+            _params: &[LiteralValue],
+        ) -> Result<S, ProofError> {
+            unreachable!()
+        }
+
+        fn get_column_references(&self, _columns: &mut IndexSet<ColumnRef>) {
+            unreachable!()
+        }
+    }
+
+    impl DecimalProofExpr for TestDecimalProofExpr {}
+
+    #[test]
+    fn decimal_proof_expr_exposes_precision_and_scale() {
+        let expr = TestDecimalProofExpr(ColumnType::Decimal75(Precision::new(12).unwrap(), -3));
+
+        assert_eq!(expr.precision(), Precision::new(12).unwrap());
+        assert_eq!(expr.scale(), -3);
+    }
+}


### PR DESCRIPTION
## Summary
- Add boundary tests for Dory evaluation proofs, including unsupported generator offsets and small setup paths
- Cover byte integer Dory commitment branches, empty dynamic Dory commitment output, Ristretto commitment behavior with blitzar disabled, invalid sumcheck proof size, and DecimalProofExpr precision/scale defaults

## Verification
- cargo fmt --check
- cargo test -p proof-of-sql --lib dory_commitment_evaluation_proof --no-default-features --features cpu-perf
- cargo test -p proof-of-sql --lib ristretto_point --no-default-features --features cpu-perf
- cargo llvm-cov -p proof-of-sql --lib --no-default-features --features cpu-perf --lcov --output-path target\small-proof-helpers-focused.lcov
- cargo test -p proof-of-sql --lib --no-default-features --features cpu-perf
- git diff --check
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"

Coverage report confirms 30 target lines that were previously uncovered are now hit.

/claim #560