### PR TITLE
test: cover Dory offset byte conversions

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -60,3 +60,66 @@ impl OffsetToBytes<32> for [u64; 4] {
         bytemuck::cast(*self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OffsetToBytes;
+
+    #[test]
+    fn we_can_convert_unsigned_values_to_little_endian_bytes() {
+        assert_eq!(0u8.offset_to_bytes(), [0]);
+        assert_eq!(u8::MAX.offset_to_bytes(), [u8::MAX]);
+        assert_eq!(
+            0x0102_0304_0506_0708_u64.offset_to_bytes(),
+            [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]
+        );
+    }
+
+    #[test]
+    fn we_can_convert_boolean_values_to_bytes() {
+        assert_eq!(false.offset_to_bytes(), [0]);
+        assert_eq!(true.offset_to_bytes(), [1]);
+    }
+
+    #[test]
+    fn we_can_offset_signed_integer_bounds_to_unsigned_bytes() {
+        assert_eq!(i8::MIN.offset_to_bytes(), [0]);
+        assert_eq!(0i8.offset_to_bytes(), [128]);
+        assert_eq!(i8::MAX.offset_to_bytes(), [u8::MAX]);
+
+        assert_eq!(i16::MIN.offset_to_bytes(), 0u16.to_le_bytes());
+        assert_eq!(0i16.offset_to_bytes(), (1u16 << 15).to_le_bytes());
+        assert_eq!(i16::MAX.offset_to_bytes(), u16::MAX.to_le_bytes());
+
+        assert_eq!(i32::MIN.offset_to_bytes(), 0u32.to_le_bytes());
+        assert_eq!(0i32.offset_to_bytes(), (1u32 << 31).to_le_bytes());
+        assert_eq!(i32::MAX.offset_to_bytes(), u32::MAX.to_le_bytes());
+
+        assert_eq!(i64::MIN.offset_to_bytes(), 0u64.to_le_bytes());
+        assert_eq!(0i64.offset_to_bytes(), (1u64 << 63).to_le_bytes());
+        assert_eq!(i64::MAX.offset_to_bytes(), u64::MAX.to_le_bytes());
+
+        assert_eq!(i128::MIN.offset_to_bytes(), 0u128.to_le_bytes());
+        assert_eq!(0i128.offset_to_bytes(), (1u128 << 127).to_le_bytes());
+        assert_eq!(i128::MAX.offset_to_bytes(), u128::MAX.to_le_bytes());
+    }
+
+    #[test]
+    fn we_can_convert_scalar_limbs_to_bytes() {
+        let limbs = [
+            0x0102_0304_0506_0708,
+            0x1112_1314_1516_1718,
+            0x2122_2324_2526_2728,
+            0x3132_3334_3536_3738,
+        ];
+
+        assert_eq!(
+            limbs.offset_to_bytes(),
+            [
+                0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13,
+                0x12, 0x11, 0x28, 0x27, 0x26, 0x25, 0x24, 0x23, 0x22, 0x21, 0x38, 0x37, 0x36, 0x35,
+                0x34, 0x33, 0x32, 0x31,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

# Please go through the following checklist

- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This contributes to issue #560 by adding focused unit coverage for the Dory `OffsetToBytes` helper. The helper is used when packing column data for Dory commitments, including signed integer offsetting and scalar limb byte layout.

# What changes are included in this PR?

- Adds tests for unsigned integer and boolean byte conversion.
- Adds signed integer boundary tests covering the min/zero/max offset mapping for i8, i16, i32, i64, and i128.
- Adds a scalar limb array test to verify the 32-byte layout produced for `[u64; 4]`.

# Are these changes tested?

Yes. I ran:

- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features="std" offset_to_bytes -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features="std" --summary-only -- offset_to_bytes`

The targeted coverage report shows `proof_primitive/dory/offset_to_bytes.rs` at 100% functions and 100% lines for this test run.
