### PR TITLE
test: cover standard serialization helpers

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,21 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn serializes_fixed_width_in_big_endian_order() {
+        let serialized = try_standard_binary_serialization((0x1234_u16, 0x0102_0304_u32)).unwrap();
+
+        assert_eq!(serialized, [0x12, 0x34, 0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn deserialization_reports_consumed_bytes_and_leaves_trailing_data() {
+        let bytes = [0x12, 0x34, 0xaa, 0xbb];
+        let (value, consumed): (u16, _) = try_standard_binary_deserialization(&bytes).unwrap();
+
+        assert_eq!(value, 0x1234);
+        assert_eq!(consumed, 2);
+        assert_eq!(&bytes[consumed..], [0xaa, 0xbb]);
+    }
 }

--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,54 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn serializes_limbs_in_reverse_order() {
+        let value = LimbWrapper {
+            limbs: [0x11, 0x22, 0x33, 0x44],
+        };
+
+        assert_eq!(
+            serde_json::to_value(value).unwrap(),
+            serde_json::json!({ "limbs": [0x44, 0x33, 0x22, 0x11] })
+        );
+    }
+
+    #[test]
+    fn deserializes_limbs_from_reverse_order() {
+        let value: LimbWrapper =
+            serde_json::from_value(serde_json::json!({ "limbs": [0x44, 0x33, 0x22, 0x11] }))
+                .unwrap();
+
+        assert_eq!(
+            value,
+            LimbWrapper {
+                limbs: [0x11, 0x22, 0x33, 0x44]
+            }
+        );
+    }
+
+    #[test]
+    fn deserialization_rejects_arrays_with_the_wrong_limb_count() {
+        let err = serde_json::from_value::<LimbWrapper>(serde_json::json!({
+            "limbs": [0x33, 0x22, 0x11]
+        }))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("invalid length 3"));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary

- Adds direct coverage for the standard binary serialization contract, including fixed-width big-endian output and consumed-byte reporting during decode.
- Adds coverage for limb serialization adapters, verifying reverse-order serialization, reverse-order deserialization, and rejection of malformed limb arrays.

## Testing

- `cargo fmt --check`
- `cargo --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' --config 'target.x86_64-unknown-linux-gnu.linker="cc"' test -p proof-of-sql standard_serializations --no-default-features --features test`
- `cargo --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' --config 'target.x86_64-unknown-linux-gnu.linker="cc"' test -p proof-of-sql --lib --no-default-features --features test`