### PR TITLE
test: cover planner table ref errors

### DIFF
--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -165,6 +165,18 @@ AND s.salary > (
     }
 
     #[test]
+    fn we_cannot_get_table_references_with_catalog_qualified_table() {
+        let statement = Parser::parse_sql(
+            &GenericDialect {},
+            "SELECT employee_id FROM catalog.namespace.employees;",
+        )
+        .unwrap()[0]
+            .clone();
+
+        assert!(get_table_refs_from_statement(&statement).is_err());
+    }
+
+    #[test]
     fn we_can_use_abs() {
         let statements = Parser::parse_sql(&GenericDialect {}, "SELECT ABS(-1-1);").unwrap();
         sql_to_posql_plans(


### PR DESCRIPTION
/claim #560

Adds focused, test-only coverage for `proof-of-sql-planner/src/conversion.rs` table-reference extraction error handling. Codecov currently marks the invalid `get_table_refs_from_statement` break branch as missed; this test parses a catalog-qualified table reference and verifies the conversion returns an error.

Validation:

- `cargo test -p proof-of-sql-planner --lib we_cannot_get_table_references_with_catalog_qualified_table -- --nocapture`
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One`
- `scripts/check_commits.sh`