### PR TITLE
test: cover AnalyzeError formatting and conversions

### DIFF
--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,182 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        database::ColumnType,
+        math::decimal::{DecimalError, IntermediateDecimalError},
+    };
+
+    #[test]
+    fn we_can_format_invalid_data_type_error() {
+        let err = AnalyzeError::InvalidDataType {
+            expr_type: ColumnType::Boolean,
+        };
+        assert_eq!(
+            err.to_string(),
+            "Expression has datatype BOOLEAN, which was not valid"
+        );
+    }
+
+    #[test]
+    fn we_can_format_invalid_data_type_error_for_each_simple_type() {
+        let cases = [
+            (ColumnType::Uint8, "UINT8"),
+            (ColumnType::TinyInt, "TINYINT"),
+            (ColumnType::SmallInt, "SMALLINT"),
+            (ColumnType::Int, "INT"),
+            (ColumnType::BigInt, "BIGINT"),
+            (ColumnType::Int128, "DECIMAL"),
+            (ColumnType::VarChar, "VARCHAR"),
+            (ColumnType::VarBinary, "BINARY"),
+            (ColumnType::Scalar, "SCALAR"),
+        ];
+        for (col_type, type_name) in cases {
+            let err = AnalyzeError::InvalidDataType { expr_type: col_type };
+            assert_eq!(
+                err.to_string(),
+                format!("Expression has datatype {type_name}, which was not valid")
+            );
+        }
+    }
+
+    #[test]
+    fn we_can_format_data_type_mismatch_error() {
+        let err = AnalyzeError::DataTypeMismatch {
+            left_type: "BIGINT".into(),
+            right_type: "BOOLEAN".into(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Left side has 'BIGINT' type but right side has 'BOOLEAN' type"
+        );
+    }
+
+    #[test]
+    fn we_can_format_data_type_mismatch_with_empty_strings() {
+        let err = AnalyzeError::DataTypeMismatch {
+            left_type: String::new(),
+            right_type: String::new(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Left side has '' type but right side has '' type"
+        );
+    }
+
+    #[test]
+    fn we_can_format_different_column_length_error() {
+        let err = AnalyzeError::DifferentColumnLength { len_a: 5, len_b: 7 };
+        assert_eq!(err.to_string(), "Columns have different lengths: 5 != 7");
+    }
+
+    #[test]
+    fn we_can_format_different_column_length_error_with_zero() {
+        let err = AnalyzeError::DifferentColumnLength { len_a: 0, len_b: 0 };
+        assert_eq!(err.to_string(), "Columns have different lengths: 0 != 0");
+    }
+
+    #[test]
+    fn we_can_format_not_enough_input_plans_error() {
+        let err = AnalyzeError::NotEnoughInputPlans;
+        assert_eq!(err.to_string(), "Not enough input plans");
+    }
+
+    #[test]
+    fn we_can_convert_analyze_error_to_string_via_from() {
+        let err = AnalyzeError::NotEnoughInputPlans;
+        let s: String = String::from(err);
+        assert_eq!(s, "Not enough input plans");
+    }
+
+    #[test]
+    fn we_can_convert_analyze_error_to_string_via_into() {
+        let err = AnalyzeError::DifferentColumnLength { len_a: 3, len_b: 4 };
+        let s: String = err.into();
+        assert_eq!(s, "Columns have different lengths: 3 != 4");
+    }
+
+    #[test]
+    fn we_can_convert_intermediate_decimal_error_to_analyze_error() {
+        let err: AnalyzeError = IntermediateDecimalError::OutOfRange.into();
+        // The conversion wraps it under DecimalConversionError → IntermediateDecimalConversionError.
+        assert!(matches!(
+            err,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::OutOfRange,
+                },
+            }
+        ));
+    }
+
+    #[test]
+    fn we_can_convert_lossy_cast_intermediate_decimal_error() {
+        let err: AnalyzeError = IntermediateDecimalError::LossyCast.into();
+        assert!(matches!(
+            err,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::LossyCast,
+                },
+            }
+        ));
+    }
+
+    #[test]
+    fn analyze_errors_with_same_data_are_equal() {
+        assert_eq!(
+            AnalyzeError::NotEnoughInputPlans,
+            AnalyzeError::NotEnoughInputPlans
+        );
+        assert_eq!(
+            AnalyzeError::DifferentColumnLength { len_a: 1, len_b: 2 },
+            AnalyzeError::DifferentColumnLength { len_a: 1, len_b: 2 }
+        );
+        assert_eq!(
+            AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::Int,
+            },
+            AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::Int,
+            }
+        );
+    }
+
+    #[test]
+    fn analyze_errors_with_different_data_are_not_equal() {
+        assert_ne!(
+            AnalyzeError::DifferentColumnLength { len_a: 1, len_b: 2 },
+            AnalyzeError::DifferentColumnLength { len_a: 1, len_b: 3 }
+        );
+        assert_ne!(
+            AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::Int,
+            },
+            AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::BigInt,
+            }
+        );
+        assert_ne!(
+            AnalyzeError::DataTypeMismatch {
+                left_type: "BIGINT".into(),
+                right_type: "BOOLEAN".into(),
+            },
+            AnalyzeError::DataTypeMismatch {
+                left_type: "BOOLEAN".into(),
+                right_type: "BIGINT".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn analyze_errors_with_different_variants_are_not_equal() {
+        assert_ne!(
+            AnalyzeError::NotEnoughInputPlans,
+            AnalyzeError::DifferentColumnLength { len_a: 0, len_b: 0 }
+        );
+    }
+}


### PR DESCRIPTION
Taking a small non-overlapping test-only coverage slice in `crates/proof-of-sql/src/sql/error.rs`. I checked open PR file lists referencing #560 and did not find this file. The module previously had zero tests despite containing format strings, Display impls and From conversions that should be pinned down by tests.

# What's added

Inline `#[cfg(test)] mod tests` in the same file:

- `we_can_format_invalid_data_type_error` + `..._for_each_simple_type`: verifies `Display` for `AnalyzeError::InvalidDataType` against each simple `ColumnType` variant (Boolean, Uint8, TinyInt, SmallInt, Int, BigInt, Int128, VarChar, VarBinary, Scalar). Skips the parametric `Decimal75`/`TimestampTZ` to keep the test deterministic and avoid pulling in `Precision`/timezone fixtures.
- `we_can_format_data_type_mismatch_error` + empty-string case: pins the exact quoted format `Left side has 'X' type but right side has 'Y' type`.
- `we_can_format_different_column_length_error` + zero-length case.
- `we_can_format_not_enough_input_plans_error`.
- `we_can_convert_analyze_error_to_string_via_from` / `..._via_into`: pins both call sites of the existing `From<AnalyzeError> for String` impl.
- `we_can_convert_intermediate_decimal_error_to_analyze_error` and `..._lossy_cast_..._error`: verifies the existing `From<IntermediateDecimalError> for AnalyzeError` impl wraps under `DecimalConversionError → IntermediateDecimalConversionError`.
- `analyze_errors_with_same_data_are_equal`, `..._with_different_data_are_not_equal`, `..._with_different_variants_are_not_equal`: exercises the derived `PartialEq`.

No source code or behavior was modified — tests only.

/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`. (unable to run locally — environment lacks the required clang/lld linker toolchain; relying on CI for verification of these test-only changes)
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guide