### PR TITLE
test: cover table and column operation errors

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,95 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::math::decimal::DecimalError;
+    use alloc::string::{String, ToString};
+
+    #[test]
+    fn we_display_basic_column_operation_errors() {
+        assert_eq!(
+            ColumnOperationError::DifferentColumnLength { len_a: 2, len_b: 3 }.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+        assert_eq!(
+            ColumnOperationError::BinaryOperationInvalidColumnType {
+                operator: String::from("add"),
+                left_type: ColumnType::Int,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "\"add\"(lhs: Int, rhs: VarChar) is not supported"
+        );
+        assert_eq!(
+            ColumnOperationError::UnaryOperationInvalidColumnType {
+                operator: String::from("not"),
+                operand_type: ColumnType::Scalar,
+            }
+            .to_string(),
+            "\"not\"(operand: Scalar) is not supported"
+        );
+        assert_eq!(
+            ColumnOperationError::IntegerOverflow {
+                error: String::from("i64 overflow"),
+            }
+            .to_string(),
+            "Overflow in integer operation: i64 overflow"
+        );
+        assert_eq!(
+            ColumnOperationError::DivisionByZero.to_string(),
+            "Division by zero"
+        );
+    }
+
+    #[test]
+    fn we_display_column_conversion_and_bounds_errors() {
+        assert_eq!(
+            ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidScale {
+                    scale: String::from("-1"),
+                },
+            }
+            .to_string(),
+            "Decimal scale is not valid: -1"
+        );
+        assert_eq!(
+            ColumnOperationError::UnionDifferentTypes {
+                correct_type: ColumnType::Boolean,
+                actual_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Cannot union columns of different types: Boolean and BigInt"
+        );
+        assert_eq!(
+            ColumnOperationError::IndexOutOfBounds { index: 4, len: 4 }.to_string(),
+            "Index out of bounds: 4 >= 4"
+        );
+        assert_eq!(
+            ColumnOperationError::SignedCastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            "Cannot fit TINYINT into UINT8 without losing data"
+        );
+        assert_eq!(
+            ColumnOperationError::CastingError {
+                left_type: ColumnType::VarChar,
+                right_type: ColumnType::Int,
+            }
+            .to_string(),
+            "Cannot fit VARCHAR into INT without losing data"
+        );
+        assert_eq!(
+            ColumnOperationError::ScaleCastingError {
+                left_type: ColumnType::BigInt,
+                right_type: ColumnType::Scalar,
+            }
+            .to_string(),
+            "Cannot fit BIGINT into SCALAR without losing data"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,72 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{string::ToString, vec};
+
+    fn column_field(name: &str, data_type: ColumnType) -> ColumnField {
+        ColumnField::new(Ident::new(name), data_type)
+    }
+
+    #[test]
+    fn we_display_table_operation_errors() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+        assert_eq!(
+            TableOperationError::JoinWithDifferentNumberOfColumns {
+                left_num_columns: 1,
+                right_num_columns: 2,
+            }
+            .to_string(),
+            "Cannot join tables with different numbers of columns: 1 and 2"
+        );
+        assert_eq!(
+            TableOperationError::JoinIncompatibleTypes {
+                left_type: ColumnType::Boolean,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Cannot join tables on columns with incompatible types: Boolean and VarChar"
+        );
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+        assert_eq!(
+            TableOperationError::ColumnIndexOutOfBounds { column_index: 7 }.to_string(),
+            "Column index out of bounds: 7"
+        );
+    }
+
+    #[test]
+    fn we_display_schema_and_nested_column_errors() {
+        let union_error = TableOperationError::UnionIncompatibleSchemas {
+            correct_schema: vec![column_field("id", ColumnType::Int)],
+            actual_schema: vec![column_field("id", ColumnType::BigInt)],
+        }
+        .to_string();
+        assert!(union_error.contains("Cannot union tables with incompatible schemas"));
+        assert!(union_error.contains("Int"));
+        assert!(union_error.contains("BigInt"));
+
+        let missing_column_error = TableOperationError::ColumnDoesNotExist {
+            column_ident: Ident::new("missing_column"),
+        }
+        .to_string();
+        assert!(missing_column_error.contains("missing_column"));
+        assert!(missing_column_error.contains("does not exist in table"));
+
+        assert_eq!(
+            TableOperationError::ColumnOperationError {
+                source: ColumnOperationError::DifferentColumnLength { len_a: 3, len_b: 5 },
+            }
+            .to_string(),
+            "Columns have different lengths: 3 != 5"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

/claim #560

Adds focused, test-only coverage for database operation error formatting:

- `ColumnOperationError` display output for length mismatch, invalid operand types, integer overflow, division by zero, decimal conversion, union type mismatch, index bounds, and casting errors
- `TableOperationError` display output for union/join/schema/index errors plus transparent nested `ColumnOperationError` propagation

This does not change production behavior.

## Tests

- `GIT_CONFIG_GLOBAL=/dev/null CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p proof-of-sql --lib --no-default-features --features="test" we_display`
- `cargo fmt --all -- --check`
- `git diff --check`