### PR TITLE
test: run owned table accessor tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -108,7 +108,7 @@ pub use test_accessor::TestAccessor;
 
 mod owned_table_test_accessor;
 pub use owned_table_test_accessor::OwnedTableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod owned_table_test_accessor_test;
 
 mod table_test_accessor;


### PR DESCRIPTION
/claim #560

Runs the owned table accessor tests in the no-default test profile.

Tests:
- cargo test -p proof-of-sql base::database::owned_table_test_accessor --no-default-features --features=test
- cargo test -p proof-of-sql --no-default-features --features=test
- cargo llvm-cov --text --show-missing-lines --output-path /tmp/sxt-owned-table-accessor-coverage.txt -p proof-of-sql --no-default-features --features=test -- base::database::owned_table_test_accessor
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh