### PR TITLE
test: cover comparator permutation constructor

### DIFF
--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -29,7 +29,7 @@ pub struct Permutation {
 
 impl Permutation {
     /// Create a new permutation from a comparison function with the given length
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn unchecked_new_from_cmp<F>(length: usize, cmp: F) -> Self
     where
         F: Fn(&usize, &usize) -> Ordering + Sync,
@@ -99,6 +99,25 @@ mod test {
         assert_eq!(
             permutation.try_apply(&["and", "Space", "Time"]).unwrap(),
             vec!["Space", "and", "Time"]
+        );
+    }
+
+    #[test]
+    fn test_unchecked_new_from_cmp() {
+        let values = [30, 10, 20, 10];
+        let permutation = Permutation::unchecked_new_from_cmp(values.len(), |left, right| {
+            values[*left].cmp(&values[*right]).then(left.cmp(right))
+        });
+
+        assert_eq!(
+            permutation,
+            Permutation {
+                permutation: vec![1, 3, 2, 0]
+            }
+        );
+        assert_eq!(
+            permutation.try_apply(&values).unwrap(),
+            vec![10, 10, 20, 30]
         );
     }
 


### PR DESCRIPTION
## Summary
/claim #560

Adds focused coverage for `Permutation::unchecked_new_from_cmp` in `base/math/permutation.rs`. The new test builds a comparator-derived permutation from an external value array, asserts the generated index order, and verifies the permutation applies to the source values as expected.

I also changed the existing dead-code lint expectation to `#[cfg_attr(not(test), expect(dead_code))]` so using this helper from tests does not introduce an `unfulfilled_lint_expectations` warning while preserving the non-test dead-code expectation.

## Why this slice
I checked #560 issue comments and the current open PR list for `base/math/permutation.rs`, `permutation.rs`, and `unchecked_new_from_cmp`; I did not find an overlapping claim/open PR. The focused coverage report shows `unchecked_new_from_cmp` now executing.

## Validation
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --no-default-features --features=test base::math::permutation`
  - 4 passed; 0 failed
- `BLITZAR_BACKEND=cpu cargo llvm-cov --lib -p proof-of-sql --no-default-features --features=test --text --show-missing-lines --output-path /tmp/sxt-permutation-coverage.txt -- base::math::permutation`
  - 4 passed; target report shows `unchecked_new_from_cmp` executed
- `rustfmt --check --edition 2021 crates/proof-of-sql/src/base/math/permutation.rs`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: full `cargo fmt --check` currently reports an unrelated pre-existing import-order diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`; I kept this PR limited to the permutation coverage slice.

AI-assisted with Codex; I reviewed and verified the diff and local validation before submitting.