### PR TITLE
test: run table commitment tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -374,20 +374,24 @@ fn num_rows_of_columns<'a>(
     Ok(num_rows)
 }
 
-#[cfg(all(test, feature = "arrow", feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "arrow")]
+    use crate::base::database::Column;
     use crate::base::{
         commitment::naive_commitment::NaiveCommitment,
-        database::{owned_table_utility::*, Column, OwnedColumn},
+        database::{owned_table_utility::*, OwnedColumn},
         map::IndexMap,
         scalar::test_scalar::TestScalar,
     };
+    #[cfg(feature = "arrow")]
     use arrow::{
         array::{Int64Array, StringArray},
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
+    #[cfg(feature = "arrow")]
     use std::sync::Arc;
 
     #[test]
@@ -1151,6 +1155,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "arrow")]
     #[test]
     fn we_can_create_and_append_table_commitments_with_record_batches() {
         let schema = Arc::new(Schema::new(vec![


### PR DESCRIPTION
/claim #560

Lets the pure table_commitment tests run in no-default test builds, while keeping the record-batch test behind the arrow feature. No production behavior changes.

Tested:
- cargo test -p proof-of-sql base::commitment::table_commitment --no-default-features --features=test
- cargo test -p proof-of-sql base::commitment::table_commitment --no-default-features --features=\"arrow test\"
- cargo test -p proof-of-sql --no-default-features --features=test
- cargo test -p proof-of-sql --no-default-features --features=\"arrow test\"
- cargo llvm-cov --text --show-missing-lines --output-path /tmp/sxt-table-commitment-coverage.txt -p proof-of-sql --no-default-features --features=test -- base::commitment::table_commitment
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh