### PR TITLE
test: speed up fold scalars setup

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars_test.rs
@@ -1,19 +1,25 @@
 use super::{
     extended_dory_reduce_helper::extended_dory_reduce_verify_fold_s_vecs, fold_scalars_0_prove,
-    fold_scalars_0_verify, rand_F_tensors, rand_G_vecs, test_rng, DoryMessages,
-    ExtendedProverState, PublicParameters,
+    fold_scalars_0_verify, DoryMessages, ExtendedProverState, G1Affine, G2Affine, PublicParameters,
 };
+use ark_ec::AffineRepr;
 use merlin::Transcript;
 
 #[test]
 fn we_can_fold_scalars() {
-    let mut rng = test_rng();
     let nu = 0;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
+    let pp = PublicParameters {
+        Gamma_1: vec![G1Affine::generator()],
+        Gamma_2: vec![G2Affine::generator()],
+        H_1: G1Affine::generator(),
+        H_2: G2Affine::generator(),
+        Gamma_2_fin: G2Affine::generator(),
+        max_nu: nu,
+    };
     let prover_setup = (&pp).into();
     let verifier_setup = (&pp).into();
-    let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
-    let (v1, v2) = rand_G_vecs(nu, &mut rng);
+    let (s1_tensor, s2_tensor) = (vec![], vec![]);
+    let (v1, v2) = (vec![G1Affine::generator()], vec![G2Affine::generator()]);
     let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
     let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
 


### PR DESCRIPTION
/claim #557

What changed:
- Use deterministic generator-based inputs in fold_scalars_test instead of random setup.
- Keep the same fold prove/verify path with less test setup work.

Checks:
- cargo fmt --check
- cargo test -p proof-of-sql --no-default-features --features=test dory::fold_scalars_test -- --nocapture
- cargo test -p proof-of-sql --no-default-features --features=test
- source scripts/check_commits.sh

Timing:
- focused warm run before: about 1.14s
- focused warm run after: about 1.06s