### PR TITLE
test: cover aggregate exec without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_no_blitzar_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_no_blitzar_test.rs
@@ -1,0 +1,172 @@
+use super::{
+    test_utility::{aggregate, table_exec},
+    AggregateExec, DynProofPlan,
+};
+use crate::{
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        database::{
+            owned_table_utility::*, ColumnField, ColumnType, OwnedTableTestAccessor, TableRef,
+            TestAccessor,
+        },
+    },
+    sql::{
+        proof::{ProofPlan, VerifiableQueryResult},
+        proof_exprs::{
+            test_utility::{
+                add, aliased_plan, col_ref, cols_expr_plan, column, const_bigint, const_bool,
+                const_int128, equal, multiply, sum_expr,
+            },
+            ProofExpr,
+        },
+    },
+};
+use alloc::{boxed::Box, vec};
+
+fn add_test_table(
+    accessor: &mut OwnedTableTestAccessor<NaiveEvaluationProof>,
+    table_ref: &TableRef,
+) {
+    accessor.add_table(
+        table_ref.clone(),
+        owned_table([
+            bigint("a", [1, 2, 2, 1, 2]),
+            bigint("b", [99, 99, 99, 99, 0]),
+            bigint("c", [101, 102, 103, 104, 105]),
+        ]),
+        0,
+    );
+}
+
+fn test_schema() -> Vec<ColumnField> {
+    vec![
+        ColumnField::new("a".into(), ColumnType::BigInt),
+        ColumnField::new("b".into(), ColumnType::BigInt),
+        ColumnField::new("c".into(), ColumnType::BigInt),
+    ]
+}
+
+#[test]
+fn we_can_verify_aggregate_without_group_by_without_blitzar() {
+    let table_ref = TableRef::new("sxt", "t");
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    add_test_table(&mut accessor, &table_ref);
+
+    let plan = aggregate(
+        vec![],
+        vec![sum_expr(column(&table_ref, "c", &accessor), "sum_c")],
+        "__count__",
+        table_exec(table_ref.clone(), test_schema()),
+        equal(column(&table_ref, "b", &accessor), const_int128(99)),
+    );
+
+    let verifiable_result =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+    let result = verifiable_result
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    assert_eq!(
+        result,
+        owned_table([bigint("sum_c", [410]), bigint("__count__", [4])])
+    );
+}
+
+#[test]
+fn we_can_verify_grouped_aggregate_without_blitzar() {
+    let table_ref = TableRef::new("sxt", "t");
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    add_test_table(&mut accessor, &table_ref);
+
+    let plan = aggregate(
+        cols_expr_plan(&table_ref, &["a"], &accessor),
+        vec![sum_expr(
+            add(
+                multiply(column(&table_ref, "c", &accessor), const_bigint(2)),
+                const_bigint(1),
+            ),
+            "sum_c",
+        )],
+        "__count__",
+        table_exec(table_ref.clone(), test_schema()),
+        equal(column(&table_ref, "b", &accessor), const_int128(99)),
+    );
+
+    let verifiable_result =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+    let result = verifiable_result
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    assert_eq!(
+        result,
+        owned_table([
+            bigint("a", [1, 2]),
+            decimal75("sum_c", 40, 0, [412, 412]),
+            bigint("__count__", [2, 2]),
+        ])
+    );
+}
+
+#[test]
+fn aggregate_metadata_accessors_and_unsupported_grouping_are_covered() {
+    let table_ref = TableRef::new("sxt", "t");
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    add_test_table(&mut accessor, &table_ref);
+
+    let plan = aggregate(
+        cols_expr_plan(&table_ref, &["a"], &accessor),
+        vec![sum_expr(column(&table_ref, "c", &accessor), "sum_c")],
+        "row_count",
+        table_exec(table_ref.clone(), test_schema()),
+        const_bool(true),
+    );
+
+    let DynProofPlan::Aggregate(aggregate_exec) = plan else {
+        panic!("expected aggregate plan");
+    };
+
+    assert!(matches!(aggregate_exec.input(), DynProofPlan::Table(_)));
+    assert_eq!(aggregate_exec.group_by_exprs().len(), 1);
+    assert_eq!(aggregate_exec.sum_expr().len(), 1);
+    assert_eq!(aggregate_exec.count_alias().value, "row_count");
+    assert_eq!(
+        aggregate_exec.where_clause().data_type(),
+        ColumnType::Boolean
+    );
+    assert_eq!(aggregate_exec.try_get_is_uniqueness_provable(), Some(true));
+    assert_eq!(
+        aggregate_exec.get_column_result_fields(),
+        vec![
+            ColumnField::new("a".into(), ColumnType::BigInt),
+            ColumnField::new("sum_c".into(), ColumnType::BigInt),
+            ColumnField::new("row_count".into(), ColumnType::BigInt),
+        ]
+    );
+    assert_eq!(
+        aggregate_exec
+            .get_column_references()
+            .into_iter()
+            .collect::<Vec<_>>(),
+        vec![
+            col_ref(&table_ref, "a", &accessor),
+            col_ref(&table_ref, "b", &accessor),
+            col_ref(&table_ref, "c", &accessor),
+        ]
+    );
+    assert!(aggregate_exec.get_table_references().contains(&table_ref));
+
+    let unsupported = AggregateExec::try_new(
+        vec![
+            aliased_plan(column(&table_ref, "a", &accessor), "a"),
+            aliased_plan(column(&table_ref, "b", &accessor), "b"),
+        ],
+        vec![sum_expr(column(&table_ref, "c", &accessor), "sum_c")],
+        "row_count".into(),
+        Box::new(table_exec(table_ref, test_schema())),
+        const_bool(true),
+    );
+    assert!(unsupported.is_none());
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -44,6 +44,9 @@ mod filter_exec_test;
 mod aggregate_exec;
 pub(crate) use aggregate_exec::AggregateExec;
 
+#[cfg(test)]
+mod aggregate_exec_no_blitzar_test;
+
 #[cfg(all(test, feature = "blitzar"))]
 mod aggregate_exec_test;
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

/claim #560

`aggregate_exec_test` currently only builds with the `blitzar` feature, so `AggregateExec` has a large uncovered no-default test gap. This adds focused no-blitzar coverage using `NaiveEvaluationProof` while leaving production behavior unchanged.

# What changes are included in this PR?

- Registers a no-default `aggregate_exec_no_blitzar_test` module.
- Adds coverage for aggregate verification without a group-by using `NaiveEvaluationProof`.
- Adds coverage for grouped aggregate verification using computed sum expressions.
- Adds coverage for `AggregateExec` metadata accessors and unsupported multi-column grouping rejection.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql --lib --no-default-features --features="test" aggregate_exec_no_blitzar -- --nocapture`
- `LLVM_COV=${LLVM_COV:-$(command -v llvm-cov || true)} LLVM_PROFDATA=${LLVM_PROFDATA:-$(command -v llvm-profdata || true)} cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --lcov --output-path target/proof-of-sql-aggregate-no-blitzar.lcov -- aggregate_exec_no_blitzar`
- `cargo test -p proof-of-sql --lib --no-default-features --features="test"` (963 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `source scripts/check_commits.sh`

Local LCOV spot-check: comparing the previous no-default baseline at `target/proof-of-sql-test.lcov` with `target/proof-of-sql-aggregate-no-blitzar.lcov`, this test slice covers 274 previously uncovered lines in `crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs`.