### PR TITLE
test: cover uint8 column bounds

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -611,11 +611,11 @@ mod tests {
             ColumnBounds::Int(Bounds::Sharp(BoundsInner { min: 1, max: 6 }))
         );
 
-        let bigint_a = ColumnBounds::BigInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
-        let bigint_b = ColumnBounds::BigInt(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
+        let uint8_a = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
+        let uint8_b = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
         assert_eq!(
-            bigint_a.try_union(bigint_b).unwrap(),
-            ColumnBounds::BigInt(Bounds::Sharp(BoundsInner { min: 1, max: 6 }))
+            uint8_a.try_union(uint8_b).unwrap(),
+            ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 6 }))
         );
 
         let bigint_a = ColumnBounds::BigInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
@@ -732,5 +732,20 @@ mod tests {
 
         assert!(smallint.try_difference(timestamp).is_err());
         assert!(timestamp.try_difference(smallint).is_err());
+    }
+
+    #[test]
+    fn we_can_use_uint8_column_bounds() {
+        let uint8_column = OwnedColumn::<TestScalar>::Uint8([1, 2, 3, 1, 0].to_vec());
+        let committable_uint8_column = CommittableColumn::from(&uint8_column);
+        let uint8_column_bounds = ColumnBounds::from_column(&committable_uint8_column);
+        assert_eq!(
+            uint8_column_bounds,
+            ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
+        );
+
+        let uint8_a = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
+        let uint8_b = ColumnBounds::Uint8(Bounds::Empty);
+        assert_eq!(uint8_a.try_difference(uint8_b).unwrap(), uint8_a);
     }
 }


### PR DESCRIPTION
## Summary
- cover the Uint8 union and difference arms in ColumnBounds
- replace a duplicate BigInt union assertion with a Uint8 assertion
- add a focused Uint8 bounds test for column conversion and difference

## Verification
- cargo fmt --all -- --check
- cargo test -p proof-of-sql base::commitment::column_bounds --lib --no-default-features --features test
- cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/column-bounds-uint8.lcov -- base::commitment::column_bounds
- cargo test -p proof-of-sql --lib --no-default-features --features test
- git diff --check
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"

Focused LCOV covers 13 previously uncovered lines in column_bounds.rs, including 4 production branch lines: 252, 253, 287, 288.

/claim #560