### PR TITLE
test: cover fold utility helpers

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
@@ -37,6 +37,7 @@ fn powers<S: Scalar>(init: S, base: S) -> impl Iterator<Item = S> {
 mod tests {
     use super::*;
     use crate::base::scalar::test_scalar::TestScalar;
+    use ark_std::Zero;
     use alloc::vec;
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
@@ -32,3 +32,48 @@ pub fn fold_vals<S: Scalar>(beta: S, vals: &[S]) -> S {
 fn powers<S: Scalar>(init: S, base: S) -> impl Iterator<Item = S> {
     core::iter::successors(Some(init), move |&m| Some(m * base))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::vec;
+
+    #[test]
+    fn fold_vals_evaluates_values_as_beta_polynomial() {
+        let beta = TestScalar::from(2_u64);
+        let vals = [
+            TestScalar::from(1_u64),
+            TestScalar::from(2_u64),
+            TestScalar::from(3_u64),
+        ];
+
+        assert_eq!(fold_vals(beta, &vals), TestScalar::from(11_u64));
+        assert_eq!(fold_vals(beta, &[]), TestScalar::zero());
+    }
+
+    #[test]
+    fn fold_columns_accumulates_reversed_beta_powers() {
+        let mut res = vec![TestScalar::from(10_u64); 3];
+        let first = [1_u64, 2, 3];
+        let second = [4_u64, 5, 6];
+        let third = [7_u64, 8, 9];
+        let columns: [&[u64]; 3] = [&first, &second, &third];
+
+        fold_columns(
+            &mut res,
+            TestScalar::from(3_u64),
+            TestScalar::from(2_u64),
+            &columns,
+        );
+
+        assert_eq!(
+            res,
+            vec![
+                TestScalar::from(67_u64),
+                TestScalar::from(88_u64),
+                TestScalar::from(109_u64)
+            ]
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for `fold_vals` polynomial evaluation, including the empty input identity.
- Add focused coverage for `fold_columns` showing that reversed columns receive increasing beta powers and accumulate into an existing result buffer.
- Keep the change test-only and limited to `crates/proof-of-sql/src/sql/proof_plans/fold_util.rs`.

## Non-overlap check
Before opening this PR, I searched current open #560 PRs for `fold_util`, `fold_columns`, `fold_vals`, and related fold utility terms and did not find an active overlapping claim.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test fold_util` passed locally on Windows with Rust stable GNU after installing a portable MinGW toolchain.
- Result: 6 passed; 0 failed; 956 filtered out.

AI-assisted with OpenAI Codex; diff reviewed before posting.
