### PR TITLE
test: cover Dory message serialization

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
@@ -1,4 +1,5 @@
 use super::{test_rng, DoryMessages, G1Affine, G2Affine, F, GT};
+use crate::base::{try_standard_binary_deserialization, try_standard_binary_serialization};
 use ark_std::UniformRand;
 use merlin::Transcript;
 
@@ -72,6 +73,25 @@ fn we_can_send_and_receive_the_correct_messages_in_the_same_order() {
         messages.prover_receive_F_message(&mut transcript),
         Pmessage9
     );
+}
+
+#[test]
+fn we_can_serialize_and_deserialize_dory_messages() {
+    let mut rng = test_rng();
+    let mut messages = DoryMessages::default();
+    let mut transcript = Transcript::new(b"test");
+
+    messages.prover_send_F_message(&mut transcript, F::rand(&mut rng));
+    messages.prover_send_G1_message(&mut transcript, G1Affine::rand(&mut rng));
+    messages.prover_send_G2_message(&mut transcript, G2Affine::rand(&mut rng));
+    messages.prover_send_GT_message(&mut transcript, GT::rand(&mut rng));
+
+    let serialized = try_standard_binary_serialization(messages.clone()).unwrap();
+    let (deserialized, bytes_read): (DoryMessages, _) =
+        try_standard_binary_deserialization(&serialized).unwrap();
+
+    assert_eq!(bytes_read, serialized.len());
+    assert_eq!(deserialized, messages);
 }
 
 #[test]


### PR DESCRIPTION
/claim #560

Adds a focused test-only coverage slice for `DoryMessages` serialization.

Coverage:
- standard binary serialization of a populated `DoryMessages` value
- standard binary deserialization back into the same message queues
- byte consumption check for the serialized payload

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" dory_messages -- --nocapture`
- `rustfmt --check crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs`
- `git diff --check`
- `LLVM_COV=/opt/homebrew/opt/llvm/bin/llvm-cov LLVM_PROFDATA=/opt/homebrew/opt/llvm/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --lcov --output-path target/proof-of-sql-dory-messages.lcov -- dory_messages`