### PR TITLE
test: cover dory evaluation setup guards

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,8 +1,14 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    dory_commitment_evaluation_proof::DoryError, test_rng, DoryEvaluationProof,
+    DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup, ProverSetup, PublicParameters,
+    VerifierSetup,
 };
-use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
+use crate::base::{
+    commitment::{
+        commitment_evaluation_proof_test::*, CommitmentEvaluationProof, VecCommitmentExt,
+    },
+    database::Column,
+};
 use ark_std::UniformRand;
 use merlin::Transcript;
 
@@ -91,4 +97,59 @@ fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
     let encoded = postcard::to_allocvec(&proof).unwrap();
     let decoded: DoryEvaluationProof = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(decoded, proof);
+}
+
+#[test]
+fn we_get_empty_dory_evaluation_proofs_for_invalid_prover_inputs() {
+    let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let a = [DoryScalar::from(1), DoryScalar::from(2)];
+    let b_point = [DoryScalar::from(3)];
+
+    let mut transcript = Transcript::new(b"evaluation_proof");
+    let proof = DoryEvaluationProof::new(&mut transcript, &a, &b_point, 1, &setup);
+    assert_eq!(proof, DoryEvaluationProof::default());
+
+    let oversized_b_point = vec![DoryScalar::from(3); 5];
+    let mut transcript = Transcript::new(b"evaluation_proof");
+    let proof = DoryEvaluationProof::new(&mut transcript, &a, &oversized_b_point, 0, &setup);
+    assert_eq!(proof, DoryEvaluationProof::default());
+}
+
+#[test]
+fn we_get_an_error_when_verifier_setup_is_too_small() {
+    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let prover_setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let small_public_parameters = PublicParameters::test_rand(2, &mut test_rng());
+    let small_verifier_setup = VerifierSetup::from(&small_public_parameters);
+    let small_verifier_setup = DoryVerifierPublicSetup::new(&small_verifier_setup, 2);
+    let a = (1..=8).map(DoryScalar::from).collect::<Vec<_>>();
+    let b_point = vec![DoryScalar::from(3); 5];
+
+    let mut transcript = Transcript::new(b"evaluation_proof");
+    let proof = DoryEvaluationProof::new(&mut transcript, &a, &b_point, 0, &prover_setup);
+    let commits = Vec::from_columns_with_offset([Column::Scalar(&a)], 0, &prover_setup);
+
+    let mut transcript = Transcript::new(b"evaluation_proof");
+    let err = proof
+        .verify_proof(
+            &mut transcript,
+            &commits[0],
+            &DoryScalar::from(0),
+            &b_point,
+            0,
+            a.len(),
+            &small_verifier_setup,
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DoryError::SmallSetup {
+            actual: 2,
+            required: 3
+        }
+    ));
 }


### PR DESCRIPTION
/claim #560

### What changed
- Added coverage for `DoryEvaluationProof::new` returning an empty proof for unsupported generator offsets.
- Added coverage for `DoryEvaluationProof::new` returning an empty proof when the prover setup is too small for the requested evaluation point.
- Added coverage for `verify_proof` returning `DoryError::SmallSetup` when verifier setup is too small.

### Verification
- `cargo test -p proof-of-sql --lib --no-default-features --features test dory_commitment_evaluation_proof_test::we_get`
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One`
- `git diff --check`