### PR TITLE
test: reduce posql db example setup size

### DIFF
--- a/crates/proof-of-sql-planner/examples/posql_db/main.rs
+++ b/crates/proof-of-sql-planner/examples/posql_db/main.rs
@@ -43,6 +43,9 @@ struct CliArgs {
     /// Path to the directory where the csv files are stored.
     #[arg(short, long, default_value = ".")]
     path: String,
+    /// Maximum nu to use for the Dory setup.
+    #[arg(long, default_value_t = 5)]
+    dory_setup_max_nu: usize,
     #[command(subcommand)]
     /// TODO: add docs
     command: Commands,
@@ -154,7 +157,7 @@ fn main() {
     let args = CliArgs::parse();
 
     let mut rng = <ark_std::rand::rngs::StdRng as ark_std::rand::SeedableRng>::from_seed([0u8; 32]);
-    let public_parameters = PublicParameters::rand(5, &mut rng);
+    let public_parameters = PublicParameters::rand(args.dory_setup_max_nu, &mut rng);
     let prover_setup = ProverSetup::from(&public_parameters);
     let verifier_setup = VerifierSetup::from(&public_parameters);
     match args.command {

--- a/crates/proof-of-sql-planner/examples/posql_db/run_example.sh
+++ b/crates/proof-of-sql-planner/examples/posql_db/run_example.sh
@@ -1,5 +1,5 @@
 cd crates/proof-of-sql-planner/examples/posql_db
-cargo run  --features="proof-of-sql/utils" "$@" --example posql_db create -t sxt.table -c a,b -d BIGINT,VARCHAR
-cargo run  --features="proof-of-sql/utils" "$@" --example posql_db append -t sxt.table -f hello_world.csv
-cargo run  --features="proof-of-sql/utils" "$@" --example posql_db prove -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
-cargo run  --features="proof-of-sql/utils" "$@" --example posql_db verify -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
+cargo run  --features="proof-of-sql/utils" "$@" --example posql_db -- --dory-setup-max-nu 2 create -t sxt.table -c a,b -d BIGINT,VARCHAR
+cargo run  --features="proof-of-sql/utils" "$@" --example posql_db -- --dory-setup-max-nu 2 append -t sxt.table -f hello_world.csv
+cargo run  --features="proof-of-sql/utils" "$@" --example posql_db -- --dory-setup-max-nu 2 prove -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
+cargo run  --features="proof-of-sql/utils" "$@" --example posql_db -- --dory-setup-max-nu 2 verify -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The `posql_db` CI example always creates and proves a tiny four-row fixture, but every command currently builds a Dory setup with `max_nu = 5`. This PR keeps the example CLI default at `5` for manual use and adds a `--dory-setup-max-nu` option so the CI helper can use `2` for its fixed fixture.

This avoids reducing the example's default capacity while trimming unnecessary setup generation in the two CI jobs that run `run_example.sh`.

/claim #557

# What changes are included in this PR?

- Add `--dory-setup-max-nu` to the `posql_db` example, defaulting to the previous value of `5`.
- Update `run_example.sh` to pass `--dory-setup-max-nu 2` for the known four-row CI fixture.
- Keep the create, append, prove, and verify commands otherwise unchanged.

# Are these changes tested?

Yes, with the already-built example binary on the same Termux checkout using `BLITZAR_BACKEND=cpu`:

- Default setup size 5: create, append, prove, verify completed in 31s and returned `hello`, `world`.
- CI setup size 2: create, append, prove, verify completed in 12s and returned `hello`, `world`.
- `--dory-setup-max-nu 1` was also tried and verification failed with `round evaluation does not match claimed sum`, so `2` is the smallest passing setup size for this fixture.

Additional checks:

- `CARGO_INCREMENTAL=0 cargo fmt --check --all`
- `git diff --check`
- `CARGO_INCREMENTAL=0 BLITZAR_BACKEND=cpu bash crates/proof-of-sql-planner/examples/posql_db/run_example.sh`

The no-default-features variant was attempted locally, but this Android Termux environment ran out of storage during compilation before reaching the example commands. The changed script path is the same option wiring as the default run; project CI should cover that runner environment.
