### PR TITLE
test: reduce public parameters file roundtrip size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -276,7 +276,7 @@ mod tests {
     // nu = 15 |  9.000 MB  | 504.351756724s
     #[test]
     fn we_can_read_and_write_a_file_round_trip() {
-        let nu_values = vec![1, 2, 4];
+        let nu_values = vec![1, 2, 3];
 
         // Loop through each nu value
         for &nu in &nu_values {


### PR DESCRIPTION
/claim #557

## Summary
- reduce the largest Dory public parameters file roundtrip test case from `nu = 4` to `nu = 3`
- keep the same multi-size serialization, file write, load, equality, metadata, timing, and cleanup assertions

## Timing
- before: focused test finished in 0.40s locally
- after: focused test finished in 0.30s locally

## Testing
- cargo fmt --all -- --check
- cargo test -p proof-of-sql proof_primitive::dory::public_parameters::tests::we_can_read_and_write_a_file_round_trip --lib --no-default-features --features test
- cargo test -p proof-of-sql proof_primitive::dory::public_parameters::tests --lib --no-default-features --features test
- cargo test -p proof-of-sql --lib --no-default-features --features test
- git diff --check HEAD~1..HEAD
- bash -c "tr -d '\r' < scripts/check_commits.sh | bash"