### PR TITLE
refactor!: make scalar limb conversions explicit

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
@@ -14,7 +14,7 @@ const MAX_SUPPORTED_I256: i256 = i256::from_parts(
 pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
     let is_negative = val > &S::MAX_SIGNED;
     let abs_scalar = if is_negative { -*val } else { *val };
-    let limbs: [u64; 4] = abs_scalar.into();
+    let limbs = abs_scalar.to_limbs();
 
     let low = u128::from(limbs[0]) | (u128::from(limbs[1]) << 64);
     let high = i128::from(limbs[2]) | (i128::from(limbs[3]) << 64);
@@ -47,7 +47,7 @@ pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
         ];
 
         // Convert limbs to Scalar and adjust for sign
-        let scalar: S = limbs.into();
+        let scalar = S::from_limbs(limbs);
         Some(if value.is_negative() { -scalar } else { scalar })
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -3,7 +3,6 @@ use crate::base::{
     if_rayon,
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    ref_into::RefInto,
     scalar::{Scalar, ScalarExt},
 };
 use alloc::vec::Vec;
@@ -116,16 +115,16 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::BigInt(ints) => CommittableColumn::BigInt(ints),
             Column::Int128(ints) => CommittableColumn::Int128(ints),
             Column::Decimal75(precision, scale, decimals) => {
-                let as_limbs: Vec<_> = decimals.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = decimals.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::Decimal75(*precision, *scale, as_limbs)
             }
             Column::Scalar(scalars) => (scalars as &[_]).into(),
             Column::VarChar((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarChar(as_limbs)
             }
             Column::VarBinary((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarBinary(as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
@@ -152,25 +151,21 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
             OwnedColumn::Decimal75(precision, scale, decimals) => CommittableColumn::Decimal75(
                 *precision,
                 *scale,
-                decimals
-                    .iter()
-                    .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
-                    .collect(),
+                decimals.iter().map(Scalar::to_limbs).collect(),
             ),
             OwnedColumn::Scalar(scalars) => (scalars as &[_]).into(),
             OwnedColumn::VarChar(strings) => CommittableColumn::VarChar(
                 strings
                     .iter()
                     .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             OwnedColumn::VarBinary(bytes) => CommittableColumn::VarBinary(
                 bytes
                     .iter()
                     .map(|b| S::from_byte_slice_via_hash(b))
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             OwnedColumn::TimestampTZ(tu, tz, times) => {
@@ -216,7 +211,7 @@ impl<'a, S: Scalar> From<&'a [S]> for CommittableColumn<'a> {
     fn from(value: &'a [S]) -> Self {
         CommittableColumn::Scalar(
             if_rayon!(value.par_iter(), value.iter())
-                .map(RefInto::<[u64; 4]>::ref_into)
+                .map(Scalar::to_limbs)
                 .collect(),
         )
     }

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -21,7 +21,7 @@ impl U256 {
 /// This trait converts a dalek scalar into a U256 integer
 impl<T: MontConfig<4>> From<&MontScalar<T>> for U256 {
     fn from(val: &MontScalar<T>) -> Self {
-        let buf: [u64; 4] = val.into();
+        let buf = val.to_limbs();
         let low: u128 = u128::from(buf[0]) | (u128::from(buf[1]) << 64);
         let high: u128 = u128::from(buf[2]) | (u128::from(buf[3]) << 64);
         U256::from_words(low, high)

--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -1,8 +1,5 @@
 use super::Transcript;
-use crate::base::{
-    ref_into::RefInto,
-    scalar::{Scalar, ScalarExt},
-};
+use crate::base::scalar::{Scalar, ScalarExt};
 use bnum::types::U256;
 use zerocopy::{AsBytes, FromBytes};
 
@@ -57,7 +54,7 @@ impl<T: TranscriptCore> Transcript for T {
         &mut self,
         messages: impl IntoIterator<Item = &'a S>,
     ) {
-        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(RefInto::ref_into));
+        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(Scalar::to_limbs));
     }
     fn scalar_challenge_as_be<S: Scalar>(&mut self) -> S {
         ScalarExt::from_wrapping(

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -189,6 +189,12 @@ impl<T: MontConfig<4>> MontScalar<T> {
     pub fn from_bigint(vals: [u64; 4]) -> Self {
         Self(Fp::from_bigint(ark_ff::BigInt(vals)).unwrap())
     }
+    /// Create a new `MontScalar<T>` from little-endian `u64` limbs, reducing modulo the field
+    /// modulus when needed.
+    #[must_use]
+    pub fn from_limbs(value: [u64; 4]) -> Self {
+        Self(Fp::new(ark_ff::BigInt(value)))
+    }
     /// Create a new `MontScalar<T>` from a `[u8]` modulus the field order. The array is expected to be in non-montgomery form.
     #[must_use]
     pub fn from_le_bytes_mod_order(bytes: &[u8]) -> Self {
@@ -198,6 +204,11 @@ impl<T: MontConfig<4>> MontScalar<T> {
     #[must_use]
     pub fn to_bytes_le(&self) -> Vec<u8> {
         self.0.into_bigint().to_bytes_le()
+    }
+    /// Return the scalar as canonical little-endian `u64` limbs.
+    #[must_use]
+    pub fn to_limbs(&self) -> [u64; 4] {
+        self.0.into_bigint().0
     }
     /// Convenience function for converting a slice of `ark_curve25519::Fr` into a vector of `Curve25519Scalar`. Should not be used outside of tests.
     #[cfg(test)]
@@ -230,7 +241,7 @@ where
         assert!(digits.len() <= 4); // This should not happen if the above check is correct
         let mut limbs = [0u64; 4];
         limbs[..digits.len()].copy_from_slice(&digits);
-        let result = Self::from(limbs);
+        let result = Self::from_limbs(limbs);
         Ok(match sign {
             num_bigint::Sign::Minus => -result,
             num_bigint::Sign::Plus | num_bigint::Sign::NoSign => result,
@@ -239,7 +250,7 @@ where
 }
 impl<T: MontConfig<4>> From<[u64; 4]> for MontScalar<T> {
     fn from(value: [u64; 4]) -> Self {
-        Self(Fp::new(ark_ff::BigInt(value)))
+        Self::from_limbs(value)
     }
 }
 
@@ -275,7 +286,7 @@ impl<T: MontConfig<4>> num_traits::Inv for MontScalar<T> {
 }
 impl<T: MontConfig<4>> Serialize for MontScalar<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut limbs: [u64; 4] = self.into();
+        let mut limbs = self.to_limbs();
         limbs.reverse();
         limbs.serialize(serializer)
     }
@@ -284,7 +295,7 @@ impl<'de, T: MontConfig<4>> Deserialize<'de> for MontScalar<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let mut limbs: [u64; 4] = Deserialize::deserialize(deserializer)?;
         limbs.reverse();
-        Ok(limbs.into())
+        Ok(Self::from_limbs(limbs))
     }
 }
 
@@ -297,13 +308,13 @@ impl<T: MontConfig<4>> core::ops::Neg for &MontScalar<T> {
 
 impl<T: MontConfig<4>> From<MontScalar<T>> for [u64; 4] {
     fn from(value: MontScalar<T>) -> Self {
-        (&value).into()
+        value.to_limbs()
     }
 }
 
 impl<T: MontConfig<4>> From<&MontScalar<T>> for [u64; 4] {
     fn from(value: &MontScalar<T>) -> Self {
-        value.0.into_bigint().0
+        value.to_limbs()
     }
 }
 
@@ -403,6 +414,14 @@ where
         255 - T::MODULUS.0[3].leading_zeros() as u8
     };
     const MAX_SIGNED_U256: U256 = U256::from_digits(T::MODULUS.divide_by_2_round_down().0);
+
+    fn from_limbs(limbs: [u64; 4]) -> Self {
+        MontScalar::<T>::from_limbs(limbs)
+    }
+
+    fn to_limbs(&self) -> [u64; 4] {
+        MontScalar::<T>::to_limbs(self)
+    }
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool
@@ -413,9 +432,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -447,7 +466,7 @@ where
             });
         }
 
-        let abs: [u64; 4] = value.into();
+        let abs = value.to_limbs();
 
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -471,9 +490,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -495,9 +514,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -519,9 +538,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -543,9 +562,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -569,9 +588,9 @@ where
     #[expect(clippy::cast_possible_wrap)]
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -603,7 +622,7 @@ where
         } else {
             num_bigint::Sign::Plus
         };
-        let value_abs: [u64; 4] = (if is_negative { -value } else { value }).into();
+        let value_abs = (if is_negative { -value } else { value }).to_limbs();
         let bits: &[u8] = bytemuck::cast_slice(&value_abs);
         BigInt::from_bytes_le(sign, bits)
     }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,12 +1,36 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
+use crate::base::{encode::VarInt, scalar::ScalarConversionError};
 use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
 
 /// A trait for the scalar field used in Proof of SQL.
+///
+/// Scalar limb conversions should be explicit at generic call sites:
+///
+/// ```
+/// use proof_of_sql::base::scalar::Scalar;
+///
+/// fn round_trip_limbs<S: Scalar>(value: S) -> S {
+///     S::from_limbs(value.to_limbs())
+/// }
+/// ```
+///
+/// Generic scalar code should not rely on implicit conversion traits for limbs:
+///
+/// ```compile_fail
+/// use proof_of_sql::base::scalar::Scalar;
+///
+/// fn implicit_limb_conversion<S: Scalar>(value: S) -> [u64; 4] {
+///     value.into()
+/// }
+/// ```
+///
+/// This explicit limb API is a public contract for `Scalar` implementors. Downstream
+/// implementations that previously satisfied the trait only through limb `From`/`Into`
+/// implementations need to provide these methods when updating.
 pub trait Scalar:
     Clone
     + core::fmt::Debug
@@ -40,8 +64,6 @@ pub trait Scalar:
     + core::convert::TryInto <i32>
     + core::convert::TryInto <i64>
     + core::convert::TryInto <i128>
-    + core::convert::Into<[u64; 4]>
-    + core::convert::From<[u64; 4]>
     + core::convert::From<u8>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
@@ -51,7 +73,6 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + RefInto<[u64; 4]>
     + for<'a> core::convert::From<&'a String>
     + VarInt
     + core::convert::From<String>
@@ -85,4 +106,14 @@ pub trait Scalar:
     const MAX_BITS: u8;
     /// A U256 representation of the largest signed value in the field.
     const MAX_SIGNED_U256: U256;
+
+    /// Construct a scalar from little-endian `u64` limbs.
+    ///
+    /// The input has the same representation previously accepted through `From<[u64; 4]>`.
+    /// Implementations must accept arbitrary 256-bit limb values and preserve the field's
+    /// existing wrapping/reduction semantics when the limbs are outside the canonical field range.
+    fn from_limbs(limbs: [u64; 4]) -> Self;
+
+    /// Return the scalar as canonical little-endian `u64` limbs.
+    fn to_limbs(&self) -> [u64; 4];
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -21,15 +21,18 @@ pub trait ScalarExt: Scalar {
     }
 
     #[must_use]
-    /// Converts a U256 to Scalar, wrapping as needed
+    /// Converts a U256 to Scalar, wrapping as needed.
+    ///
+    /// This intentionally goes through `Scalar::from_limbs`, whose contract requires accepting
+    /// non-canonical limb values with the field's wrapping/reduction semantics.
     fn from_wrapping(value: U256) -> Self {
         let value_as_limbs: [u64; 4] = value.into();
-        Self::from(value_as_limbs)
+        Self::from_limbs(value_as_limbs)
     }
 
     /// Converts a Scalar to U256. Note that any values above `MAX_SIGNED` shall remain positive, even if they are representative of negative values.
     fn into_u256_wrapping(self) -> U256 {
-        U256::from(Into::<[u64; 4]>::into(self))
+        U256::from(self.to_limbs())
     }
 
     /// Converts a byte slice to a Scalar using a hash function, preventing collisions.
@@ -102,7 +105,7 @@ mod tests {
             u64::from_le_bytes(limbs_native[2].to_le_bytes()),
             u64::from_le_bytes(limbs_native[3].to_le_bytes()),
         ];
-        let scalar_from_ref = TestScalar::from(limbs_le);
+        let scalar_from_ref = TestScalar::from_limbs(limbs_le);
 
         assert_eq!(
             scalar_from_bytes, scalar_from_ref,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -191,7 +191,8 @@ where
             .take(31)
             .collect();
     for (i, scalar) in column_data.iter().enumerate() {
-        let scalar_array: [u64; 4] = (*scalar).into().into();
+        let scalar_value: S = (*scalar).into();
+        let scalar_array = scalar_value.to_limbs();
         // Convert the [u64; 4] into a slice of bytes
         let scalar_bytes = &cast_slice::<u64, u8>(&scalar_array)[..31];
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This addresses the first conversion-bound item in #228. `Scalar` currently requires every implementation to expose limb conversions through `Into<[u64; 4]>`, `From<[u64; 4]>`, and `RefInto<[u64; 4]>`. Those conversions are easier to audit when the generic API names them directly.

# What changes are included in this PR?

- Add `Scalar::from_limbs` and `Scalar::to_limbs` for explicit limb conversion.
- Remove the limb conversion trait bounds from `Scalar`.
- Update generic scalar call sites in transcript encoding, committable columns, Arrow i256 conversion, U256 conversion, scalar helpers, and range checking to use the explicit methods.
- Document that `from_limbs` accepts arbitrary 256-bit little-endian limbs and must preserve the existing field wrapping/reduction semantics.
- Add trait doctests showing the intended explicit API and rejecting generic implicit limb conversion.

# Breaking change

This is intentionally marked breaking. Downstream custom `Scalar` implementors now need to implement `from_limbs` and `to_limbs` directly. Keeping a non-breaking default would require retaining the same implicit limb conversion bounds this issue is trying to remove.

# Are these changes tested?

Partially, from this Windows environment:

- `cargo fmt --all -- --check`
- `git diff --check`
- PowerShell equivalent of `scripts/check_commits.sh`: 1 commit checked, 0 failures

I could not run the Rust doctests or full CI locally because Cargo dependency fetches fail on this machine with a Windows schannel TLS error before compilation starts. The branch is current with `origin/main`, so GitHub CI should provide the full compile/test signal.

/claim #228

Breaking-change note: this intentionally adds explicit `Scalar::from_limbs` and `Scalar::to_limbs` requirements for downstream `Scalar` implementors, matching the `refactor!` title and commit footer.