### PR TITLE
test: reduce dynamic dory helper setup size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn we_can_compute_dynamic_T_vec_prime() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
 
         let a: Vec<F> = (100..109).map(Into::into).collect();


### PR DESCRIPTION
/claim #557

## Summary
- reduce the `we_can_compute_dynamic_T_vec_prime` Dory public parameter setup from max_nu 5 to 3
- keep the same `nu = 3` test inputs and assertions while avoiding unused setup rows

## Timing
- before: focused test finished in 0.45s locally
- after: focused test finished in 0.14s locally

## Testing
- cargo fmt --all -- --check
- cargo test -p proof-of-sql proof_primitive::dory::dynamic_dory_helper::tests --lib --no-default-features --features test
- cargo test -p proof-of-sql --lib --no-default-features --features test
- git diff --check HEAD~1..HEAD
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"