### PR TITLE
test: reduce Dory state test size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_state_test.rs
@@ -9,7 +9,7 @@ use ark_ff::Fp;
 #[test]
 pub fn we_can_create_an_extended_verifier_state_from_an_extended_prover_state() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
     for nu in 0..max_nu {

--- a/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
@@ -4,7 +4,7 @@ use ark_ec::pairing::Pairing;
 #[test]
 pub fn we_can_create_a_verifier_state_from_a_prover_state() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
     for nu in 0..max_nu {


### PR DESCRIPTION
## Summary

- reduce the Dory state and extended-state test setup range from `max_nu = 5` to `max_nu = 4`
- keep coverage across multiple dimensions (`nu = 0..3`) while avoiding the highest-cost state setup tier

## Timing

Before, from full lib JSON timing:
- `state_test::we_can_create_a_verifier_state_from_a_prover_state`: 5.206114s
- `extended_state_test::we_can_create_an_extended_verifier_state_from_an_extended_prover_state`: 5.528251s

After, from targeted JSON timing:
- `state_test::we_can_create_a_verifier_state_from_a_prover_state`: 1.823706s
- `extended_state_test::we_can_create_an_extended_verifier_state_from_an_extended_prover_state`: 1.955462s

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --no-default-features --features test proof_primitive::dory::state_test --lib -- --quiet`
- `cargo test -p proof-of-sql --no-default-features --features test proof_primitive::dory::extended_state_test --lib -- --quiet`
- `cargo test -p proof-of-sql --no-default-features --features test --lib -- --quiet` (960 passed; 114.19s)
- `git diff --check HEAD~1..HEAD`
- `bash -c "tr -d '\r' < scripts/check_commits.sh | bash"`

/claim #557