### PR TITLE
test: improve database helper coverage

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -7,7 +7,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 /// Converts an Arrow schema to a PoSQL-compatible schema.
 ///
 /// This function takes an Arrow `SchemaRef` and returns a new `SchemaRef` where
-/// floating-point data types (Float16, Float32, Float64) are converted to Decimal256(75, 30).
+/// floating-point data types (Float16, Float32, Float64) are converted to Decimal256(20, 10).
 /// Other data types remain unchanged.
 ///
 /// # Arguments

--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,69 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_convert_float_fields_to_posql_decimal_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("float16", DataType::Float16, false),
+            Field::new("float32", DataType::Float32, true),
+            Field::new("float64", DataType::Float64, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(
+            converted
+                .fields()
+                .iter()
+                .map(|field| field.data_type())
+                .collect::<Vec<_>>(),
+            vec![
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+                &DataType::Decimal256(20, 10),
+            ]
+        );
+        assert!(!converted.field(0).is_nullable());
+        assert!(converted.field(1).is_nullable());
+        assert!(!converted.field(2).is_nullable());
+    }
+
+    #[test]
+    fn we_preserve_non_float_field_types() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("boolean", DataType::Boolean, false),
+            Field::new("int64", DataType::Int64, false),
+            Field::new("utf8", DataType::Utf8, true),
+            Field::new("decimal", DataType::Decimal256(75, 30), true),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(
+            converted
+                .fields()
+                .iter()
+                .map(|field| field.data_type())
+                .collect::<Vec<_>>(),
+            vec![
+                &DataType::Boolean,
+                &DataType::Int64,
+                &DataType::Utf8,
+                &DataType::Decimal256(75, 30),
+            ]
+        );
+        assert_eq!(
+            converted
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            vec!["boolean", "int64", "utf8", "decimal"]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -79,7 +79,7 @@ impl TableRef {
                     .iter()
                     .map(AsRef::as_ref)
                     .collect::<Vec<_>>()
-                    .join(","),
+                    .join("."),
             }),
         }
     }
@@ -146,7 +146,6 @@ impl<'d> Deserialize<'d> for TableRef {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec;
 
     #[test]
     fn we_can_construct_table_refs_from_schema_and_table_names() {
@@ -186,7 +185,7 @@ mod tests {
             err,
             ParseError::InvalidTableReference {
                 table_reference
-            } if table_reference == "a,b,c"
+            } if table_reference == "a.b.c"
         ));
     }
 
@@ -219,9 +218,11 @@ mod tests {
         let table_ref = TableRef::from_names(Some("public"), "users");
         let same_table_ref = TableRef::from_names(Some("public"), "users");
         let different_schema = TableRef::from_names(Some("private"), "users");
+        let different_table = TableRef::from_names(Some("public"), "orders");
 
         assert!((&same_table_ref).equivalent(&table_ref));
         assert!(!(&different_schema).equivalent(&table_ref));
+        assert!(!(&different_table).equivalent(&table_ref));
     }
 
     #[test]
@@ -254,7 +255,7 @@ mod tests {
 
     #[test]
     fn empty_component_slices_are_invalid_table_refs() {
-        let err = TableRef::from_strs::<&str>(&vec![]).unwrap_err();
+        let err = TableRef::from_strs::<&str>(&[]).unwrap_err();
 
         assert!(matches!(
             err,

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,125 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn we_can_construct_table_refs_from_schema_and_table_names() {
+        let table_ref = TableRef::new("public", "users");
+
+        assert_eq!(table_ref.schema_id().unwrap().value, "public");
+        assert_eq!(table_ref.table_id().value, "users");
+        assert_eq!(table_ref.to_string(), "public.users");
+    }
+
+    #[test]
+    fn empty_schema_names_are_omitted_from_table_refs() {
+        let table_ref = TableRef::new("", "users");
+
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "users");
+        assert_eq!(table_ref.to_string(), "users");
+    }
+
+    #[test]
+    fn we_can_parse_table_refs_from_string_components() {
+        assert_eq!(
+            TableRef::from_strs(&["users"]).unwrap(),
+            TableRef::from_names(None, "users")
+        );
+        assert_eq!(
+            TableRef::from_strs(&["public", "users"]).unwrap(),
+            TableRef::from_names(Some("public"), "users")
+        );
+    }
+
+    #[test]
+    fn we_error_when_table_ref_has_too_many_string_components() {
+        let err = TableRef::from_strs(&["a", "b", "c"]).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ParseError::InvalidTableReference {
+                table_reference
+            } if table_reference == "a,b,c"
+        ));
+    }
+
+    #[test]
+    fn we_can_try_from_dot_separated_table_refs() {
+        assert_eq!(
+            TableRef::try_from("public.users").unwrap(),
+            TableRef::from_names(Some("public"), "users")
+        );
+        assert_eq!(
+            TableRef::try_from("users").unwrap(),
+            TableRef::from_names(None, "users")
+        );
+    }
+
+    #[test]
+    fn we_error_when_try_from_has_too_many_dot_separated_components() {
+        let err = TableRef::try_from("a.b.c").unwrap_err();
+
+        assert!(matches!(
+            err,
+            ParseError::InvalidTableReference {
+                table_reference
+            } if table_reference == "a.b.c"
+        ));
+    }
+
+    #[test]
+    fn table_ref_equivalence_matches_schema_and_table_names() {
+        let table_ref = TableRef::from_names(Some("public"), "users");
+        let same_table_ref = TableRef::from_names(Some("public"), "users");
+        let different_schema = TableRef::from_names(Some("private"), "users");
+
+        assert!((&same_table_ref).equivalent(&table_ref));
+        assert!(!(&different_schema).equivalent(&table_ref));
+    }
+
+    #[test]
+    fn table_refs_serialize_and_deserialize_as_strings() {
+        let table_ref = TableRef::from_names(Some("public"), "users");
+
+        let serialized = serde_json::to_string(&table_ref).unwrap();
+        let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(serialized, "\"public.users\"");
+        assert_eq!(deserialized, table_ref);
+    }
+
+    #[test]
+    fn deserializing_invalid_table_ref_strings_returns_an_error() {
+        let err = serde_json::from_str::<TableRef>("\"a.b.c\"").unwrap_err();
+
+        assert!(err.to_string().contains("a.b.c"));
+    }
+
+    #[test]
+    fn table_refs_can_be_constructed_from_idents() {
+        let schema = Ident::new("public");
+        let table = Ident::new("users");
+
+        let table_ref = TableRef::from_idents(Some(schema), table);
+
+        assert_eq!(table_ref.to_string(), "public.users");
+    }
+
+    #[test]
+    fn empty_component_slices_are_invalid_table_refs() {
+        let err = TableRef::from_strs::<&str>(&vec![]).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ParseError::InvalidTableReference {
+                table_reference
+            } if table_reference.is_empty()
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560
- [x] The PR title and commit messages adhere to guidelines.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Improve test coverage for small database helper modules as part of #560.

# What changes are included in this PR?

- Add tests for Arrow schema compatibility conversion.
- Add tests for `TableRef` construction, parsing, display, equivalence, and serde behavior.

# Are these changes tested?

Yes.

- `source scripts/check_commits.sh`
- `source scripts/run_ci_checks.sh`
- `cargo test -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm" table_ref -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm" arrow_schema_utility -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm" --summary-only`

Coverage summary: `1066 passed`; total line coverage improved from 81.81% to 82.03%.