### PR TITLE
test: cover provable query result without arrow

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -239,6 +239,222 @@ impl ProvableQueryResult {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        database::{
+            owned_table_utility::{
+                bigint, boolean, decimal75, int, int128, owned_table, scalar, smallint,
+                timestamptz, tinyint, uint8, varbinary, varchar,
+            },
+            table_utility::{borrowed_bigint, borrowed_boolean, table},
+        },
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
+    use bumpalo::Bump;
+
+    fn mixed_fields() -> Vec<ColumnField> {
+        vec![
+            ColumnField::new("flag".into(), ColumnType::Boolean),
+            ColumnField::new("uint8_col".into(), ColumnType::Uint8),
+            ColumnField::new("tinyint_col".into(), ColumnType::TinyInt),
+            ColumnField::new("smallint_col".into(), ColumnType::SmallInt),
+            ColumnField::new("int_col".into(), ColumnType::Int),
+            ColumnField::new("bigint_col".into(), ColumnType::BigInt),
+            ColumnField::new("int128_col".into(), ColumnType::Int128),
+            ColumnField::new("varchar_col".into(), ColumnType::VarChar),
+            ColumnField::new("varbinary_col".into(), ColumnType::VarBinary),
+            ColumnField::new("scalar_col".into(), ColumnType::Scalar),
+            ColumnField::new(
+                "decimal_col".into(),
+                ColumnType::Decimal75(Precision::new(75).unwrap(), 2),
+            ),
+            ColumnField::new(
+                "timestamp_col".into(),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+            ),
+        ]
+    }
+
+    #[test]
+    fn we_can_evaluate_all_column_types_without_arrow() {
+        let bool_values = [true];
+        let uint8_values = [7_u8];
+        let tinyint_values = [-2_i8];
+        let smallint_values = [-3_i16];
+        let int_values = [-4_i32];
+        let bigint_values = [-5_i64];
+        let int128_values = [-6_i128];
+        let varchar_values = ["abc"];
+        let varchar_scalars = [TestScalar::from("abc")];
+        let raw_bytes = [b"raw".as_slice()];
+        let binary_scalars = [TestScalar::from_byte_slice_via_hash(raw_bytes[0])];
+        let scalar_values = [TestScalar::from(11_u64)];
+        let decimal_values = [TestScalar::from(13_u64)];
+        let timestamp_values = [1_234_i64];
+        let columns = [
+            Column::Boolean(&bool_values),
+            Column::Uint8(&uint8_values),
+            Column::TinyInt(&tinyint_values),
+            Column::SmallInt(&smallint_values),
+            Column::Int(&int_values),
+            Column::BigInt(&bigint_values),
+            Column::Int128(&int128_values),
+            Column::VarChar((&varchar_values, &varchar_scalars)),
+            Column::VarBinary((&raw_bytes, &binary_scalars)),
+            Column::Scalar(&scalar_values),
+            Column::Decimal75(Precision::new(75).unwrap(), 2, &decimal_values),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                &timestamp_values,
+            ),
+        ];
+        let result = ProvableQueryResult::new(1, &columns);
+
+        let evaluations = result
+            .evaluate::<TestScalar>(&[], 1, &mixed_fields())
+            .unwrap();
+
+        assert_eq!(
+            evaluations,
+            vec![
+                TestScalar::from(1_u64),
+                TestScalar::from(7_u64),
+                -TestScalar::from(2_u64),
+                -TestScalar::from(3_u64),
+                -TestScalar::from(4_u64),
+                -TestScalar::from(5_u64),
+                -TestScalar::from(6_u64),
+                TestScalar::from("abc"),
+                TestScalar::from_byte_slice_via_hash(raw_bytes[0]),
+                TestScalar::from(11_u64),
+                TestScalar::from(13_u64),
+                TestScalar::from(1_234_u64),
+            ]
+        );
+    }
+
+    #[test]
+    fn we_can_convert_all_column_types_to_owned_table_without_arrow() {
+        let bool_values = [true, false];
+        let uint8_values = [7_u8, 8];
+        let tinyint_values = [-2_i8, 3];
+        let smallint_values = [-3_i16, 4];
+        let int_values = [-4_i32, 5];
+        let bigint_values = [-5_i64, 6];
+        let int128_values = [-6_i128, 7];
+        let varchar_values = ["abc", "de"];
+        let varchar_scalars = [TestScalar::from("abc"), TestScalar::from("de")];
+        let raw_bytes = [b"raw".as_slice(), b"bytes".as_slice()];
+        let binary_scalars = [
+            TestScalar::from_byte_slice_via_hash(raw_bytes[0]),
+            TestScalar::from_byte_slice_via_hash(raw_bytes[1]),
+        ];
+        let scalar_values = [TestScalar::from(11_u64), TestScalar::from(12_u64)];
+        let decimal_values = [TestScalar::from(13_u64), TestScalar::from(14_u64)];
+        let timestamp_values = [1_234_i64, 5_678];
+        let columns = [
+            Column::Boolean(&bool_values),
+            Column::Uint8(&uint8_values),
+            Column::TinyInt(&tinyint_values),
+            Column::SmallInt(&smallint_values),
+            Column::Int(&int_values),
+            Column::BigInt(&bigint_values),
+            Column::Int128(&int128_values),
+            Column::VarChar((&varchar_values, &varchar_scalars)),
+            Column::VarBinary((&raw_bytes, &binary_scalars)),
+            Column::Scalar(&scalar_values),
+            Column::Decimal75(Precision::new(75).unwrap(), 2, &decimal_values),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                &timestamp_values,
+            ),
+        ];
+        let result = ProvableQueryResult::new(2, &columns);
+        let expected = owned_table::<TestScalar>([
+            boolean("flag", bool_values),
+            uint8("uint8_col", uint8_values),
+            tinyint("tinyint_col", tinyint_values),
+            smallint("smallint_col", smallint_values),
+            int("int_col", int_values),
+            bigint("bigint_col", bigint_values),
+            int128("int128_col", int128_values),
+            varchar("varchar_col", varchar_values),
+            varbinary(
+                "varbinary_col",
+                [raw_bytes[0].to_vec(), raw_bytes[1].to_vec()],
+            ),
+            scalar("scalar_col", scalar_values),
+            decimal75("decimal_col", 75, 2, decimal_values),
+            timestamptz(
+                "timestamp_col",
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                timestamp_values,
+            ),
+        ]);
+
+        assert_eq!(
+            result
+                .to_owned_table::<TestScalar>(&mixed_fields())
+                .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn we_can_create_result_from_table_without_arrow() {
+        let alloc = Bump::new();
+        let source = table::<TestScalar>([
+            borrowed_bigint("amount", [10_i64, 12], &alloc),
+            borrowed_boolean("flag", [true, false], &alloc),
+        ]);
+        let fields = source.schema();
+
+        let result = ProvableQueryResult::from(source);
+        let expected = owned_table::<TestScalar>([
+            bigint("amount", [10_i64, 12]),
+            boolean("flag", [true, false]),
+        ]);
+
+        assert_eq!(result.num_columns(), 2);
+        assert_eq!(result.table_length(), 2);
+        assert_eq!(
+            result.to_owned_table::<TestScalar>(&fields).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn conversion_and_evaluation_report_invalid_encoded_shapes() {
+        let columns: [Column<TestScalar>; 1] = [Column::BigInt(&[10_i64])];
+        let mut result = ProvableQueryResult::new(1, &columns);
+        let fields = [ColumnField::new("amount".into(), ColumnType::BigInt)];
+
+        *result.num_columns_mut() = 2;
+        assert!(matches!(
+            result.evaluate::<TestScalar>(&[], 1, &fields),
+            Err(QueryError::InvalidColumnCount)
+        ));
+        assert!(matches!(
+            result.to_owned_table::<TestScalar>(&fields),
+            Err(QueryError::InvalidColumnCount)
+        ));
+
+        *result.num_columns_mut() = 1;
+        result.data_mut().push(1);
+        assert!(matches!(
+            result.evaluate::<TestScalar>(&[], 1, &fields),
+            Err(QueryError::MiscellaneousEvaluationError)
+        ));
+    }
+}
+
 impl<S: Scalar> From<Table<'_, S>> for ProvableQueryResult {
     fn from(table: Table<S>) -> Self {
         let num_rows = table.num_rows();


### PR DESCRIPTION
/claim #560

## Summary
- add no-default tests for `ProvableQueryResult` without requiring the Arrow feature
- cover evaluation and owned-table conversion for boolean, integer, varchar, varbinary, scalar, decimal, and timestamp result columns
- cover `From<Table>` construction plus invalid column count and trailing data error paths

## Coverage
- focused LCOV confirms 129 previously uncovered lines in `crates/proof-of-sql/src/sql/proof/provable_query_result.rs` are now covered

## Verification
- `cargo test -p proof-of-sql --lib sql::proof::provable_query_result::tests --no-default-features --features cpu-perf`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features cpu-perf --lcov --output-path target\provable-query-result-focused.lcov -- sql::proof::provable_query_result::tests`
- `cargo test -p proof-of-sql --lib --no-default-features --features cpu-perf`
- `cargo fmt --check`
- `git diff --check`
- `bash -c "tr -d '\r' < scripts/check_commits.sh | bash"`