### PR TITLE
test: cover limb serialization order

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,52 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct SerializedLimbs {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn serialize_limbs_reverses_limb_order() {
+        let limbs = SerializedLimbs {
+            limbs: [1, 2, 3, 4],
+        };
+
+        let serialized = serde_json::to_string(&limbs).unwrap();
+
+        assert_eq!(serialized, r#"{"limbs":[4,3,2,1]}"#);
+    }
+
+    #[test]
+    fn deserialize_to_limbs_reverses_wire_order() {
+        let deserialized: SerializedLimbs = serde_json::from_str(r#"{"limbs":[8,6,4,2]}"#).unwrap();
+
+        assert_eq!(
+            deserialized,
+            SerializedLimbs {
+                limbs: [2, 4, 6, 8],
+            }
+        );
+    }
+
+    #[test]
+    fn limbs_round_trip_through_reversed_wire_order() {
+        let limbs = SerializedLimbs {
+            limbs: [u64::MIN, 17, u64::MAX - 1, u64::MAX],
+        };
+
+        let serialized = serde_json::to_string(&limbs).unwrap();
+        let deserialized: SerializedLimbs = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, limbs);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Added focused coverage for the limb serialization helpers
- Verified the reversed wire order for serialization and deserialization
- Added a round-trip check for boundary limb values

## Verification
- cargo test -p proof-of-sql --no-default-features --features std limbs_
- cargo check -p proof-of-sql --no-default-features --features std
- cargo fmt --check
- git diff --check
