### PR TITLE
test: cover bigdecimal parser boundaries

### DIFF
--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,28 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn find_bigdecimals_ignores_non_table_statements_and_decimal_38() {
+        let sql = "
+            CREATE SCHEMA ETHEREUM;
+            CREATE TABLE ETHEREUM.TRANSFERS(
+                AMOUNT DECIMAL(38, 2),
+                VALUE DECIMAL(39, 3),
+                GAS_PRICE DECIMAL(75, 0)
+            );
+            CREATE VIEW ETHEREUM.TRANSFER_VALUES AS SELECT VALUE FROM ETHEREUM.TRANSFERS;
+        ";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("ETHEREUM.TRANSFERS").unwrap(),
+            &[
+                ("VALUE".to_string(), 39, 3),
+                ("GAS_PRICE".to_string(), 75, 0)
+            ]
+        );
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add boundary coverage for `find_bigdecimals`
- verify that non-table SQL statements are ignored
- verify that `DECIMAL(38, ...)` is excluded while wider decimal columns are collected

## Tests
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features="test" utils::parse::`
- `git diff --check`