### PR TITLE
test: cover standard binary serialization

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,23 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn serializes_fixed_width_integers_as_big_endian() {
+        let serialized = try_standard_binary_serialization(0x0102_0304_u32).unwrap();
+
+        assert_eq!(serialized, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn deserialization_reports_consumed_length_with_trailing_bytes() {
+        let mut serialized = try_standard_binary_serialization(0x0102_u16).unwrap();
+        serialized.extend([0xaa, 0xbb]);
+
+        let (deserialized, consumed): (u16, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, 0x0102);
+        assert_eq!(consumed, 2);
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- Added focused coverage for the standard binary serialization helpers
- Verified fixed-width integers serialize as big-endian bytes
- Covered consumed-length reporting when deserializing with trailing bytes

## Verification
- cargo test -p proof-of-sql --no-default-features --features std base::standard_serializations::binary::tests
- cargo check -p proof-of-sql --no-default-features --features std
- cargo fmt --check
- git diff --check
