### PR TITLE
test: cover join utility accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -978,6 +978,37 @@ mod tests {
             join_left_right_columns.remaining_right_columns[0],
             Column::BigInt(&[7_i64, 8, 9, 8, 9])
         );
+        assert_eq!(
+            join_left_right_columns.right_less_join_columns(),
+            vec![
+                Column::BigInt(&[7_i64, 8, 9, 8, 9]),
+                Column::Int128(&[5_i128, 3, 4, 3, 4])
+            ]
+        );
+        assert_eq!(
+            join_left_right_columns.left_columns(),
+            vec![
+                Column::Int(&[4_i32, 5, 5, 5, 5]),
+                Column::SmallInt(&[1_i16, 2, 2, 3, 3]),
+                Column::Int128(&[3_i128, 1, 1, 4, 4])
+            ]
+        );
+        assert_eq!(
+            join_left_right_columns.right_columns(),
+            vec![
+                Column::Int(&[4_i32, 5, 5, 5, 5]),
+                Column::BigInt(&[7_i64, 8, 9, 8, 9]),
+                Column::Int128(&[5_i128, 3, 4, 3, 4])
+            ]
+        );
+        assert_eq!(
+            join_left_right_columns.result_columns(),
+            vec![
+                Column::Int(&[4_i32, 5, 5, 5, 5]),
+                Column::SmallInt(&[1_i16, 2, 2, 3, 3]),
+                Column::BigInt(&[7_i64, 8, 9, 8, 9])
+            ]
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -778,6 +778,11 @@ mod tests {
 
         let result = get_multiplicities(&data, &unique, &alloc);
         assert_eq!(result, &[1, 0, 3, 1], "Expected multiplicities");
+
+        let data_before_unique = vec![Column::<TestScalar>::Int(&[1])];
+        let unique_after_data = vec![Column::<TestScalar>::Int(&[5])];
+        let result = get_multiplicities(&data_before_unique, &unique_after_data, &alloc);
+        assert_eq!(result, &[0]);
     }
 
     // Get Columns of Table
@@ -925,6 +930,14 @@ mod tests {
         let left_on = vec![Column::<TestScalar>::Int(&[0_i32; 0])];
         let right_on = vec![Column::<TestScalar>::Int(&[0_i32; 0])];
         let row_indexes = get_sort_merge_join_indexes(&left_on, &right_on, 0, 0);
+        assert!(row_indexes.is_empty());
+    }
+
+    #[test]
+    fn we_get_empty_sort_merge_join_indexes_for_incompatible_columns() {
+        let left_on = vec![Column::<TestScalar>::Int(&[1])];
+        let right_on = vec![Column::<TestScalar>::BigInt(&[1_i64])];
+        let row_indexes = get_sort_merge_join_indexes(&left_on, &right_on, 1, 1);
         assert!(row_indexes.is_empty());
     }
 


### PR DESCRIPTION
/claim #560

Adds focused coverage for join utility column accessors.

Tests:
- cargo test -p proof-of-sql base::database::join_util --no-default-features --features=test
- cargo test -p proof-of-sql --no-default-features --features=test
- cargo llvm-cov --text --show-missing-lines --output-path /tmp/sxt-join-util-accessors-coverage.txt -p proof-of-sql --no-default-features --features=test -- base::database::join_util
- cargo fmt --check
- git diff --check
- source scripts/check_commits.sh