### PR TITLE
test: run table test accessor tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -113,7 +113,7 @@ mod owned_table_test_accessor_test;
 
 mod table_test_accessor;
 pub use table_test_accessor::TableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod table_test_accessor_test;
 
 /// Module providing utilities for filtering columns based on selection vectors.


### PR DESCRIPTION
/claim #560

## Summary
- ungate `table_test_accessor_test` from `feature = "blitzar"` so the existing `TableTestAccessor` tests can run in no-default coverage configurations
- keep the change scoped to test module wiring in `base/database/mod.rs`
- leave production code and test contents unchanged

## Verification
- not run locally
- local Windows GNU toolchain in this environment could not complete `cargo test -p proof-of-sql --lib --no-default-features --features "arrow test" --no-run`
- change is limited to enabling an existing `NaiveEvaluationProof`-based test module