### PR TITLE
test: reuse dynamic dory public parameters

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
@@ -10,11 +10,20 @@ use crate::{
 };
 use ark_ec::pairing::Pairing;
 use num_traits::Zero;
+use std::sync::LazyLock;
+
+static PUBLIC_PARAMETERS: LazyLock<PublicParameters> =
+    LazyLock::new(|| PublicParameters::test_rand(5, &mut test_rng()));
+
+fn test_setup() -> (&'static PublicParameters, ProverSetup<'static>) {
+    let public_parameters = &*PUBLIC_PARAMETERS;
+    let setup = ProverSetup::from(public_parameters);
+    (public_parameters, setup)
+}
 
 #[test]
 fn we_can_handle_calling_with_an_empty_committable_column() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (_, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(&[], 0, &setup);
 
     assert!(res.is_empty());
@@ -22,8 +31,7 @@ fn we_can_handle_calling_with_an_empty_committable_column() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -31,8 +39,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(2)
@@ -57,8 +65,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -66,8 +73,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_o
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[3]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[3]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[3]) * F::from(2)
@@ -92,11 +99,10 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_o
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_signed_bigint_values_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[2]) * F::from(-3);
     assert_eq!(res[0].0, expected);
@@ -104,8 +110,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_signed_bigint_values_and_an_off
 
 #[test]
 fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::BigInt(&[
@@ -121,8 +126,8 @@ fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[3]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[3]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[3]) * F::from(2)
@@ -189,8 +194,7 @@ fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset
 
 #[test]
 fn we_can_compute_an_empty_dynamic_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (_, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
     assert_eq!(res[0].0, GT::zero());
     let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 5, &setup);
@@ -231,8 +235,7 @@ fn we_can_compute_an_empty_dynamic_dory_commitment() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[0, 1]),
@@ -257,8 +260,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -306,8 +309,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[0, 1]),
@@ -332,8 +334,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
         2,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[2]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -381,8 +383,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[-2, -1, 0, 1, 2]),
@@ -407,8 +408,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(-1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(0)
@@ -469,8 +470,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, setup) = test_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[-2, -1, 0, 1, 2]),
@@ -495,8 +495,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
         4,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[3]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[3]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[3]) * F::from(0)


### PR DESCRIPTION
/claim #557

## Summary

This keeps the dynamic Dory compute commitment test assertions unchanged while avoiding repeated generation of the same max-nu 5 Dory public parameters in every test.

`dynamic_dory_compute_commitments_test.rs` now uses a local `LazyLock<PublicParameters>` and creates a fresh lightweight `ProverSetup` from that shared data per test. This removes 9 repeated `PublicParameters::test_rand(5, ...)` calls from the module without changing offsets, input columns, expected pairings, production code, or test names.

This is intentionally scoped to `dynamic_dory_compute_commitments_test.rs` so it does not overlap with the open #557 PRs touching the regular Dory compute tests or the evaluation-proof setup caches.

## Timing

Local Apple Silicon baseline, warm build:

```text
BLITZAR_BACKEND=cpu /usr/bin/time -p cargo test -p proof-of-sql proof_primitive::dory::dynamic_dory_compute_commitments_test --no-default-features --features="test"
10 passed
Rust test time: 2.68s
real: 2.78s
```

After this change, warm build:

```text
BLITZAR_BACKEND=cpu /usr/bin/time -p cargo test -p proof-of-sql proof_primitive::dory::dynamic_dory_compute_commitments_test --no-default-features --features="test"
10 passed
Rust test time: 2.32s
real: 2.44s
```

The package-scoped `test` feature is used locally because the workspace-level `std` feature path hits the known macOS/ARM `halo2curves` `asm` limitation. The CI `testother` job runs this module on Linux/x86_64.

## Validation

```text
cargo check -p proof-of-sql --no-default-features --features="test"
BLITZAR_BACKEND=cpu cargo test -p proof-of-sql proof_primitive::dory::dory_compute_commitments_test --no-default-features --features="test"
BLITZAR_BACKEND=cpu cargo test -p proof-of-sql proof_primitive::dory::dynamic_dory_compute_commitments_test --no-default-features --features="test"
cargo f --check
git diff --check
```

All passed locally with existing warnings.
