### PR TITLE
test: reduce sumcheck random case matrix

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/test_cases.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/test_cases.rs
@@ -44,8 +44,9 @@ impl<S: Scalar> SumcheckTestCase<S> {
 pub fn sumcheck_test_cases<S: Scalar>(
     rng: &mut (impl ark_std::rand::Rng + ?Sized),
 ) -> impl Iterator<Item = SumcheckTestCase<S>> + '_ {
-    (1..=8)
+    (1..=7)
         .cartesian_product(0..=5)
+        .chain([(8, 0), (8, 5)])
         .flat_map(|(num_vars, max_multiplicands)| {
             [
                 Some(vec![]),


### PR DESCRIPTION
## Summary

- reduce the full sumcheck randomized matrix to `num_vars = 1..=7`
- keep 8-variable coverage through representative low-degree and complex high-degree smoke cases
- avoid rerunning the most expensive 8-variable combinations for every `max_multiplicands` value

## Timing

Before, from full lib JSON timing:
- `sumcheck::proof_test::we_can_verify_many_random_test_cases`: 1.003477s

After, from targeted JSON timing:
- `sumcheck::proof_test::we_can_verify_many_random_test_cases`: 0.470585s

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --no-default-features --features test proof_primitive::sumcheck::proof_test::we_can_verify_many_random_test_cases --lib -- --quiet`
- `cargo test -p proof-of-sql --no-default-features --features test --lib -- --quiet` (960 passed; 117.36s)
- `git diff --check`
- `bash -c "tr -d '\r' < scripts/check_commits.sh | bash"`

/claim #557