### PR TITLE
test: cover RefInto blanket implementation

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,27 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+
+    #[derive(Debug, PartialEq)]
+    struct Source(u8);
+
+    impl From<&Source> for u16 {
+        fn from(value: &Source) -> Self {
+            u16::from(value.0) + 1
+        }
+    }
+
+    #[test]
+    fn ref_into_uses_reference_conversion_without_consuming_value() {
+        let source = Source(41);
+
+        let converted: u16 = source.ref_into();
+
+        assert_eq!(converted, 42);
+        assert_eq!(source, Source(41));
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused unit test for the `RefInto` blanket implementation
- verify conversion happens through the reference implementation and does not consume the source value

## Verification
- Not run locally: `cargo` is not installed in this environment.

Part of #560