### PR TITLE
test: cover Dory random tensor helpers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/rand_util.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/rand_util.rs
@@ -142,3 +142,55 @@ fn we_can_create_different_rand_F_vecs_from_different_seeds() {
         assert_ne!(s2, s2_2);
     }
 }
+
+#[test]
+fn we_can_create_rand_F_tensors() {
+    let mut rng = test_rng();
+    for nu in 0..5 {
+        let (s1, s2) = rand_F_tensors(nu, &mut rng);
+        assert_eq!(s1.len(), nu);
+        assert_eq!(s2.len(), nu);
+        if nu > 0 {
+            assert_ne!(s1, s2);
+        }
+    }
+}
+
+#[test]
+fn we_can_create_different_rand_F_tensors_consecutively_from_the_same_rng() {
+    let mut rng = test_rng();
+    for nu in 0..5 {
+        let (s1, s2) = rand_F_tensors(nu, &mut rng);
+        let (s1_2, s2_2) = rand_F_tensors(nu, &mut rng);
+        if nu > 0 {
+            assert_ne!(s1, s1_2);
+            assert_ne!(s2, s2_2);
+        }
+    }
+}
+
+#[test]
+fn we_can_create_the_same_rand_F_tensors_from_the_same_seed() {
+    let mut rng = test_seed_rng([1; 32]);
+    let mut rng_2 = test_seed_rng([1; 32]);
+    for nu in 0..5 {
+        let (s1, s2) = rand_F_tensors(nu, &mut rng);
+        let (s1_2, s2_2) = rand_F_tensors(nu, &mut rng_2);
+        assert_eq!(s1, s1_2);
+        assert_eq!(s2, s2_2);
+    }
+}
+
+#[test]
+fn we_can_create_different_rand_F_tensors_from_different_seeds() {
+    let mut rng = test_seed_rng([1; 32]);
+    let mut rng_2 = test_seed_rng([2; 32]);
+    for nu in 0..5 {
+        let (s1, s2) = rand_F_tensors(nu, &mut rng);
+        let (s1_2, s2_2) = rand_F_tensors(nu, &mut rng_2);
+        if nu > 0 {
+            assert_ne!(s1, s1_2);
+            assert_ne!(s2, s2_2);
+        }
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add coverage for `rand_F_tensors`
- verify tensor length, consecutive RNG variance, same-seed determinism, and different-seed variance

## Tests
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features="test" proof_primitive::dory::rand_util::`

## Note
- `cargo test -p proof-of-sql --no-default-features --features="test,blitzar" proof_primitive::dory::rand_util::` is blocked on Windows because `blitzar-sys` only supports Linux.