### PR TITLE
refactor!: make scalar string hashing explicit

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -279,7 +279,9 @@ impl ArrayRefExt for ArrayRef {
                     let scals = if let Some(scals) = precomputed_scals {
                         &scals[range.start..range.end]
                     } else {
-                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S { vals[i].into() })
+                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S {
+                            S::from_str_via_hash(vals[i])
+                        })
                     };
 
                     Ok(Column::VarChar((vals, scals)))

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -139,7 +139,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, S::from(string)),
+                alloc.alloc_slice_fill_copy(length, S::from_str_via_hash(string.as_str())),
             )),
             LiteralValue::VarBinary(bytes) => {
                 // Convert the bytes to a slice of bytes references
@@ -177,7 +177,10 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
             OwnedColumn::VarChar(col) => {
-                let scalars = col.iter().map(S::from).collect::<Vec<_>>();
+                let scalars = col
+                    .iter()
+                    .map(|value| S::from_str_via_hash(value.as_str()))
+                    .collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -81,7 +81,7 @@ impl LiteralValue {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar(str) => str.into(),
+            Self::VarChar(str) => S::from_str_via_hash(str.as_str()),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -143,7 +143,8 @@ macro_rules! impl_from_for_mont_scalar_for_string {
     ($tt:ty) => {
         impl<T: MontConfig<4>> From<$tt> for MontScalar<T> {
             fn from(x: $tt) -> Self {
-                x.as_bytes().into()
+                let value: &str = x.as_ref();
+                Self::from_str_via_hash(value)
             }
         }
     };

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,19 +1,36 @@
 #![expect(clippy::module_inception)]
 
 use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
-use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
+use tiny_keccak::Hasher;
 
 /// A trait for the scalar field used in Proof of SQL.
+///
+/// String hashing should be explicit at generic call sites:
+///
+/// ```
+/// # use proof_of_sql::base::scalar::Scalar;
+/// fn hash_str<S: Scalar>(value: &str) -> S {
+///     S::from_str_via_hash(value)
+/// }
+/// ```
+///
+/// Generic `Scalar` code should not rely on implicit string conversions:
+///
+/// ```compile_fail
+/// # use proof_of_sql::base::scalar::Scalar;
+/// fn implicit_string_conversion<S: Scalar>(value: &str) -> S {
+///     value.into()
+/// }
+/// ```
 pub trait Scalar:
     Clone
     + core::fmt::Debug
     + core::fmt::Display
     + PartialEq
     + Default
-    + for<'a> From<&'a str>
     + Sync
     + Send
     + num_traits::One
@@ -52,9 +69,7 @@ pub trait Scalar:
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
-    + for<'a> core::convert::From<&'a String>
     + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>
@@ -85,4 +100,25 @@ pub trait Scalar:
     const MAX_BITS: u8;
     /// A U256 representation of the largest signed value in the field.
     const MAX_SIGNED_U256: U256;
+
+    /// Converts a string to a scalar by hashing its bytes.
+    ///
+    /// This is not a parsing method. It hashes the UTF-8 bytes and masks the result
+    /// into the range supported by Proof of SQL cryptographic objects.
+    #[must_use]
+    fn from_str_via_hash(value: &str) -> Self {
+        if value.is_empty() {
+            return Self::zero();
+        }
+
+        let mut hasher = tiny_keccak::Keccak::v256();
+        hasher.update(value.as_bytes());
+        let mut hashed_bytes = [0_u8; 32];
+        hasher.finalize(&mut hashed_bytes);
+        let hashed_val =
+            U256::from_le_slice(&hashed_bytes).expect("32 bytes => guaranteed to parse as U256");
+        let masked_val = hashed_val & Self::CHALLENGE_MASK;
+        let limbs: [u64; 4] = masked_val.into();
+        Self::from(limbs)
+    }
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -111,6 +111,19 @@ mod tests {
     }
 
     #[test]
+    fn scalar_trait_hashes_str_with_default_method() {
+        assert_eq!(
+            TestScalar::from_str_via_hash("abc"),
+            TestScalar::from_byte_slice_via_hash(b"abc")
+        );
+    }
+
+    #[test]
+    fn scalar_trait_hashes_empty_str_to_zero() {
+        assert_eq!(TestScalar::from_str_via_hash(""), TestScalar::ZERO);
+    }
+
+    #[test]
     fn we_can_compute_powers_of_10() {
         for i in 0..=u128::MAX.ilog10() {
             assert_eq!(


### PR DESCRIPTION
/claim #228

This handles the string conversion part of #228. It removes the string From bounds from Scalar, adds Scalar::from_str_via_hash(&str) as the explicit hash path, and leaves the concrete MontScalar string From impls as compatibility wrappers around that method.

I also migrated the generic call sites that were still relying on implicit string conversions: Arrow UTF-8 conversion, Column::from_literal_with_length, Column::from_owned_column, and LiteralValue::to_scalar.

Breaking change: generic Scalar users should call Scalar::from_str_via_hash instead of relying on Scalar: From<&str>, From<String>, or From<&String>.

Verification:
- cargo fmt --all -- --check`n- git diff --check HEAD`n- commit-message regex equivalent to scripts/check_commits.sh`n- searched for the old generic string conversion patterns called out in review

I also tried the targeted Cargo test locally after downloading dependencies. This Windows machine stops in litzar-sys's build script with Unsupported OS. Only Linux is supported, so the Rust test run needs the repository's Linux CI.