### PR TITLE
test: reduce dynamic vector dimension sweep

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/standard_basis_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/standard_basis_helper.rs
@@ -710,7 +710,7 @@ pub(crate) mod tests {
     fn we_can_compute_dynamic_vecs_that_matches_evaluation_vec() {
         use ark_std::UniformRand;
         let mut rng = ark_std::test_rng();
-        for num_vars in 0..20 {
+        for num_vars in (0..=12).chain([19]) {
             let point: Vec<_> = core::iter::repeat_with(|| MontScalar(F::rand(&mut rng)))
                 .take(num_vars)
                 .collect();


### PR DESCRIPTION
## Summary

- reduce the dynamic vector/evaluation-vector comparison sweep from every dimension `0..20` to `0..=12` plus a 19-variable smoke case
- keep continuous low-dimension coverage and retain the largest existing dimension check
- avoid repeated high-cost middle dimensions that allocate and compare large evaluation vectors

## Timing

Before, from full lib JSON timing:
- `dynamic_matrix_utils::standard_basis_helper::tests::we_can_compute_dynamic_vecs_that_matches_evaluation_vec`: 0.495904s

After, from targeted JSON timing:
- `dynamic_matrix_utils::standard_basis_helper::tests::we_can_compute_dynamic_vecs_that_matches_evaluation_vec`: 0.121827s

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --no-default-features --features test proof_primitive::dynamic_matrix_utils::standard_basis_helper::tests::we_can_compute_dynamic_vecs_that_matches_evaluation_vec --lib -- --quiet`
- `cargo test -p proof-of-sql --no-default-features --features test --lib -- --quiet` (960 passed; 109.78s)
- `git diff --check`
- `bash -c "tr -d '\r' < scripts/check_commits.sh | bash"`

/claim #557