### PR TITLE
test: cover table empty and index helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -168,3 +168,33 @@ impl<'a, S: Scalar> core::ops::Index<&str> for Table<'a, S> {
         self.table.get(&Ident::new(index)).unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_identify_empty_table_with_specified_row_count() {
+        let table = Table::<TestScalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions::new(Some(3)),
+        )
+        .unwrap();
+
+        assert!(table.is_empty());
+        assert_eq!(table.num_rows(), 3);
+    }
+
+    #[test]
+    fn we_can_index_table_by_column_name() {
+        let table = Table::<TestScalar>::try_new(IndexMap::from_iter([
+            (Ident::new("bigint"), Column::BigInt(&[1_i64, 2])),
+            (Ident::new("int"), Column::Int(&[3_i32, 4])),
+        ]))
+        .unwrap();
+
+        assert_eq!(table["bigint"], Column::BigInt(&[1_i64, 2]));
+        assert_eq!(table["int"], Column::Int(&[3_i32, 4]));
+    }
+}


### PR DESCRIPTION
## Summary
- add focused coverage for `Table::is_empty` on an empty table with a specified row count
- add focused coverage for the test-only `Table` string index helper

/claim #560

## Verification
- `cargo fmt --all -- --config imports_granularity=Crate,group_imports=One`
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One`
- `cargo test -p proof-of-sql --lib --no-default-features --features test base::database::table::tests::`