### PR TITLE
test: cover first round builder length tracking

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/first_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder_test.rs
@@ -73,3 +73,28 @@ fn we_can_add_post_result_challenges() {
     builder.request_post_result_challenges(2);
     assert_eq!(builder.num_post_result_challenges(), 3);
 }
+
+#[test]
+fn we_can_track_evaluation_lengths_and_range_length() {
+    let mut builder = FirstRoundBuilder::<Curve25519Scalar>::new(4);
+
+    assert_eq!(builder.range_length(), 4);
+    assert!(builder.chi_evaluation_lengths().is_empty());
+    assert!(builder.rho_evaluation_lengths().is_empty());
+
+    builder.produce_chi_evaluation_length(2);
+    assert_eq!(builder.range_length(), 4);
+
+    builder.produce_chi_evaluation_length(9);
+    builder.produce_rho_evaluation_length(3);
+
+    assert_eq!(builder.chi_evaluation_lengths(), &[2, 9]);
+    assert_eq!(builder.rho_evaluation_lengths(), &[3]);
+    assert_eq!(builder.range_length(), 9);
+
+    builder.update_range_length(5);
+    assert_eq!(builder.range_length(), 9);
+
+    builder.update_range_length(12);
+    assert_eq!(builder.range_length(), 12);
+}


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Adds a focused, test-only coverage slice for `FirstRoundBuilder` bookkeeping under #560. The existing tests cover intermediate MLE commitment/evaluation and post-result challenge counting; this adds direct coverage for range-length updates and chi/rho evaluation length accessors.

# What changes are included in this PR?

- Covers the initial `range_length` value.
- Verifies `produce_chi_evaluation_length` records lengths and only increases `range_length` when the new length is larger.
- Verifies `produce_rho_evaluation_length` records rho lengths without changing the range length.
- Verifies direct `update_range_length` keeps the current maximum.

# Are these changes tested?

Yes, with local checks that could run in this Windows environment:

```bash
cargo fmt --check
C:/Program\ Files/Git/bin/sh.exe scripts/check_commits.sh
git diff --check
```

I also attempted the focused test command:

```bash
cargo test -p proof-of-sql sql::proof::first_round_builder --no-default-features --features=test
```

but this local Windows environment does not have the MSVC linker (`link.exe`) available, so compilation stopped before the test binary could be linked. The patch itself is limited to a unit test in the existing `first_round_builder_test.rs` module.