### PR TITLE
test: cover proof expr test utility

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -225,3 +225,156 @@ pub fn sum_expr(expr: DynProofExpr, alias: &str) -> AliasedDynProofExpr {
         alias: alias.into(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{database::SchemaAccessorImpl, map::indexmap, scalar::test_scalar::TestScalar},
+        sql::proof_exprs::{ProofExpr, ScalingCastExpr},
+    };
+
+    fn test_schema() -> (TableRef, SchemaAccessorImpl) {
+        let table_ref = TableRef::from_names(Some("sxt"), "orders");
+        let schema = SchemaAccessorImpl::new(indexmap! {
+            table_ref.clone() => vec![
+                ("id".into(), ColumnType::Int),
+                ("flag".into(), ColumnType::Boolean),
+                ("amount".into(), ColumnType::BigInt),
+            ],
+        });
+
+        (table_ref, schema)
+    }
+
+    #[test]
+    fn we_can_construct_column_helpers() {
+        let (table_ref, schema) = test_schema();
+
+        let id_ref = col_ref(&table_ref, "id", &schema);
+        assert_eq!(id_ref.table_ref(), table_ref);
+        assert_eq!(id_ref.column_id().value, "id");
+        assert_eq!(*id_ref.column_type(), ColumnType::Int);
+
+        assert!(matches!(
+            column(&table_ref, "flag", &schema),
+            DynProofExpr::Column(_)
+        ));
+        assert_eq!(
+            col_expr(&table_ref, "amount", &schema).data_type(),
+            ColumnType::BigInt
+        );
+
+        let columns = cols_expr(&table_ref, &["id", "flag"], &schema);
+        assert_eq!(columns.len(), 2);
+        assert_eq!(columns[0].column_id().value, "id");
+        assert_eq!(columns[1].column_id().value, "flag");
+
+        let aliased_columns = cols_expr_plan(&table_ref, &["id", "amount"], &schema);
+        assert_eq!(aliased_columns.len(), 2);
+        assert_eq!(aliased_columns[0].alias.value, "id");
+        assert_eq!(aliased_columns[1].alias.value, "amount");
+
+        assert_eq!(tab(&table_ref).table_ref, table_ref);
+    }
+
+    #[test]
+    fn we_can_construct_binary_expression_helpers() {
+        let lhs = const_int(3);
+        let rhs = const_int(4);
+
+        assert!(matches!(
+            equal(lhs.clone(), rhs.clone()),
+            DynProofExpr::Equals(_)
+        ));
+        assert!(matches!(
+            lt(lhs.clone(), rhs.clone()),
+            DynProofExpr::Inequality(_)
+        ));
+        assert!(matches!(
+            gt(lhs.clone(), rhs.clone()),
+            DynProofExpr::Inequality(_)
+        ));
+        assert!(matches!(
+            lte(lhs.clone(), rhs.clone()),
+            DynProofExpr::Not(_)
+        ));
+        assert!(matches!(
+            gte(lhs.clone(), rhs.clone()),
+            DynProofExpr::Not(_)
+        ));
+        assert!(matches!(
+            add(lhs.clone(), rhs.clone()),
+            DynProofExpr::Add(_)
+        ));
+        assert!(matches!(
+            subtract(lhs.clone(), rhs.clone()),
+            DynProofExpr::Subtract(_)
+        ));
+        assert!(matches!(
+            multiply(lhs.clone(), rhs.clone()),
+            DynProofExpr::Multiply(_)
+        ));
+
+        let truthy = const_bool(true);
+        let falsy = const_bool(false);
+        assert!(matches!(not(truthy.clone()), DynProofExpr::Not(_)));
+        assert!(matches!(
+            and(truthy.clone(), falsy.clone()),
+            DynProofExpr::And(_)
+        ));
+        assert!(matches!(or(truthy, falsy), DynProofExpr::Or(_)));
+    }
+
+    #[test]
+    fn we_can_construct_cast_and_literal_helpers() {
+        assert!(matches!(
+            cast(const_smallint(7), ColumnType::BigInt),
+            DynProofExpr::Cast(_)
+        ));
+        assert!(matches!(
+            scaling_cast(
+                const_decimal75(10, 2, 12345),
+                ColumnType::Decimal75(Precision::new(12).unwrap(), 4)
+            ),
+            DynProofExpr::ScalingCast(ScalingCastExpr { .. })
+        ));
+
+        assert_eq!(const_bool(true).data_type(), ColumnType::Boolean);
+        assert_eq!(const_smallint(-1).data_type(), ColumnType::SmallInt);
+        assert_eq!(const_int(2).data_type(), ColumnType::Int);
+        assert_eq!(const_bigint(3).data_type(), ColumnType::BigInt);
+        assert_eq!(const_int128(4).data_type(), ColumnType::Int128);
+        assert_eq!(const_varchar("hello").data_type(), ColumnType::VarChar);
+        assert_eq!(const_varbinary(b"abc").data_type(), ColumnType::VarBinary);
+        assert_eq!(
+            const_scalar::<TestScalar, _>(5).data_type(),
+            ColumnType::Scalar
+        );
+        assert_eq!(
+            const_decimal75(18, 2, 100).data_type(),
+            ColumnType::Decimal75(Precision::new(18).unwrap(), 2)
+        );
+    }
+
+    #[test]
+    fn we_can_construct_alias_helpers() {
+        let (table_ref, schema) = test_schema();
+
+        let aliased = aliased_placeholder(1, ColumnType::BigInt, "p");
+        assert_eq!(aliased.alias.value, "p");
+        assert!(matches!(aliased.expr, DynProofExpr::Placeholder(_)));
+
+        let plan = aliased_plan(const_bigint(9), "nine");
+        assert_eq!(plan.alias.value, "nine");
+        assert!(matches!(plan.expr, DynProofExpr::Literal(_)));
+
+        let column_plan = col_expr_plan(&table_ref, "amount", &schema);
+        assert_eq!(column_plan.alias.value, "amount");
+        assert!(matches!(column_plan.expr, DynProofExpr::Column(_)));
+
+        let sum = sum_expr(const_bigint(8), "total");
+        assert_eq!(sum.alias.value, "total");
+        assert!(matches!(sum.expr, DynProofExpr::Literal(_)));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused tests for proof expression test utility constructors
- verify schema-backed column helpers, boolean/numeric expression helpers, literal helpers, casts, placeholders, and aliases
- keep the change test-only and scoped to `sql/proof_exprs/test_utility.rs`

## Coverage
- focused LCOV confirms 109 previously uncovered lines in `crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs` are now covered

## Verification
- `cargo test -p proof-of-sql --lib sql::proof_exprs::test_utility::tests --no-default-features --features cpu-perf`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features cpu-perf --lcov --output-path target\proof-expr-test-utility-focused.lcov -- sql::proof_exprs::test_utility::tests`
- `cargo test -p proof-of-sql --lib --no-default-features --features cpu-perf`
- `cargo fmt --check`
- `git diff --check`
- `bash -c "tr -d '\r' < scripts/check_commits.sh | bash"`