### PR TITLE
test: cover sumcheck::prover_state::ProverState (new, create, panic)

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -62,3 +62,94 @@ impl<S: Scalar> ProverState<S> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::{rc::Rc, vec, vec::Vec};
+
+    fn s(x: i64) -> TestScalar {
+        TestScalar::from(x)
+    }
+
+    #[test]
+    fn new_with_empty_inputs_initializes_round_to_zero() {
+        let state: ProverState<TestScalar> = ProverState::new(vec![], vec![], 3, 2);
+        assert_eq!(state.round, 0);
+        assert_eq!(state.num_vars, 3);
+        assert_eq!(state.max_multiplicands, 2);
+        assert!(state.list_of_products.is_empty());
+        assert!(state.flattened_ml_extensions.is_empty());
+    }
+
+    #[test]
+    fn new_preserves_field_values_verbatim() {
+        let products: Vec<(TestScalar, Vec<usize>)> =
+            vec![(s(2), vec![0, 1]), (s(3), vec![1, 2])];
+        let extensions: Vec<Vec<TestScalar>> =
+            vec![vec![s(1), s(2)], vec![s(3), s(4)], vec![s(5), s(6)]];
+        let state = ProverState::new(products.clone(), extensions.clone(), 4, 2);
+        assert_eq!(state.list_of_products, products);
+        assert_eq!(state.flattened_ml_extensions, extensions);
+        assert_eq!(state.num_vars, 4);
+        assert_eq!(state.max_multiplicands, 2);
+        assert_eq!(state.round, 0);
+    }
+
+    #[test]
+    fn new_always_sets_round_to_zero_regardless_of_other_fields() {
+        let state: ProverState<TestScalar> = ProverState::new(vec![], vec![], 0, 0);
+        assert_eq!(state.round, 0);
+        let state2: ProverState<TestScalar> = ProverState::new(vec![], vec![], 100, 50);
+        assert_eq!(state2.round, 0);
+    }
+
+    #[test]
+    fn create_copies_fields_from_composite_polynomial() {
+        let mut poly: CompositePolynomial<TestScalar> = CompositePolynomial::new(3);
+        let ext1 = Rc::new(vec![s(1), s(2), s(3), s(4), s(5), s(6), s(7), s(8)]);
+        let ext2 = Rc::new(vec![s(2), s(4), s(6), s(8), s(10), s(12), s(14), s(16)]);
+        poly.add_product([ext1, ext2], s(5));
+
+        let state = ProverState::create(&poly);
+        assert_eq!(state.num_vars, poly.num_variables);
+        assert_eq!(state.max_multiplicands, poly.max_multiplicands);
+        assert_eq!(state.list_of_products, poly.products);
+        assert_eq!(state.round, 0);
+        assert_eq!(state.flattened_ml_extensions.len(), 2);
+    }
+
+    #[test]
+    fn create_performs_a_deep_copy_of_ml_extensions() {
+        let mut poly: CompositePolynomial<TestScalar> = CompositePolynomial::new(1);
+        let original = vec![s(11), s(22)];
+        let shared = Rc::new(original.clone());
+        poly.add_product([shared], s(1));
+
+        let state = ProverState::create(&poly);
+        // The state owns Vec<Vec<S>> — not Rc — so its data is independent of any
+        // outstanding Rc references on the original polynomial.
+        assert_eq!(state.flattened_ml_extensions, vec![original]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Attempt to prove a constant.")]
+    fn create_panics_when_polynomial_has_zero_variables() {
+        let poly: CompositePolynomial<TestScalar> = CompositePolynomial::new(0);
+        let _ = ProverState::create(&poly);
+    }
+
+    #[test]
+    fn create_from_polynomial_with_no_products_yields_empty_state_lists() {
+        // A non-zero num_variables polynomial with no products added still satisfies
+        // the create() precondition; we should get empty product/extension lists.
+        let poly: CompositePolynomial<TestScalar> = CompositePolynomial::new(1);
+        let state = ProverState::create(&poly);
+        assert_eq!(state.num_vars, 1);
+        assert_eq!(state.max_multiplicands, 0);
+        assert!(state.list_of_products.is_empty());
+        assert!(state.flattened_ml_extensions.is_empty());
+        assert_eq!(state.round, 0);
+    }
+}


### PR DESCRIPTION
Taking a small non-overlapping test-only coverage slice in `crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs`. I checked open PR file lists referencing #560 and did not find this file. The module previously had zero tests despite owning a load-bearing constructor (`create`) with a documented panic precondition and a deep-copy semantics requirement.

# What's added

Inline `#[cfg(test)] mod tests` in the same file (7 tests):

- `new_with_empty_inputs_initializes_round_to_zero` — basic field init
- `new_preserves_field_values_verbatim` — non-empty products / extensions / num_vars / max_multiplicands round-trip
- `new_always_sets_round_to_zero_regardless_of_other_fields` — pins the `round = 0` invariant
- `create_copies_fields_from_composite_polynomial` — maps `CompositePolynomial` → `ProverState` (num_vars, max_multiplicands, products, extension count)
- `create_performs_a_deep_copy_of_ml_extensions` — the state owns `Vec<Vec<S>>` (not `Rc`), so it is independent of outstanding shared references on the input
- `create_panics_when_polynomial_has_zero_variables` (`#[should_panic(expected = "Attempt to prove a constant.")]`) — pins the documented panic precondition
- `create_from_polynomial_with_no_products_yields_empty_state_lists` — degenerate but valid input path

All cases use `TestScalar` (a prime-field `MontScalar`).

No source code modified — tests only.

# Local verification

```
$ cargo test --package proof-of-sql --lib proof_primitive::sumcheck::prover_state::tests
running 7 tests
test proof_primitive::sumcheck::prover_state::tests::new_always_sets_round_to_zero_regardless_of_other_fields ... ok
test proof_primitive::sumcheck::prover_state::tests::create_from_polynomial_with_no_products_yields_empty_state_lists ... ok
test proof_primitive::sumcheck::prover_state::tests::create_panics_when_polynomial_has_zero_variables - should panic ... ok
test proof_primitive::sumcheck::prover_state::tests::new_with_empty_inputs_initializes_round_to_zero ... ok
test proof_primitive::sumcheck::prover_state::tests::new_preserves_field_values_verbatim ... ok
test proof_primitive::sumcheck::prover_state::tests::create_copies_fields_from_composite_polynomial ... ok
test proof_primitive::sumcheck::prover_state::tests::create_performs_a_deep_copy_of_ml_extensions ... ok

test result: ok. 7 passed; 0 failed
```

/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md.
- [x] I have run the relevant module tests locally (7 passed, output above). I did not run the full `scripts/run_ci_checks.sh` script.
- [x] The commit history is a single focused commit and follows the clean commit guide.