### PR TITLE
test: cover byte distribution serialization

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_distribution.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_distribution.rs
@@ -73,7 +73,10 @@ impl ByteDistribution {
 #[cfg(test)]
 mod tests {
     use super::ByteDistribution;
-    use crate::base::scalar::{test_scalar::TestScalar, ScalarExt};
+    use crate::base::{
+        scalar::{test_scalar::TestScalar, ScalarExt},
+        try_standard_binary_deserialization, try_standard_binary_serialization,
+    };
     use bnum::types::U256;
     use core::ops::{Neg, Shl, Shr};
     use itertools::Itertools;
@@ -256,5 +259,24 @@ mod tests {
             byte_distribution.varying_byte_indices().collect_vec(),
             (0u8..32).map(|i| i * 8).collect_vec()
         );
+    }
+
+    #[test]
+    fn we_can_serialize_round_trip() {
+        let byte_distribution = ByteDistribution {
+            vary_mask: 0b0000_0000_0000_0000_0000_0001_0000_0101,
+            constant_mask: [2, 3, 5, 7],
+        };
+
+        let expected_serialization = [
+            0u8, 0, 1, 5, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5,
+            0, 0, 0, 0, 0, 0, 0, 7,
+        ];
+        let serialized = try_standard_binary_serialization(byte_distribution.clone()).unwrap();
+        assert_eq!(serialized, expected_serialization);
+
+        let deserialized: ByteDistribution =
+            try_standard_binary_deserialization(&serialized).unwrap().0;
+        assert_eq!(deserialized, byte_distribution);
     }
 }


### PR DESCRIPTION
/claim #560

This adds a focused test-only coverage slice for ByteDistribution serialization. The test verifies the standard binary layout and round-trips the value through deserialization.

Validation:
- cargo fmt --check
- git diff --check
- cargo test -p proof-of-sql --no-default-features --features="test" base::byte::byte_distribution::tests::

Note: cargo test -p proof-of-sql --all-features ... is blocked locally on Windows because blitzar-sys build script supports Linux only.