### PR TITLE
test: cover owned column error messages

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,46 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owned_column_errors_have_descriptive_display_messages() {
+        assert_eq!(
+            OwnedColumnError::TypeCastError {
+                from_type: ColumnType::Boolean,
+                to_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Can not perform type casting from Boolean to BigInt"
+        );
+        assert_eq!(
+            OwnedColumnError::ScalarConversionError {
+                error: "outside target range".into(),
+            }
+            .to_string(),
+            "Error in converting scalars to a given column type: outside target range"
+        );
+        assert_eq!(
+            OwnedColumnError::Unsupported {
+                error: "VarBinary arithmetic".into(),
+            }
+            .to_string(),
+            "Unsupported operation: VarBinary arithmetic"
+        );
+    }
+
+    #[test]
+    fn column_coercion_errors_have_descriptive_display_messages() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Added focused coverage for owned column error display messages
- Covered type cast, scalar conversion, unsupported operation, and column coercion errors
- Kept the change test-only

## Verification
- cargo test -p proof-of-sql --no-default-features --features std base::database::owned_column_error
- cargo check -p proof-of-sql --no-default-features --features std
- cargo fmt --check
- git diff --check