### PR TITLE
test: cover evaluation vector branches

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -67,3 +67,35 @@ where
 
     log::log_memory_usage("End");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_point_fills_the_allowed_prefix_with_one() {
+        let mut single = [0_i64];
+        compute_evaluation_vector(&mut single, &[]);
+        assert_eq!(single, [1]);
+
+        let mut empty: [i64; 0] = [];
+        compute_evaluation_vector(&mut empty, &[]);
+        assert_eq!(empty, []);
+    }
+
+    #[test]
+    fn single_point_produces_left_and_right_factors() {
+        let mut v = [0_i64; 2];
+        compute_evaluation_vector(&mut v, &[3]);
+
+        assert_eq!(v, [-2, 3]);
+    }
+
+    #[test]
+    fn partial_vector_keeps_the_truncated_multilinear_prefix() {
+        let mut v = [0_i64; 3];
+        compute_evaluation_vector(&mut v, &[2, 3]);
+
+        assert_eq!(v, [2, -4, -3]);
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -80,7 +80,7 @@ mod tests {
 
         let mut empty: [i64; 0] = [];
         compute_evaluation_vector(&mut empty, &[]);
-        assert_eq!(empty, []);
+        assert!(empty.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for the empty-point identity behavior in `compute_evaluation_vector`.
- Add focused coverage for a single-point vector and a truncated two-point vector.
- Keep the change test-only and limited to `crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs`.

## Non-overlap check
Before opening this PR, I searched current open #560 PRs for `evaluation_vector` and `compute_evaluation_vector` and did not find an active overlapping claim.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test evaluation_vector` passed locally on Windows with Rust stable GNU after installing a portable MinGW toolchain.
- Result: 10 passed; 0 failed; 953 filtered out.

AI-assisted with OpenAI Codex; diff reviewed before posting.
