### PR TITLE
test: cover memory logging helper

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -84,7 +84,7 @@ test = ["dep:rand", "std"]
 perf = ["blitzar", "cpu-perf"]
 cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm", "halo2curves/asm"]
 rayon = ["dep:rayon", "std"]
-std = ["snafu/std", "ark-serialize/std", "dep:sysinfo" ]
+std = ["snafu/std", "ark-serialize/std", "dep:sysinfo", "tracing/std" ]
 
 [lints]
 workspace = true

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -30,3 +30,46 @@ pub fn log_memory_usage(name: &str) {
         );
     }
 }
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::log_memory_usage;
+    use tracing::{
+        span::{Attributes, Id, Record},
+        subscriber::{with_default, Interest},
+        Event, Metadata, Subscriber,
+    };
+
+    struct TraceSubscriber;
+
+    impl Subscriber for TraceSubscriber {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _attrs: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, _event: &Event<'_>) {}
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+
+        fn register_callsite(&self, _metadata: &'static Metadata<'static>) -> Interest {
+            Interest::always()
+        }
+    }
+
+    #[test]
+    fn we_can_log_memory_usage_when_trace_enabled() {
+        with_default(TraceSubscriber, || {
+            log_memory_usage("coverage");
+        });
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- covers the TRACE-enabled `utils::log::log_memory_usage` path with a minimal in-test subscriber
- wires the crate `std` feature to enable `tracing/std`, matching the std-only logging helper and avoiding a new test dependency

## Verification
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_log_memory_usage_when_trace_enabled`
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One`
- `git diff --check`
- `scripts/check_commits.sh`