### PR TITLE
test: cover scalar point multiplication

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
@@ -39,6 +39,19 @@ fn test_dalek_interop_m1() {
 }
 
 #[test]
+fn curve25519_scalar_multiplies_ristretto_points_from_either_side() {
+    let scalar = Curve25519Scalar::from(7_u64);
+    let dalek_scalar = curve25519_dalek::scalar::Scalar::from(7_u64);
+    let point = curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
+    let expected = dalek_scalar * point;
+
+    assert_eq!(scalar * point, expected);
+    assert_eq!(scalar * &point, expected);
+    assert_eq!(point * scalar, expected);
+    assert_eq!((&point) * scalar, expected);
+}
+
+#[test]
 fn test_add() {
     let one = Curve25519Scalar::from(1u64);
     let two = Curve25519Scalar::from(2u64);

--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -206,6 +206,18 @@ mod tests {
     }
 
     #[test]
+    fn owned_strings_are_correctly_encoded_and_decoded() {
+        let value = String::from("owned test string");
+        let mut out = vec![0_u8; value.required_bytes()];
+        let written_bytes = value.encode(&mut out[..]);
+        let (decoded_value, read_bytes) = String::decode(&out[..]).unwrap();
+
+        assert_eq!(written_bytes, out.len());
+        assert_eq!(read_bytes, out.len());
+        assert_eq!(decoded_value, value);
+    }
+
+    #[test]
     fn we_can_encode_and_decode_a_simple_array() {
         let value = &[1_u8, 3_u8, 5_u8][..];
         let mut out = vec![0_u8; value.required_bytes()];


### PR DESCRIPTION
## Summary
- add direct coverage for Curve25519Scalar multiplication with RistrettoPoint operands from both sides
- add owned String ProvableResultElement encode/decode round-trip coverage

/claim #560

## Validation
- cargo fmt --check
- cargo test -p proof-of-sql --lib --no-default-features --features test curve25519_scalar_multiplies_ristretto_points_from_either_side
- cargo test -p proof-of-sql --lib --no-default-features --features test owned_strings_are_correctly_encoded_and_decoded
- cargo llvm-cov -p proof-of-sql --no-default-features --features test --lcov --output-path target/curve25519-scalar-followup.lcov -- curve25519_scalar_multiplies_ristretto_points_from_either_side
- cargo llvm-cov -p proof-of-sql --no-default-features --features test --lcov --output-path target/owned-string-followup.lcov -- owned_strings_are_correctly_encoded_and_decoded
- git diff --check
- source scripts/check_commits.sh

## Payout
Payment method: Algora bounty-platform payout to GitHub user @jamilahmadzai for issue #560 coverage-pool accounting.


