### PR TITLE
test: cover table expression metadata

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -65,6 +65,8 @@ mod equals_expr_test;
 
 mod table_expr;
 pub use table_expr::TableExpr;
+#[cfg(test)]
+mod table_expr_test;
 
 #[cfg(test)]
 pub(crate) mod test_utility;

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -7,34 +7,3 @@ pub struct TableExpr {
     /// The `TableRef` for the table
     pub table_ref: TableRef,
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn we_can_round_trip_a_table_expr_through_json() {
-        let table_expr = TableExpr {
-            table_ref: TableRef::new("sxt", "orders"),
-        };
-
-        let serialized = serde_json::to_string(&table_expr).unwrap();
-        assert_eq!(serialized, r#"{"table_ref":"sxt.orders"}"#);
-
-        let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, table_expr);
-        assert_eq!(deserialized.table_ref.to_string(), "sxt.orders");
-    }
-
-    #[test]
-    fn we_can_clone_a_table_expr_without_losing_the_table_ref() {
-        let table_expr = TableExpr {
-            table_ref: TableRef::new("", "line_items"),
-        };
-
-        let cloned = table_expr.clone();
-
-        assert_eq!(cloned, table_expr);
-        assert_eq!(cloned.table_ref.to_string(), "line_items");
-    }
-}

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -7,3 +7,34 @@ pub struct TableExpr {
     /// The `TableRef` for the table
     pub table_ref: TableRef,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_round_trip_a_table_expr_through_json() {
+        let table_expr = TableExpr {
+            table_ref: TableRef::new("sxt", "orders"),
+        };
+
+        let serialized = serde_json::to_string(&table_expr).unwrap();
+        assert_eq!(serialized, r#"{"table_ref":"sxt.orders"}"#);
+
+        let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, table_expr);
+        assert_eq!(deserialized.table_ref.to_string(), "sxt.orders");
+    }
+
+    #[test]
+    fn we_can_clone_a_table_expr_without_losing_the_table_ref() {
+        let table_expr = TableExpr {
+            table_ref: TableRef::new("", "line_items"),
+        };
+
+        let cloned = table_expr.clone();
+
+        assert_eq!(cloned, table_expr);
+        assert_eq!(cloned.table_ref.to_string(), "line_items");
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr_test.rs
@@ -1,0 +1,28 @@
+use super::TableExpr;
+use crate::base::database::TableRef;
+
+#[test]
+fn we_can_round_trip_a_table_expr_through_json() {
+    let table_expr = TableExpr {
+        table_ref: TableRef::new("sxt", "orders"),
+    };
+
+    let serialized = serde_json::to_string(&table_expr).unwrap();
+    assert_eq!(serialized, r#"{"table_ref":"sxt.orders"}"#);
+
+    let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized, table_expr);
+    assert_eq!(deserialized.table_ref.to_string(), "sxt.orders");
+}
+
+#[test]
+fn we_can_clone_a_table_expr_without_losing_the_table_ref() {
+    let table_expr = TableExpr {
+        table_ref: TableRef::new("", "line_items"),
+    };
+
+    let cloned = table_expr.clone();
+
+    assert_eq!(cloned, table_expr);
+    assert_eq!(cloned.table_ref.to_string(), "line_items");
+}


### PR DESCRIPTION
## Summary
- add focused coverage for `TableExpr` JSON serialization and deserialization
- verify cloning preserves schema-qualified and unqualified table references

/claim #560

## Validation
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features=test table_expr -- --nocapture`
- `git diff --check`

Note: this is a narrow coverage slice for #560 and does not overlap the recent open coverage PRs I found for other modules.