### PR TITLE
test: cover decimal proof expr accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -78,3 +78,58 @@ pub(crate) trait DecimalProofExpr: ProofExpr {
         self.data_type().scale().expect("Scale should be valid")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestDecimalExpr(ColumnType);
+
+    impl ProofExpr for TestDecimalExpr {
+        fn data_type(&self) -> ColumnType {
+            self.0
+        }
+
+        fn first_round_evaluate<'a, S: Scalar>(
+            &self,
+            _alloc: &'a Bump,
+            _table: &Table<'a, S>,
+            _params: &[LiteralValue],
+        ) -> PlaceholderResult<Column<'a, S>> {
+            unreachable!("decimal accessor tests do not evaluate columns")
+        }
+
+        fn final_round_evaluate<'a, S: Scalar>(
+            &self,
+            _builder: &mut FinalRoundBuilder<'a, S>,
+            _alloc: &'a Bump,
+            _table: &Table<'a, S>,
+            _params: &[LiteralValue],
+        ) -> PlaceholderResult<Column<'a, S>> {
+            unreachable!("decimal accessor tests do not evaluate columns")
+        }
+
+        fn verifier_evaluate<S: Scalar>(
+            &self,
+            _builder: &mut impl VerificationBuilder<S>,
+            _accessor: &IndexMap<Ident, S>,
+            _chi_eval: S,
+            _params: &[LiteralValue],
+        ) -> Result<S, ProofError> {
+            unreachable!("decimal accessor tests do not verify expressions")
+        }
+
+        fn get_column_references(&self, _columns: &mut IndexSet<ColumnRef>) {}
+    }
+
+    impl DecimalProofExpr for TestDecimalExpr {}
+
+    #[test]
+    fn we_can_read_decimal_precision_and_scale_from_proof_expr() {
+        let expr = TestDecimalExpr(ColumnType::Decimal75(Precision::new(12).unwrap(), -3));
+
+        assert_eq!(expr.precision(), Precision::new(12).unwrap());
+        assert_eq!(expr.scale(), -3);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add a no-default test for `DecimalProofExpr` default accessor methods
- cover precision and scale extraction from a decimal proof expression
- keep the change test-only and scoped to `sql/proof_exprs/proof_expr.rs`

## Coverage
- focused LCOV confirms 10 previously uncovered lines in `crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs` are now covered

## Verification
- `cargo test -p proof-of-sql --lib sql::proof_exprs::proof_expr::tests --no-default-features --features cpu-perf`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features cpu-perf --lcov --output-path target\proof-expr-focused.lcov -- sql::proof_exprs::proof_expr::tests`
- `cargo test -p proof-of-sql --lib --no-default-features --features cpu-perf`
- `cargo fmt --check`
- `git diff --check`
- `bash -c "tr -d '\r' < scripts/check_commits.sh | bash"`