### PR TITLE
test: cover prover state constant rejection

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -62,3 +62,17 @@ impl<S: Scalar> ProverState<S> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar;
+
+    #[test]
+    #[should_panic(expected = "Attempt to prove a constant.")]
+    fn we_cannot_create_prover_state_for_constant_polynomial() {
+        let polynomial = CompositePolynomial::<Curve25519Scalar>::new(0);
+
+        ProverState::create(&polynomial);
+    }
+}


### PR DESCRIPTION
## Summary
- add focused coverage for `ProverState::create` rejecting constant polynomials
- keeps the change test-only and scoped to `sumcheck/prover_state.rs`

## Verification
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_cannot_create_prover_state_for_constant_polynomial`
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One`
- `perl -pe 's/\r$//' scripts/check_commits.sh | bash`

/claim #560