### PR TITLE
test: cover sumcheck rho 256 evaluation

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
@@ -48,3 +48,36 @@ fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
         expected_eval
     );
 }
+
+#[test]
+fn we_can_track_rho_256_evaluation_for_large_sumchecks() {
+    let evaluation_point = [
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+    ];
+    let random_scalars = [Curve25519Scalar::from(0u64); 10];
+    let sumcheck_random_scalars = SumcheckRandomScalars::new(&random_scalars, 3, 10);
+
+    let evals = SumcheckMleEvaluations::new(
+        3,
+        [],
+        [],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &[],
+        &[],
+    );
+
+    assert_eq!(
+        evals.rho_256_evaluation,
+        Some(Curve25519Scalar::from(85u64))
+    );
+}


### PR DESCRIPTION
## Summary
- Adds a focused test for `SumcheckMleEvaluations::new` when the sumcheck evaluation point has at least 8 variables.
- Covers the `rho_256_evaluation` branch and asserts the folded 8-bit value with trailing `(1 - x)` factors.

## Coverage
- Before: `sumcheck_mle_evaluations.rs` had 9 uncovered lines from the `rho_256_evaluation` branch in local LCOV on current `main`.
- After focused llvm-cov: `sumcheck_mle_evaluations.rs` reports 54/54 covered lines.

## Verification
- `cargo test -p proof-of-sql --no-default-features --features test sql::proof::sumcheck_mle_evaluations_test --lib -- --quiet`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features test --lib --lcov --output-path target\sumcheck-mle-rho256.lcov -- sql::proof::sumcheck_mle_evaluations_test`
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --no-default-features --features test --lib -- --quiet`
- `git diff --check HEAD~1..HEAD`
- `bash -c "tr -d '\r' < scripts/check_commits.sh | bash"`

/claim #560