### PR TITLE
Add nullable column foundation

### DIFF
--- a/crates/proof-of-sql-planner/src/aggregate.rs
+++ b/crates/proof-of-sql-planner/src/aggregate.rs
@@ -1,5 +1,5 @@
 use super::{PlannerError, PlannerResult};
-use crate::expr_to_proof_expr;
+use crate::expr_to_proof_expr_with_fields;
 use datafusion::{
     logical_expr::{
         expr::{AggregateFunction, AggregateFunctionDefinition},
@@ -8,10 +8,9 @@ use datafusion::{
     physical_plan,
 };
 use proof_of_sql::{
-    base::database::{ColumnType, LiteralValue},
+    base::database::{ColumnField, LiteralValue},
     sql::proof_exprs::DynProofExpr,
 };
-use sqlparser::ast::Ident;
 
 /// An aggregate function we support
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -27,7 +26,7 @@ pub enum AggregateFunc {
 /// TODO: Some moderate changes are necessary once we upgrade `DataFusion` to 46.0.0
 pub(crate) fn aggregate_function_to_proof_expr(
     function: &AggregateFunction,
-    schema: &[(Ident, ColumnType)],
+    schema: &[ColumnField],
 ) -> PlannerResult<(AggregateFunc, DynProofExpr)> {
     match function {
         AggregateFunction {
@@ -45,12 +44,14 @@ pub(crate) fn aggregate_function_to_proof_expr(
                     let proof_expr = DynProofExpr::new_literal(LiteralValue::BigInt(1));
                     Ok((AggregateFunc::Count, proof_expr))
                 }
-                (physical_plan::aggregates::AggregateFunction::Sum, _) => {
-                    Ok((AggregateFunc::Sum, expr_to_proof_expr(arg, schema)?))
-                }
-                (physical_plan::aggregates::AggregateFunction::Count, _) => {
-                    Ok((AggregateFunc::Count, expr_to_proof_expr(arg, schema)?))
-                }
+                (physical_plan::aggregates::AggregateFunction::Sum, _) => Ok((
+                    AggregateFunc::Sum,
+                    expr_to_proof_expr_with_fields(arg, schema)?,
+                )),
+                (physical_plan::aggregates::AggregateFunction::Count, _) => Ok((
+                    AggregateFunc::Count,
+                    expr_to_proof_expr_with_fields(arg, schema)?,
+                )),
                 _ => Err(PlannerError::UnsupportedAggregateOperation { op: op.clone() }),
             }
         }
@@ -64,13 +65,13 @@ pub(crate) fn aggregate_function_to_proof_expr(
 mod tests {
     use super::*;
     use crate::df_util::*;
-    use proof_of_sql::base::database::{ColumnRef, ColumnType, TableRef};
+    use proof_of_sql::base::database::{ColumnField, ColumnRef, ColumnType, TableRef};
 
     // AggregateFunction to DynProofExpr
     #[test]
     fn we_can_convert_an_aggregate_function_to_proof_expr() {
         let expr = df_column("table", "a");
-        let schema: Vec<(Ident, ColumnType)> = vec![("a".into(), ColumnType::BigInt)];
+        let schema = vec![ColumnField::new("a".into(), ColumnType::BigInt)];
         for (function, operator) in &[
             (
                 physical_plan::aggregates::AggregateFunction::Sum,
@@ -108,7 +109,7 @@ mod tests {
         use proof_of_sql::base::database::LiteralValue;
 
         let wildcard_expr = Expr::Wildcard { qualifier: None };
-        let schema: Vec<(Ident, ColumnType)> = vec![("a".into(), ColumnType::BigInt)];
+        let schema = vec![ColumnField::new("a".into(), ColumnType::BigInt)];
         let function = AggregateFunction::new(
             physical_plan::aggregates::AggregateFunction::Count,
             vec![wildcard_expr],
@@ -129,7 +130,7 @@ mod tests {
     #[test]
     fn we_cannot_convert_an_aggregate_function_to_pair_if_unsupported() {
         let expr = df_column("table", "a");
-        let schema = vec![("a".into(), ColumnType::BigInt)];
+        let schema = vec![ColumnField::new("a".into(), ColumnType::BigInt)];
         let function = AggregateFunction::new(
             physical_plan::aggregates::AggregateFunction::RegrIntercept,
             vec![expr.clone()],
@@ -147,7 +148,7 @@ mod tests {
     #[test]
     fn we_cannot_convert_an_aggregate_function_to_pair_if_too_many_or_no_exprs() {
         let expr = df_column("table", "a");
-        let schema = vec![("a".into(), ColumnType::BigInt)];
+        let schema = vec![ColumnField::new("a".into(), ColumnType::BigInt)];
         // Too many exprs
         let function = AggregateFunction::new(
             physical_plan::aggregates::AggregateFunction::Sum,
@@ -183,7 +184,7 @@ mod tests {
 
         // Distinct
         let expr = df_column("table", "a");
-        let schema = vec![("a".into(), ColumnType::BigInt)];
+        let schema = vec![ColumnField::new("a".into(), ColumnType::BigInt)];
         let function = AggregateFunction::new(
             physical_plan::aggregates::AggregateFunction::Count,
             vec![expr.clone()],

--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -1,5 +1,4 @@
 use super::table_reference_to_table_ref;
-use crate::schema_to_column_fields;
 use alloc::sync::Arc;
 use arrow::datatypes::{Field, Schema};
 use core::any::Any;
@@ -49,8 +48,7 @@ impl<A: SchemaAccessor> ContextProvider for PoSqlContextProvider<A> {
     ) -> Result<Arc<dyn TableSource>, DataFusionError> {
         let table_ref = table_reference_to_table_ref(&name)
             .map_err(|err| DataFusionError::External(Box::new(err)))?;
-        let schema = self.accessor.lookup_schema(&table_ref);
-        let column_fields = schema_to_column_fields(schema);
+        let column_fields = self.accessor.lookup_column_fields(&table_ref);
         Ok(Arc::new(PoSqlTableSource::new(column_fields)) as Arc<dyn TableSource>)
     }
     fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>> {
@@ -95,7 +93,7 @@ impl PoSqlTableSource {
                     Field::new(
                         column_field.name().value.as_str(),
                         (&column_field.data_type()).into(),
-                        false,
+                        column_field.is_nullable(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -145,6 +143,7 @@ mod tests {
         let column_fields = vec![
             ColumnField::new("a".into(), ColumnType::SmallInt),
             ColumnField::new("b".into(), ColumnType::VarChar),
+            ColumnField::new_nullable("c".into(), ColumnType::BigInt),
         ];
         let table_source = PoSqlTableSource::new(column_fields);
         assert_eq!(
@@ -152,6 +151,7 @@ mod tests {
             vec![
                 &Field::new("a", DataType::Int16, false),
                 &Field::new("b", DataType::Utf8, false),
+                &Field::new("c", DataType::Int64, true),
             ]
         );
         assert_eq!(

--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -117,10 +117,43 @@ mod tests {
     use datafusion::{config::ConfigOptions, logical_expr::LogicalPlan};
     use indexmap::IndexSet;
     use proof_of_sql::{
-        base::database::{TableRef, TableTestAccessor},
+        base::database::{
+            ColumnField, ColumnRef, ColumnType, SchemaAccessor, TableRef, TableTestAccessor,
+        },
         proof_primitive::dory::DynamicDoryEvaluationProof,
+        sql::{
+            proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+            proof_plans::DynProofPlan,
+        },
     };
+    use sqlparser::ast::Ident;
     use sqlparser::{dialect::GenericDialect, parser::Parser};
+
+    #[derive(Clone)]
+    struct NullableOrdersSchema;
+
+    impl SchemaAccessor for NullableOrdersSchema {
+        fn lookup_column(&self, _table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
+            match column_id.value.as_str() {
+                "id" | "amount" => Some(ColumnType::BigInt),
+                _ => None,
+            }
+        }
+
+        fn lookup_schema(&self, _table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
+            vec![
+                ("id".into(), ColumnType::BigInt),
+                ("amount".into(), ColumnType::BigInt),
+            ]
+        }
+
+        fn lookup_column_fields(&self, _table_ref: &TableRef) -> Vec<ColumnField> {
+            vec![
+                ColumnField::new("id".into(), ColumnType::BigInt),
+                ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+            ]
+        }
+    }
 
     #[test]
     fn we_can_get_table_references() {
@@ -174,5 +207,48 @@ AND s.salary > (
             |a, _| -> PlannerResult<LogicalPlan> { Ok(a.clone()) },
         )
         .unwrap();
+    }
+
+    #[test]
+    fn sql_is_null_uses_generated_presence_column_in_plan() {
+        let statements = Parser::parse_sql(
+            &GenericDialect {},
+            "SELECT id FROM orders WHERE amount IS NULL;",
+        )
+        .unwrap();
+        let plans = super::sql_to_proof_plans(
+            &statements,
+            &NullableOrdersSchema,
+            &ConfigOptions::default(),
+        )
+        .unwrap();
+        let table_ref = TableRef::from_names(None, "orders");
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), "amount".into(), ColumnType::BigInt);
+
+        assert_eq!(
+            plans,
+            vec![DynProofPlan::new_filter(
+                vec![AliasedDynProofExpr {
+                    expr: DynProofExpr::new_column(ColumnRef::new(
+                        table_ref.clone(),
+                        "id".into(),
+                        ColumnType::BigInt,
+                    )),
+                    alias: "id".into(),
+                }],
+                DynProofPlan::new_table(
+                    table_ref,
+                    vec![
+                        ColumnField::new("id".into(), ColumnType::BigInt),
+                        ColumnField::new(
+                            ColumnRef::presence_column_id(&"amount".into()),
+                            ColumnType::Boolean,
+                        ),
+                    ],
+                ),
+                DynProofExpr::new_is_null(amount_ref),
+            )]
+        );
     }
 }

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -1,6 +1,6 @@
 use super::{
-    column_to_column_ref, placeholder_to_placeholder_expr, scalar_value_to_literal_value,
-    PlannerError, PlannerResult,
+    column_to_column_ref_from_fields, placeholder_to_placeholder_expr,
+    scalar_value_to_literal_value, PlannerError, PlannerResult,
 };
 use datafusion::logical_expr::{
     expr::{Alias, Cast, Placeholder},
@@ -8,7 +8,7 @@ use datafusion::logical_expr::{
 };
 use indexmap::IndexSet;
 use proof_of_sql::{
-    base::database::ColumnType,
+    base::database::{ColumnField, ColumnRef, ColumnType},
     sql::{proof_exprs::DynProofExpr, scale_cast_binary_op},
 };
 use sqlparser::ast::Ident;
@@ -26,6 +26,14 @@ pub(crate) fn get_column_idents_from_expr(expr: &Expr) -> IndexSet<Ident> {
             left_idents.extend(get_column_idents_from_expr(right));
             left_idents
         }
+        Expr::IsNull(inner) | Expr::IsNotNull(inner) => match &**inner {
+            Expr::Column(col) => {
+                let mut set = IndexSet::new();
+                set.insert(ColumnRef::presence_column_id(&col.name.as_str().into()));
+                set
+            }
+            _ => get_column_idents_from_expr(inner),
+        },
         Expr::Not(inner) => get_column_idents_from_expr(inner),
         Expr::Alias(Alias { expr, .. }) | Expr::Cast(Cast { expr, .. }) => {
             get_column_idents_from_expr(expr)
@@ -48,10 +56,10 @@ fn binary_expr_to_proof_expr(
     left: &Expr,
     right: &Expr,
     op: Operator,
-    schema: &[(Ident, ColumnType)],
+    schema: &[ColumnField],
 ) -> PlannerResult<DynProofExpr> {
-    let left_proof_expr = expr_to_proof_expr(left, schema)?;
-    let right_proof_expr = expr_to_proof_expr(right, schema)?;
+    let left_proof_expr = expr_to_proof_expr_with_fields(left, schema)?;
+    let right_proof_expr = expr_to_proof_expr_with_fields(right, schema)?;
 
     let (left_proof_expr, right_proof_expr) = match op {
         Operator::Eq
@@ -127,9 +135,26 @@ pub fn expr_to_proof_expr(
     expr: &Expr,
     schema: &[(Ident, ColumnType)],
 ) -> PlannerResult<DynProofExpr> {
+    let column_fields = schema
+        .iter()
+        .map(|(ident, column_type)| ColumnField::new(ident.clone(), *column_type))
+        .collect::<Vec<_>>();
+    expr_to_proof_expr_with_fields(expr, &column_fields)
+}
+
+/// Convert a [`datafusion::expr::Expr`] to [`DynProofExpr`] while preserving column nullability.
+///
+/// # Panics
+/// The function should not panic if Proof of SQL is working correctly
+pub(crate) fn expr_to_proof_expr_with_fields(
+    expr: &Expr,
+    schema: &[ColumnField],
+) -> PlannerResult<DynProofExpr> {
     match expr {
-        Expr::Alias(Alias { expr, .. }) => expr_to_proof_expr(expr, schema),
-        Expr::Column(col) => Ok(DynProofExpr::new_column(column_to_column_ref(col, schema)?)),
+        Expr::Alias(Alias { expr, .. }) => expr_to_proof_expr_with_fields(expr, schema),
+        Expr::Column(col) => Ok(DynProofExpr::new_column(column_to_column_ref_from_fields(
+            col, schema,
+        )?)),
         Expr::Placeholder(placeholder) => placeholder_to_placeholder_expr(placeholder),
         Expr::BinaryExpr(BinaryExpr { left, right, op }) => {
             binary_expr_to_proof_expr(left, right, *op, schema)
@@ -138,9 +163,25 @@ pub fn expr_to_proof_expr(
             val.clone(),
         )?)),
         Expr::Not(expr) => {
-            let proof_expr = expr_to_proof_expr(expr, schema)?;
+            let proof_expr = expr_to_proof_expr_with_fields(expr, schema)?;
             Ok(DynProofExpr::try_new_not(proof_expr)?)
         }
+        Expr::IsNull(expr) => match &**expr {
+            Expr::Column(col) => Ok(DynProofExpr::new_is_null(column_to_column_ref_from_fields(
+                col, schema,
+            )?)),
+            _ => Err(PlannerError::UnsupportedLogicalExpression {
+                expr: Box::new(expr.as_ref().clone()),
+            }),
+        },
+        Expr::IsNotNull(expr) => match &**expr {
+            Expr::Column(col) => Ok(DynProofExpr::new_is_not_null(
+                column_to_column_ref_from_fields(col, schema)?,
+            )),
+            _ => Err(PlannerError::UnsupportedLogicalExpression {
+                expr: Box::new(expr.as_ref().clone()),
+            }),
+        },
         Expr::Cast(cast) => {
             match &*cast.expr {
                 // handle cases such as `$1::int`
@@ -150,7 +191,7 @@ pub fn expr_to_proof_expr(
                     placeholder_to_placeholder_expr(&typed_placeholder)
                 }
                 _ => {
-                    let from_expr = expr_to_proof_expr(&cast.expr, schema)?;
+                    let from_expr = expr_to_proof_expr_with_fields(&cast.expr, schema)?;
                     let to_type = cast.data_type.clone().try_into().map_err(|_| {
                         PlannerError::UnsupportedDataType {
                             data_type: cast.data_type.clone(),
@@ -183,7 +224,7 @@ mod tests {
         logical_expr::{expr::Placeholder, Cast},
     };
     use proof_of_sql::base::{
-        database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+        database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef},
         math::decimal::Precision,
     };
 
@@ -272,6 +313,33 @@ mod tests {
         let expr = df_column("namespace.table_name", "column");
         let schema = vec![("column".into(), ColumnType::Int)];
         assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), COLUMN_INT());
+    }
+
+    #[test]
+    fn we_can_convert_nullable_column_is_null_expr_to_proof_expr() {
+        let expr = Expr::IsNull(Box::new(df_column("namespace.table_name", "column")));
+        let schema = vec![ColumnField::new_nullable("column".into(), ColumnType::Int)];
+        let column_ref = ColumnRef::new_nullable(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column".into(),
+            ColumnType::Int,
+        );
+
+        assert_eq!(
+            expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
+            DynProofExpr::new_is_null(column_ref)
+        );
+    }
+
+    #[test]
+    fn we_can_convert_non_nullable_column_is_not_null_expr_to_constant_true() {
+        let expr = Expr::IsNotNull(Box::new(df_column("namespace.table_name", "column")));
+        let schema = vec![ColumnField::new("column".into(), ColumnType::Int)];
+
+        assert_eq!(
+            expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true))
+        );
     }
 
     // BinaryExpr
@@ -797,6 +865,16 @@ mod tests {
         let expr = Expr::Not(Box::new(df_column("table", "bool_col")));
         let result = get_column_idents_from_expr(&expr);
         let expected: IndexSet<Ident> = ["bool_col".into()].into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_extract_column_idents_from_is_null_expr() {
+        let expr = Expr::IsNull(Box::new(df_column("table", "nullable_col")));
+        let result = get_column_idents_from_expr(&expr);
+        let expected: IndexSet<Ident> = [ColumnRef::presence_column_id(&"nullable_col".into())]
+            .into_iter()
+            .collect();
         assert_eq!(result, expected);
     }
 

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -223,6 +223,18 @@ pub(crate) fn filter_expr_to_proof_expr_with_fields(
         Expr::Column(col) => Ok(DynProofExpr::try_new_is_true(
             column_to_column_ref_from_fields(col, schema)?,
         )?),
+        Expr::BinaryExpr(BinaryExpr { left, right, op }) if *op == Operator::And => {
+            Ok(DynProofExpr::try_new_and(
+                filter_expr_to_proof_expr_with_fields(left, schema)?,
+                filter_expr_to_proof_expr_with_fields(right, schema)?,
+            )?)
+        }
+        Expr::BinaryExpr(BinaryExpr { left, right, op }) if *op == Operator::Or => {
+            Ok(DynProofExpr::try_new_or(
+                filter_expr_to_proof_expr_with_fields(left, schema)?,
+                filter_expr_to_proof_expr_with_fields(right, schema)?,
+            )?)
+        }
         Expr::Not(inner) => match &**inner {
             Expr::Column(col) => Ok(DynProofExpr::try_new_is_false(
                 column_to_column_ref_from_fields(col, schema)?,
@@ -371,6 +383,39 @@ mod tests {
         assert_eq!(
             filter_expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
             DynProofExpr::try_new_is_false(column_ref).unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_convert_nested_nullable_boolean_filter_columns_to_truth_proof_exprs() {
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(df_column("namespace.table_name", "is_paid")),
+            right: Box::new(
+                df_column("namespace.table_name", "id")
+                    .eq(Expr::Literal(ScalarValue::Int64(Some(4)))),
+            ),
+            op: Operator::Or,
+        });
+        let schema = vec![
+            ColumnField::new_nullable("is_paid".into(), ColumnType::Boolean),
+            ColumnField::new("id".into(), ColumnType::BigInt),
+        ];
+        let table_ref = TableRef::from_names(Some("namespace"), "table_name");
+        let is_paid_ref =
+            ColumnRef::new_nullable(table_ref.clone(), "is_paid".into(), ColumnType::Boolean);
+        let id_ref = ColumnRef::new(table_ref, "id".into(), ColumnType::BigInt);
+
+        assert_eq!(
+            filter_expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_or(
+                DynProofExpr::try_new_is_true(is_paid_ref).unwrap(),
+                DynProofExpr::try_new_equals(
+                    DynProofExpr::new_column(id_ref),
+                    DynProofExpr::new_literal(LiteralValue::BigInt(4)),
+                )
+                .unwrap(),
+            )
+            .unwrap()
         );
     }
 

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -294,6 +294,12 @@ pub(crate) fn filter_expr_to_proof_expr_with_fields(
             Expr::Column(col) => Ok(DynProofExpr::try_new_is_false(
                 column_to_column_ref_from_fields(col, schema)?,
             )?),
+            Expr::BinaryExpr(BinaryExpr { op, .. }) if is_filter_comparison_operator(*op) => {
+                and_nullable_presence_guards(
+                    DynProofExpr::try_new_not(expr_to_proof_expr_with_fields(inner, schema)?)?,
+                    nullable_column_refs_in_expr(inner, schema)?,
+                )
+            }
             _ => expr_to_proof_expr_with_fields(expr, schema),
         },
         _ => expr_to_proof_expr_with_fields(expr, schema),
@@ -495,6 +501,40 @@ mod tests {
                     DynProofExpr::new_column(amount_ref.clone()),
                     DynProofExpr::new_literal(LiteralValue::BigInt(15)),
                     false,
+                )
+                .unwrap(),
+                DynProofExpr::new_is_not_null(amount_ref),
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_convert_negated_nullable_comparison_filter_to_presence_guarded_proof_expr() {
+        let expr = Expr::Not(Box::new(
+            df_column("namespace.table_name", "amount")
+                .lt(Expr::Literal(ScalarValue::Int64(Some(15)))),
+        ));
+        let schema = vec![ColumnField::new_nullable(
+            "amount".into(),
+            ColumnType::BigInt,
+        )];
+        let amount_ref = ColumnRef::new_nullable(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(
+            filter_expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_and(
+                DynProofExpr::try_new_not(
+                    DynProofExpr::try_new_inequality(
+                        DynProofExpr::new_column(amount_ref.clone()),
+                        DynProofExpr::new_literal(LiteralValue::BigInt(15)),
+                        true,
+                    )
+                    .unwrap(),
                 )
                 .unwrap(),
                 DynProofExpr::new_is_not_null(amount_ref),

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -85,68 +85,6 @@ fn nullable_column_refs_in_expr(
     }
 }
 
-fn nullable_propagating_column_refs_in_expr(
-    expr: &Expr,
-    schema: &[ColumnField],
-) -> PlannerResult<IndexSet<ColumnRef>> {
-    match expr {
-        Expr::Column(col) => {
-            let column_ref = column_to_column_ref_from_fields(col, schema)?;
-            Ok(if column_ref.is_nullable() {
-                IndexSet::from_iter([column_ref])
-            } else {
-                IndexSet::new()
-            })
-        }
-        Expr::Literal(_) | Expr::Placeholder(_) | Expr::IsNull(_) | Expr::IsNotNull(_) => {
-            Ok(IndexSet::new())
-        }
-        Expr::BinaryExpr(BinaryExpr { left, right, op })
-            if matches!(
-                op,
-                Operator::Eq
-                    | Operator::NotEq
-                    | Operator::Lt
-                    | Operator::Gt
-                    | Operator::LtEq
-                    | Operator::GtEq
-                    | Operator::Plus
-                    | Operator::Minus
-                    | Operator::Multiply
-            ) =>
-        {
-            let mut left_refs = nullable_propagating_column_refs_in_expr(left, schema)?;
-            left_refs.extend(nullable_propagating_column_refs_in_expr(right, schema)?);
-            Ok(left_refs)
-        }
-        Expr::Not(inner)
-        | Expr::Alias(Alias { expr: inner, .. })
-        | Expr::Cast(Cast { expr: inner, .. }) => {
-            nullable_propagating_column_refs_in_expr(inner, schema)
-        }
-        _ => Err(PlannerError::UnsupportedLogicalExpression {
-            expr: Box::new(expr.clone()),
-        }),
-    }
-}
-
-fn nullable_propagating_presence_expr(
-    expr: &Expr,
-    schema: &[ColumnField],
-) -> PlannerResult<Option<DynProofExpr>> {
-    let column_refs = nullable_propagating_column_refs_in_expr(expr, schema)?;
-    let mut column_refs = column_refs.into_iter();
-    let Some(first_column_ref) = column_refs.next() else {
-        return Ok(None);
-    };
-    let mut proof_expr = DynProofExpr::new_is_not_null(first_column_ref);
-    for column_ref in column_refs {
-        proof_expr =
-            DynProofExpr::try_new_and(proof_expr, DynProofExpr::new_is_not_null(column_ref))?;
-    }
-    Ok(Some(proof_expr))
-}
-
 fn and_nullable_presence_guards(
     mut proof_expr: DynProofExpr,
     column_refs: IndexSet<ColumnRef>,
@@ -281,21 +219,22 @@ pub(crate) fn expr_to_proof_expr_with_fields(
             Expr::Column(col) => Ok(DynProofExpr::new_is_null(column_to_column_ref_from_fields(
                 col, schema,
             )?)),
-            _ => Ok(
-                nullable_propagating_presence_expr(expr, schema)?.map_or_else(
+            _ => Ok(expr_to_proof_expr_with_fields(expr, schema)?
+                .nullable_result_presence_expr()
+                .map_or_else(
                     || DynProofExpr::new_literal(LiteralValue::Boolean(false)),
                     |presence_expr| {
                         DynProofExpr::try_new_not(presence_expr)
                             .expect("Presence expressions have boolean type")
                     },
-                ),
-            ),
+                )),
         },
         Expr::IsNotNull(expr) => match &**expr {
             Expr::Column(col) => Ok(DynProofExpr::new_is_not_null(
                 column_to_column_ref_from_fields(col, schema)?,
             )),
-            _ => Ok(nullable_propagating_presence_expr(expr, schema)?
+            _ => Ok(expr_to_proof_expr_with_fields(expr, schema)?
+                .nullable_result_presence_expr()
                 .unwrap_or_else(|| DynProofExpr::new_literal(LiteralValue::Boolean(true)))),
         },
         Expr::Cast(cast) => {
@@ -655,18 +594,26 @@ mod tests {
     }
 
     #[test]
-    fn we_reject_is_null_for_general_logical_exprs() {
-        let expr = Expr::IsNull(Box::new(Expr::BinaryExpr(BinaryExpr {
+    fn we_can_convert_is_null_for_nullable_logical_exprs() {
+        let logical_expr = Expr::BinaryExpr(BinaryExpr {
             left: Box::new(df_column("namespace.table_name", "is_paid")),
-            right: Box::new(Expr::Literal(ScalarValue::Boolean(Some(true)))),
+            right: Box::new(Expr::Literal(ScalarValue::Boolean(Some(false)))),
             op: Operator::Or,
-        })));
+        });
         let schema = vec![ColumnField::new_nullable(
             "is_paid".into(),
             ColumnType::Boolean,
         )];
 
-        assert!(expr_to_proof_expr_with_fields(&expr, &schema).is_err());
+        assert!(expr_to_proof_expr_with_fields(
+            &Expr::IsNull(Box::new(logical_expr.clone())),
+            &schema
+        )
+        .is_ok());
+        assert!(
+            expr_to_proof_expr_with_fields(&Expr::IsNotNull(Box::new(logical_expr)), &schema)
+                .is_ok()
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -8,7 +8,7 @@ use datafusion::logical_expr::{
 };
 use indexmap::IndexSet;
 use proof_of_sql::{
-    base::database::{ColumnField, ColumnRef, ColumnType},
+    base::database::{ColumnField, ColumnRef, ColumnType, LiteralValue},
     sql::{proof_exprs::DynProofExpr, scale_cast_binary_op},
 };
 use sqlparser::ast::Ident;
@@ -83,6 +83,68 @@ fn nullable_column_refs_in_expr(
         Expr::IsNull(_) | Expr::IsNotNull(_) => Ok(IndexSet::new()),
         _ => Ok(IndexSet::new()),
     }
+}
+
+fn nullable_propagating_column_refs_in_expr(
+    expr: &Expr,
+    schema: &[ColumnField],
+) -> PlannerResult<IndexSet<ColumnRef>> {
+    match expr {
+        Expr::Column(col) => {
+            let column_ref = column_to_column_ref_from_fields(col, schema)?;
+            Ok(if column_ref.is_nullable() {
+                IndexSet::from_iter([column_ref])
+            } else {
+                IndexSet::new()
+            })
+        }
+        Expr::Literal(_) | Expr::Placeholder(_) | Expr::IsNull(_) | Expr::IsNotNull(_) => {
+            Ok(IndexSet::new())
+        }
+        Expr::BinaryExpr(BinaryExpr { left, right, op })
+            if matches!(
+                op,
+                Operator::Eq
+                    | Operator::NotEq
+                    | Operator::Lt
+                    | Operator::Gt
+                    | Operator::LtEq
+                    | Operator::GtEq
+                    | Operator::Plus
+                    | Operator::Minus
+                    | Operator::Multiply
+            ) =>
+        {
+            let mut left_refs = nullable_propagating_column_refs_in_expr(left, schema)?;
+            left_refs.extend(nullable_propagating_column_refs_in_expr(right, schema)?);
+            Ok(left_refs)
+        }
+        Expr::Not(inner)
+        | Expr::Alias(Alias { expr: inner, .. })
+        | Expr::Cast(Cast { expr: inner, .. }) => {
+            nullable_propagating_column_refs_in_expr(inner, schema)
+        }
+        _ => Err(PlannerError::UnsupportedLogicalExpression {
+            expr: Box::new(expr.clone()),
+        }),
+    }
+}
+
+fn nullable_propagating_presence_expr(
+    expr: &Expr,
+    schema: &[ColumnField],
+) -> PlannerResult<Option<DynProofExpr>> {
+    let column_refs = nullable_propagating_column_refs_in_expr(expr, schema)?;
+    let mut column_refs = column_refs.into_iter();
+    let Some(first_column_ref) = column_refs.next() else {
+        return Ok(None);
+    };
+    let mut proof_expr = DynProofExpr::new_is_not_null(first_column_ref);
+    for column_ref in column_refs {
+        proof_expr =
+            DynProofExpr::try_new_and(proof_expr, DynProofExpr::new_is_not_null(column_ref))?;
+    }
+    Ok(Some(proof_expr))
 }
 
 fn and_nullable_presence_guards(
@@ -219,17 +281,22 @@ pub(crate) fn expr_to_proof_expr_with_fields(
             Expr::Column(col) => Ok(DynProofExpr::new_is_null(column_to_column_ref_from_fields(
                 col, schema,
             )?)),
-            _ => Err(PlannerError::UnsupportedLogicalExpression {
-                expr: Box::new(expr.as_ref().clone()),
-            }),
+            _ => Ok(
+                nullable_propagating_presence_expr(expr, schema)?.map_or_else(
+                    || DynProofExpr::new_literal(LiteralValue::Boolean(false)),
+                    |presence_expr| {
+                        DynProofExpr::try_new_not(presence_expr)
+                            .expect("Presence expressions have boolean type")
+                    },
+                ),
+            ),
         },
         Expr::IsNotNull(expr) => match &**expr {
             Expr::Column(col) => Ok(DynProofExpr::new_is_not_null(
                 column_to_column_ref_from_fields(col, schema)?,
             )),
-            _ => Err(PlannerError::UnsupportedLogicalExpression {
-                expr: Box::new(expr.as_ref().clone()),
-            }),
+            _ => Ok(nullable_propagating_presence_expr(expr, schema)?
+                .unwrap_or_else(|| DynProofExpr::new_literal(LiteralValue::Boolean(true)))),
         },
         Expr::Cast(cast) => {
             match &*cast.expr {
@@ -541,6 +608,65 @@ mod tests {
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn we_can_convert_nullable_arithmetic_is_null_expr_to_presence_proof_expr() {
+        let expr = Expr::IsNull(Box::new(
+            df_column("namespace.table_name", "amount")
+                .add(Expr::Literal(ScalarValue::Int64(Some(5)))),
+        ));
+        let schema = vec![ColumnField::new_nullable(
+            "amount".into(),
+            ColumnType::BigInt,
+        )];
+        let amount_ref = ColumnRef::new_nullable(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(
+            expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_not(DynProofExpr::new_is_not_null(amount_ref)).unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_convert_nullable_comparison_is_not_null_expr_to_presence_proof_expr() {
+        let expr = Expr::IsNotNull(Box::new(
+            df_column("namespace.table_name", "amount")
+                .lt(Expr::Literal(ScalarValue::Int64(Some(15)))),
+        ));
+        let schema = vec![ColumnField::new_nullable(
+            "amount".into(),
+            ColumnType::BigInt,
+        )];
+        let amount_ref = ColumnRef::new_nullable(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(
+            expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
+            DynProofExpr::new_is_not_null(amount_ref)
+        );
+    }
+
+    #[test]
+    fn we_reject_is_null_for_general_logical_exprs() {
+        let expr = Expr::IsNull(Box::new(Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(df_column("namespace.table_name", "is_paid")),
+            right: Box::new(Expr::Literal(ScalarValue::Boolean(Some(true)))),
+            op: Operator::Or,
+        })));
+        let schema = vec![ColumnField::new_nullable(
+            "is_paid".into(),
+            ColumnType::Boolean,
+        )];
+
+        assert!(expr_to_proof_expr_with_fields(&expr, &schema).is_err());
     }
 
     #[test]

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -212,6 +212,21 @@ pub(crate) fn expr_to_proof_expr_with_fields(
     }
 }
 
+/// Convert a filter predicate to a [`DynProofExpr`] while applying SQL `IS TRUE`
+/// semantics to direct nullable boolean columns.
+pub(crate) fn filter_expr_to_proof_expr_with_fields(
+    expr: &Expr,
+    schema: &[ColumnField],
+) -> PlannerResult<DynProofExpr> {
+    match expr {
+        Expr::Alias(Alias { expr, .. }) => filter_expr_to_proof_expr_with_fields(expr, schema),
+        Expr::Column(col) => Ok(DynProofExpr::try_new_is_true(
+            column_to_column_ref_from_fields(col, schema)?,
+        )?),
+        _ => expr_to_proof_expr_with_fields(expr, schema),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -313,6 +328,25 @@ mod tests {
         let expr = df_column("namespace.table_name", "column");
         let schema = vec![("column".into(), ColumnType::Int)];
         assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), COLUMN_INT());
+    }
+
+    #[test]
+    fn we_can_convert_nullable_boolean_filter_column_to_is_true_proof_expr() {
+        let expr = df_column("namespace.table_name", "is_paid");
+        let schema = vec![ColumnField::new_nullable(
+            "is_paid".into(),
+            ColumnType::Boolean,
+        )];
+        let column_ref = ColumnRef::new_nullable(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "is_paid".into(),
+            ColumnType::Boolean,
+        );
+
+        assert_eq!(
+            filter_expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_is_true(column_ref).unwrap()
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -47,6 +47,55 @@ pub(crate) fn get_column_idents_from_expr(expr: &Expr) -> IndexSet<Ident> {
     }
 }
 
+fn is_filter_comparison_operator(op: Operator) -> bool {
+    matches!(
+        op,
+        Operator::Eq
+            | Operator::NotEq
+            | Operator::Lt
+            | Operator::Gt
+            | Operator::LtEq
+            | Operator::GtEq
+    )
+}
+
+fn nullable_column_refs_in_expr(
+    expr: &Expr,
+    schema: &[ColumnField],
+) -> PlannerResult<IndexSet<ColumnRef>> {
+    match expr {
+        Expr::Column(col) => {
+            let column_ref = column_to_column_ref_from_fields(col, schema)?;
+            Ok(if column_ref.is_nullable() {
+                IndexSet::from_iter([column_ref])
+            } else {
+                IndexSet::new()
+            })
+        }
+        Expr::BinaryExpr(BinaryExpr { left, right, .. }) => {
+            let mut left_refs = nullable_column_refs_in_expr(left, schema)?;
+            left_refs.extend(nullable_column_refs_in_expr(right, schema)?);
+            Ok(left_refs)
+        }
+        Expr::Not(inner)
+        | Expr::Alias(Alias { expr: inner, .. })
+        | Expr::Cast(Cast { expr: inner, .. }) => nullable_column_refs_in_expr(inner, schema),
+        Expr::IsNull(_) | Expr::IsNotNull(_) => Ok(IndexSet::new()),
+        _ => Ok(IndexSet::new()),
+    }
+}
+
+fn and_nullable_presence_guards(
+    mut proof_expr: DynProofExpr,
+    column_refs: IndexSet<ColumnRef>,
+) -> PlannerResult<DynProofExpr> {
+    for column_ref in column_refs {
+        proof_expr =
+            DynProofExpr::try_new_and(proof_expr, DynProofExpr::new_is_not_null(column_ref))?;
+    }
+    Ok(proof_expr)
+}
+
 /// Convert a [`BinaryExpr`] to [`DynProofExpr`]
 #[expect(
     clippy::missing_panics_doc,
@@ -235,6 +284,12 @@ pub(crate) fn filter_expr_to_proof_expr_with_fields(
                 filter_expr_to_proof_expr_with_fields(right, schema)?,
             )?)
         }
+        Expr::BinaryExpr(BinaryExpr { op, .. }) if is_filter_comparison_operator(*op) => {
+            and_nullable_presence_guards(
+                expr_to_proof_expr_with_fields(expr, schema)?,
+                nullable_column_refs_in_expr(expr, schema)?,
+            )
+        }
         Expr::Not(inner) => match &**inner {
             Expr::Column(col) => Ok(DynProofExpr::try_new_is_false(
                 column_to_column_ref_from_fields(col, schema)?,
@@ -414,6 +469,35 @@ mod tests {
                     DynProofExpr::new_literal(LiteralValue::BigInt(4)),
                 )
                 .unwrap(),
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_convert_nullable_comparison_filter_to_presence_guarded_proof_expr() {
+        let expr = df_column("namespace.table_name", "amount")
+            .gt(Expr::Literal(ScalarValue::Int64(Some(15))));
+        let schema = vec![ColumnField::new_nullable(
+            "amount".into(),
+            ColumnType::BigInt,
+        )];
+        let amount_ref = ColumnRef::new_nullable(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(
+            filter_expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_and(
+                DynProofExpr::try_new_inequality(
+                    DynProofExpr::new_column(amount_ref.clone()),
+                    DynProofExpr::new_literal(LiteralValue::BigInt(15)),
+                    false,
+                )
+                .unwrap(),
+                DynProofExpr::new_is_not_null(amount_ref),
             )
             .unwrap()
         );

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -223,6 +223,12 @@ pub(crate) fn filter_expr_to_proof_expr_with_fields(
         Expr::Column(col) => Ok(DynProofExpr::try_new_is_true(
             column_to_column_ref_from_fields(col, schema)?,
         )?),
+        Expr::Not(inner) => match &**inner {
+            Expr::Column(col) => Ok(DynProofExpr::try_new_is_false(
+                column_to_column_ref_from_fields(col, schema)?,
+            )?),
+            _ => expr_to_proof_expr_with_fields(expr, schema),
+        },
         _ => expr_to_proof_expr_with_fields(expr, schema),
     }
 }
@@ -346,6 +352,25 @@ mod tests {
         assert_eq!(
             filter_expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
             DynProofExpr::try_new_is_true(column_ref).unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_convert_nullable_boolean_filter_not_column_to_is_false_proof_expr() {
+        let expr = Expr::Not(Box::new(df_column("namespace.table_name", "is_paid")));
+        let schema = vec![ColumnField::new_nullable(
+            "is_paid".into(),
+            ColumnType::Boolean,
+        )];
+        let column_ref = ColumnRef::new_nullable(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "is_paid".into(),
+            ColumnType::Boolean,
+        );
+
+        assert_eq!(
+            filter_expr_to_proof_expr_with_fields(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_is_false(column_ref).unwrap()
         );
     }
 

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -15,7 +15,7 @@ pub use conversion::{get_table_refs_from_statement, sql_to_proof_plans};
 mod df_util;
 mod expr;
 pub use expr::expr_to_proof_expr;
-pub(crate) use expr::get_column_idents_from_expr;
+pub(crate) use expr::{expr_to_proof_expr_with_fields, get_column_idents_from_expr};
 mod error;
 pub use error::{PlannerError, PlannerResult};
 mod plan;
@@ -25,6 +25,6 @@ pub use uppercase_column_visitor::{statement_with_uppercase_identifiers, upperca
 mod util;
 pub use util::column_fields_to_schema;
 pub(crate) use util::{
-    column_to_column_ref, placeholder_to_placeholder_expr, scalar_value_to_literal_value,
-    schema_to_column_fields, table_reference_to_table_ref,
+    column_to_column_ref_from_fields, placeholder_to_placeholder_expr,
+    scalar_value_to_literal_value, table_reference_to_table_ref,
 };

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -15,7 +15,10 @@ pub use conversion::{get_table_refs_from_statement, sql_to_proof_plans};
 mod df_util;
 mod expr;
 pub use expr::expr_to_proof_expr;
-pub(crate) use expr::{expr_to_proof_expr_with_fields, get_column_idents_from_expr};
+pub(crate) use expr::{
+    expr_to_proof_expr_with_fields, filter_expr_to_proof_expr_with_fields,
+    get_column_idents_from_expr,
+};
 mod error;
 pub use error::{PlannerError, PlannerResult};
 mod plan;

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1162,6 +1162,47 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    #[test]
+    fn table_scan_filter_includes_presence_for_nullable_expression_is_null_filter() {
+        let projected_schema = df_schema("table", vec![("id", DataType::Int64)]);
+        let amount_ref =
+            ColumnRef::new_nullable(TABLE_REF_TABLE(), "amount".into(), ColumnType::BigInt);
+        let id_ref = ColumnRef::new(TABLE_REF_TABLE(), "id".into(), ColumnType::BigInt);
+        let filter = Expr::IsNull(Box::new(
+            df_column("table", "amount").add(Expr::Literal(ScalarValue::Int64(Some(5)))),
+        ));
+
+        let result = table_scan_to_filter(
+            &TableReference::from("table"),
+            &NullableSchemas,
+            &[0],
+            &projected_schema,
+            &[filter],
+        )
+        .unwrap();
+
+        let expected = DynProofPlan::new_filter(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(id_ref.clone()),
+                alias: "id".into(),
+            }],
+            DynProofPlan::new_table(
+                TABLE_REF_TABLE(),
+                vec![
+                    ColumnField::new("id".into(), ColumnType::BigInt),
+                    ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                    ColumnField::new(
+                        ColumnRef::presence_column_id(&"amount".into()),
+                        ColumnType::Boolean,
+                    ),
+                ],
+            ),
+            DynProofExpr::try_new_not(DynProofExpr::new_is_not_null(amount_ref)).unwrap(),
+        );
+
+        assert_eq!(result, expected);
+    }
+
     // aggregate_to_proof_plan
     #[test]
     fn we_can_aggregate_with_group_by_and_sum_count() {

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1,5 +1,6 @@
 use super::{
-    aggregate_function_to_proof_expr, expr_to_proof_expr_with_fields, get_column_idents_from_expr,
+    aggregate_function_to_proof_expr, expr_to_proof_expr_with_fields,
+    filter_expr_to_proof_expr_with_fields, get_column_idents_from_expr,
     table_reference_to_table_ref, AggregateFunc, PlannerError, PlannerResult,
 };
 use alloc::vec::Vec;
@@ -30,12 +31,17 @@ use proof_of_sql::{
 /// However that shouldn't be taken for granted.
 trait PlannerSchemaField {
     fn schema_ident(&self) -> Ident;
+    fn is_nullable(&self) -> bool;
     fn to_column_ref(&self, table_ref: TableRef) -> ColumnRef;
 }
 
 impl PlannerSchemaField for ColumnField {
     fn schema_ident(&self) -> Ident {
         self.name()
+    }
+
+    fn is_nullable(&self) -> bool {
+        ColumnField::is_nullable(self)
     }
 
     fn to_column_ref(&self, table_ref: TableRef) -> ColumnRef {
@@ -47,6 +53,10 @@ impl PlannerSchemaField for ColumnField {
 impl PlannerSchemaField for (Ident, ColumnType) {
     fn schema_ident(&self) -> Ident {
         self.0.clone()
+    }
+
+    fn is_nullable(&self) -> bool {
+        false
     }
 
     fn to_column_ref(&self, table_ref: TableRef) -> ColumnRef {
@@ -83,11 +93,25 @@ fn table_scan_get_required_columns<F: PlannerSchemaField>(
     filters: &[Expr],
     input_schema: &[F],
 ) -> IndexSet<Ident> {
-    projection
+    let mut required_columns = projection
         .iter()
         .filter_map(|&i| input_schema.get(i).map(PlannerSchemaField::schema_ident))
         .chain(filters.iter().flat_map(get_column_idents_from_expr))
-        .collect()
+        .collect::<IndexSet<_>>();
+
+    for filter in filters {
+        if let Expr::Column(col) = filter {
+            let column_id: Ident = col.name.as_str().into();
+            if input_schema
+                .iter()
+                .any(|field| field.schema_ident() == column_id && field.is_nullable())
+            {
+                required_columns.insert(ColumnRef::presence_column_id(&column_id));
+            }
+        }
+    }
+
+    required_columns
 }
 
 fn table_scan_input_fields_for_required_columns(
@@ -157,7 +181,7 @@ fn table_scan_to_filter(
     let table_exec = DynProofPlan::new_table(table_ref, input_column_fields);
     let filter_proof_exprs = filters
         .iter()
-        .map(|f| expr_to_proof_expr_with_fields(f, &input_schema))
+        .map(|f| filter_expr_to_proof_expr_with_fields(f, &input_schema))
         .reduce(|a, b| Ok(DynProofExpr::try_new_and(a?, b?)?))
         .expect("At least one filter expression is required")?;
     Ok(DynProofPlan::new_filter(
@@ -465,7 +489,8 @@ pub fn logical_plan_to_proof_plan(
         }) => {
             let input_plan = logical_plan_to_proof_plan(input, schema_accessor)?;
             let input_schema = input_plan.get_column_result_fields().to_vec();
-            let filter_proof_expr = expr_to_proof_expr_with_fields(predicate, &input_schema)?;
+            let filter_proof_expr =
+                filter_expr_to_proof_expr_with_fields(predicate, &input_schema)?;
             let aliased_exprs = input_plan
                 .get_column_result_fields()
                 .iter()
@@ -569,6 +594,7 @@ mod tests {
         fn lookup_column(&self, _table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
             match column_id.value.as_str() {
                 "id" | "amount" => Some(ColumnType::BigInt),
+                "flag" => Some(ColumnType::Boolean),
                 _ => None,
             }
         }
@@ -577,6 +603,7 @@ mod tests {
             vec![
                 ("id".into(), ColumnType::BigInt),
                 ("amount".into(), ColumnType::BigInt),
+                ("flag".into(), ColumnType::Boolean),
             ]
         }
 
@@ -584,6 +611,7 @@ mod tests {
             vec![
                 ColumnField::new("id".into(), ColumnType::BigInt),
                 ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                ColumnField::new_nullable("flag".into(), ColumnType::Boolean),
             ]
         }
     }
@@ -866,6 +894,47 @@ mod tests {
                 ],
             ),
             DynProofExpr::new_is_null(amount_ref),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn table_scan_filter_includes_generated_presence_columns_for_nullable_boolean_predicate() {
+        let projected_schema = df_schema("table", vec![("id", DataType::Int64)]);
+        let flag_ref =
+            ColumnRef::new_nullable(TABLE_REF_TABLE(), "flag".into(), ColumnType::Boolean);
+
+        let result = table_scan_to_filter(
+            &TableReference::from("table"),
+            &NullableSchemas,
+            &[0],
+            &projected_schema,
+            &[df_column("table", "flag")],
+        )
+        .unwrap();
+
+        let expected = DynProofPlan::new_filter(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "id".into(),
+                    ColumnType::BigInt,
+                )),
+                alias: "id".into(),
+            }],
+            DynProofPlan::new_table(
+                TABLE_REF_TABLE(),
+                vec![
+                    ColumnField::new("id".into(), ColumnType::BigInt),
+                    ColumnField::new_nullable("flag".into(), ColumnType::Boolean),
+                    ColumnField::new(
+                        ColumnRef::presence_column_id(&"flag".into()),
+                        ColumnType::Boolean,
+                    ),
+                ],
+            ),
+            DynProofExpr::try_new_is_true(flag_ref).unwrap(),
         );
 
         assert_eq!(result, expected);

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -7,8 +7,8 @@ use alloc::vec::Vec;
 use datafusion::{
     common::{DFSchema, JoinConstraint, JoinType},
     logical_expr::{
-        Aggregate, BinaryExpr, Expr, Filter, Join, Limit, LogicalPlan, Operator, Projection,
-        SubqueryAlias, TableScan, Union,
+        Aggregate, BinaryExpr, Expr, Filter, Join, Limit, LogicalPlan, Projection, SubqueryAlias,
+        TableScan, Union,
     },
     sql::{sqlparser::ast::Ident, TableReference},
 };
@@ -88,7 +88,7 @@ fn get_aliased_dyn_proof_exprs<F: PlannerSchemaField>(
 }
 
 /// Get column identifiers needed in a `TableScan` given its projection and filters
-fn insert_nullable_boolean_filter_presence_column<F: PlannerSchemaField>(
+fn insert_nullable_filter_presence_columns<F: PlannerSchemaField>(
     filter: &Expr,
     input_schema: &[F],
     required_columns: &mut IndexSet<Ident>,
@@ -104,13 +104,20 @@ fn insert_nullable_boolean_filter_presence_column<F: PlannerSchemaField>(
             }
         }
         Expr::Not(inner) => {
-            insert_nullable_boolean_filter_presence_column(inner, input_schema, required_columns);
+            insert_nullable_filter_presence_columns(inner, input_schema, required_columns);
         }
-        Expr::BinaryExpr(BinaryExpr { left, right, op })
-            if matches!(op, Operator::And | Operator::Or) =>
-        {
-            insert_nullable_boolean_filter_presence_column(left, input_schema, required_columns);
-            insert_nullable_boolean_filter_presence_column(right, input_schema, required_columns);
+        Expr::BinaryExpr(BinaryExpr { left, right, .. }) => {
+            insert_nullable_filter_presence_columns(left, input_schema, required_columns);
+            insert_nullable_filter_presence_columns(right, input_schema, required_columns);
+        }
+        Expr::Alias(alias) => {
+            insert_nullable_filter_presence_columns(&alias.expr, input_schema, required_columns);
+        }
+        Expr::Cast(cast) => {
+            insert_nullable_filter_presence_columns(&cast.expr, input_schema, required_columns);
+        }
+        Expr::IsNull(inner) | Expr::IsNotNull(inner) => {
+            insert_nullable_filter_presence_columns(inner, input_schema, required_columns);
         }
         _ => {}
     }
@@ -128,7 +135,7 @@ fn table_scan_get_required_columns<F: PlannerSchemaField>(
         .collect::<IndexSet<_>>();
 
     for filter in filters {
-        insert_nullable_boolean_filter_presence_column(filter, input_schema, &mut required_columns);
+        insert_nullable_filter_presence_columns(filter, input_schema, &mut required_columns);
     }
 
     required_columns
@@ -1047,6 +1054,54 @@ mod tests {
                     DynProofExpr::new_literal(LiteralValue::BigInt(4)),
                 )
                 .unwrap(),
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn table_scan_filter_includes_presence_for_nullable_comparison_filter() {
+        let projected_schema = df_schema("table", vec![("id", DataType::Int64)]);
+        let amount_ref =
+            ColumnRef::new_nullable(TABLE_REF_TABLE(), "amount".into(), ColumnType::BigInt);
+        let id_ref = ColumnRef::new(TABLE_REF_TABLE(), "id".into(), ColumnType::BigInt);
+        let filter = df_column("table", "amount").gt(Expr::Literal(ScalarValue::Int64(Some(15))));
+
+        let result = table_scan_to_filter(
+            &TableReference::from("table"),
+            &NullableSchemas,
+            &[0],
+            &projected_schema,
+            &[filter],
+        )
+        .unwrap();
+
+        let expected = DynProofPlan::new_filter(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(id_ref.clone()),
+                alias: "id".into(),
+            }],
+            DynProofPlan::new_table(
+                TABLE_REF_TABLE(),
+                vec![
+                    ColumnField::new("id".into(), ColumnType::BigInt),
+                    ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                    ColumnField::new(
+                        ColumnRef::presence_column_id(&"amount".into()),
+                        ColumnType::Boolean,
+                    ),
+                ],
+            ),
+            DynProofExpr::try_new_and(
+                DynProofExpr::try_new_inequality(
+                    DynProofExpr::new_column(amount_ref.clone()),
+                    DynProofExpr::new_literal(LiteralValue::BigInt(15)),
+                    false,
+                )
+                .unwrap(),
+                DynProofExpr::new_is_not_null(amount_ref),
             )
             .unwrap(),
         );

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1,5 +1,5 @@
 use super::{
-    aggregate_function_to_proof_expr, expr_to_proof_expr, get_column_idents_from_expr,
+    aggregate_function_to_proof_expr, expr_to_proof_expr_with_fields, get_column_idents_from_expr,
     table_reference_to_table_ref, AggregateFunc, PlannerError, PlannerResult,
 };
 use alloc::vec::Vec;
@@ -28,10 +28,36 @@ use proof_of_sql::{
 /// the output schema should be a subset of the input schema
 /// and that no aliasing should take place.
 /// However that shouldn't be taken for granted.
-fn get_aliased_dyn_proof_exprs(
+trait PlannerSchemaField {
+    fn schema_ident(&self) -> Ident;
+    fn to_column_ref(&self, table_ref: TableRef) -> ColumnRef;
+}
+
+impl PlannerSchemaField for ColumnField {
+    fn schema_ident(&self) -> Ident {
+        self.name()
+    }
+
+    fn to_column_ref(&self, table_ref: TableRef) -> ColumnRef {
+        ColumnRef::from_field(table_ref, self)
+    }
+}
+
+#[cfg(test)]
+impl PlannerSchemaField for (Ident, ColumnType) {
+    fn schema_ident(&self) -> Ident {
+        self.0.clone()
+    }
+
+    fn to_column_ref(&self, table_ref: TableRef) -> ColumnRef {
+        ColumnRef::new(table_ref, self.0.clone(), self.1)
+    }
+}
+
+fn get_aliased_dyn_proof_exprs<F: PlannerSchemaField>(
     table_ref: &TableRef,
     projection: &[usize],
-    input_schema: &[(Ident, ColumnType)],
+    input_schema: &[F],
     output_schema: &DFSchema,
 ) -> PlannerResult<Vec<AliasedDynProofExpr>> {
     projection
@@ -41,14 +67,10 @@ fn get_aliased_dyn_proof_exprs(
             |(output_index, input_index)| -> PlannerResult<AliasedDynProofExpr> {
                 // Get output column name / alias
                 let alias: Ident = output_schema.field(output_index).name().as_str().into();
-                let (input_column_name, data_type) = input_schema
+                let input_field = input_schema
                     .get(*input_index)
                     .ok_or(PlannerError::ColumnNotFound)?;
-                let expr = DynProofExpr::new_column(ColumnRef::new(
-                    table_ref.clone(),
-                    input_column_name.clone(),
-                    *data_type,
-                ));
+                let expr = DynProofExpr::new_column(input_field.to_column_ref(table_ref.clone()));
                 Ok(AliasedDynProofExpr { expr, alias })
             },
         )
@@ -56,15 +78,34 @@ fn get_aliased_dyn_proof_exprs(
 }
 
 /// Get column identifiers needed in a `TableScan` given its projection and filters
-fn table_scan_get_required_columns(
+fn table_scan_get_required_columns<F: PlannerSchemaField>(
     projection: &[usize],
     filters: &[Expr],
-    input_schema: &[(Ident, ColumnType)],
+    input_schema: &[F],
 ) -> IndexSet<Ident> {
     projection
         .iter()
-        .filter_map(|&i| input_schema.get(i).map(|(ident, _)| ident.clone()))
+        .filter_map(|&i| input_schema.get(i).map(PlannerSchemaField::schema_ident))
         .chain(filters.iter().flat_map(get_column_idents_from_expr))
+        .collect()
+}
+
+fn table_scan_input_fields_for_required_columns(
+    input_schema: &[ColumnField],
+    required_columns: &IndexSet<Ident>,
+) -> Vec<ColumnField> {
+    input_schema
+        .iter()
+        .flat_map(|field| {
+            let value_field = required_columns
+                .contains(&field.name())
+                .then(|| field.clone());
+            let presence_field_id = ColumnRef::presence_column_id(&field.name());
+            let presence_field = (field.is_nullable()
+                && required_columns.contains(&presence_field_id))
+            .then(|| ColumnField::new(presence_field_id, ColumnType::Boolean));
+            value_field.into_iter().chain(presence_field)
+        })
         .collect()
 }
 
@@ -79,15 +120,15 @@ fn table_scan_to_proof_plan(
 ) -> PlannerResult<DynProofPlan> {
     // Check if the table exists
     let table_ref = table_reference_to_table_ref(table_name)?;
-    let input_schema = schemas.lookup_schema(&table_ref);
+    let input_schema = schemas.lookup_column_fields(&table_ref);
     // Filter for only the fields we use
     let input_column_fields = projection
         .iter()
         .map(|i| {
-            let (ident, column_type) = input_schema
+            input_schema
                 .get(*i)
-                .expect("Projection index out of bounds");
-            ColumnField::new(ident.clone(), *column_type)
+                .expect("Projection index out of bounds")
+                .clone()
         })
         .collect::<Vec<_>>();
     Ok(DynProofPlan::new_table(table_ref, input_column_fields))
@@ -106,20 +147,17 @@ fn table_scan_to_filter(
 ) -> PlannerResult<DynProofPlan> {
     // Check if the table exists
     let table_ref = table_reference_to_table_ref(table_name)?;
-    let input_schema = schemas.lookup_schema(&table_ref);
+    let input_schema = schemas.lookup_column_fields(&table_ref);
     // Get aliased expressions
     let aliased_dyn_proof_exprs =
         get_aliased_dyn_proof_exprs(&table_ref, projection, &input_schema, projected_schema)?;
     let required_columns = table_scan_get_required_columns(projection, filters, &input_schema);
-    let input_column_fields = input_schema
-        .iter()
-        .filter(|(ident, _)| required_columns.contains(ident))
-        .map(|(ident, column_type)| ColumnField::new(ident.clone(), *column_type))
-        .collect::<Vec<_>>();
+    let input_column_fields =
+        table_scan_input_fields_for_required_columns(&input_schema, &required_columns);
     let table_exec = DynProofPlan::new_table(table_ref, input_column_fields);
     let filter_proof_exprs = filters
         .iter()
-        .map(|f| expr_to_proof_expr(f, &input_schema))
+        .map(|f| expr_to_proof_expr_with_fields(f, &input_schema))
         .reduce(|a, b| Ok(DynProofExpr::try_new_and(a?, b?)?))
         .expect("At least one filter expression is required")?;
     Ok(DynProofPlan::new_filter(
@@ -137,16 +175,12 @@ fn projection_to_proof_plan(
     schemas: &impl SchemaAccessor,
 ) -> PlannerResult<DynProofPlan> {
     let input_plan = logical_plan_to_proof_plan(input, schemas)?;
-    let input_schema = input_plan
-        .get_column_result_fields()
-        .iter()
-        .map(|field| (field.name(), field.data_type()))
-        .collect::<Vec<_>>();
+    let input_schema = input_plan.get_column_result_fields().to_vec();
     let aliased_exprs = expr
         .iter()
         .zip(output_schema.fields().iter())
         .map(|(e, field)| -> PlannerResult<AliasedDynProofExpr> {
-            let proof_expr = expr_to_proof_expr(e, &input_schema)?;
+            let proof_expr = expr_to_proof_expr_with_fields(e, &input_schema)?;
             let alias = field.name().as_str().into();
             Ok(AliasedDynProofExpr {
                 expr: proof_expr,
@@ -172,11 +206,7 @@ fn aggregate_to_proof_plan(
     alias_map: &IndexMap<String, String>,
 ) -> PlannerResult<DynProofPlan> {
     let input_plan = logical_plan_to_proof_plan(input, schemas)?;
-    let input_schema = input_plan
-        .get_column_result_fields()
-        .iter()
-        .map(|field| (field.name(), field.data_type()))
-        .collect::<Vec<_>>();
+    let input_schema = input_plan.get_column_result_fields().to_vec();
     let dummy_table_ref = TableRef::from_names(None, "");
     // We keep an extra alias just in case there is no count in the aggregate expr list
     let mut inner_aliases = 0..=(group_expr.len() + aggr_expr.len());
@@ -185,7 +215,7 @@ fn aggregate_to_proof_plan(
         .zip(&mut inner_aliases)
         .map(|(e, aggregate_alias)| -> PlannerResult<_> {
             let aggregate_alias: Ident = aggregate_alias.to_string().as_str().into();
-            let aggregate_proof_expr = expr_to_proof_expr(e, &input_schema)?;
+            let aggregate_proof_expr = expr_to_proof_expr_with_fields(e, &input_schema)?;
             let name_string = e.clone().unalias().display_name()?;
             let alias = alias_map.get(&name_string).ok_or_else(|| {
                 PlannerError::UnsupportedLogicalPlan {
@@ -434,22 +464,17 @@ pub fn logical_plan_to_proof_plan(
             input, predicate, ..
         }) => {
             let input_plan = logical_plan_to_proof_plan(input, schema_accessor)?;
-            let input_schema = input_plan
-                .get_column_result_fields()
-                .iter()
-                .map(|field| (field.name(), field.data_type()))
-                .collect::<Vec<_>>();
-            let filter_proof_expr = expr_to_proof_expr(predicate, &input_schema)?;
+            let input_schema = input_plan.get_column_result_fields().to_vec();
+            let filter_proof_expr = expr_to_proof_expr_with_fields(predicate, &input_schema)?;
             let aliased_exprs = input_plan
                 .get_column_result_fields()
                 .iter()
                 .map(|field| -> PlannerResult<AliasedDynProofExpr> {
                     let alias = field.name();
                     Ok(AliasedDynProofExpr {
-                        expr: DynProofExpr::new_column(ColumnRef::new(
+                        expr: DynProofExpr::new_column(ColumnRef::from_field(
                             TableRef::from_names(None, "__filter_input__"), // Dummy table ref
-                            alias.clone(),
-                            field.data_type(),
+                            field,
                         )),
                         alias,
                     })
@@ -535,6 +560,32 @@ mod tests {
             table_ref => schema
         };
         SchemaAccessorImpl::new(schema_accessor)
+    }
+
+    #[derive(Clone)]
+    struct NullableSchemas;
+
+    impl SchemaAccessor for NullableSchemas {
+        fn lookup_column(&self, _table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
+            match column_id.value.as_str() {
+                "id" | "amount" => Some(ColumnType::BigInt),
+                _ => None,
+            }
+        }
+
+        fn lookup_schema(&self, _table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
+            vec![
+                ("id".into(), ColumnType::BigInt),
+                ("amount".into(), ColumnType::BigInt),
+            ]
+        }
+
+        fn lookup_column_fields(&self, _table_ref: &TableRef) -> Vec<ColumnField> {
+            vec![
+                ColumnField::new("id".into(), ColumnType::BigInt),
+                ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+            ]
+        }
     }
 
     #[expect(non_snake_case)]
@@ -755,6 +806,68 @@ mod tests {
             get_aliased_dyn_proof_exprs(&table_ref, &[0, 1, 2, 3], &input_schema, &output_schema)
                 .unwrap();
         let expected = vec![ALIASED_A(), ALIASED_B(), ALIASED_C(), ALIASED_D()];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_preserve_nullable_projection_column_refs() {
+        let table_ref = TABLE_REF_TABLE();
+        let input_schema = vec![ColumnField::new_nullable("a".into(), ColumnType::BigInt)];
+        let output_schema = df_schema("table", vec![("a", DataType::Int64)]);
+
+        let result =
+            get_aliased_dyn_proof_exprs(&table_ref, &[0], &input_schema, &output_schema).unwrap();
+
+        assert_eq!(
+            result,
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(ColumnRef::new_nullable(
+                    TABLE_REF_TABLE(),
+                    "a".into(),
+                    ColumnType::BigInt
+                )),
+                alias: "a".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn table_scan_filter_includes_generated_presence_columns_for_is_null() {
+        let projected_schema = df_schema("table", vec![("id", DataType::Int64)]);
+        let amount_ref =
+            ColumnRef::new_nullable(TABLE_REF_TABLE(), "amount".into(), ColumnType::BigInt);
+
+        let result = table_scan_to_filter(
+            &TableReference::from("table"),
+            &NullableSchemas,
+            &[0],
+            &projected_schema,
+            &[Expr::IsNull(Box::new(df_column("table", "amount")))],
+        )
+        .unwrap();
+
+        let expected = DynProofPlan::new_filter(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "id".into(),
+                    ColumnType::BigInt,
+                )),
+                alias: "id".into(),
+            }],
+            DynProofPlan::new_table(
+                TABLE_REF_TABLE(),
+                vec![
+                    ColumnField::new("id".into(), ColumnType::BigInt),
+                    ColumnField::new(
+                        ColumnRef::presence_column_id(&"amount".into()),
+                        ColumnType::Boolean,
+                    ),
+                ],
+            ),
+            DynProofExpr::new_is_null(amount_ref),
+        );
+
         assert_eq!(result, expected);
     }
 

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -7,8 +7,8 @@ use alloc::vec::Vec;
 use datafusion::{
     common::{DFSchema, JoinConstraint, JoinType},
     logical_expr::{
-        Aggregate, Expr, Filter, Join, Limit, LogicalPlan, Projection, SubqueryAlias, TableScan,
-        Union,
+        Aggregate, BinaryExpr, Expr, Filter, Join, Limit, LogicalPlan, Operator, Projection,
+        SubqueryAlias, TableScan, Union,
     },
     sql::{sqlparser::ast::Ident, TableReference},
 };
@@ -105,6 +105,12 @@ fn insert_nullable_boolean_filter_presence_column<F: PlannerSchemaField>(
         }
         Expr::Not(inner) => {
             insert_nullable_boolean_filter_presence_column(inner, input_schema, required_columns);
+        }
+        Expr::BinaryExpr(BinaryExpr { left, right, op })
+            if matches!(op, Operator::And | Operator::Or) =>
+        {
+            insert_nullable_boolean_filter_presence_column(left, input_schema, required_columns);
+            insert_nullable_boolean_filter_presence_column(right, input_schema, required_columns);
         }
         _ => {}
     }
@@ -990,6 +996,59 @@ mod tests {
                 ],
             ),
             DynProofExpr::try_new_is_false(flag_ref).unwrap(),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn table_scan_filter_includes_presence_for_nested_nullable_boolean_filter() {
+        let projected_schema = df_schema("table", vec![("id", DataType::Int64)]);
+        let flag_ref =
+            ColumnRef::new_nullable(TABLE_REF_TABLE(), "flag".into(), ColumnType::Boolean);
+        let id_ref = ColumnRef::new(TABLE_REF_TABLE(), "id".into(), ColumnType::BigInt);
+        let filter = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(df_column("table", "flag")),
+            right: Box::new(
+                df_column("table", "id").eq(Expr::Literal(ScalarValue::Int64(Some(4)))),
+            ),
+            op: Operator::Or,
+        });
+
+        let result = table_scan_to_filter(
+            &TableReference::from("table"),
+            &NullableSchemas,
+            &[0],
+            &projected_schema,
+            &[filter],
+        )
+        .unwrap();
+
+        let expected = DynProofPlan::new_filter(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(id_ref.clone()),
+                alias: "id".into(),
+            }],
+            DynProofPlan::new_table(
+                TABLE_REF_TABLE(),
+                vec![
+                    ColumnField::new("id".into(), ColumnType::BigInt),
+                    ColumnField::new_nullable("flag".into(), ColumnType::Boolean),
+                    ColumnField::new(
+                        ColumnRef::presence_column_id(&"flag".into()),
+                        ColumnType::Boolean,
+                    ),
+                ],
+            ),
+            DynProofExpr::try_new_or(
+                DynProofExpr::try_new_is_true(flag_ref).unwrap(),
+                DynProofExpr::try_new_equals(
+                    DynProofExpr::new_column(id_ref),
+                    DynProofExpr::new_literal(LiteralValue::BigInt(4)),
+                )
+                .unwrap(),
+            )
+            .unwrap(),
         );
 
         assert_eq!(result, expected);

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1109,6 +1109,59 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    #[test]
+    fn table_scan_filter_includes_presence_for_negated_nullable_comparison_filter() {
+        let projected_schema = df_schema("table", vec![("id", DataType::Int64)]);
+        let amount_ref =
+            ColumnRef::new_nullable(TABLE_REF_TABLE(), "amount".into(), ColumnType::BigInt);
+        let id_ref = ColumnRef::new(TABLE_REF_TABLE(), "id".into(), ColumnType::BigInt);
+        let filter = Expr::Not(Box::new(
+            df_column("table", "amount").lt(Expr::Literal(ScalarValue::Int64(Some(15)))),
+        ));
+
+        let result = table_scan_to_filter(
+            &TableReference::from("table"),
+            &NullableSchemas,
+            &[0],
+            &projected_schema,
+            &[filter],
+        )
+        .unwrap();
+
+        let expected = DynProofPlan::new_filter(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(id_ref.clone()),
+                alias: "id".into(),
+            }],
+            DynProofPlan::new_table(
+                TABLE_REF_TABLE(),
+                vec![
+                    ColumnField::new("id".into(), ColumnType::BigInt),
+                    ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                    ColumnField::new(
+                        ColumnRef::presence_column_id(&"amount".into()),
+                        ColumnType::Boolean,
+                    ),
+                ],
+            ),
+            DynProofExpr::try_new_and(
+                DynProofExpr::try_new_not(
+                    DynProofExpr::try_new_inequality(
+                        DynProofExpr::new_column(amount_ref.clone()),
+                        DynProofExpr::new_literal(LiteralValue::BigInt(15)),
+                        true,
+                    )
+                    .unwrap(),
+                )
+                .unwrap(),
+                DynProofExpr::new_is_not_null(amount_ref),
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(result, expected);
+    }
+
     // aggregate_to_proof_plan
     #[test]
     fn we_can_aggregate_with_group_by_and_sum_count() {

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -88,6 +88,28 @@ fn get_aliased_dyn_proof_exprs<F: PlannerSchemaField>(
 }
 
 /// Get column identifiers needed in a `TableScan` given its projection and filters
+fn insert_nullable_boolean_filter_presence_column<F: PlannerSchemaField>(
+    filter: &Expr,
+    input_schema: &[F],
+    required_columns: &mut IndexSet<Ident>,
+) {
+    match filter {
+        Expr::Column(col) => {
+            let column_id: Ident = col.name.as_str().into();
+            if input_schema
+                .iter()
+                .any(|field| field.schema_ident() == column_id && field.is_nullable())
+            {
+                required_columns.insert(ColumnRef::presence_column_id(&column_id));
+            }
+        }
+        Expr::Not(inner) => {
+            insert_nullable_boolean_filter_presence_column(inner, input_schema, required_columns);
+        }
+        _ => {}
+    }
+}
+
 fn table_scan_get_required_columns<F: PlannerSchemaField>(
     projection: &[usize],
     filters: &[Expr],
@@ -100,15 +122,7 @@ fn table_scan_get_required_columns<F: PlannerSchemaField>(
         .collect::<IndexSet<_>>();
 
     for filter in filters {
-        if let Expr::Column(col) = filter {
-            let column_id: Ident = col.name.as_str().into();
-            if input_schema
-                .iter()
-                .any(|field| field.schema_ident() == column_id && field.is_nullable())
-            {
-                required_columns.insert(ColumnRef::presence_column_id(&column_id));
-            }
-        }
+        insert_nullable_boolean_filter_presence_column(filter, input_schema, &mut required_columns);
     }
 
     required_columns
@@ -935,6 +949,47 @@ mod tests {
                 ],
             ),
             DynProofExpr::try_new_is_true(flag_ref).unwrap(),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn table_scan_filter_includes_presence_for_nullable_not_boolean() {
+        let projected_schema = df_schema("table", vec![("id", DataType::Int64)]);
+        let flag_ref =
+            ColumnRef::new_nullable(TABLE_REF_TABLE(), "flag".into(), ColumnType::Boolean);
+
+        let result = table_scan_to_filter(
+            &TableReference::from("table"),
+            &NullableSchemas,
+            &[0],
+            &projected_schema,
+            &[Expr::Not(Box::new(df_column("table", "flag")))],
+        )
+        .unwrap();
+
+        let expected = DynProofPlan::new_filter(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "id".into(),
+                    ColumnType::BigInt,
+                )),
+                alias: "id".into(),
+            }],
+            DynProofPlan::new_table(
+                TABLE_REF_TABLE(),
+                vec![
+                    ColumnField::new("id".into(), ColumnType::BigInt),
+                    ColumnField::new_nullable("flag".into(), ColumnType::Boolean),
+                    ColumnField::new(
+                        ColumnRef::presence_column_id(&"flag".into()),
+                        ColumnType::Boolean,
+                    ),
+                ],
+            ),
+            DynProofExpr::try_new_is_false(flag_ref).unwrap(),
         );
 
         assert_eq!(result, expected);

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -5,9 +5,11 @@ use datafusion::{
     common::{Column, ScalarValue},
     logical_expr::expr::Placeholder,
 };
+#[cfg(test)]
+use proof_of_sql::base::database::ColumnType;
 use proof_of_sql::{
     base::{
-        database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef},
+        database::{ColumnField, ColumnRef, LiteralValue, TableRef},
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
@@ -111,9 +113,9 @@ pub(crate) fn scalar_value_to_literal_value(value: ScalarValue) -> PlannerResult
 ///
 /// Note that the table name must be provided in the column which resolved logical plans do
 /// Otherwise we error out
-pub(crate) fn column_to_column_ref(
+pub(crate) fn column_to_column_ref_from_fields(
     column: &Column,
-    schema: &[(Ident, ColumnType)],
+    schema: &[ColumnField],
 ) -> PlannerResult<ColumnRef> {
     let table_ref = column
         .relation
@@ -122,12 +124,25 @@ pub(crate) fn column_to_column_ref(
         .transpose()?
         .unwrap_or_else(|| TableRef::from_names(None, ""));
     let ident: Ident = column.name.as_str().into();
-    let column_type = schema
+    let column_field = schema
         .iter()
-        .find(|(i, _t)| *i == ident)
+        .find(|field| field.name() == ident)
         .ok_or(PlannerError::ColumnNotFound)?
-        .1;
-    Ok(ColumnRef::new(table_ref, ident, column_type))
+        .clone();
+    Ok(ColumnRef::from_field(table_ref, &column_field))
+}
+
+/// Find a column in a non-nullable schema and return its info as a [`ColumnRef`].
+#[cfg(test)]
+pub(crate) fn column_to_column_ref(
+    column: &Column,
+    schema: &[(Ident, ColumnType)],
+) -> PlannerResult<ColumnRef> {
+    let column_fields = schema
+        .iter()
+        .map(|(ident, column_type)| ColumnField::new(ident.clone(), *column_type))
+        .collect::<Vec<_>>();
+    column_to_column_ref_from_fields(column, &column_fields)
 }
 
 /// Convert a Vec<ColumnField> to a Schema
@@ -137,9 +152,12 @@ pub fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
         column_fields
             .into_iter()
             .map(|column_field| {
-                //TODO: Make columns nullable
                 let data_type = (&column_field.data_type()).into();
-                Field::new(column_field.name().value.as_str(), data_type, false)
+                Field::new(
+                    column_field.name().value.as_str(),
+                    data_type,
+                    column_field.is_nullable(),
+                )
             })
             .collect::<Vec<_>>(),
     )
@@ -148,6 +166,7 @@ pub fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
 /// Convert a [`DFSchema`] to a Vec<ColumnField>
 ///
 /// Note that this returns an error if any column has an unsupported `DataType`
+#[cfg(test)]
 pub(crate) fn schema_to_column_fields(schema: Vec<(Ident, ColumnType)>) -> Vec<ColumnField> {
     schema
         .into_iter()
@@ -516,6 +535,7 @@ mod tests {
         let column_fields = vec![
             ColumnField::new("a".into(), ColumnType::SmallInt),
             ColumnField::new("b".into(), ColumnType::VarChar),
+            ColumnField::new_nullable("c".into(), ColumnType::BigInt),
         ];
         let schema = column_fields_to_schema(column_fields);
         assert_eq!(
@@ -523,6 +543,7 @@ mod tests {
             vec![
                 &Field::new("a", DataType::Int16, false),
                 &Field::new("b", DataType::Utf8, false),
+                &Field::new("c", DataType::Int64, true),
             ]
         );
     }

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -7,8 +7,9 @@ use proof_of_sql::{
     base::{
         commitment::CommitmentEvaluationProof,
         database::{
-            owned_table_utility::*, table_utility::*, LiteralValue, OwnedTable, Table, TableRef,
-            TableTestAccessor, TestAccessor,
+            owned_table_utility::*, table_utility::*, LiteralValue, NullableOwnedColumn,
+            NullableOwnedTable, NullableOwnedTableTestAccessor, OwnedColumn, OwnedTable, Table,
+            TableRef, TableTestAccessor, TestAccessor,
         },
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
@@ -116,6 +117,65 @@ fn test_tableless_queries() {
             LiteralValue::BigInt(0),
         ],
     );
+}
+
+/// Test SQL `IS NULL` against a nullable table with generated presence columns.
+#[test]
+fn test_nullable_is_null_query() {
+    let sql = "
+        SELECT id FROM nullable WHERE amount IS NULL;
+        SELECT amount FROM nullable WHERE amount IS NOT NULL AND amount > 15;
+    ";
+    let table_ref = TableRef::from_names(None, "nullable");
+    let nullable_table = NullableOwnedTable::try_from_iter([
+        (
+            "id".into(),
+            NullableOwnedColumn::new_nonnullable(OwnedColumn::<DoryScalar>::BigInt(vec![
+                1, 2, 3, 4,
+            ])),
+        ),
+        (
+            "amount".into(),
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<DoryScalar>::BigInt(vec![10, 0, 30, 50]),
+                Some(vec![true, false, true, true]),
+            )
+            .unwrap(),
+        ),
+    ])
+    .unwrap();
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup_ref = &prover_setup;
+    let verifier_setup_ref = &verifier_setup;
+    let accessor = NullableOwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_from_table(
+        table_ref,
+        nullable_table,
+        0,
+        prover_setup_ref,
+    );
+    let statements = Parser::parse_sql(&GenericDialect {}, sql).unwrap();
+    let plans = sql_to_proof_plans(&statements, &accessor, &ConfigOptions::default()).unwrap();
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        owned_table([bigint("id", [2_i64])]),
+        owned_table([bigint("amount", [30_i64, 50])]),
+    ];
+
+    for (plan, expected) in plans.iter().zip(expected_results.iter()) {
+        let res = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
+            plan,
+            &accessor,
+            &prover_setup_ref,
+            &[],
+        )
+        .unwrap();
+        let verified = res
+            .verify(plan, &accessor, &verifier_setup_ref, &[])
+            .unwrap()
+            .table;
+        assert_eq!(verified, expected.clone());
+    }
 }
 
 /// Test a simple SQL query

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -131,6 +131,8 @@ fn test_nullable_is_null_query() {
         SELECT id FROM nullable WHERE flag AND id > 1;
         SELECT id FROM nullable WHERE amount > 15;
         SELECT id FROM nullable WHERE NOT (amount < 15);
+        SELECT id FROM nullable WHERE (amount + 5) IS NULL;
+        SELECT id FROM nullable WHERE (amount < 15) IS NOT NULL;
     ";
     let table_ref = TableRef::from_names(None, "nullable");
     let nullable_table = NullableOwnedTable::try_from_iter([
@@ -180,6 +182,8 @@ fn test_nullable_is_null_query() {
         owned_table([bigint("id", [4_i64])]),
         owned_table([bigint("id", [3_i64, 4])]),
         owned_table([bigint("id", [3_i64, 4])]),
+        owned_table([bigint("id", [2_i64])]),
+        owned_table([bigint("id", [1_i64, 3, 4])]),
     ];
 
     for (plan, expected) in plans.iter().zip(expected_results.iter()) {

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -202,6 +202,100 @@ fn test_nullable_is_null_query() {
     }
 }
 
+/// Test SQL queries that return nullable result columns and reassemble verified
+/// value-plus-presence proof outputs.
+#[test]
+fn test_nullable_select_results_can_round_trip_nulls() {
+    let sql = "
+        SELECT amount FROM nullable;
+        SELECT amount + 5 AS total FROM nullable;
+        SELECT flag AND (id > 1) AS maybe_flag FROM nullable;
+    ";
+    let table_ref = TableRef::from_names(None, "nullable");
+    let nullable_table = NullableOwnedTable::try_from_iter([
+        (
+            "id".into(),
+            NullableOwnedColumn::new_nonnullable(OwnedColumn::<DoryScalar>::BigInt(vec![
+                1, 2, 3, 4,
+            ])),
+        ),
+        (
+            "amount".into(),
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<DoryScalar>::BigInt(vec![10, 99, 30, 50]),
+                Some(vec![true, false, true, true]),
+            )
+            .unwrap(),
+        ),
+        (
+            "flag".into(),
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<DoryScalar>::Boolean(vec![true, true, false, true]),
+                Some(vec![true, false, true, true]),
+            )
+            .unwrap(),
+        ),
+    ])
+    .unwrap();
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup_ref = &prover_setup;
+    let verifier_setup_ref = &verifier_setup;
+    let accessor = NullableOwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_from_table(
+        table_ref,
+        nullable_table,
+        0,
+        prover_setup_ref,
+    );
+    let statements = Parser::parse_sql(&GenericDialect {}, sql).unwrap();
+    let plans = sql_to_proof_plans(&statements, &accessor, &ConfigOptions::default()).unwrap();
+    let expected_results: Vec<NullableOwnedTable<DoryScalar>> = vec![
+        NullableOwnedTable::try_from_iter([(
+            "amount".into(),
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<DoryScalar>::BigInt(vec![10, 99, 30, 50]),
+                Some(vec![true, false, true, true]),
+            )
+            .unwrap(),
+        )])
+        .unwrap(),
+        NullableOwnedTable::try_from_iter([(
+            "total".into(),
+            NullableOwnedColumn::try_new(
+                decimal75::<DoryScalar>("total", 20, 0, [15_i64, 104, 35, 55]).1,
+                Some(vec![true, false, true, true]),
+            )
+            .unwrap(),
+        )])
+        .unwrap(),
+        NullableOwnedTable::try_from_iter([(
+            "maybe_flag".into(),
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<DoryScalar>::Boolean(vec![false, true, false, true]),
+                Some(vec![true, false, true, true]),
+            )
+            .unwrap(),
+        )])
+        .unwrap(),
+    ];
+
+    for (plan, expected) in plans.iter().zip(expected_results.iter()) {
+        let res = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
+            plan,
+            &accessor,
+            &prover_setup_ref,
+            &[],
+        )
+        .unwrap();
+        let verified = res
+            .verify_nullable(plan, &accessor, &verifier_setup_ref, &[])
+            .unwrap()
+            .table;
+        assert_eq!(verified, expected.clone());
+    }
+}
+
 /// Test a simple SQL query
 #[test]
 fn test_simple_filter_queries() {

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -129,6 +129,7 @@ fn test_nullable_is_null_query() {
         SELECT id FROM nullable WHERE NOT flag;
         SELECT id FROM nullable WHERE flag OR id = 4;
         SELECT id FROM nullable WHERE flag AND id > 1;
+        SELECT id FROM nullable WHERE amount > 15;
     ";
     let table_ref = TableRef::from_names(None, "nullable");
     let nullable_table = NullableOwnedTable::try_from_iter([
@@ -141,7 +142,7 @@ fn test_nullable_is_null_query() {
         (
             "amount".into(),
             NullableOwnedColumn::try_new(
-                OwnedColumn::<DoryScalar>::BigInt(vec![10, 0, 30, 50]),
+                OwnedColumn::<DoryScalar>::BigInt(vec![10, 99, 30, 50]),
                 Some(vec![true, false, true, true]),
             )
             .unwrap(),
@@ -176,6 +177,7 @@ fn test_nullable_is_null_query() {
         owned_table([bigint("id", [3_i64])]),
         owned_table([bigint("id", [1_i64, 4])]),
         owned_table([bigint("id", [4_i64])]),
+        owned_table([bigint("id", [3_i64, 4])]),
     ];
 
     for (plan, expected) in plans.iter().zip(expected_results.iter()) {

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -130,6 +130,7 @@ fn test_nullable_is_null_query() {
         SELECT id FROM nullable WHERE flag OR id = 4;
         SELECT id FROM nullable WHERE flag AND id > 1;
         SELECT id FROM nullable WHERE amount > 15;
+        SELECT id FROM nullable WHERE NOT (amount < 15);
     ";
     let table_ref = TableRef::from_names(None, "nullable");
     let nullable_table = NullableOwnedTable::try_from_iter([
@@ -177,6 +178,7 @@ fn test_nullable_is_null_query() {
         owned_table([bigint("id", [3_i64])]),
         owned_table([bigint("id", [1_i64, 4])]),
         owned_table([bigint("id", [4_i64])]),
+        owned_table([bigint("id", [3_i64, 4])]),
         owned_table([bigint("id", [3_i64, 4])]),
     ];
 

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -125,6 +125,7 @@ fn test_nullable_is_null_query() {
     let sql = "
         SELECT id FROM nullable WHERE amount IS NULL;
         SELECT amount FROM nullable WHERE amount IS NOT NULL AND amount > 15;
+        SELECT id FROM nullable WHERE flag;
     ";
     let table_ref = TableRef::from_names(None, "nullable");
     let nullable_table = NullableOwnedTable::try_from_iter([
@@ -138,6 +139,14 @@ fn test_nullable_is_null_query() {
             "amount".into(),
             NullableOwnedColumn::try_new(
                 OwnedColumn::<DoryScalar>::BigInt(vec![10, 0, 30, 50]),
+                Some(vec![true, false, true, true]),
+            )
+            .unwrap(),
+        ),
+        (
+            "flag".into(),
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<DoryScalar>::Boolean(vec![true, true, false, true]),
                 Some(vec![true, false, true, true]),
             )
             .unwrap(),
@@ -160,6 +169,7 @@ fn test_nullable_is_null_query() {
     let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
         owned_table([bigint("id", [2_i64])]),
         owned_table([bigint("amount", [30_i64, 50])]),
+        owned_table([bigint("id", [1_i64, 4])]),
     ];
 
     for (plan, expected) in plans.iter().zip(expected_results.iter()) {

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -133,6 +133,10 @@ fn test_nullable_is_null_query() {
         SELECT id FROM nullable WHERE NOT (amount < 15);
         SELECT id FROM nullable WHERE (amount + 5) IS NULL;
         SELECT id FROM nullable WHERE (amount < 15) IS NOT NULL;
+        SELECT id FROM nullable WHERE (flag OR id > 0) IS NULL;
+        SELECT id FROM nullable WHERE (flag OR id = 0) IS NULL;
+        SELECT id FROM nullable WHERE (flag AND id = 0) IS NULL;
+        SELECT id FROM nullable WHERE (flag AND id > 0) IS NOT NULL;
     ";
     let table_ref = TableRef::from_names(None, "nullable");
     let nullable_table = NullableOwnedTable::try_from_iter([
@@ -183,6 +187,10 @@ fn test_nullable_is_null_query() {
         owned_table([bigint("id", [3_i64, 4])]),
         owned_table([bigint("id", [3_i64, 4])]),
         owned_table([bigint("id", [2_i64])]),
+        owned_table([bigint("id", [1_i64, 3, 4])]),
+        owned_table([bigint("id", Vec::<i64>::new())]),
+        owned_table([bigint("id", [2_i64])]),
+        owned_table([bigint("id", Vec::<i64>::new())]),
         owned_table([bigint("id", [1_i64, 3, 4])]),
     ];
 

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -127,6 +127,8 @@ fn test_nullable_is_null_query() {
         SELECT amount FROM nullable WHERE amount IS NOT NULL AND amount > 15;
         SELECT id FROM nullable WHERE flag;
         SELECT id FROM nullable WHERE NOT flag;
+        SELECT id FROM nullable WHERE flag OR id = 4;
+        SELECT id FROM nullable WHERE flag AND id > 1;
     ";
     let table_ref = TableRef::from_names(None, "nullable");
     let nullable_table = NullableOwnedTable::try_from_iter([
@@ -147,7 +149,7 @@ fn test_nullable_is_null_query() {
         (
             "flag".into(),
             NullableOwnedColumn::try_new(
-                OwnedColumn::<DoryScalar>::Boolean(vec![true, false, false, true]),
+                OwnedColumn::<DoryScalar>::Boolean(vec![true, true, false, true]),
                 Some(vec![true, false, true, true]),
             )
             .unwrap(),
@@ -172,6 +174,8 @@ fn test_nullable_is_null_query() {
         owned_table([bigint("amount", [30_i64, 50])]),
         owned_table([bigint("id", [1_i64, 4])]),
         owned_table([bigint("id", [3_i64])]),
+        owned_table([bigint("id", [1_i64, 4])]),
+        owned_table([bigint("id", [4_i64])]),
     ];
 
     for (plan, expected) in plans.iter().zip(expected_results.iter()) {

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -126,6 +126,7 @@ fn test_nullable_is_null_query() {
         SELECT id FROM nullable WHERE amount IS NULL;
         SELECT amount FROM nullable WHERE amount IS NOT NULL AND amount > 15;
         SELECT id FROM nullable WHERE flag;
+        SELECT id FROM nullable WHERE NOT flag;
     ";
     let table_ref = TableRef::from_names(None, "nullable");
     let nullable_table = NullableOwnedTable::try_from_iter([
@@ -146,7 +147,7 @@ fn test_nullable_is_null_query() {
         (
             "flag".into(),
             NullableOwnedColumn::try_new(
-                OwnedColumn::<DoryScalar>::Boolean(vec![true, true, false, true]),
+                OwnedColumn::<DoryScalar>::Boolean(vec![true, false, false, true]),
                 Some(vec![true, false, true, true]),
             )
             .unwrap(),
@@ -170,6 +171,7 @@ fn test_nullable_is_null_query() {
         owned_table([bigint("id", [2_i64])]),
         owned_table([bigint("amount", [30_i64, 50])]),
         owned_table([bigint("id", [1_i64, 4])]),
+        owned_table([bigint("id", [3_i64])]),
     ];
 
     for (plan, expected) in plans.iter().zip(expected_results.iter()) {

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -14,7 +14,7 @@
 //! However, the actual arrow backing `i128` is the correct value.
 use super::scalar_and_i256_conversions::{convert_i256_to_scalar, convert_scalar_to_i256};
 use crate::base::{
-    database::{OwnedColumn, OwnedTable, OwnedTableError},
+    database::{NullableOwnedColumn, NullableOwnedTable, OwnedColumn, OwnedTable, OwnedTableError},
     map::IndexMap,
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError},
@@ -23,11 +23,11 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
+        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
         Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
         TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
     },
-    datatypes::{i256, DataType, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
+    datatypes::{i256, DataType, Field, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
     error::ArrowError,
     record_batch::RecordBatch,
 };
@@ -58,6 +58,12 @@ pub enum OwnedArrowConversionError {
     /// This error occurs when trying to convert from an Arrow array with nulls.
     #[snafu(display("null values are not supported in OwnedColumn yet"))]
     NullNotSupportedYet,
+    /// This error occurs when trying to convert from an i256 to a Scalar.
+    #[snafu(display("decimal conversion failed: {number}"))]
+    DecimalConversionFailed {
+        /// The `i256` value for which conversion is attempted
+        number: i256,
+    },
     /// Using `TimeError` to handle all time-related errors
     #[snafu(transparent)]
     TimestampConversionError {
@@ -109,6 +115,79 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
     }
 }
 
+fn nullable_values<T>(values: Vec<T>, presence: Vec<bool>) -> Vec<Option<T>> {
+    values
+        .into_iter()
+        .zip(presence)
+        .map(|(value, present)| present.then_some(value))
+        .collect()
+}
+
+/// # Panics
+///
+/// Will panic if setting precision and scale fails when converting decimal columns.
+/// Will panic if trying to convert `OwnedColumn::Scalar`, as this conversion is not implemented.
+impl<S: Scalar> From<NullableOwnedColumn<S>> for ArrayRef {
+    fn from(value: NullableOwnedColumn<S>) -> Self {
+        let (values, presence) = value.into_parts();
+        let Some(presence) = presence else {
+            return ArrayRef::from(values);
+        };
+        match values {
+            OwnedColumn::Boolean(col) => {
+                Arc::new(BooleanArray::from(nullable_values(col, presence)))
+            }
+            OwnedColumn::Uint8(col) => Arc::new(UInt8Array::from(nullable_values(col, presence))),
+            OwnedColumn::TinyInt(col) => Arc::new(Int8Array::from(nullable_values(col, presence))),
+            OwnedColumn::SmallInt(col) => {
+                Arc::new(Int16Array::from(nullable_values(col, presence)))
+            }
+            OwnedColumn::Int(col) => Arc::new(Int32Array::from(nullable_values(col, presence))),
+            OwnedColumn::BigInt(col) => Arc::new(Int64Array::from(nullable_values(col, presence))),
+            OwnedColumn::Int128(col) => Arc::new(
+                Decimal128Array::from(nullable_values(col, presence))
+                    .with_precision_and_scale(38, 0)
+                    .unwrap(),
+            ),
+            OwnedColumn::Decimal75(precision, scale, col) => {
+                let converted_col = col
+                    .into_iter()
+                    .zip(presence)
+                    .map(|(value, present)| present.then_some(convert_scalar_to_i256(&value)))
+                    .collect::<Vec<_>>();
+                Arc::new(
+                    Decimal256Array::from(converted_col)
+                        .with_precision_and_scale(precision.value(), scale)
+                        .unwrap(),
+                )
+            }
+            OwnedColumn::Scalar(_) => unimplemented!("Cannot convert Scalar type to arrow type"),
+            OwnedColumn::VarChar(col) => {
+                Arc::new(StringArray::from(nullable_values(col, presence)))
+            }
+            OwnedColumn::VarBinary(col) => Arc::new(LargeBinaryArray::from_iter(
+                col.iter()
+                    .zip(presence.iter())
+                    .map(|(value, present)| present.then_some(value.as_slice())),
+            )),
+            OwnedColumn::TimestampTZ(time_unit, _, col) => match time_unit {
+                PoSQLTimeUnit::Second => {
+                    Arc::new(TimestampSecondArray::from(nullable_values(col, presence)))
+                }
+                PoSQLTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(
+                    nullable_values(col, presence),
+                )),
+                PoSQLTimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(
+                    nullable_values(col, presence),
+                )),
+                PoSQLTimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::from(
+                    nullable_values(col, presence),
+                )),
+            },
+        }
+    }
+}
+
 impl<S: Scalar> TryFrom<OwnedTable<S>> for RecordBatch {
     type Error = ArrowError;
     fn try_from(value: OwnedTable<S>) -> Result<Self, Self::Error> {
@@ -127,10 +206,224 @@ impl<S: Scalar> TryFrom<OwnedTable<S>> for RecordBatch {
     }
 }
 
+impl<S: Scalar> TryFrom<NullableOwnedTable<S>> for RecordBatch {
+    type Error = ArrowError;
+    fn try_from(value: NullableOwnedTable<S>) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            Ok(RecordBatch::new_empty(SchemaRef::new(Schema::empty())))
+        } else {
+            let (fields, columns): (Vec<_>, Vec<_>) = value
+                .into_inner()
+                .into_iter()
+                .map(|(identifier, nullable_owned_column)| {
+                    let is_nullable = nullable_owned_column.is_nullable();
+                    let array_ref = ArrayRef::from(nullable_owned_column);
+                    (
+                        Field::new(identifier.value, array_ref.data_type().clone(), is_nullable),
+                        array_ref,
+                    )
+                })
+                .unzip();
+            RecordBatch::try_new(SchemaRef::new(Schema::new(fields)), columns)
+        }
+    }
+}
+
 impl<S: Scalar> TryFrom<ArrayRef> for OwnedColumn<S> {
     type Error = OwnedArrowConversionError;
     fn try_from(value: ArrayRef) -> Result<Self, Self::Error> {
         Self::try_from(&value)
+    }
+}
+
+fn arrow_presence(value: &ArrayRef, preserve_nullable: bool) -> Option<Vec<bool>> {
+    (preserve_nullable || value.null_count() != 0)
+        .then(|| (0..value.len()).map(|i| !value.is_null(i)).collect())
+}
+
+fn nullable_owned_column_from_array_ref<S: Scalar>(
+    value: &ArrayRef,
+    preserve_nullable: bool,
+) -> Result<NullableOwnedColumn<S>, OwnedArrowConversionError> {
+    let presence = arrow_presence(value, preserve_nullable);
+    let values = match &value.data_type() {
+        DataType::Boolean => OwnedColumn::Boolean(
+            value
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        ),
+        DataType::UInt8 => OwnedColumn::Uint8(
+            value
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        ),
+        DataType::Int8 => OwnedColumn::TinyInt(
+            value
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        ),
+        DataType::Int16 => OwnedColumn::SmallInt(
+            value
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        ),
+        DataType::Int32 => OwnedColumn::Int(
+            value
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        ),
+        DataType::Int64 => OwnedColumn::BigInt(
+            value
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        ),
+        DataType::Decimal128(38, 0) => OwnedColumn::Int128(
+            value
+                .as_any()
+                .downcast_ref::<Decimal128Array>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default())
+                .collect(),
+        ),
+        DataType::Decimal256(precision, scale) if *precision <= 75 => OwnedColumn::Decimal75(
+            Precision::new(*precision).expect("precision is less than 76"),
+            *scale,
+            value
+                .as_any()
+                .downcast_ref::<Decimal256Array>()
+                .unwrap()
+                .iter()
+                .map(|value| {
+                    value.map_or(Ok(S::ZERO), |value| {
+                        convert_i256_to_scalar(&value).ok_or(
+                            OwnedArrowConversionError::DecimalConversionFailed { number: value },
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        DataType::Utf8 => OwnedColumn::VarChar(
+            value
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .iter()
+                .map(|value| value.unwrap_or_default().to_string())
+                .collect(),
+        ),
+        DataType::LargeBinary => OwnedColumn::VarBinary(
+            value
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .unwrap()
+                .iter()
+                .map(|value| value.map(<[u8]>::to_vec).unwrap_or_default())
+                .collect(),
+        ),
+        DataType::Timestamp(time_unit, timezone) => match time_unit {
+            ArrowTimeUnit::Second => {
+                let array = value
+                    .as_any()
+                    .downcast_ref::<TimestampSecondArray>()
+                    .expect("This cannot fail, all Arrow TimeUnits are mapped to PoSQL TimeUnits");
+                OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Second,
+                    PoSQLTimeZone::try_from(timezone)?,
+                    array
+                        .iter()
+                        .map(|value| value.unwrap_or_default())
+                        .collect(),
+                )
+            }
+            ArrowTimeUnit::Millisecond => {
+                let array = value
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .expect("This cannot fail, all Arrow TimeUnits are mapped to PoSQL TimeUnits");
+                OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Millisecond,
+                    PoSQLTimeZone::try_from(timezone)?,
+                    array
+                        .iter()
+                        .map(|value| value.unwrap_or_default())
+                        .collect(),
+                )
+            }
+            ArrowTimeUnit::Microsecond => {
+                let array = value
+                    .as_any()
+                    .downcast_ref::<TimestampMicrosecondArray>()
+                    .expect("This cannot fail, all Arrow TimeUnits are mapped to PoSQL TimeUnits");
+                OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Microsecond,
+                    PoSQLTimeZone::try_from(timezone)?,
+                    array
+                        .iter()
+                        .map(|value| value.unwrap_or_default())
+                        .collect(),
+                )
+            }
+            ArrowTimeUnit::Nanosecond => {
+                let array = value
+                    .as_any()
+                    .downcast_ref::<TimestampNanosecondArray>()
+                    .expect("This cannot fail, all Arrow TimeUnits are mapped to PoSQL TimeUnits");
+                OwnedColumn::TimestampTZ(
+                    PoSQLTimeUnit::Nanosecond,
+                    PoSQLTimeZone::try_from(timezone)?,
+                    array
+                        .iter()
+                        .map(|value| value.unwrap_or_default())
+                        .collect(),
+                )
+            }
+        },
+        &data_type => {
+            return Err(OwnedArrowConversionError::UnsupportedType {
+                datatype: data_type.clone(),
+            })
+        }
+    };
+    Ok(NullableOwnedColumn::try_new(values, presence)
+        .expect("Arrow arrays should produce matching value and presence lengths"))
+}
+
+impl<S: Scalar> TryFrom<ArrayRef> for NullableOwnedColumn<S> {
+    type Error = OwnedArrowConversionError;
+    fn try_from(value: ArrayRef) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl<S: Scalar> TryFrom<&ArrayRef> for NullableOwnedColumn<S> {
+    type Error = OwnedArrowConversionError;
+    fn try_from(value: &ArrayRef) -> Result<Self, Self::Error> {
+        nullable_owned_column_from_array_ref(value, false)
     }
 }
 impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
@@ -315,6 +608,31 @@ impl<S: Scalar> TryFrom<RecordBatch> for OwnedTable<S> {
             .zip(value.columns())
             .map(|(field, array_ref)| {
                 let owned_column = OwnedColumn::try_from(array_ref)?;
+                let identifier = Ident::new(field.name());
+                Ok((identifier, owned_column))
+            })
+            .collect();
+        let owned_table = Self::try_new(table?)?;
+        if num_columns == owned_table.num_columns() {
+            Ok(owned_table)
+        } else {
+            Err(OwnedArrowConversionError::DuplicateIdents)
+        }
+    }
+}
+
+impl<S: Scalar> TryFrom<RecordBatch> for NullableOwnedTable<S> {
+    type Error = OwnedArrowConversionError;
+    fn try_from(value: RecordBatch) -> Result<Self, Self::Error> {
+        let num_columns = value.num_columns();
+        let table: Result<IndexMap<_, _>, Self::Error> = value
+            .schema()
+            .fields()
+            .iter()
+            .zip(value.columns())
+            .map(|(field, array_ref)| {
+                let owned_column =
+                    nullable_owned_column_from_array_ref(array_ref, field.is_nullable())?;
                 let identifier = Ident::new(field.name());
                 Ok((identifier, owned_column))
             })

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -1,13 +1,15 @@
 use super::owned_and_arrow_conversions::OwnedArrowConversionError;
 use crate::base::{
-    database::{owned_table_utility::*, OwnedColumn, OwnedTable},
+    database::{
+        owned_table_utility::*, NullableOwnedColumn, NullableOwnedTable, OwnedColumn, OwnedTable,
+    },
     map::IndexMap,
     scalar::test_scalar::TestScalar,
 };
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
+        Array, ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
         StringArray,
     },
     datatypes::{DataType, Field, Schema},
@@ -99,6 +101,92 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
         OwnedColumn::<TestScalar>::try_from(array_ref),
         Err(OwnedArrowConversionError::UnsupportedType { .. })
     ));
+}
+
+#[test]
+fn nullable_owned_column_converts_arrow_nulls_to_presence() {
+    let array_ref: ArrayRef = Arc::new(Int64Array::from(vec![Some(10), None, Some(30)]));
+
+    let nullable_column = NullableOwnedColumn::<TestScalar>::try_from(array_ref).unwrap();
+
+    assert_eq!(
+        nullable_column.values(),
+        &OwnedColumn::<TestScalar>::BigInt(vec![10, 0, 30])
+    );
+    assert_eq!(nullable_column.presence(), Some(&[true, false, true][..]));
+
+    let roundtrip_array = ArrayRef::from(nullable_column);
+    let roundtrip_values = roundtrip_array
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .iter()
+        .collect::<Vec<_>>();
+    assert_eq!(roundtrip_values, vec![Some(10), None, Some(30)]);
+}
+
+#[test]
+fn nullable_owned_column_keeps_nonnullable_arrow_columns_compact() {
+    let array_ref: ArrayRef = Arc::new(Int64Array::from(vec![10, 20]));
+
+    let nullable_column = NullableOwnedColumn::<TestScalar>::try_from(array_ref).unwrap();
+
+    assert_eq!(
+        nullable_column.values(),
+        &OwnedColumn::<TestScalar>::BigInt(vec![10, 20])
+    );
+    assert_eq!(nullable_column.presence(), None);
+    assert!(!nullable_column.is_nullable());
+}
+
+#[test]
+fn nullable_owned_table_converts_to_nullable_record_batch() {
+    let nullable_table = NullableOwnedTable::try_new(IndexMap::from_iter([(
+        "amount".into(),
+        NullableOwnedColumn::<TestScalar>::try_new(
+            OwnedColumn::BigInt(vec![10, 0, 30]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap(),
+    )]))
+    .unwrap();
+
+    let record_batch = RecordBatch::try_from(nullable_table).unwrap();
+
+    assert!(record_batch.schema().field(0).is_nullable());
+    assert_eq!(record_batch.column(0).null_count(), 1);
+    let values = record_batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .iter()
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![Some(10), None, Some(30)]);
+}
+
+#[test]
+fn nullable_owned_table_preserves_arrow_nullable_schema_without_null_rows() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "amount",
+        DataType::Int64,
+        true,
+    )]));
+    let record_batch =
+        RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![10, 20]))]).unwrap();
+
+    let nullable_table = NullableOwnedTable::<TestScalar>::try_from(record_batch).unwrap();
+    let amount = nullable_table.column_by_index(0).unwrap();
+
+    assert_eq!(
+        amount.values(),
+        &OwnedColumn::<TestScalar>::BigInt(vec![10, 20])
+    );
+    assert_eq!(amount.presence(), Some(&[true, true][..]));
+
+    let roundtrip_batch = RecordBatch::try_from(nullable_table).unwrap();
+    assert!(roundtrip_batch.schema().field(0).is_nullable());
+    assert_eq!(roundtrip_batch.column(0).null_count(), 0);
 }
 
 fn we_can_convert_between_owned_table_and_record_batch_impl(

--- a/crates/proof-of-sql/src/base/database/accessor.rs
+++ b/crates/proof-of-sql/src/base/database/accessor.rs
@@ -1,6 +1,9 @@
 use crate::base::{
     commitment::Commitment,
-    database::{Column, ColumnType, Table, TableOptions, TableRef},
+    database::{
+        Column, ColumnField, ColumnType, NullableColumn, NullableTable, Table, TableOptions,
+        TableRef,
+    },
     map::{IndexMap, IndexSet},
     scalar::Scalar,
 };
@@ -110,6 +113,42 @@ pub trait DataAccessor<S: Scalar>: MetadataAccessor {
     }
 }
 
+/// Access nullable database columns of an in-memory table span.
+///
+/// This extends [`DataAccessor`] for callers that need the SQL-null presence bits
+/// in addition to the backing value column.
+pub trait NullableDataAccessor<S: Scalar>: DataAccessor<S> {
+    /// Return the nullable data span in the table.
+    fn get_nullable_column(&self, table_ref: &TableRef, column_id: &Ident)
+        -> NullableColumn<'_, S>;
+
+    /// Creates a new [`NullableTable`] from a [`TableRef`] and [`Ident`]s.
+    ///
+    /// Columns are retrieved from the [`NullableDataAccessor`] using the provided [`TableRef`] and [`Ident`]s.
+    /// The only reason why [`table_ref`] is needed is because [`column_ids`] can be empty.
+    /// # Panics
+    /// Column length mismatches can occur in theory. In practice, this should not happen.
+    fn get_nullable_table(
+        &self,
+        table_ref: &TableRef,
+        column_ids: &IndexSet<Ident>,
+    ) -> NullableTable<'_, S> {
+        if column_ids.is_empty() {
+            let input_length = self.get_length(table_ref);
+            NullableTable::<S>::try_new_with_options(
+                IndexMap::default(),
+                TableOptions::new(Some(input_length)),
+            )
+        } else {
+            NullableTable::<S>::try_from_iter(column_ids.into_iter().map(|column_id| {
+                let column = self.get_nullable_column(table_ref, column_id);
+                (column_id.clone(), column)
+            }))
+        }
+        .expect("Failed to create nullable table from table and column references")
+    }
+}
+
 /// Access tables and their schemas in a database.
 ///
 /// This accessor should be implemented by both the prover and verifier
@@ -134,6 +173,24 @@ pub trait SchemaAccessor {
     /// Precondition 1: the table must exist and be tamperproof.
     /// Precondition 2: `table_name` must be lowercase.
     fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)>;
+
+    /// Lookup the full column field in the specified table.
+    ///
+    /// Implementations that support nullable metadata should override this.
+    fn lookup_column_field(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnField> {
+        self.lookup_column(table_ref, column_id)
+            .map(|column_type| ColumnField::new(column_id.clone(), column_type))
+    }
+
+    /// Lookup all column fields in the specified table.
+    ///
+    /// Implementations that support nullable metadata should override this.
+    fn lookup_column_fields(&self, table_ref: &TableRef) -> Vec<ColumnField> {
+        self.lookup_schema(table_ref)
+            .into_iter()
+            .map(|(column_id, column_type)| ColumnField::new(column_id, column_type))
+            .collect()
+    }
 }
 
 /// The simplest implementation of `SchemaAccessor`.

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -1,4 +1,5 @@
-use super::ColumnType;
+use super::{ColumnRef, ColumnType};
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -52,6 +53,25 @@ impl ColumnField {
     pub const fn is_nullable(&self) -> bool {
         self.nullable
     }
+
+    /// Expand logical nullable fields into the physical value plus presence result schema.
+    pub(crate) fn value_and_presence_fields<T>(fields: T) -> Vec<ColumnField>
+    where
+        T: IntoIterator<Item = ColumnField>,
+    {
+        fields
+            .into_iter()
+            .flat_map(|field| {
+                let presence_field = field.is_nullable().then(|| {
+                    ColumnField::new(
+                        ColumnRef::presence_column_id(&field.name()),
+                        ColumnType::Boolean,
+                    )
+                });
+                core::iter::once(field).chain(presence_field)
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -74,5 +94,22 @@ mod tests {
         assert_eq!(field.name(), "amount".into());
         assert_eq!(field.data_type(), ColumnType::BigInt);
         assert!(field.is_nullable());
+    }
+
+    #[test]
+    fn nullable_fields_expand_to_value_and_presence_fields() {
+        let physical_fields = ColumnField::value_and_presence_fields([
+            ColumnField::new("id".into(), ColumnType::BigInt),
+            ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+        ]);
+
+        assert_eq!(
+            physical_fields,
+            vec![
+                ColumnField::new("id".into(), ColumnType::BigInt),
+                ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                ColumnField::new("__posql_presence_amount".into(), ColumnType::Boolean),
+            ]
+        );
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -10,13 +10,29 @@ use sqlparser::ast::Ident;
 pub struct ColumnField {
     name: Ident,
     data_type: ColumnType,
+    #[serde(default)]
+    nullable: bool,
 }
 
 impl ColumnField {
     /// Create a new `ColumnField` from a name and a type
     #[must_use]
     pub fn new(name: Ident, data_type: ColumnType) -> ColumnField {
-        ColumnField { name, data_type }
+        ColumnField {
+            name,
+            data_type,
+            nullable: false,
+        }
+    }
+
+    /// Create a new nullable `ColumnField` from a name and a type.
+    #[must_use]
+    pub fn new_nullable(name: Ident, data_type: ColumnType) -> ColumnField {
+        ColumnField {
+            name,
+            data_type,
+            nullable: true,
+        }
     }
 
     /// Returns the name of the column
@@ -29,5 +45,34 @@ impl ColumnField {
     #[must_use]
     pub fn data_type(&self) -> ColumnType {
         self.data_type
+    }
+
+    /// Returns whether the column can contain SQL `NULL` values.
+    #[must_use]
+    pub const fn is_nullable(&self) -> bool {
+        self.nullable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_column_fields_are_non_nullable_by_default() {
+        let field = ColumnField::new("amount".into(), ColumnType::BigInt);
+
+        assert_eq!(field.name(), "amount".into());
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+        assert!(!field.is_nullable());
+    }
+
+    #[test]
+    fn nullable_column_fields_carry_nullable_metadata() {
+        let field = ColumnField::new_nullable("amount".into(), ColumnType::BigInt);
+
+        assert_eq!(field.name(), "amount".into());
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+        assert!(field.is_nullable());
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -1,4 +1,5 @@
 use super::{ColumnField, ColumnType, TableRef};
+use alloc::format;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -43,6 +44,22 @@ impl ColumnRef {
         } else {
             Self::new(table_ref, field.name(), field.data_type())
         }
+    }
+
+    /// Returns the generated proof-column name for a nullable column's row-presence data.
+    #[must_use]
+    pub fn presence_column_id(column_id: &Ident) -> Ident {
+        Ident::new(format!("__posql_presence_{}", column_id.value))
+    }
+
+    /// Returns the generated proof-column reference for this nullable column's row-presence data.
+    #[must_use]
+    pub fn presence_column_ref(&self) -> Self {
+        Self::new(
+            self.table_ref(),
+            Self::presence_column_id(&self.column_id),
+            ColumnType::Boolean,
+        )
     }
 
     /// Returns the table reference of this column
@@ -124,5 +141,27 @@ mod tests {
         assert_eq!(column_ref.column_id(), "amount".into());
         assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
         assert!(column_ref.is_nullable());
+    }
+
+    #[test]
+    fn nullable_column_refs_can_derive_presence_column_refs() {
+        let column_ref = ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(
+            ColumnRef::presence_column_id(&"amount".into()),
+            "__posql_presence_amount".into()
+        );
+        assert_eq!(
+            column_ref.presence_column_ref(),
+            ColumnRef::new(
+                TableRef::new("sxt", "orders"),
+                "__posql_presence_amount".into(),
+                ColumnType::Boolean
+            )
+        );
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -1,4 +1,4 @@
-use super::{ColumnType, TableRef};
+use super::{ColumnField, ColumnType, TableRef};
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -8,6 +8,8 @@ pub struct ColumnRef {
     column_id: Ident,
     table_ref: TableRef,
     column_type: ColumnType,
+    #[serde(default)]
+    nullable: bool,
 }
 
 impl ColumnRef {
@@ -18,6 +20,28 @@ impl ColumnRef {
             column_id,
             table_ref,
             column_type,
+            nullable: false,
+        }
+    }
+
+    /// Create a new nullable `ColumnRef` from a table, column identifier and column type.
+    #[must_use]
+    pub fn new_nullable(table_ref: TableRef, column_id: Ident, column_type: ColumnType) -> Self {
+        Self {
+            column_id,
+            table_ref,
+            column_type,
+            nullable: true,
+        }
+    }
+
+    /// Create a new `ColumnRef` from a table and column field.
+    #[must_use]
+    pub fn from_field(table_ref: TableRef, field: &ColumnField) -> Self {
+        if field.is_nullable() {
+            Self::new_nullable(table_ref, field.name(), field.data_type())
+        } else {
+            Self::new(table_ref, field.name(), field.data_type())
         }
     }
 
@@ -37,5 +61,68 @@ impl ColumnRef {
     #[must_use]
     pub fn column_type(&self) -> &ColumnType {
         &self.column_type
+    }
+
+    /// Returns whether this column reference can contain SQL `NULL` values.
+    #[must_use]
+    pub const fn is_nullable(&self) -> bool {
+        self.nullable
+    }
+
+    /// Wrap the column output name, type, and nullability within a [`ColumnField`].
+    #[must_use]
+    pub fn column_field(&self) -> ColumnField {
+        if self.nullable {
+            ColumnField::new_nullable(self.column_id(), self.column_type)
+        } else {
+            ColumnField::new(self.column_id(), self.column_type)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_column_refs_are_non_nullable_by_default() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(column_ref.column_id(), "amount".into());
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+        assert!(!column_ref.is_nullable());
+        assert_eq!(
+            column_ref.column_field(),
+            ColumnField::new("amount".into(), ColumnType::BigInt)
+        );
+    }
+
+    #[test]
+    fn nullable_column_refs_carry_nullable_metadata() {
+        let column_ref = ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert!(column_ref.is_nullable());
+        assert_eq!(
+            column_ref.column_field(),
+            ColumnField::new_nullable("amount".into(), ColumnType::BigInt)
+        );
+    }
+
+    #[test]
+    fn column_refs_can_be_built_from_column_fields() {
+        let field = ColumnField::new_nullable("amount".into(), ColumnType::BigInt);
+        let column_ref = ColumnRef::from_field(TableRef::new("sxt", "orders"), &field);
+
+        assert_eq!(column_ref.column_id(), "amount".into());
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+        assert!(column_ref.is_nullable());
     }
 }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -3,7 +3,8 @@
 //! between Arrow and `OwnedTable`.
 mod accessor;
 pub use accessor::{
-    CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor, SchemaAccessorImpl,
+    CommitmentAccessor, DataAccessor, MetadataAccessor, NullableDataAccessor, SchemaAccessor,
+    SchemaAccessorImpl,
 };
 
 mod column;
@@ -122,6 +123,9 @@ mod owned_table_test_accessor;
 pub use owned_table_test_accessor::OwnedTableTestAccessor;
 #[cfg(all(test, feature = "blitzar"))]
 mod owned_table_test_accessor_test;
+
+mod nullable_owned_table_test_accessor;
+pub use nullable_owned_table_test_accessor::NullableOwnedTableTestAccessor;
 
 mod table_test_accessor;
 pub use table_test_accessor::TableTestAccessor;

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -74,6 +74,12 @@ pub mod arrow_schema_utility;
 mod owned_column;
 pub use owned_column::OwnedColumn;
 
+mod nullable_column;
+pub use nullable_column::NullableColumn;
+
+mod nullable_owned_column;
+pub use nullable_owned_column::NullableOwnedColumn;
+
 mod owned_column_error;
 pub(crate) use owned_column_error::ColumnCoercionError;
 pub use owned_column_error::{OwnedColumnError, OwnedColumnResult};

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -80,6 +80,12 @@ pub use nullable_column::NullableColumn;
 mod nullable_owned_column;
 pub use nullable_owned_column::NullableOwnedColumn;
 
+mod nullable_table;
+pub use nullable_table::NullableTable;
+
+mod nullable_owned_table;
+pub use nullable_owned_table::NullableOwnedTable;
+
 mod owned_column_error;
 pub(crate) use owned_column_error::ColumnCoercionError;
 pub use owned_column_error::{OwnedColumnError, OwnedColumnResult};

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -106,7 +106,6 @@ mod owned_table_test;
 pub mod owned_table_utility;
 
 mod table;
-#[cfg(test)]
 pub(crate) use table::TableError;
 pub use table::{Table, TableOptions};
 #[cfg(test)]

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -78,6 +78,26 @@ impl<'a, S: Scalar> NullableColumn<'a, S> {
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
+
+    /// Returns a non-nullable boolean column matching SQL `IS NULL`.
+    #[must_use]
+    pub fn is_null(&self, alloc: &'a Bump) -> Column<'a, S> {
+        Column::Boolean(match self.presence {
+            Some(presence) => {
+                alloc.alloc_slice_fill_iter(presence.iter().map(|is_present| !*is_present))
+            }
+            None => alloc.alloc_slice_fill_copy(self.len(), false),
+        })
+    }
+
+    /// Returns a non-nullable boolean column matching SQL `IS NOT NULL`.
+    #[must_use]
+    pub fn is_not_null(&self, alloc: &'a Bump) -> Column<'a, S> {
+        Column::Boolean(match self.presence {
+            Some(presence) => alloc.alloc_slice_copy(presence),
+            None => alloc.alloc_slice_fill_copy(self.len(), true),
+        })
+    }
 }
 
 impl<'a, S: Scalar> From<Column<'a, S>> for NullableColumn<'a, S> {
@@ -118,5 +138,39 @@ mod tests {
             result,
             Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
+    }
+
+    #[test]
+    fn nullable_column_null_checks_reflect_presence() {
+        let alloc = Bump::new();
+        let column = NullableColumn::<TestScalar>::try_new(
+            Column::BigInt(&[10, 20, 30]),
+            Some(&[true, false, true]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            column.is_null(&alloc),
+            Column::Boolean(&[false, true, false])
+        );
+        assert_eq!(
+            column.is_not_null(&alloc),
+            Column::Boolean(&[true, false, true])
+        );
+    }
+
+    #[test]
+    fn nonnullable_column_null_checks_are_constant() {
+        let alloc = Bump::new();
+        let column = NullableColumn::<TestScalar>::new_nonnullable(Column::BigInt(&[10, 20, 30]));
+
+        assert_eq!(
+            column.is_null(&alloc),
+            Column::Boolean(&[false, false, false])
+        );
+        assert_eq!(
+            column.is_not_null(&alloc),
+            Column::Boolean(&[true, true, true])
+        );
     }
 }

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -1,0 +1,122 @@
+use super::{Column, ColumnOperationError, ColumnOperationResult, NullableOwnedColumn};
+use crate::base::scalar::Scalar;
+use bumpalo::Bump;
+
+/// A borrowed column plus optional row-presence data.
+///
+/// `None` means the column is non-nullable. `Some(presence)` means the column is
+/// nullable, with `true` for present values and `false` for SQL `NULL`.
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub struct NullableColumn<'a, S: Scalar> {
+    values: Column<'a, S>,
+    presence: Option<&'a [bool]>,
+}
+
+impl<'a, S: Scalar> NullableColumn<'a, S> {
+    /// Creates a nullable column and checks that the presence slice matches the value length.
+    pub fn try_new(
+        values: Column<'a, S>,
+        presence: Option<&'a [bool]>,
+    ) -> ColumnOperationResult<Self> {
+        if let Some(presence) = presence {
+            if presence.len() != values.len() {
+                return Err(ColumnOperationError::DifferentColumnLength {
+                    len_a: values.len(),
+                    len_b: presence.len(),
+                });
+            }
+        }
+        Ok(Self { values, presence })
+    }
+
+    /// Wraps a non-nullable column.
+    #[must_use]
+    pub const fn new_nonnullable(values: Column<'a, S>) -> Self {
+        Self {
+            values,
+            presence: None,
+        }
+    }
+
+    /// Converts an owned nullable column into a borrowed nullable column.
+    pub fn from_owned_column(
+        owned_column: &'a NullableOwnedColumn<S>,
+        alloc: &'a Bump,
+    ) -> ColumnOperationResult<Self> {
+        Self::try_new(
+            Column::from_owned_column(owned_column.values(), alloc),
+            owned_column.presence(),
+        )
+    }
+
+    /// Returns the backing non-nullable values.
+    #[must_use]
+    pub const fn values(&self) -> Column<'a, S> {
+        self.values
+    }
+
+    /// Returns the optional row-presence slice.
+    #[must_use]
+    pub const fn presence(&self) -> Option<&'a [bool]> {
+        self.presence
+    }
+
+    /// Returns whether this column carries nullable presence data.
+    #[must_use]
+    pub const fn is_nullable(&self) -> bool {
+        self.presence.is_some()
+    }
+
+    /// Returns the length of the value and presence columns.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Returns `true` if the column has no rows.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+impl<'a, S: Scalar> From<Column<'a, S>> for NullableColumn<'a, S> {
+    fn from(values: Column<'a, S>) -> Self {
+        Self::new_nonnullable(values)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{database::OwnedColumn, scalar::test_scalar::TestScalar};
+    use alloc::vec;
+
+    #[test]
+    fn we_can_borrow_a_nullable_owned_column() {
+        let alloc = Bump::new();
+        let owned = NullableOwnedColumn::try_new(
+            OwnedColumn::<TestScalar>::BigInt(vec![10, 20, 30]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+
+        let column = NullableColumn::from_owned_column(&owned, &alloc).unwrap();
+
+        assert_eq!(column.values(), Column::BigInt(&[10, 20, 30]));
+        assert_eq!(column.presence(), Some([true, false, true].as_slice()));
+        assert!(column.is_nullable());
+        assert_eq!(column.len(), 3);
+    }
+
+    #[test]
+    fn we_reject_borrowed_presence_with_wrong_length() {
+        let result =
+            NullableColumn::<TestScalar>::try_new(Column::BigInt(&[10, 20]), Some(&[true]));
+
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::DifferentColumnLength { .. })
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -1,4 +1,6 @@
-use super::{Column, ColumnOperationError, ColumnOperationResult, NullableOwnedColumn};
+use super::{
+    Column, ColumnOperationError, ColumnOperationResult, NullableOwnedColumn, OwnedColumn,
+};
 use crate::base::scalar::Scalar;
 use bumpalo::Bump;
 
@@ -77,6 +79,76 @@ impl<'a, S: Scalar> NullableColumn<'a, S> {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
+    }
+
+    fn binary_presence(
+        &self,
+        rhs: &Self,
+        alloc: &'a Bump,
+    ) -> ColumnOperationResult<Option<&'a [bool]>> {
+        if self.len() != rhs.len() {
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
+        }
+
+        Ok(match (self.presence(), rhs.presence()) {
+            (None, None) => None,
+            (Some(lhs), None) => Some(alloc.alloc_slice_copy(lhs)),
+            (None, Some(rhs)) => Some(alloc.alloc_slice_copy(rhs)),
+            (Some(lhs), Some(rhs)) => {
+                Some(alloc.alloc_slice_fill_iter(
+                    lhs.iter().zip(rhs.iter()).map(|(lhs, rhs)| *lhs && *rhs),
+                ))
+            }
+        })
+    }
+
+    fn apply_binary_operation(
+        &self,
+        rhs: &Self,
+        alloc: &'a Bump,
+        operation: impl FnOnce(
+            &OwnedColumn<S>,
+            &OwnedColumn<S>,
+        ) -> ColumnOperationResult<OwnedColumn<S>>,
+    ) -> ColumnOperationResult<Self> {
+        let lhs_values = OwnedColumn::from(&self.values);
+        let rhs_values = OwnedColumn::from(&rhs.values);
+        let values = alloc.alloc(operation(&lhs_values, &rhs_values)?);
+        let presence = self.binary_presence(rhs, alloc)?;
+        Self::try_new(Column::from_owned_column(values, alloc), presence)
+    }
+
+    /// Adds two columns element-wise and propagates nullable presence data.
+    pub fn element_wise_add(&self, rhs: &Self, alloc: &'a Bump) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, alloc, OwnedColumn::element_wise_add)
+    }
+
+    /// Subtracts two columns element-wise and propagates nullable presence data.
+    pub fn element_wise_sub(&self, rhs: &Self, alloc: &'a Bump) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, alloc, OwnedColumn::element_wise_sub)
+    }
+
+    /// Multiplies two columns element-wise and propagates nullable presence data.
+    pub fn element_wise_mul(&self, rhs: &Self, alloc: &'a Bump) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, alloc, OwnedColumn::element_wise_mul)
+    }
+
+    /// Compares two columns for equality and propagates nullable presence data.
+    pub fn element_wise_eq(&self, rhs: &Self, alloc: &'a Bump) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, alloc, OwnedColumn::element_wise_eq)
+    }
+
+    /// Compares two columns with less-than and propagates nullable presence data.
+    pub fn element_wise_lt(&self, rhs: &Self, alloc: &'a Bump) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, alloc, OwnedColumn::element_wise_lt)
+    }
+
+    /// Compares two columns with greater-than and propagates nullable presence data.
+    pub fn element_wise_gt(&self, rhs: &Self, alloc: &'a Bump) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, alloc, OwnedColumn::element_wise_gt)
     }
 
     /// Returns a non-nullable boolean column matching SQL `IS NULL`.
@@ -171,6 +243,84 @@ mod tests {
         assert_eq!(
             column.is_not_null(&alloc),
             Column::Boolean(&[true, true, true])
+        );
+    }
+
+    #[test]
+    fn nullable_column_propagates_presence_from_nullable_lhs() {
+        let alloc = Bump::new();
+        let lhs = NullableColumn::<TestScalar>::try_new(
+            Column::BigInt(&[10, 20, 30]),
+            Some(&[true, false, true]),
+        )
+        .unwrap();
+        let rhs = NullableColumn::<TestScalar>::new_nonnullable(Column::BigInt(&[1, 2, 3]));
+
+        let result = lhs.element_wise_add(&rhs, &alloc).unwrap();
+
+        assert_eq!(
+            result,
+            NullableColumn::try_new(Column::BigInt(&[11, 22, 33]), Some(&[true, false, true]))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn nullable_column_ands_presence_for_two_nullable_columns() {
+        let alloc = Bump::new();
+        let lhs = NullableColumn::<TestScalar>::try_new(
+            Column::BigInt(&[10, 20, 30]),
+            Some(&[true, false, true]),
+        )
+        .unwrap();
+        let rhs = NullableColumn::<TestScalar>::try_new(
+            Column::BigInt(&[1, 2, 3]),
+            Some(&[false, true, true]),
+        )
+        .unwrap();
+
+        let result = lhs.element_wise_add(&rhs, &alloc).unwrap();
+
+        assert_eq!(
+            result,
+            NullableColumn::try_new(Column::BigInt(&[11, 22, 33]), Some(&[false, false, true]))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn nullable_column_keeps_nonnullable_result_when_inputs_are_nonnullable() {
+        let alloc = Bump::new();
+        let lhs = NullableColumn::<TestScalar>::new_nonnullable(Column::BigInt(&[10, 20, 30]));
+        let rhs = NullableColumn::<TestScalar>::new_nonnullable(Column::BigInt(&[1, 2, 3]));
+
+        let result = lhs.element_wise_add(&rhs, &alloc).unwrap();
+
+        assert_eq!(
+            result,
+            NullableColumn::new_nonnullable(Column::BigInt(&[11, 22, 33]))
+        );
+    }
+
+    #[test]
+    fn nullable_column_propagates_presence_for_comparison_results() {
+        let alloc = Bump::new();
+        let lhs = NullableColumn::<TestScalar>::try_new(
+            Column::BigInt(&[10, 20, 30]),
+            Some(&[true, false, true]),
+        )
+        .unwrap();
+        let rhs = NullableColumn::<TestScalar>::new_nonnullable(Column::BigInt(&[10, 2, 30]));
+
+        let result = lhs.element_wise_eq(&rhs, &alloc).unwrap();
+
+        assert_eq!(
+            result,
+            NullableColumn::try_new(
+                Column::Boolean(&[true, false, true]),
+                Some(&[true, false, true])
+            )
+            .unwrap()
         );
     }
 }

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -81,7 +81,11 @@ impl<'a, S: Scalar> NullableColumn<'a, S> {
         self.values.is_empty()
     }
 
-    fn binary_presence(
+    /// Returns row presence for a binary nullable-propagating operation.
+    ///
+    /// A binary expression is present only when both operands are present. `None`
+    /// is preserved when both operands are non-nullable.
+    pub fn propagated_binary_presence(
         &self,
         rhs: &Self,
         alloc: &'a Bump,
@@ -117,7 +121,7 @@ impl<'a, S: Scalar> NullableColumn<'a, S> {
         let lhs_values = OwnedColumn::from(&self.values);
         let rhs_values = OwnedColumn::from(&rhs.values);
         let values = alloc.alloc(operation(&lhs_values, &rhs_values)?);
-        let presence = self.binary_presence(rhs, alloc)?;
+        let presence = self.propagated_binary_presence(rhs, alloc)?;
         Self::try_new(Column::from_owned_column(values, alloc), presence)
     }
 

--- a/crates/proof-of-sql/src/base/database/nullable_owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_column.rs
@@ -1,0 +1,278 @@
+use super::{ColumnOperationError, ColumnOperationResult, OwnedColumn};
+use crate::base::scalar::Scalar;
+use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
+
+/// An owned column plus optional row-presence data.
+///
+/// `None` means the column is non-nullable. `Some(presence)` means the column is
+/// nullable, with `true` for present values and `false` for SQL `NULL`.
+#[derive(Debug, PartialEq, Clone, Eq, Serialize, Deserialize)]
+pub struct NullableOwnedColumn<S: Scalar> {
+    values: OwnedColumn<S>,
+    presence: Option<Vec<bool>>,
+}
+
+impl<S: Scalar> NullableOwnedColumn<S> {
+    /// Creates a nullable owned column and checks that presence matches value length.
+    pub fn try_new(
+        values: OwnedColumn<S>,
+        presence: Option<Vec<bool>>,
+    ) -> ColumnOperationResult<Self> {
+        if let Some(presence) = &presence {
+            if presence.len() != values.len() {
+                return Err(ColumnOperationError::DifferentColumnLength {
+                    len_a: values.len(),
+                    len_b: presence.len(),
+                });
+            }
+        }
+        Ok(Self { values, presence })
+    }
+
+    /// Wraps a non-nullable owned column.
+    #[must_use]
+    pub const fn new_nonnullable(values: OwnedColumn<S>) -> Self {
+        Self {
+            values,
+            presence: None,
+        }
+    }
+
+    /// Returns the backing non-nullable values.
+    #[must_use]
+    pub const fn values(&self) -> &OwnedColumn<S> {
+        &self.values
+    }
+
+    /// Returns the optional row-presence slice.
+    #[must_use]
+    pub fn presence(&self) -> Option<&[bool]> {
+        self.presence.as_deref()
+    }
+
+    /// Returns whether this column carries nullable presence data.
+    #[must_use]
+    pub const fn is_nullable(&self) -> bool {
+        self.presence.is_some()
+    }
+
+    /// Returns the length of the value and presence columns.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Returns `true` if the column has no rows.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Returns the backing values and optional row-presence vector.
+    #[must_use]
+    pub fn into_parts(self) -> (OwnedColumn<S>, Option<Vec<bool>>) {
+        (self.values, self.presence)
+    }
+
+    fn binary_presence(&self, rhs: &Self) -> ColumnOperationResult<Option<Vec<bool>>> {
+        if self.len() != rhs.len() {
+            return Err(ColumnOperationError::DifferentColumnLength {
+                len_a: self.len(),
+                len_b: rhs.len(),
+            });
+        }
+
+        Ok(match (self.presence(), rhs.presence()) {
+            (None, None) => None,
+            (Some(lhs), None) => Some(lhs.to_vec()),
+            (None, Some(rhs)) => Some(rhs.to_vec()),
+            (Some(lhs), Some(rhs)) => Some(
+                lhs.iter()
+                    .zip(rhs.iter())
+                    .map(|(lhs, rhs)| *lhs && *rhs)
+                    .collect(),
+            ),
+        })
+    }
+
+    fn apply_binary_operation(
+        &self,
+        rhs: &Self,
+        operation: impl FnOnce(
+            &OwnedColumn<S>,
+            &OwnedColumn<S>,
+        ) -> ColumnOperationResult<OwnedColumn<S>>,
+    ) -> ColumnOperationResult<Self> {
+        let values = operation(&self.values, &rhs.values)?;
+        let presence = self.binary_presence(rhs)?;
+        Self::try_new(values, presence)
+    }
+
+    /// Adds two columns element-wise and propagates nullable presence data.
+    pub fn element_wise_add(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, OwnedColumn::element_wise_add)
+    }
+
+    /// Subtracts two columns element-wise and propagates nullable presence data.
+    pub fn element_wise_sub(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, OwnedColumn::element_wise_sub)
+    }
+
+    /// Multiplies two columns element-wise and propagates nullable presence data.
+    pub fn element_wise_mul(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, OwnedColumn::element_wise_mul)
+    }
+
+    /// Compares two columns for equality and propagates nullable presence data.
+    pub fn element_wise_eq(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, OwnedColumn::element_wise_eq)
+    }
+
+    /// Compares two columns with less-than and propagates nullable presence data.
+    pub fn element_wise_lt(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, OwnedColumn::element_wise_lt)
+    }
+
+    /// Compares two columns with greater-than and propagates nullable presence data.
+    pub fn element_wise_gt(&self, rhs: &Self) -> ColumnOperationResult<Self> {
+        self.apply_binary_operation(rhs, OwnedColumn::element_wise_gt)
+    }
+}
+
+impl<S: Scalar> From<OwnedColumn<S>> for NullableOwnedColumn<S> {
+    fn from(values: OwnedColumn<S>) -> Self {
+        Self::new_nonnullable(values)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::vec;
+
+    #[test]
+    fn we_reject_presence_with_wrong_length() {
+        let result = NullableOwnedColumn::try_new(
+            OwnedColumn::<TestScalar>::BigInt(vec![10, 20]),
+            Some(vec![true]),
+        );
+
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::DifferentColumnLength { .. })
+        ));
+    }
+
+    #[test]
+    fn we_propagate_presence_from_nullable_lhs() {
+        let lhs = NullableOwnedColumn::try_new(
+            OwnedColumn::<TestScalar>::BigInt(vec![10, 20, 30]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+        let rhs =
+            NullableOwnedColumn::new_nonnullable(OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3]));
+
+        let result = lhs.element_wise_add(&rhs).unwrap();
+
+        assert_eq!(
+            result,
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<TestScalar>::BigInt(vec![11, 22, 33]),
+                Some(vec![true, false, true])
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_propagate_presence_from_nullable_rhs() {
+        let lhs = NullableOwnedColumn::new_nonnullable(OwnedColumn::<TestScalar>::BigInt(vec![
+            10, 20, 30,
+        ]));
+        let rhs = NullableOwnedColumn::try_new(
+            OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+
+        let result = lhs.element_wise_add(&rhs).unwrap();
+
+        assert_eq!(
+            result,
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<TestScalar>::BigInt(vec![11, 22, 33]),
+                Some(vec![true, false, true])
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_and_presence_for_two_nullable_columns() {
+        let lhs = NullableOwnedColumn::try_new(
+            OwnedColumn::<TestScalar>::BigInt(vec![10, 20, 30]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+        let rhs = NullableOwnedColumn::try_new(
+            OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3]),
+            Some(vec![false, true, true]),
+        )
+        .unwrap();
+
+        let result = lhs.element_wise_add(&rhs).unwrap();
+
+        assert_eq!(
+            result,
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<TestScalar>::BigInt(vec![11, 22, 33]),
+                Some(vec![false, false, true])
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_keep_nonnullable_result_when_inputs_are_nonnullable() {
+        let lhs = NullableOwnedColumn::new_nonnullable(OwnedColumn::<TestScalar>::BigInt(vec![
+            10, 20, 30,
+        ]));
+        let rhs =
+            NullableOwnedColumn::new_nonnullable(OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3]));
+
+        let result = lhs.element_wise_add(&rhs).unwrap();
+
+        assert_eq!(
+            result,
+            NullableOwnedColumn::new_nonnullable(OwnedColumn::<TestScalar>::BigInt(vec![
+                11, 22, 33
+            ]))
+        );
+    }
+
+    #[test]
+    fn we_propagate_presence_for_comparison_results() {
+        let lhs = NullableOwnedColumn::try_new(
+            OwnedColumn::<TestScalar>::BigInt(vec![10, 20, 30]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+        let rhs = NullableOwnedColumn::new_nonnullable(OwnedColumn::<TestScalar>::BigInt(vec![
+            10, 2, 30,
+        ]));
+
+        let result = lhs.element_wise_eq(&rhs).unwrap();
+
+        assert_eq!(
+            result,
+            NullableOwnedColumn::try_new(
+                OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]),
+                Some(vec![true, false, true])
+            )
+            .unwrap()
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/nullable_owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_column.rs
@@ -1,6 +1,6 @@
 use super::{ColumnOperationError, ColumnOperationResult, OwnedColumn};
 use crate::base::scalar::Scalar;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use serde::{Deserialize, Serialize};
 
 /// An owned column plus optional row-presence data.
@@ -138,6 +138,24 @@ impl<S: Scalar> NullableOwnedColumn<S> {
     pub fn element_wise_gt(&self, rhs: &Self) -> ColumnOperationResult<Self> {
         self.apply_binary_operation(rhs, OwnedColumn::element_wise_gt)
     }
+
+    /// Returns a non-nullable boolean column matching SQL `IS NULL`.
+    #[must_use]
+    pub fn is_null(&self) -> OwnedColumn<S> {
+        OwnedColumn::Boolean(match self.presence() {
+            Some(presence) => presence.iter().map(|is_present| !*is_present).collect(),
+            None => vec![false; self.len()],
+        })
+    }
+
+    /// Returns a non-nullable boolean column matching SQL `IS NOT NULL`.
+    #[must_use]
+    pub fn is_not_null(&self) -> OwnedColumn<S> {
+        OwnedColumn::Boolean(match self.presence() {
+            Some(presence) => presence.to_vec(),
+            None => vec![true; self.len()],
+        })
+    }
 }
 
 impl<S: Scalar> From<OwnedColumn<S>> for NullableOwnedColumn<S> {
@@ -273,6 +291,40 @@ mod tests {
                 Some(vec![true, false, true])
             )
             .unwrap()
+        );
+    }
+
+    #[test]
+    fn nullable_owned_column_null_checks_reflect_presence() {
+        let column = NullableOwnedColumn::try_new(
+            OwnedColumn::<TestScalar>::BigInt(vec![10, 20, 30]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            column.is_null(),
+            OwnedColumn::<TestScalar>::Boolean(vec![false, true, false])
+        );
+        assert_eq!(
+            column.is_not_null(),
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false, true])
+        );
+    }
+
+    #[test]
+    fn nonnullable_owned_column_null_checks_are_constant() {
+        let column = NullableOwnedColumn::new_nonnullable(OwnedColumn::<TestScalar>::BigInt(vec![
+            10, 20, 30,
+        ]));
+
+        assert_eq!(
+            column.is_null(),
+            OwnedColumn::<TestScalar>::Boolean(vec![false, false, false])
+        );
+        assert_eq!(
+            column.is_not_null(),
+            OwnedColumn::<TestScalar>::Boolean(vec![true, true, true])
         );
     }
 }

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
@@ -1,6 +1,6 @@
 use super::{
-    ColumnField, ColumnRef, NullableOwnedColumn, NullableTable, OwnedColumn, OwnedTable,
-    OwnedTableError,
+    ColumnField, ColumnRef, ColumnType, NullableOwnedColumn, NullableTable, OwnedColumn,
+    OwnedTable, OwnedTableError, TableCoercionError,
 };
 use crate::base::{map::IndexMap, scalar::Scalar};
 use alloc::vec::Vec;
@@ -136,6 +136,59 @@ impl<S: Scalar> NullableOwnedTable<S> {
             })
             .collect()
     }
+
+    pub(crate) fn try_from_values_and_presence_table_with_fields<T>(
+        values_and_presence_table: OwnedTable<S>,
+        fields: T,
+    ) -> Result<Self, TableCoercionError>
+    where
+        T: IntoIterator<Item = ColumnField>,
+    {
+        let fields = fields.into_iter().collect::<Vec<_>>();
+        let physical_fields = fields
+            .iter()
+            .flat_map(|field| {
+                let value_field = field.clone();
+                let presence_field = field.is_nullable().then(|| {
+                    ColumnField::new(
+                        Self::presence_column_name(&field.name()),
+                        ColumnType::Boolean,
+                    )
+                });
+                core::iter::once(value_field).chain(presence_field)
+            })
+            .collect::<Vec<_>>();
+        let mut physical_columns = values_and_presence_table
+            .try_coerce_with_fields(physical_fields)?
+            .into_inner()
+            .into_iter();
+        let table = fields
+            .into_iter()
+            .map(|field| {
+                let (name, value_column) = physical_columns
+                    .next()
+                    .expect("Coerced table should have a value column for each field");
+                debug_assert_eq!(name, field.name());
+                let column = if field.is_nullable() {
+                    let (presence_name, presence_column) = physical_columns
+                        .next()
+                        .expect("Coerced table should have presence columns for nullable fields");
+                    debug_assert_eq!(presence_name, Self::presence_column_name(&name));
+                    let OwnedColumn::Boolean(presence) = presence_column else {
+                        unreachable!("Presence fields are coerced to Boolean before reassembly");
+                    };
+                    NullableOwnedColumn::try_new(value_column, Some(presence))
+                        .expect("OwnedTable guarantees matching value and presence lengths")
+                } else {
+                    NullableOwnedColumn::new_nonnullable(value_column)
+                };
+                Ok((name, column))
+            })
+            .collect::<Result<_, TableCoercionError>>()?;
+        debug_assert!(physical_columns.next().is_none());
+
+        Self::try_new(table).map_err(|_| TableCoercionError::ColumnCountMismatch)
+    }
 }
 
 impl<S: Scalar> PartialEq for NullableOwnedTable<S> {
@@ -250,6 +303,41 @@ mod tests {
             Ident::new("__posql_presence_amount")
         );
         assert_eq!(proof_schema[2].data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn values_and_presence_table_reassembles_nullable_table() {
+        let nullable_table = nullable_table_for_proof();
+        let proof_table = nullable_table.values_and_presence_table();
+        let logical_schema = nullable_table.schema();
+
+        let reassembled = NullableOwnedTable::try_from_values_and_presence_table_with_fields(
+            proof_table,
+            logical_schema,
+        )
+        .unwrap();
+
+        assert_eq!(reassembled, nullable_table);
+    }
+
+    #[test]
+    fn values_and_presence_reassembly_rejects_missing_presence_column() {
+        let proof_table = owned_table([bigint("amount", [10_i64, 20])]);
+        let logical_schema = vec![ColumnField::new_nullable(
+            Ident::new("amount"),
+            ColumnType::BigInt,
+        )];
+
+        let result =
+            NullableOwnedTable::<TestScalar>::try_from_values_and_presence_table_with_fields(
+                proof_table,
+                logical_schema,
+            );
+
+        assert!(matches!(
+            result,
+            Err(TableCoercionError::ColumnCountMismatch)
+        ));
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
@@ -18,6 +18,7 @@ impl<S: Scalar> NullableOwnedTable<S> {
     pub fn try_new(
         table: IndexMap<Ident, NullableOwnedColumn<S>>,
     ) -> Result<Self, OwnedTableError> {
+        Self::reject_generated_column_name_collisions(&table)?;
         if table.is_empty() {
             return Ok(Self { table });
         }
@@ -27,6 +28,22 @@ impl<S: Scalar> NullableOwnedTable<S> {
         } else {
             Ok(Self { table })
         }
+    }
+
+    fn reject_generated_column_name_collisions(
+        table: &IndexMap<Ident, NullableOwnedColumn<S>>,
+    ) -> Result<(), OwnedTableError> {
+        for (name, column) in table {
+            if column.is_nullable() {
+                let presence_column_name = Self::presence_column_name(name);
+                if table.contains_key(&presence_column_name) {
+                    return Err(OwnedTableError::GeneratedColumnNameCollision {
+                        column: presence_column_name,
+                    });
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Creates a new [`NullableOwnedTable`] from an iterator.
@@ -242,6 +259,26 @@ mod tests {
         });
 
         assert_eq!(result, Err(OwnedTableError::ColumnLengthMismatch));
+    }
+
+    #[test]
+    fn nullable_owned_table_rejects_generated_presence_name_collisions() {
+        let result = NullableOwnedTable::try_new(indexmap! {
+            "amount".into() => NullableOwnedColumn::<TestScalar>::try_new(
+                OwnedColumn::BigInt(vec![10, 20]),
+                Some(vec![true, false])
+            ).unwrap(),
+            "__posql_presence_amount".into() => NullableOwnedColumn::new_nonnullable(
+                OwnedColumn::Boolean(vec![false, false])
+            ),
+        });
+
+        assert_eq!(
+            result,
+            Err(OwnedTableError::GeneratedColumnNameCollision {
+                column: "__posql_presence_amount".into()
+            })
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
@@ -1,8 +1,9 @@
 use super::{
-    ColumnField, NullableOwnedColumn, NullableTable, OwnedColumn, OwnedTable, OwnedTableError,
+    ColumnField, ColumnRef, NullableOwnedColumn, NullableTable, OwnedColumn, OwnedTable,
+    OwnedTableError,
 };
 use crate::base::{map::IndexMap, scalar::Scalar};
-use alloc::{format, vec::Vec};
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -98,7 +99,7 @@ impl<S: Scalar> NullableOwnedTable<S> {
     /// Returns the generated proof-column name for a nullable column's row-presence data.
     #[must_use]
     pub fn presence_column_name(column_name: &Ident) -> Ident {
-        Ident::new(format!("__posql_presence_{}", column_name.value))
+        ColumnRef::presence_column_id(column_name)
     }
 
     /// Returns a non-null proof table with backing values plus presence columns for nullable data.
@@ -265,20 +266,17 @@ mod tests {
         );
         let amount_ref =
             ColumnRef::new_nullable(table_ref.clone(), Ident::new("amount"), ColumnType::BigInt);
-        let amount_presence_ref = ColumnRef::new(
-            table_ref.clone(),
-            NullableOwnedTable::<TestScalar>::presence_column_name(&Ident::new("amount")),
-            ColumnType::Boolean,
-        );
         let amount_gt_15 = DynProofExpr::try_new_inequality(
             DynProofExpr::new_column(amount_ref.clone()),
             DynProofExpr::new_literal(LiteralValue::BigInt(15)),
             false,
         )
         .unwrap();
-        let where_clause =
-            DynProofExpr::try_new_and(DynProofExpr::new_column(amount_presence_ref), amount_gt_15)
-                .unwrap();
+        let where_clause = DynProofExpr::try_new_and(
+            DynProofExpr::new_is_not_null(amount_ref.clone()),
+            amount_gt_15,
+        )
+        .unwrap();
         let plan = filter(
             vec![AliasedDynProofExpr {
                 expr: DynProofExpr::new_column(amount_ref),
@@ -298,6 +296,39 @@ mod tests {
             verified.table,
             owned_table([bigint("amount", [30_i64, 50])])
         );
+    }
+
+    #[test]
+    fn nullable_is_null_expr_can_drive_a_query_proof() {
+        let table_ref = TableRef::new("sxt", "nullable");
+        let nullable_table = nullable_table_for_proof();
+        let schema = nullable_table.values_and_presence_schema();
+        let proof_table = nullable_table.values_and_presence_table();
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            proof_table,
+            0,
+            (),
+        );
+        let id_ref = ColumnRef::new(table_ref.clone(), Ident::new("id"), ColumnType::BigInt);
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), Ident::new("amount"), ColumnType::BigInt);
+        let plan = filter(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(id_ref),
+                alias: Ident::new("id"),
+            }],
+            table_exec(table_ref, schema),
+            DynProofExpr::new_is_null(amount_ref),
+        );
+
+        let verifiable_result =
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+        let verified = verifiable_result
+            .verify(&plan, &accessor, &(), &[])
+            .unwrap();
+
+        assert_eq!(verified.table, owned_table([bigint("id", [2_i64])]));
     }
 
     fn nullable_table_for_proof() -> NullableOwnedTable<TestScalar> {

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
@@ -209,14 +209,18 @@ impl<S: Scalar> core::ops::Index<&str> for NullableOwnedTable<S> {
 mod tests {
     use super::*;
     use crate::base::{
-        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        commitment::{naive_evaluation_proof::NaiveEvaluationProof, CommitmentEvaluationProof},
         database::{
             owned_table_utility::{bigint, boolean, owned_table},
             Column, ColumnRef, ColumnType, LiteralValue, NullableColumn,
             NullableOwnedTableTestAccessor, OwnedColumn, OwnedTableTestAccessor, TableRef,
         },
         map::indexmap,
-        scalar::test_scalar::TestScalar,
+        scalar::{test_scalar::TestScalar, Scalar},
+    };
+    use crate::proof_primitive::dory::{
+        test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup, ProverSetup,
+        PublicParameters, VerifierSetup,
     };
     use crate::sql::{
         proof::VerifiableQueryResult,
@@ -429,6 +433,93 @@ mod tests {
     }
 
     #[test]
+    fn nullable_projection_query_result_verifies_with_dory_evaluation_proof() {
+        let table_ref = TableRef::new("sxt", "nullable");
+        let nullable_table = nullable_table_for_scalar::<
+            <DoryEvaluationProof as CommitmentEvaluationProof>::Scalar,
+        >();
+        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let prover_setup_ref = DoryProverPublicSetup::new(&prover_setup, 3);
+        let verifier_setup_ref = DoryVerifierPublicSetup::new(&verifier_setup, 3);
+        let accessor = NullableOwnedTableTestAccessor::<DoryEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            nullable_table.clone(),
+            0,
+            prover_setup_ref,
+        );
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), Ident::new("amount"), ColumnType::BigInt);
+        let plan = projection(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(amount_ref),
+                alias: Ident::new("amount"),
+            }],
+            table_exec(table_ref, nullable_table.schema()),
+        );
+
+        let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+            &plan,
+            &accessor,
+            &prover_setup_ref,
+            &[],
+        )
+        .unwrap();
+        let verified_nullable = verifiable_result
+            .verify_nullable(&plan, &accessor, &verifier_setup_ref, &[])
+            .unwrap();
+
+        assert_eq!(
+            verified_nullable.table,
+            NullableOwnedTable::try_new(indexmap! {
+                "amount".into() => nullable_table["amount"].clone(),
+            })
+            .unwrap()
+        );
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn nullable_projection_query_result_verifies_with_inner_product_proof() {
+        use crate::base::commitment::{init_backend, InnerProductProof};
+
+        init_backend();
+        let table_ref = TableRef::new("sxt", "nullable");
+        let nullable_table =
+            nullable_table_for_scalar::<<InnerProductProof as CommitmentEvaluationProof>::Scalar>();
+        let accessor = NullableOwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+            table_ref.clone(),
+            nullable_table.clone(),
+            0,
+            (),
+        );
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), Ident::new("amount"), ColumnType::BigInt);
+        let plan = projection(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(amount_ref),
+                alias: Ident::new("amount"),
+            }],
+            table_exec(table_ref, nullable_table.schema()),
+        );
+
+        let verifiable_result =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+        let verified_nullable = verifiable_result
+            .verify_nullable(&plan, &accessor, &(), &[])
+            .unwrap();
+
+        assert_eq!(
+            verified_nullable.table,
+            NullableOwnedTable::try_new(indexmap! {
+                "amount".into() => nullable_table["amount"].clone(),
+            })
+            .unwrap()
+        );
+    }
+
+    #[test]
     fn nullable_is_null_expr_can_drive_a_query_proof() {
         let table_ref = TableRef::new("sxt", "nullable");
         let nullable_table = nullable_table_for_proof();
@@ -462,12 +553,16 @@ mod tests {
     }
 
     fn nullable_table_for_proof() -> NullableOwnedTable<TestScalar> {
+        nullable_table_for_scalar()
+    }
+
+    fn nullable_table_for_scalar<S: Scalar>() -> NullableOwnedTable<S> {
         NullableOwnedTable::try_new(indexmap! {
             "id".into() => NullableOwnedColumn::new_nonnullable(
-                OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3, 4])
+                OwnedColumn::<S>::BigInt(vec![1, 2, 3, 4])
             ),
             "amount".into() => NullableOwnedColumn::try_new(
-                OwnedColumn::<TestScalar>::BigInt(vec![10, 0, 30, 50]),
+                OwnedColumn::<S>::BigInt(vec![10, 0, 30, 50]),
                 Some(vec![true, false, true, true])
             ).unwrap(),
         })

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
@@ -211,9 +211,9 @@ mod tests {
     use crate::base::{
         commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
-            owned_table_utility::{bigint, owned_table},
-            Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, OwnedColumn,
-            OwnedTableTestAccessor, TableRef,
+            owned_table_utility::{bigint, boolean, owned_table},
+            Column, ColumnRef, ColumnType, LiteralValue, NullableColumn,
+            NullableOwnedTableTestAccessor, OwnedColumn, OwnedTableTestAccessor, TableRef,
         },
         map::indexmap,
         scalar::test_scalar::TestScalar,
@@ -221,7 +221,7 @@ mod tests {
     use crate::sql::{
         proof::VerifiableQueryResult,
         proof_exprs::{AliasedDynProofExpr, DynProofExpr},
-        proof_plans::test_utility::{filter, table_exec},
+        proof_plans::test_utility::{filter, projection, table_exec},
     };
     use alloc::vec;
 
@@ -371,6 +371,60 @@ mod tests {
         assert_eq!(
             verified.table,
             owned_table([bigint("amount", [30_i64, 50])])
+        );
+    }
+
+    #[test]
+    fn nullable_projection_query_result_can_reassemble_presence_after_verification() {
+        let table_ref = TableRef::new("sxt", "nullable");
+        let nullable_table = nullable_table_for_proof();
+        let accessor = NullableOwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            nullable_table.clone(),
+            0,
+            (),
+        );
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), Ident::new("amount"), ColumnType::BigInt);
+        let plan = projection(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(amount_ref),
+                alias: Ident::new("amount"),
+            }],
+            table_exec(table_ref, nullable_table.schema()),
+        );
+
+        let verifiable_result =
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+
+        assert_eq!(
+            verifiable_result.result,
+            owned_table([
+                bigint("amount", [10_i64, 0, 30, 50]),
+                boolean("__posql_presence_amount", [true, false, true, true]),
+            ])
+        );
+
+        let verified_nullable = verifiable_result
+            .verify_nullable(&plan, &accessor, &(), &[])
+            .unwrap();
+        assert_eq!(
+            verified_nullable.table,
+            NullableOwnedTable::try_new(indexmap! {
+                "amount".into() => nullable_table["amount"].clone(),
+            })
+            .unwrap()
+        );
+
+        let verified_values =
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[])
+                .unwrap()
+                .verify(&plan, &accessor, &(), &[])
+                .unwrap()
+                .table;
+        assert_eq!(
+            verified_values,
+            owned_table([bigint("amount", [10_i64, 0, 30, 50])])
         );
     }
 

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
@@ -1,6 +1,6 @@
 use super::{
-    ColumnField, ColumnRef, ColumnType, NullableOwnedColumn, NullableTable, OwnedColumn,
-    OwnedTable, OwnedTableError, TableCoercionError,
+    ColumnField, ColumnRef, NullableOwnedColumn, NullableTable, OwnedColumn, OwnedTable,
+    OwnedTableError, TableCoercionError,
 };
 use crate::base::{map::IndexMap, scalar::Scalar};
 use alloc::vec::Vec;
@@ -145,19 +145,7 @@ impl<S: Scalar> NullableOwnedTable<S> {
         T: IntoIterator<Item = ColumnField>,
     {
         let fields = fields.into_iter().collect::<Vec<_>>();
-        let physical_fields = fields
-            .iter()
-            .flat_map(|field| {
-                let value_field = field.clone();
-                let presence_field = field.is_nullable().then(|| {
-                    ColumnField::new(
-                        Self::presence_column_name(&field.name()),
-                        ColumnType::Boolean,
-                    )
-                });
-                core::iter::once(value_field).chain(presence_field)
-            })
-            .collect::<Vec<_>>();
+        let physical_fields = ColumnField::value_and_presence_fields(fields.iter().cloned());
         let mut physical_columns = values_and_presence_table
             .try_coerce_with_fields(physical_fields)?
             .into_inner()

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
@@ -1,0 +1,160 @@
+use super::{NullableOwnedColumn, NullableTable, OwnedTableError};
+use crate::base::{map::IndexMap, scalar::Scalar};
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
+
+/// An owned table whose columns can carry nullable row-presence data.
+#[derive(Debug, Clone, Eq, Serialize, Deserialize)]
+pub struct NullableOwnedTable<S: Scalar> {
+    table: IndexMap<Ident, NullableOwnedColumn<S>>,
+}
+
+impl<S: Scalar> NullableOwnedTable<S> {
+    /// Creates a new [`NullableOwnedTable`].
+    pub fn try_new(
+        table: IndexMap<Ident, NullableOwnedColumn<S>>,
+    ) -> Result<Self, OwnedTableError> {
+        if table.is_empty() {
+            return Ok(Self { table });
+        }
+        let num_rows = table[0].len();
+        if table.values().any(|column| column.len() != num_rows) {
+            Err(OwnedTableError::ColumnLengthMismatch)
+        } else {
+            Ok(Self { table })
+        }
+    }
+
+    /// Creates a new [`NullableOwnedTable`] from an iterator.
+    pub fn try_from_iter<T: IntoIterator<Item = (Ident, NullableOwnedColumn<S>)>>(
+        iter: T,
+    ) -> Result<Self, OwnedTableError> {
+        Self::try_new(IndexMap::from_iter(iter))
+    }
+
+    /// Number of columns in the table.
+    #[must_use]
+    pub fn num_columns(&self) -> usize {
+        self.table.len()
+    }
+
+    /// Number of rows in the table.
+    #[must_use]
+    pub fn num_rows(&self) -> usize {
+        if self.table.is_empty() {
+            0
+        } else {
+            self.table[0].len()
+        }
+    }
+
+    /// Whether the table has no columns.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
+    /// Returns the columns of this table.
+    #[must_use]
+    pub fn into_inner(self) -> IndexMap<Ident, NullableOwnedColumn<S>> {
+        self.table
+    }
+
+    /// Returns the columns of this table by reference.
+    #[must_use]
+    pub const fn inner_table(&self) -> &IndexMap<Ident, NullableOwnedColumn<S>> {
+        &self.table
+    }
+
+    /// Returns the column names as an iterator.
+    pub fn column_names(&self) -> impl Iterator<Item = &Ident> {
+        self.table.keys()
+    }
+
+    /// Returns the column with the given position.
+    #[must_use]
+    pub fn column_by_index(&self, index: usize) -> Option<&NullableOwnedColumn<S>> {
+        self.table.get_index(index).map(|(_, v)| v)
+    }
+}
+
+impl<S: Scalar> PartialEq for NullableOwnedTable<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.table == other.table
+            && self
+                .table
+                .keys()
+                .zip(other.table.keys())
+                .all(|(a, b)| a == b)
+    }
+}
+
+impl<'a, S: Scalar> From<NullableTable<'a, S>> for NullableOwnedTable<S> {
+    fn from(value: NullableTable<'a, S>) -> Self {
+        NullableOwnedTable::from(&value)
+    }
+}
+
+#[cfg(test)]
+impl<S: Scalar> core::ops::Index<&str> for NullableOwnedTable<S> {
+    type Output = NullableOwnedColumn<S>;
+
+    fn index(&self, index: &str) -> &Self::Output {
+        self.table.get(&Ident::new(index)).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        database::{Column, NullableColumn, OwnedColumn},
+        map::indexmap,
+        scalar::test_scalar::TestScalar,
+    };
+    use alloc::vec;
+
+    #[test]
+    fn nullable_owned_table_rejects_column_length_mismatches() {
+        let result = NullableOwnedTable::try_new(indexmap! {
+            "id".into() => NullableOwnedColumn::<TestScalar>::new_nonnullable(
+                OwnedColumn::BigInt(vec![1, 2])
+            ),
+            "amount".into() => NullableOwnedColumn::<TestScalar>::try_new(
+                OwnedColumn::BigInt(vec![10]),
+                Some(vec![true])
+            ).unwrap(),
+        });
+
+        assert_eq!(result, Err(OwnedTableError::ColumnLengthMismatch));
+    }
+
+    #[test]
+    fn nullable_table_converts_to_owned_table() {
+        let borrowed = NullableTable::try_new(indexmap! {
+            "id".into() => NullableColumn::<TestScalar>::new_nonnullable(Column::BigInt(&[1, 2])),
+            "amount".into() => NullableColumn::<TestScalar>::try_new(
+                Column::BigInt(&[10, 20]),
+                Some(&[true, false])
+            ).unwrap(),
+        })
+        .unwrap();
+
+        let owned = NullableOwnedTable::from(&borrowed);
+
+        assert_eq!(
+            owned["id"],
+            NullableOwnedColumn::new_nonnullable(OwnedColumn::BigInt(vec![1, 2]))
+        );
+        assert_eq!(
+            owned["amount"],
+            NullableOwnedColumn::try_new(
+                OwnedColumn::BigInt(vec![10, 20]),
+                Some(vec![true, false])
+            )
+            .unwrap()
+        );
+        assert_eq!(owned.num_rows(), 2);
+        assert_eq!(owned.num_columns(), 2);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
@@ -1,4 +1,4 @@
-use super::{NullableOwnedColumn, NullableTable, OwnedTableError};
+use super::{ColumnField, NullableOwnedColumn, NullableTable, OwnedTableError};
 use crate::base::{map::IndexMap, scalar::Scalar};
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
@@ -64,6 +64,21 @@ impl<S: Scalar> NullableOwnedTable<S> {
     #[must_use]
     pub const fn inner_table(&self) -> &IndexMap<Ident, NullableOwnedColumn<S>> {
         &self.table
+    }
+
+    /// Return the schema of this table as a `Vec` of `ColumnField`s.
+    #[must_use]
+    pub fn schema(&self) -> Vec<ColumnField> {
+        self.table
+            .iter()
+            .map(|(name, column)| {
+                if column.is_nullable() {
+                    ColumnField::new_nullable(name.clone(), column.values().column_type())
+                } else {
+                    ColumnField::new(name.clone(), column.values().column_type())
+                }
+            })
+            .collect()
     }
 
     /// Returns the column names as an iterator.

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table.rs
@@ -1,5 +1,8 @@
-use super::{ColumnField, NullableOwnedColumn, NullableTable, OwnedTableError};
+use super::{
+    ColumnField, NullableOwnedColumn, NullableTable, OwnedColumn, OwnedTable, OwnedTableError,
+};
 use crate::base::{map::IndexMap, scalar::Scalar};
+use alloc::{format, vec::Vec};
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -91,6 +94,47 @@ impl<S: Scalar> NullableOwnedTable<S> {
     pub fn column_by_index(&self, index: usize) -> Option<&NullableOwnedColumn<S>> {
         self.table.get_index(index).map(|(_, v)| v)
     }
+
+    /// Returns the generated proof-column name for a nullable column's row-presence data.
+    #[must_use]
+    pub fn presence_column_name(column_name: &Ident) -> Ident {
+        Ident::new(format!("__posql_presence_{}", column_name.value))
+    }
+
+    /// Returns a non-null proof table with backing values plus presence columns for nullable data.
+    #[must_use]
+    pub fn values_and_presence_table(&self) -> OwnedTable<S> {
+        OwnedTable::try_from_iter(self.table.iter().flat_map(|(name, column)| {
+            let value_column = (name.clone(), column.values().clone());
+            let presence_column = column.presence().map(|presence| {
+                (
+                    Self::presence_column_name(name),
+                    OwnedColumn::Boolean(presence.to_vec()),
+                )
+            });
+            core::iter::once(value_column).chain(presence_column)
+        }))
+        .expect("Generated value and presence columns should have matching lengths")
+    }
+
+    /// Returns the schema for [`Self::values_and_presence_table`].
+    #[must_use]
+    pub fn values_and_presence_schema(&self) -> Vec<ColumnField> {
+        self.table
+            .iter()
+            .flat_map(|(name, column)| {
+                let value_field = if column.is_nullable() {
+                    ColumnField::new_nullable(name.clone(), column.values().column_type())
+                } else {
+                    ColumnField::new(name.clone(), column.values().column_type())
+                };
+                let presence_field = column.presence().map(|_| {
+                    ColumnField::new(Self::presence_column_name(name), super::ColumnType::Boolean)
+                });
+                core::iter::once(value_field).chain(presence_field)
+            })
+            .collect()
+    }
 }
 
 impl<S: Scalar> PartialEq for NullableOwnedTable<S> {
@@ -123,9 +167,19 @@ impl<S: Scalar> core::ops::Index<&str> for NullableOwnedTable<S> {
 mod tests {
     use super::*;
     use crate::base::{
-        database::{Column, NullableColumn, OwnedColumn},
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        database::{
+            owned_table_utility::{bigint, owned_table},
+            Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, OwnedColumn,
+            OwnedTableTestAccessor, TableRef,
+        },
         map::indexmap,
         scalar::test_scalar::TestScalar,
+    };
+    use crate::sql::{
+        proof::VerifiableQueryResult,
+        proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+        proof_plans::test_utility::{filter, table_exec},
     };
     use alloc::vec;
 
@@ -171,5 +225,91 @@ mod tests {
         );
         assert_eq!(owned.num_rows(), 2);
         assert_eq!(owned.num_columns(), 2);
+    }
+
+    #[test]
+    fn nullable_table_expands_to_values_and_presence_columns() {
+        let nullable_table = nullable_table_for_proof();
+
+        let proof_table = nullable_table.values_and_presence_table();
+        let proof_schema = nullable_table.values_and_presence_schema();
+
+        assert_eq!(
+            proof_table["amount"],
+            OwnedColumn::<TestScalar>::BigInt(vec![10, 0, 30, 50])
+        );
+        assert_eq!(
+            proof_table["__posql_presence_amount"],
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false, true, true])
+        );
+        assert_eq!(proof_schema.len(), 3);
+        assert!(proof_schema[1].is_nullable());
+        assert_eq!(
+            proof_schema[2].name(),
+            Ident::new("__posql_presence_amount")
+        );
+        assert_eq!(proof_schema[2].data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn nullable_presence_columns_can_drive_a_non_trivial_query_proof() {
+        let table_ref = TableRef::new("sxt", "nullable");
+        let nullable_table = nullable_table_for_proof();
+        let schema = nullable_table.values_and_presence_schema();
+        let proof_table = nullable_table.values_and_presence_table();
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            proof_table,
+            0,
+            (),
+        );
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), Ident::new("amount"), ColumnType::BigInt);
+        let amount_presence_ref = ColumnRef::new(
+            table_ref.clone(),
+            NullableOwnedTable::<TestScalar>::presence_column_name(&Ident::new("amount")),
+            ColumnType::Boolean,
+        );
+        let amount_gt_15 = DynProofExpr::try_new_inequality(
+            DynProofExpr::new_column(amount_ref.clone()),
+            DynProofExpr::new_literal(LiteralValue::BigInt(15)),
+            false,
+        )
+        .unwrap();
+        let where_clause =
+            DynProofExpr::try_new_and(DynProofExpr::new_column(amount_presence_ref), amount_gt_15)
+                .unwrap();
+        let plan = filter(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(amount_ref),
+                alias: Ident::new("amount"),
+            }],
+            table_exec(table_ref, schema),
+            where_clause,
+        );
+
+        let verifiable_result =
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+        let verified = verifiable_result
+            .verify(&plan, &accessor, &(), &[])
+            .unwrap();
+
+        assert_eq!(
+            verified.table,
+            owned_table([bigint("amount", [30_i64, 50])])
+        );
+    }
+
+    fn nullable_table_for_proof() -> NullableOwnedTable<TestScalar> {
+        NullableOwnedTable::try_new(indexmap! {
+            "id".into() => NullableOwnedColumn::new_nonnullable(
+                OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3, 4])
+            ),
+            "amount".into() => NullableOwnedColumn::try_new(
+                OwnedColumn::<TestScalar>::BigInt(vec![10, 0, 30, 50]),
+                Some(vec![true, false, true, true])
+            ).unwrap(),
+        })
+        .unwrap()
     }
 }

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table_test_accessor.rs
@@ -1,0 +1,296 @@
+use super::{
+    Column, ColumnField, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor,
+    NullableColumn, NullableDataAccessor, NullableOwnedTable, SchemaAccessor, TableRef,
+    TestAccessor,
+};
+use crate::base::{
+    commitment::{CommitmentEvaluationProof, VecCommitmentExt},
+    map::IndexMap,
+};
+use alloc::vec::Vec;
+use bumpalo::Bump;
+use sqlparser::ast::Ident;
+
+/// A test accessor that uses [`NullableOwnedTable`] as the underlying table type.
+///
+/// Note: this is intended for testing and examples. It is not optimized for
+/// performance, so should not be used for benchmarks or production use-cases.
+pub struct NullableOwnedTableTestAccessor<'a, CP: CommitmentEvaluationProof> {
+    tables: IndexMap<TableRef, (NullableOwnedTable<CP::Scalar>, usize)>,
+    alloc: Bump,
+    setup: Option<CP::ProverPublicSetup<'a>>,
+}
+
+impl<CP: CommitmentEvaluationProof> Default for NullableOwnedTableTestAccessor<'_, CP> {
+    fn default() -> Self {
+        Self {
+            tables: IndexMap::default(),
+            alloc: Bump::new(),
+            setup: None,
+        }
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> Clone for NullableOwnedTableTestAccessor<'_, CP> {
+    fn clone(&self) -> Self {
+        Self {
+            tables: self.tables.clone(),
+            setup: self.setup,
+            ..Default::default()
+        }
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> TestAccessor<CP::Commitment>
+    for NullableOwnedTableTestAccessor<'_, CP>
+{
+    type Table = NullableOwnedTable<CP::Scalar>;
+
+    fn new_empty() -> Self {
+        NullableOwnedTableTestAccessor::default()
+    }
+
+    fn add_table(&mut self, table_ref: TableRef, data: Self::Table, table_offset: usize) {
+        self.tables.insert(table_ref, (data, table_offset));
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`.
+    fn get_column_names(&self, table_ref: &TableRef) -> Vec<&str> {
+        self.tables
+            .get(&table_ref)
+            .unwrap()
+            .0
+            .column_names()
+            .map(|ident| ident.value.as_str())
+            .collect()
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`.
+    fn update_offset(&mut self, table_ref: &TableRef, new_offset: usize) {
+        self.tables.get_mut(&table_ref).unwrap().1 = new_offset;
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> NullableDataAccessor<CP::Scalar>
+    for NullableOwnedTableTestAccessor<'_, CP>
+{
+    /// # Panics
+    ///
+    /// Will panic if the table or column reference is missing.
+    fn get_nullable_column(
+        &self,
+        table_ref: &TableRef,
+        column_id: &Ident,
+    ) -> NullableColumn<'_, CP::Scalar> {
+        let owned_column = self
+            .tables
+            .get(table_ref)
+            .unwrap()
+            .0
+            .inner_table()
+            .get(column_id)
+            .unwrap();
+        NullableColumn::from_owned_column(owned_column, &self.alloc)
+            .expect("Nullable owned columns should borrow without length mismatches")
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar>
+    for NullableOwnedTableTestAccessor<'_, CP>
+{
+    fn get_column(&self, table_ref: &TableRef, column_id: &Ident) -> Column<'_, CP::Scalar> {
+        self.get_nullable_column(table_ref, column_id).values()
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> CommitmentAccessor<CP::Commitment>
+    for NullableOwnedTableTestAccessor<'_, CP>
+{
+    fn get_commitment(&self, table_ref: &TableRef, column_id: &Ident) -> CP::Commitment {
+        let (table, offset) = self.tables.get(table_ref).unwrap();
+        let nullable_owned_column = table.inner_table().get(column_id).unwrap();
+        Vec::<CP::Commitment>::from_columns_with_offset(
+            [nullable_owned_column.values()],
+            *offset,
+            self.setup.as_ref().unwrap(),
+        )[0]
+        .clone()
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> MetadataAccessor for NullableOwnedTableTestAccessor<'_, CP> {
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`.
+    fn get_length(&self, table_ref: &TableRef) -> usize {
+        self.tables.get(table_ref).unwrap().0.num_rows()
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`.
+    fn get_offset(&self, table_ref: &TableRef) -> usize {
+        self.tables.get(table_ref).unwrap().1
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> SchemaAccessor for NullableOwnedTableTestAccessor<'_, CP> {
+    fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
+        Some(
+            self.tables
+                .get(table_ref)?
+                .0
+                .inner_table()
+                .get(column_id)?
+                .values()
+                .column_type(),
+        )
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`.
+    fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
+        self.tables
+            .get(table_ref)
+            .unwrap()
+            .0
+            .inner_table()
+            .iter()
+            .map(|(id, col)| (id.clone(), col.values().column_type()))
+            .collect()
+    }
+
+    fn lookup_column_field(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnField> {
+        let column = self.tables.get(table_ref)?.0.inner_table().get(column_id)?;
+        Some(if column.is_nullable() {
+            ColumnField::new_nullable(column_id.clone(), column.values().column_type())
+        } else {
+            ColumnField::new(column_id.clone(), column.values().column_type())
+        })
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`.
+    fn lookup_column_fields(&self, table_ref: &TableRef) -> Vec<ColumnField> {
+        self.tables.get(table_ref).unwrap().0.schema()
+    }
+}
+
+impl<'a, CP: CommitmentEvaluationProof> NullableOwnedTableTestAccessor<'a, CP> {
+    /// Create a new empty test accessor with the given setup.
+    pub fn new_empty_with_setup(setup: CP::ProverPublicSetup<'a>) -> Self {
+        let mut res = Self::new_empty();
+        res.setup = Some(setup);
+        res
+    }
+
+    /// Create a new test accessor containing the provided table.
+    pub fn new_from_table(
+        table_ref: TableRef,
+        nullable_owned_table: NullableOwnedTable<CP::Scalar>,
+        offset: usize,
+        setup: CP::ProverPublicSetup<'a>,
+    ) -> Self {
+        let mut res = Self::new_empty_with_setup(setup);
+        res.add_table(table_ref, nullable_owned_table, offset);
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        database::{NullableOwnedColumn, OwnedColumn},
+        map::{indexmap, IndexSet},
+        scalar::test_scalar::TestScalar,
+    };
+
+    fn nullable_table() -> NullableOwnedTable<TestScalar> {
+        NullableOwnedTable::try_new(indexmap! {
+            "id".into() => NullableOwnedColumn::new_nonnullable(
+                OwnedColumn::<TestScalar>::BigInt(vec![1, 2, 3])
+            ),
+            "amount".into() => NullableOwnedColumn::try_new(
+                OwnedColumn::<TestScalar>::BigInt(vec![10, 0, 30]),
+                Some(vec![true, false, true])
+            ).unwrap(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn nullable_accessor_returns_values_and_presence() {
+        let table_ref = TableRef::new("sxt", "nullable");
+        let accessor = NullableOwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            nullable_table(),
+            0,
+            (),
+        );
+
+        let nullable_column = accessor.get_nullable_column(&table_ref, &"amount".into());
+
+        assert_eq!(nullable_column.values(), Column::BigInt(&[10, 0, 30]));
+        assert_eq!(nullable_column.presence(), Some(&[true, false, true][..]));
+        assert_eq!(
+            accessor.get_column(&table_ref, &"amount".into()),
+            Column::BigInt(&[10, 0, 30])
+        );
+    }
+
+    #[test]
+    fn nullable_accessor_builds_nullable_tables_from_column_ids() {
+        let table_ref = TableRef::new("sxt", "nullable");
+        let accessor = NullableOwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            nullable_table(),
+            0,
+            (),
+        );
+        let column_ids = IndexSet::from_iter(["id".into(), "amount".into()]);
+
+        let table = accessor.get_nullable_table(&table_ref, &column_ids);
+        let amount = table.inner_table().get(&Ident::new("amount")).unwrap();
+
+        assert_eq!(table.num_rows(), 3);
+        assert_eq!(amount.values(), Column::BigInt(&[10, 0, 30]));
+        assert_eq!(amount.presence(), Some(&[true, false, true][..]));
+    }
+
+    #[test]
+    fn nullable_accessor_preserves_nullable_schema_fields() {
+        let table_ref = TableRef::new("sxt", "nullable");
+        let accessor = NullableOwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            nullable_table(),
+            0,
+            (),
+        );
+
+        let amount_field = accessor
+            .lookup_column_field(&table_ref, &Ident::new("amount"))
+            .unwrap();
+        let fields = accessor.lookup_column_fields(&table_ref);
+
+        assert_eq!(amount_field.name(), Ident::new("amount"));
+        assert_eq!(amount_field.data_type(), ColumnType::BigInt);
+        assert!(amount_field.is_nullable());
+        assert!(!fields[0].is_nullable());
+        assert!(fields[1].is_nullable());
+        assert_eq!(
+            accessor.lookup_schema(&table_ref),
+            vec![
+                ("id".into(), ColumnType::BigInt),
+                ("amount".into(), ColumnType::BigInt)
+            ]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/nullable_owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_owned_table_test_accessor.rs
@@ -1,7 +1,7 @@
 use super::{
     Column, ColumnField, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor,
-    NullableColumn, NullableDataAccessor, NullableOwnedTable, SchemaAccessor, TableRef,
-    TestAccessor,
+    NullableColumn, NullableDataAccessor, NullableOwnedTable, OwnedColumn, SchemaAccessor,
+    TableRef, TestAccessor,
 };
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
@@ -103,7 +103,15 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar>
     for NullableOwnedTableTestAccessor<'_, CP>
 {
     fn get_column(&self, table_ref: &TableRef, column_id: &Ident) -> Column<'_, CP::Scalar> {
-        self.get_nullable_column(table_ref, column_id).values()
+        let table = &self.tables.get(table_ref).unwrap().0;
+        if let Some(owned_column) = table.inner_table().get(column_id) {
+            return Column::from_owned_column(owned_column.values(), &self.alloc);
+        }
+        let (presence, len) = presence_column(table, column_id).unwrap();
+        Column::Boolean(match presence {
+            Some(presence) => self.alloc.alloc_slice_copy(presence),
+            None => self.alloc.alloc_slice_fill_copy(len, true),
+        })
     }
 }
 
@@ -112,13 +120,25 @@ impl<CP: CommitmentEvaluationProof> CommitmentAccessor<CP::Commitment>
 {
     fn get_commitment(&self, table_ref: &TableRef, column_id: &Ident) -> CP::Commitment {
         let (table, offset) = self.tables.get(table_ref).unwrap();
-        let nullable_owned_column = table.inner_table().get(column_id).unwrap();
-        Vec::<CP::Commitment>::from_columns_with_offset(
-            [nullable_owned_column.values()],
-            *offset,
-            self.setup.as_ref().unwrap(),
-        )[0]
-        .clone()
+        if let Some(nullable_owned_column) = table.inner_table().get(column_id) {
+            Vec::<CP::Commitment>::from_columns_with_offset(
+                [nullable_owned_column.values()],
+                *offset,
+                self.setup.as_ref().unwrap(),
+            )[0]
+            .clone()
+        } else {
+            let (presence, len) = presence_column(table, column_id).unwrap();
+            let owned_presence = OwnedColumn::<CP::Scalar>::Boolean(
+                presence.map_or_else(|| alloc::vec![true; len], |presence| presence.to_vec()),
+            );
+            Vec::<CP::Commitment>::from_columns_with_offset(
+                [&owned_presence],
+                *offset,
+                self.setup.as_ref().unwrap(),
+            )[0]
+            .clone()
+        }
     }
 }
 
@@ -140,15 +160,12 @@ impl<CP: CommitmentEvaluationProof> MetadataAccessor for NullableOwnedTableTestA
 
 impl<CP: CommitmentEvaluationProof> SchemaAccessor for NullableOwnedTableTestAccessor<'_, CP> {
     fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
-        Some(
-            self.tables
-                .get(table_ref)?
-                .0
-                .inner_table()
-                .get(column_id)?
-                .values()
-                .column_type(),
-        )
+        let table = &self.tables.get(table_ref)?.0;
+        table
+            .inner_table()
+            .get(column_id)
+            .map(|column| column.values().column_type())
+            .or_else(|| presence_column(table, column_id).map(|_| ColumnType::Boolean))
     }
 
     /// # Panics
@@ -166,7 +183,11 @@ impl<CP: CommitmentEvaluationProof> SchemaAccessor for NullableOwnedTableTestAcc
     }
 
     fn lookup_column_field(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnField> {
-        let column = self.tables.get(table_ref)?.0.inner_table().get(column_id)?;
+        let table = &self.tables.get(table_ref)?.0;
+        if presence_column(table, column_id).is_some() {
+            return Some(ColumnField::new(column_id.clone(), ColumnType::Boolean));
+        }
+        let column = table.inner_table().get(column_id)?;
         Some(if column.is_nullable() {
             ColumnField::new_nullable(column_id.clone(), column.values().column_type())
         } else {
@@ -180,6 +201,16 @@ impl<CP: CommitmentEvaluationProof> SchemaAccessor for NullableOwnedTableTestAcc
     fn lookup_column_fields(&self, table_ref: &TableRef) -> Vec<ColumnField> {
         self.tables.get(table_ref).unwrap().0.schema()
     }
+}
+
+fn presence_column<'a, S: crate::base::scalar::Scalar>(
+    table: &'a NullableOwnedTable<S>,
+    presence_column_id: &Ident,
+) -> Option<(Option<&'a [bool]>, usize)> {
+    table.inner_table().iter().find_map(|(column_id, column)| {
+        (NullableOwnedTable::<S>::presence_column_name(column_id) == *presence_column_id)
+            .then(|| (column.presence(), column.len()))
+    })
 }
 
 impl<'a, CP: CommitmentEvaluationProof> NullableOwnedTableTestAccessor<'a, CP> {
@@ -208,7 +239,7 @@ mod tests {
     use super::*;
     use crate::base::{
         commitment::naive_evaluation_proof::NaiveEvaluationProof,
-        database::{NullableOwnedColumn, OwnedColumn},
+        database::{ColumnRef, NullableOwnedColumn, OwnedColumn},
         map::{indexmap, IndexSet},
         scalar::test_scalar::TestScalar,
     };
@@ -243,6 +274,13 @@ mod tests {
         assert_eq!(
             accessor.get_column(&table_ref, &"amount".into()),
             Column::BigInt(&[10, 0, 30])
+        );
+        assert_eq!(
+            accessor.get_column(
+                &table_ref,
+                &ColumnRef::presence_column_id(&Ident::new("amount"))
+            ),
+            Column::Boolean(&[true, false, true])
         );
     }
 
@@ -291,6 +329,20 @@ mod tests {
                 ("id".into(), ColumnType::BigInt),
                 ("amount".into(), ColumnType::BigInt)
             ]
+        );
+
+        let presence_field = accessor
+            .lookup_column_field(
+                &table_ref,
+                &ColumnRef::presence_column_id(&Ident::new("amount")),
+            )
+            .unwrap();
+        assert_eq!(
+            presence_field,
+            ColumnField::new(
+                ColumnRef::presence_column_id(&Ident::new("amount")),
+                ColumnType::Boolean
+            )
         );
     }
 }

--- a/crates/proof-of-sql/src/base/database/nullable_table.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_table.rs
@@ -1,0 +1,192 @@
+use super::{ColumnField, NullableColumn, NullableOwnedTable, TableError, TableOptions};
+use crate::base::{database::OwnedColumn, map::IndexMap, scalar::Scalar};
+use alloc::vec::Vec;
+use sqlparser::ast::Ident;
+
+/// A borrowed table whose columns can carry nullable row-presence data.
+#[derive(Debug, Clone, Eq)]
+pub struct NullableTable<'a, S: Scalar> {
+    table: IndexMap<Ident, NullableColumn<'a, S>>,
+    row_count: usize,
+}
+
+impl<'a, S: Scalar> NullableTable<'a, S> {
+    /// Creates a new [`NullableTable`] with default [`TableOptions`].
+    pub fn try_new(table: IndexMap<Ident, NullableColumn<'a, S>>) -> Result<Self, TableError> {
+        Self::try_new_with_options(table, TableOptions::default())
+    }
+
+    /// Creates a new [`NullableTable`] with explicit [`TableOptions`].
+    pub fn try_new_with_options(
+        table: IndexMap<Ident, NullableColumn<'a, S>>,
+        options: TableOptions,
+    ) -> Result<Self, TableError> {
+        match (table.is_empty(), options.row_count) {
+            (true, None) => Err(TableError::EmptyTableWithoutSpecifiedRowCount),
+            (true, Some(row_count)) => Ok(Self { table, row_count }),
+            (false, None) => {
+                let row_count = table[0].len();
+                if table.values().any(|column| column.len() != row_count) {
+                    Err(TableError::ColumnLengthMismatch)
+                } else {
+                    Ok(Self { table, row_count })
+                }
+            }
+            (false, Some(row_count)) => {
+                if table.values().any(|column| column.len() != row_count) {
+                    Err(TableError::ColumnLengthMismatchWithSpecifiedRowCount)
+                } else {
+                    Ok(Self { table, row_count })
+                }
+            }
+        }
+    }
+
+    /// Creates a new [`NullableTable`] from an iterator of `(Ident, NullableColumn)` pairs.
+    pub fn try_from_iter<T: IntoIterator<Item = (Ident, NullableColumn<'a, S>)>>(
+        iter: T,
+    ) -> Result<Self, TableError> {
+        Self::try_from_iter_with_options(iter, TableOptions::default())
+    }
+
+    /// Creates a new [`NullableTable`] from an iterator and explicit [`TableOptions`].
+    pub fn try_from_iter_with_options<T: IntoIterator<Item = (Ident, NullableColumn<'a, S>)>>(
+        iter: T,
+        options: TableOptions,
+    ) -> Result<Self, TableError> {
+        Self::try_new_with_options(IndexMap::from_iter(iter), options)
+    }
+
+    /// Number of columns in the table.
+    #[must_use]
+    pub fn num_columns(&self) -> usize {
+        self.table.len()
+    }
+
+    /// Number of rows in the table.
+    #[must_use]
+    pub const fn num_rows(&self) -> usize {
+        self.row_count
+    }
+
+    /// Whether the table has no columns.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
+    /// Returns the columns of this table.
+    #[must_use]
+    pub fn into_inner(self) -> IndexMap<Ident, NullableColumn<'a, S>> {
+        self.table
+    }
+
+    /// Returns the columns of this table by reference.
+    #[must_use]
+    pub const fn inner_table(&self) -> &IndexMap<Ident, NullableColumn<'a, S>> {
+        &self.table
+    }
+
+    /// Return the schema of this table as a `Vec` of `ColumnField`s.
+    #[must_use]
+    pub fn schema(&self) -> Vec<ColumnField> {
+        self.table
+            .iter()
+            .map(|(name, column)| {
+                if column.is_nullable() {
+                    ColumnField::new_nullable(name.clone(), column.values().column_type())
+                } else {
+                    ColumnField::new(name.clone(), column.values().column_type())
+                }
+            })
+            .collect()
+    }
+
+    /// Returns the column names as an iterator.
+    pub fn column_names(&self) -> impl Iterator<Item = &Ident> {
+        self.table.keys()
+    }
+
+    /// Returns the columns as an iterator.
+    pub fn columns(&self) -> impl Iterator<Item = &NullableColumn<'a, S>> {
+        self.table.values()
+    }
+
+    /// Returns the column with the given position.
+    #[must_use]
+    pub fn column(&self, index: usize) -> Option<&NullableColumn<'a, S>> {
+        self.table.values().nth(index)
+    }
+}
+
+impl<S: Scalar> PartialEq for NullableTable<'_, S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.table == other.table
+            && self
+                .table
+                .keys()
+                .zip(other.table.keys())
+                .all(|(a, b)| a == b)
+    }
+}
+
+impl<'a, S: Scalar> From<&NullableTable<'a, S>> for NullableOwnedTable<S> {
+    fn from(value: &NullableTable<'a, S>) -> Self {
+        NullableOwnedTable::try_from_iter(value.inner_table().iter().map(|(name, column)| {
+            let values = column.values();
+            (
+                name.clone(),
+                super::NullableOwnedColumn::try_new(
+                    OwnedColumn::from(&values),
+                    column.presence().map(<[bool]>::to_vec),
+                )
+                .expect("Nullable columns should have matching value and presence lengths"),
+            )
+        }))
+        .expect("Tables should not have columns with differing lengths")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        database::{Column, ColumnType},
+        map::indexmap,
+        scalar::test_scalar::TestScalar,
+    };
+
+    #[test]
+    fn nullable_table_schema_marks_nullable_columns() {
+        let table = NullableTable::try_new(indexmap! {
+            "id".into() => NullableColumn::<TestScalar>::new_nonnullable(Column::BigInt(&[1, 2])),
+            "amount".into() => NullableColumn::<TestScalar>::try_new(
+                Column::BigInt(&[10, 20]),
+                Some(&[true, false])
+            ).unwrap(),
+        })
+        .unwrap();
+
+        let schema = table.schema();
+
+        assert_eq!(schema[0].name(), "id".into());
+        assert_eq!(schema[0].data_type(), ColumnType::BigInt);
+        assert!(!schema[0].is_nullable());
+        assert_eq!(schema[1].name(), "amount".into());
+        assert_eq!(schema[1].data_type(), ColumnType::BigInt);
+        assert!(schema[1].is_nullable());
+    }
+
+    #[test]
+    fn nullable_table_rejects_column_length_mismatches() {
+        let result = NullableTable::try_new(indexmap! {
+            "id".into() => NullableColumn::<TestScalar>::new_nonnullable(Column::BigInt(&[1, 2])),
+            "amount".into() => NullableColumn::<TestScalar>::try_new(
+                Column::BigInt(&[10]),
+                Some(&[true])
+            ).unwrap(),
+        });
+
+        assert_eq!(result, Err(TableError::ColumnLengthMismatch));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -15,6 +15,12 @@ pub enum OwnedTableError {
     /// The columns have different lengths.
     #[snafu(display("Columns have different lengths"))]
     ColumnLengthMismatch,
+    /// A user-provided column collides with an internally generated column name.
+    #[snafu(display("Column name {column} collides with an internally generated column"))]
+    GeneratedColumnNameCollision {
+        /// Column name that is reserved by generated physical columns.
+        column: Ident,
+    },
 }
 
 /// Errors that can occur when coercing a table.

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -1,6 +1,6 @@
 use super::{
-    Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedColumn,
-    OwnedTable, SchemaAccessor, TableRef, TestAccessor,
+    Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, NullableColumn,
+    NullableDataAccessor, OwnedColumn, OwnedTable, SchemaAccessor, TableRef, TestAccessor,
 };
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
@@ -128,6 +128,18 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
             }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col),
         }
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> NullableDataAccessor<CP::Scalar>
+    for OwnedTableTestAccessor<'_, CP>
+{
+    fn get_nullable_column(
+        &self,
+        table_ref: &TableRef,
+        column_id: &Ident,
+    ) -> NullableColumn<'_, CP::Scalar> {
+        NullableColumn::new_nonnullable(self.get_column(table_ref, column_id))
     }
 }
 

--- a/crates/proof-of-sql/src/base/database/table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor.rs
@@ -1,6 +1,6 @@
 use super::{
-    Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor, Table,
-    TableRef, TestAccessor,
+    Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, NullableColumn,
+    NullableDataAccessor, SchemaAccessor, Table, TableRef, TestAccessor,
 };
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
@@ -84,6 +84,16 @@ impl<'a, CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for TableTestAc
             .inner_table()
             .get(column_id)
             .unwrap()
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> NullableDataAccessor<CP::Scalar> for TableTestAccessor<'_, CP> {
+    fn get_nullable_column(
+        &self,
+        table_ref: &TableRef,
+        column_id: &Ident,
+    ) -> NullableColumn<'_, CP::Scalar> {
+        NullableColumn::new_nonnullable(self.get_column(table_ref, column_id))
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -44,7 +44,9 @@ pub use query_proof::QueryProof;
 mod query_proof_test;
 
 mod query_result;
-pub use query_result::{QueryData, QueryError, QueryResult};
+pub use query_result::{
+    NullableQueryData, NullableQueryResult, QueryData, QueryError, QueryResult,
+};
 
 mod sumcheck_subpolynomial;
 pub(crate) use sumcheck_subpolynomial::{

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -25,6 +25,11 @@ pub trait ProofPlan: Debug + Send + Sync + ProverEvaluate {
     /// Return all the result column fields
     fn get_column_result_fields(&self) -> Vec<ColumnField>;
 
+    /// Return the physical result fields, expanding nullable logical results with presence fields.
+    fn get_column_result_fields_with_presence(&self) -> Vec<ColumnField> {
+        ColumnField::value_and_presence_fields(self.get_column_result_fields())
+    }
+
     /// Return all the columns referenced in the Query
     fn get_column_references(&self) -> IndexSet<ColumnRef>;
 

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -1,6 +1,9 @@
 use super::{decode_and_convert, decode_multiple_elements, ProvableResultColumn, QueryError};
 use crate::base::{
-    database::{Column, ColumnField, ColumnType, OwnedColumn, OwnedTable, Table},
+    database::{
+        Column, ColumnField, ColumnRef, ColumnType, NullableOwnedTable, OwnedColumn, OwnedTable,
+        Table,
+    },
     polynomial::compute_evaluation_vector,
     scalar::{Scalar, ScalarExt},
 };
@@ -237,6 +240,20 @@ impl ProvableQueryResult {
 
         Ok(owned_table)
     }
+
+    /// Convert a physical value-plus-presence result into a nullable owned table.
+    pub fn to_nullable_owned_table<S: Scalar>(
+        &self,
+        column_result_fields: &[ColumnField],
+    ) -> Result<NullableOwnedTable<S>, QueryError> {
+        let physical_fields = nullable_physical_result_fields(column_result_fields);
+        let values_and_presence_table = self.to_owned_table(&physical_fields)?;
+        NullableOwnedTable::try_from_values_and_presence_table_with_fields(
+            values_and_presence_table,
+            column_result_fields.iter().cloned(),
+        )
+        .map_err(Into::into)
+    }
 }
 
 impl<S: Scalar> From<Table<'_, S>> for ProvableQueryResult {
@@ -249,4 +266,18 @@ impl<S: Scalar> From<Table<'_, S>> for ProvableQueryResult {
             .collect::<Vec<_>>();
         Self::new(num_rows as u64, &columns)
     }
+}
+
+fn nullable_physical_result_fields(column_result_fields: &[ColumnField]) -> Vec<ColumnField> {
+    column_result_fields
+        .iter()
+        .flat_map(|field| {
+            let value_field = field.clone();
+            let presence_field = field.is_nullable().then(|| {
+                let name = field.name();
+                ColumnField::new(ColumnRef::presence_column_id(&name), ColumnType::Boolean)
+            });
+            core::iter::once(value_field).chain(presence_field)
+        })
+        .collect()
 }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -1,8 +1,7 @@
 use super::{decode_and_convert, decode_multiple_elements, ProvableResultColumn, QueryError};
 use crate::base::{
     database::{
-        Column, ColumnField, ColumnRef, ColumnType, NullableOwnedTable, OwnedColumn, OwnedTable,
-        Table,
+        Column, ColumnField, ColumnType, NullableOwnedTable, OwnedColumn, OwnedTable, Table,
     },
     polynomial::compute_evaluation_vector,
     scalar::{Scalar, ScalarExt},
@@ -246,7 +245,8 @@ impl ProvableQueryResult {
         &self,
         column_result_fields: &[ColumnField],
     ) -> Result<NullableOwnedTable<S>, QueryError> {
-        let physical_fields = nullable_physical_result_fields(column_result_fields);
+        let physical_fields =
+            ColumnField::value_and_presence_fields(column_result_fields.iter().cloned());
         let values_and_presence_table = self.to_owned_table(&physical_fields)?;
         NullableOwnedTable::try_from_values_and_presence_table_with_fields(
             values_and_presence_table,
@@ -266,18 +266,4 @@ impl<S: Scalar> From<Table<'_, S>> for ProvableQueryResult {
             .collect::<Vec<_>>();
         Self::new(num_rows as u64, &columns)
     }
-}
-
-fn nullable_physical_result_fields(column_result_fields: &[ColumnField]) -> Vec<ColumnField> {
-    column_result_fields
-        .iter()
-        .flat_map(|field| {
-            let value_field = field.clone();
-            let presence_field = field.is_nullable().then(|| {
-                let name = field.name();
-                ColumnField::new(ColumnRef::presence_column_id(&name), ColumnType::Boolean)
-            });
-            core::iter::once(value_field).chain(presence_field)
-        })
-        .collect()
 }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -1,5 +1,8 @@
 use super::{ProvableQueryResult, QueryError};
-use crate::base::scalar::test_scalar::TestScalar;
+use crate::base::{
+    database::{NullableOwnedColumn, OwnedColumn},
+    scalar::test_scalar::TestScalar,
+};
 use crate::{
     base::{
         database::{Column, ColumnField, ColumnType},
@@ -11,7 +14,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 use arrow::{
-    array::{Decimal128Array, Decimal256Array, Int64Array, LargeBinaryArray, StringArray},
+    array::{Array, Decimal128Array, Decimal256Array, Int64Array, LargeBinaryArray, StringArray},
     datatypes::{i256, Field, Schema},
     record_batch::RecordBatch,
 };
@@ -225,6 +228,65 @@ fn we_can_convert_a_provable_result_to_a_final_result() {
     let expected_res =
         RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![10, 12]))]).unwrap();
     assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_convert_a_provable_result_to_a_nullable_owned_table() {
+    let amount_values = [10_i64, 0, 30];
+    let amount_presence = [true, false, true];
+    let ids = [1_i64, 2, 3];
+    let cols: [Column<TestScalar>; 3] = [
+        Column::BigInt(&amount_values),
+        Column::Boolean(&amount_presence),
+        Column::BigInt(&ids),
+    ];
+    let res = ProvableQueryResult::new(3, &cols);
+    let column_fields = vec![
+        ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+        ColumnField::new("id".into(), ColumnType::BigInt),
+    ];
+
+    let nullable_table = res
+        .to_nullable_owned_table::<TestScalar>(&column_fields)
+        .unwrap();
+
+    assert_eq!(
+        nullable_table["amount"],
+        NullableOwnedColumn::try_new(
+            OwnedColumn::BigInt(vec![10, 0, 30]),
+            Some(vec![true, false, true]),
+        )
+        .unwrap()
+    );
+    assert_eq!(
+        nullable_table["id"],
+        NullableOwnedColumn::new_nonnullable(OwnedColumn::BigInt(vec![1, 2, 3]))
+    );
+
+    let record_batch = RecordBatch::try_from(nullable_table).unwrap();
+    let amount = record_batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(amount.value(0), 10);
+    assert!(amount.is_null(1));
+    assert_eq!(amount.value(2), 30);
+}
+
+#[test]
+fn nullable_result_requires_presence_column() {
+    let cols: [Column<TestScalar>; 1] = [Column::BigInt(&[10, 0])];
+    let res = ProvableQueryResult::new(2, &cols);
+    let column_fields = vec![ColumnField::new_nullable(
+        "amount".into(),
+        ColumnType::BigInt,
+    )];
+
+    assert!(matches!(
+        res.to_nullable_owned_table::<TestScalar>(&column_fields),
+        Err(QueryError::InvalidColumnCount)
+    ));
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -1,5 +1,7 @@
 use crate::base::{
-    database::{ColumnCoercionError, OwnedTable, OwnedTableError, TableCoercionError},
+    database::{
+        ColumnCoercionError, NullableOwnedTable, OwnedTable, OwnedTableError, TableCoercionError,
+    },
     proof::ProofError,
     scalar::Scalar,
 };
@@ -69,3 +71,14 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+/// The verified nullable results of a query along with metadata produced by verification.
+pub struct NullableQueryData<S: Scalar> {
+    /// Query result reassembled from physical value-plus-presence columns.
+    pub table: NullableOwnedTable<S>,
+    /// A 32-byte verification hash included with this table.
+    pub verification_hash: [u8; 32],
+}
+
+/// The nullable result of a query -- either an error or a nullable table.
+pub type NullableQueryResult<S> = Result<NullableQueryData<S>, QueryError>;

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -1,12 +1,20 @@
-use super::{ProofPlan, QueryData, QueryProof, QueryResult};
+use super::{
+    NullableQueryData, NullableQueryResult, ProofPlan, QueryData, QueryProof, QueryResult,
+};
 use crate::{
     base::{
         commitment::CommitmentEvaluationProof,
-        database::{CommitmentAccessor, DataAccessor, LiteralValue, OwnedTable},
+        database::{
+            ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, LiteralValue,
+            NullableOwnedTable, OwnedTable,
+        },
         proof::PlaceholderResult,
+        scalar::Scalar,
     },
+    sql::proof::QueryError,
     utils::log,
 };
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 /// The result of an sql query along with a proof that the query is valid. The
@@ -97,7 +105,9 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
     /// Note: a verified result can still respresent an error (e.g. overflow), but it is a verified
     /// error.
     ///
-    /// Note: This does NOT transform the result!
+    /// Nullable results are verified against their physical value-plus-presence columns, then
+    /// returned as the compatibility value-only [`OwnedTable`]. Use [`Self::verify_nullable`] to
+    /// preserve nullable presence data.
     #[tracing::instrument(name = "VerifiableQueryResult::verify", level = "info", skip_all)]
     pub fn verify(
         self,
@@ -114,8 +124,76 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
             .proof
             .verify(expr, accessor, self.result, setup, params)?;
         Ok(QueryData {
-            table: table.try_coerce_with_fields(expr.get_column_result_fields())?,
+            table: coerce_physical_table_to_logical_values(
+                table,
+                expr.get_column_result_fields(),
+                expr.get_column_result_fields_with_presence(),
+            )?,
             verification_hash,
         })
     }
+
+    /// Verify a `VerifiableQueryResult` and return nullable columns reassembled from the
+    /// physical value-plus-presence result.
+    #[tracing::instrument(
+        name = "VerifiableQueryResult::verify_nullable",
+        level = "info",
+        skip_all
+    )]
+    pub fn verify_nullable(
+        self,
+        expr: &(impl ProofPlan + Serialize),
+        accessor: &impl CommitmentAccessor<CP::Commitment>,
+        setup: &CP::VerifierPublicSetup<'_>,
+        params: &[LiteralValue],
+    ) -> NullableQueryResult<CP::Scalar> {
+        log::log_memory_usage("Start");
+        let QueryData {
+            table,
+            verification_hash,
+        } = self
+            .proof
+            .verify(expr, accessor, self.result, setup, params)?;
+        let physical_table =
+            table.try_coerce_with_fields(expr.get_column_result_fields_with_presence())?;
+        let result = NullableQueryData {
+            table: NullableOwnedTable::try_from_values_and_presence_table_with_fields(
+                physical_table,
+                expr.get_column_result_fields(),
+            )?,
+            verification_hash,
+        };
+        log::log_memory_usage("End");
+        Ok(result)
+    }
+}
+
+fn coerce_physical_table_to_logical_values<S: Scalar>(
+    table: OwnedTable<S>,
+    logical_fields: Vec<ColumnField>,
+    physical_fields: Vec<ColumnField>,
+) -> Result<OwnedTable<S>, QueryError> {
+    let mut physical_columns = table
+        .try_coerce_with_fields(physical_fields)?
+        .into_inner()
+        .into_iter();
+    let logical_columns = logical_fields
+        .into_iter()
+        .map(|field| {
+            let (name, column) = physical_columns
+                .next()
+                .expect("Coerced physical table should include every logical value column");
+            debug_assert_eq!(name, field.name());
+            if field.is_nullable() {
+                let (presence_name, _) = physical_columns
+                    .next()
+                    .expect("Coerced physical table should include nullable presence columns");
+                debug_assert_eq!(presence_name, ColumnRef::presence_column_id(&name));
+            }
+            Ok((name, column))
+        })
+        .collect::<Result<Vec<_>, QueryError>>()?;
+    debug_assert!(physical_columns.next().is_none());
+
+    Ok(OwnedTable::try_from_iter(logical_columns)?)
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -1,4 +1,5 @@
 use super::DynProofExpr;
+use crate::base::database::ColumnField;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -9,4 +10,13 @@ pub struct AliasedDynProofExpr {
     pub expr: DynProofExpr,
     /// The alias for the expression.
     pub alias: Ident,
+}
+
+impl AliasedDynProofExpr {
+    /// Return the result field exposed by this aliased expression.
+    #[must_use]
+    pub(crate) fn result_field(&self) -> ColumnField {
+        self.expr
+            .nullable_propagating_result_field(self.alias.clone())
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -1,5 +1,6 @@
 use super::DynProofExpr;
-use crate::base::database::ColumnField;
+use crate::base::database::{ColumnField, ColumnRef, LiteralValue};
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
@@ -18,5 +19,24 @@ impl AliasedDynProofExpr {
     pub(crate) fn result_field(&self) -> ColumnField {
         self.expr
             .nullable_propagating_result_field(self.alias.clone())
+    }
+
+    /// Return the physical value-plus-presence expressions for this aliased result.
+    #[must_use]
+    pub(crate) fn physical_result_exprs(&self) -> Vec<Self> {
+        let mut exprs = Vec::with_capacity(2);
+        exprs.push(self.clone());
+
+        if self.result_field().is_nullable() {
+            exprs.push(Self {
+                expr: self
+                    .expr
+                    .nullable_result_presence_expr()
+                    .unwrap_or_else(|| DynProofExpr::new_literal(LiteralValue::Boolean(true))),
+                alias: ColumnRef::presence_column_id(&self.alias),
+            });
+        }
+
+        exprs
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -41,7 +41,7 @@ impl ColumnExpr {
     /// Wrap the column output name and its type within the [`ColumnField`]
     #[must_use]
     pub fn get_column_field(&self) -> ColumnField {
-        ColumnField::new(self.column_ref.column_id(), *self.column_ref.column_type())
+        self.column_ref.column_field()
     }
 
     /// Get the column identifier

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -57,6 +57,34 @@ impl DynProofExpr {
     pub fn new_column(column_ref: ColumnRef) -> Self {
         Self::Column(ColumnExpr::new(column_ref))
     }
+
+    /// Create a SQL `IS NULL` expression for a column reference.
+    ///
+    /// Nullable columns are represented by their generated row-presence column.
+    /// Non-nullable columns fold to constant `false`.
+    #[must_use]
+    pub fn new_is_null(column_ref: ColumnRef) -> Self {
+        if column_ref.is_nullable() {
+            Self::try_new_not(Self::new_column(column_ref.presence_column_ref()))
+                .expect("Presence columns are boolean")
+        } else {
+            Self::new_literal(LiteralValue::Boolean(false))
+        }
+    }
+
+    /// Create a SQL `IS NOT NULL` expression for a column reference.
+    ///
+    /// Nullable columns are represented by their generated row-presence column.
+    /// Non-nullable columns fold to constant `true`.
+    #[must_use]
+    pub fn new_is_not_null(column_ref: ColumnRef) -> Self {
+        if column_ref.is_nullable() {
+            Self::new_column(column_ref.presence_column_ref())
+        } else {
+            Self::new_literal(LiteralValue::Boolean(true))
+        }
+    }
+
     /// Create logical AND expression
     pub fn try_new_and(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         AndExpr::try_new(Box::new(lhs), Box::new(rhs)).map(DynProofExpr::And)
@@ -120,5 +148,48 @@ impl DynProofExpr {
         to_datatype: ColumnType,
     ) -> AnalyzeResult<Self> {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::{ColumnRef, ColumnType, TableRef};
+
+    #[test]
+    fn is_null_builders_target_presence_columns_for_nullable_refs() {
+        let column_ref = ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(
+            DynProofExpr::new_is_not_null(column_ref.clone()),
+            DynProofExpr::new_column(column_ref.presence_column_ref())
+        );
+        assert_eq!(
+            DynProofExpr::new_is_null(column_ref.clone()),
+            DynProofExpr::try_new_not(DynProofExpr::new_column(column_ref.presence_column_ref()))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn is_null_builders_fold_constants_for_non_nullable_refs() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(
+            DynProofExpr::new_is_null(column_ref.clone()),
+            DynProofExpr::new_literal(LiteralValue::Boolean(false))
+        );
+        assert_eq!(
+            DynProofExpr::new_is_not_null(column_ref),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true))
+        );
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -11,10 +11,10 @@ use crate::{
     },
     sql::{
         proof::{FinalRoundBuilder, VerificationBuilder},
-        AnalyzeResult,
+        AnalyzeError, AnalyzeResult,
     },
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
@@ -82,6 +82,29 @@ impl DynProofExpr {
             Self::new_column(column_ref.presence_column_ref())
         } else {
             Self::new_literal(LiteralValue::Boolean(true))
+        }
+    }
+
+    /// Create a SQL `IS TRUE` expression for a boolean column reference.
+    ///
+    /// Nullable boolean columns are true only when the value is true and the row
+    /// is present. Non-nullable boolean columns are already two-valued.
+    pub fn try_new_is_true(column_ref: ColumnRef) -> AnalyzeResult<Self> {
+        if column_ref.column_type() != &ColumnType::Boolean {
+            return Err(AnalyzeError::DataTypeMismatch {
+                left_type: column_ref.column_type().to_string(),
+                right_type: ColumnType::Boolean.to_string(),
+            });
+        }
+
+        let value_expr = Self::new_column(column_ref.clone());
+        if column_ref.is_nullable() {
+            Self::try_new_and(
+                value_expr,
+                Self::new_column(column_ref.presence_column_ref()),
+            )
+        } else {
+            Ok(value_expr)
         }
     }
 
@@ -191,5 +214,48 @@ mod tests {
             DynProofExpr::new_is_not_null(column_ref),
             DynProofExpr::new_literal(LiteralValue::Boolean(true))
         );
+    }
+
+    #[test]
+    fn is_true_builder_ands_value_with_presence_for_nullable_boolean_refs() {
+        let column_ref = ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "is_paid".into(),
+            ColumnType::Boolean,
+        );
+
+        assert_eq!(
+            DynProofExpr::try_new_is_true(column_ref.clone()).unwrap(),
+            DynProofExpr::try_new_and(
+                DynProofExpr::new_column(column_ref.clone()),
+                DynProofExpr::new_column(column_ref.presence_column_ref()),
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn is_true_builder_keeps_non_nullable_boolean_refs_direct() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            "is_paid".into(),
+            ColumnType::Boolean,
+        );
+
+        assert_eq!(
+            DynProofExpr::try_new_is_true(column_ref.clone()).unwrap(),
+            DynProofExpr::new_column(column_ref)
+        );
+    }
+
+    #[test]
+    fn is_true_builder_rejects_non_boolean_refs() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert!(DynProofExpr::try_new_is_true(column_ref).is_err());
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -56,6 +56,140 @@ impl DynProofExpr {
     #[must_use]
     pub fn new_column(column_ref: ColumnRef) -> Self {
         Self::Column(ColumnExpr::new(column_ref))
+    }
+
+    /// Evaluate expressions whose SQL nullability is simple operand-presence propagation.
+    ///
+    /// This returns `None` for expressions such as `AND` / `OR`, where PostgreSQL
+    /// three-valued boolean result nullability depends on both values and
+    /// presence rather than just operand presence.
+    pub fn first_round_evaluate_nullable_propagating<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Option<NullableColumn<'a, S>>> {
+        let values = self.first_round_evaluate(alloc, table, params)?;
+        let result = match self {
+            Self::Column(column) => {
+                let presence = column.column_ref().is_nullable().then(|| {
+                    let presence_column_id = column.column_ref().presence_column_ref().column_id();
+                    match table
+                        .inner_table()
+                        .get(&presence_column_id)
+                        .expect("Nullable column presence data should be available")
+                    {
+                        Column::Boolean(presence) => *presence,
+                        _ => panic!("Nullable column presence data should be boolean"),
+                    }
+                });
+                Some(
+                    NullableColumn::try_new(values, presence)
+                        .expect("Nullable column values and presence should match"),
+                )
+            }
+            Self::Literal(_) | Self::Placeholder(_) => {
+                Some(NullableColumn::new_nonnullable(values))
+            }
+            Self::Add(expr) => Self::nullable_binary_first_round_result(
+                values,
+                expr.lhs(),
+                expr.rhs(),
+                alloc,
+                table,
+                params,
+            )?,
+            Self::Subtract(expr) => Self::nullable_binary_first_round_result(
+                values,
+                expr.lhs(),
+                expr.rhs(),
+                alloc,
+                table,
+                params,
+            )?,
+            Self::Multiply(expr) => Self::nullable_binary_first_round_result(
+                values,
+                expr.lhs(),
+                expr.rhs(),
+                alloc,
+                table,
+                params,
+            )?,
+            Self::Equals(expr) => Self::nullable_binary_first_round_result(
+                values,
+                expr.lhs(),
+                expr.rhs(),
+                alloc,
+                table,
+                params,
+            )?,
+            Self::Inequality(expr) => Self::nullable_binary_first_round_result(
+                values,
+                expr.lhs(),
+                expr.rhs(),
+                alloc,
+                table,
+                params,
+            )?,
+            Self::Not(expr) => {
+                Self::nullable_unary_first_round_result(values, expr.input(), alloc, table, params)?
+            }
+            Self::Cast(expr) => Self::nullable_unary_first_round_result(
+                values,
+                expr.get_from_expr(),
+                alloc,
+                table,
+                params,
+            )?,
+            Self::ScalingCast(expr) => Self::nullable_unary_first_round_result(
+                values,
+                expr.get_from_expr(),
+                alloc,
+                table,
+                params,
+            )?,
+            Self::And(_) | Self::Or(_) => None,
+        };
+        Ok(result)
+    }
+
+    fn nullable_binary_first_round_result<'a, S: Scalar>(
+        values: Column<'a, S>,
+        lhs: &Self,
+        rhs: &Self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Option<NullableColumn<'a, S>>> {
+        let Some(lhs) = lhs.first_round_evaluate_nullable_propagating(alloc, table, params)? else {
+            return Ok(None);
+        };
+        let Some(rhs) = rhs.first_round_evaluate_nullable_propagating(alloc, table, params)? else {
+            return Ok(None);
+        };
+        Ok(Some(
+            NullableColumn::try_new(
+                values,
+                lhs.propagated_binary_presence(&rhs, alloc)
+                    .expect("Nullable operand lengths should match"),
+            )
+            .expect("Nullable expression values and presence should match"),
+        ))
+    }
+
+    fn nullable_unary_first_round_result<'a, S: Scalar>(
+        values: Column<'a, S>,
+        input: &Self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Option<NullableColumn<'a, S>>> {
+        Ok(input
+            .first_round_evaluate_nullable_propagating(alloc, table, params)?
+            .map(|input| {
+                NullableColumn::try_new(values, input.presence())
+                    .expect("Nullable expression values and presence should match")
+            }))
     }
 
     /// Create a SQL `IS NULL` expression for a column reference.
@@ -200,7 +334,11 @@ impl DynProofExpr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::{ColumnRef, ColumnType, TableRef};
+    use crate::base::{
+        database::{table_utility::*, Column, ColumnRef, ColumnType, Table, TableRef},
+        scalar::test_scalar::TestScalar,
+    };
+    use bumpalo::Bump;
 
     #[test]
     fn is_null_builders_target_presence_columns_for_nullable_refs() {
@@ -323,5 +461,91 @@ mod tests {
         );
 
         assert!(DynProofExpr::try_new_is_false(column_ref).is_err());
+    }
+
+    #[test]
+    fn nullable_first_round_evaluation_reads_generated_presence_columns() {
+        let alloc = Bump::new();
+        let table = nullable_test_table(&alloc);
+        let amount_ref = nullable_amount_ref();
+
+        let result = DynProofExpr::new_column(amount_ref)
+            .first_round_evaluate_nullable_propagating(&alloc, &table, &[])
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.values(), Column::BigInt(&[10, 20, 30]));
+        assert_eq!(result.presence(), Some([true, false, true].as_slice()));
+    }
+
+    #[test]
+    fn nullable_first_round_evaluation_propagates_arithmetic_comparison_presence() {
+        let alloc = Bump::new();
+        let table = nullable_test_table(&alloc);
+        let amount_ref = nullable_amount_ref();
+        let fee_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            "fee".into(),
+            ColumnType::BigInt,
+        );
+        let amount_plus_fee = DynProofExpr::try_new_add(
+            DynProofExpr::new_column(amount_ref),
+            DynProofExpr::new_column(fee_ref),
+        )
+        .unwrap();
+        let expression = DynProofExpr::try_new_inequality(
+            amount_plus_fee,
+            DynProofExpr::new_literal(LiteralValue::BigInt(30)),
+            true,
+        )
+        .unwrap();
+
+        let result = expression
+            .first_round_evaluate_nullable_propagating(&alloc, &table, &[])
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.values(), Column::Boolean(&[true, true, false]));
+        assert_eq!(result.presence(), Some([true, false, true].as_slice()));
+    }
+
+    #[test]
+    fn nullable_first_round_evaluation_does_not_guess_and_or_nullability() {
+        let alloc = Bump::new();
+        let table = nullable_test_table(&alloc);
+        let flag_ref = ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "flag".into(),
+            ColumnType::Boolean,
+        );
+        let expression = DynProofExpr::try_new_and(
+            DynProofExpr::new_column(flag_ref),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        )
+        .unwrap();
+
+        let result = expression
+            .first_round_evaluate_nullable_propagating(&alloc, &table, &[])
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    fn nullable_test_table<'a>(alloc: &'a Bump) -> Table<'a, TestScalar> {
+        table([
+            borrowed_bigint("amount", [10, 20, 30], alloc),
+            borrowed_boolean("__posql_presence_amount", [true, false, true], alloc),
+            borrowed_bigint("fee", [5, 5, 5], alloc),
+            borrowed_boolean("flag", [true, true, false], alloc),
+            borrowed_boolean("__posql_presence_flag", [true, false, true], alloc),
+        ])
+    }
+
+    fn nullable_amount_ref() -> ColumnRef {
+        ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "amount".into(),
+            ColumnType::BigInt,
+        )
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -60,11 +60,7 @@ impl DynProofExpr {
         Self::Column(ColumnExpr::new(column_ref))
     }
 
-    /// Return the output field for expressions whose nullability is simple presence propagation.
-    ///
-    /// `AND` / `OR` are deliberately not marked nullable here because their
-    /// PostgreSQL three-valued result nullability depends on values as well as
-    /// operand presence.
+    /// Return the output field for expressions whose nullability can be derived locally.
     #[must_use]
     pub(crate) fn nullable_propagating_result_field(&self, alias: Ident) -> ColumnField {
         if self
@@ -99,7 +95,8 @@ impl DynProofExpr {
             Self::ScalingCast(expr) => expr
                 .get_from_expr()
                 .nullable_propagating_result_is_nullable(),
-            Self::And(_) | Self::Or(_) => None,
+            Self::And(expr) => Self::nullable_binary_result_is_nullable(expr.lhs(), expr.rhs()),
+            Self::Or(expr) => Self::nullable_binary_result_is_nullable(expr.lhs(), expr.rhs()),
         }
     }
 
@@ -110,11 +107,7 @@ impl DynProofExpr {
         )
     }
 
-    /// Evaluate expressions whose SQL nullability is simple operand-presence propagation.
-    ///
-    /// This returns `None` for expressions such as `AND` / `OR`, where PostgreSQL
-    /// three-valued boolean result nullability depends on both values and
-    /// presence rather than just operand presence.
+    /// Evaluate expressions whose SQL nullability can be derived from local operands.
     pub fn first_round_evaluate_nullable_propagating<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
@@ -200,7 +193,32 @@ impl DynProofExpr {
                 table,
                 params,
             )?,
-            Self::And(_) | Self::Or(_) => None,
+            Self::And(expr) => Self::nullable_boolean_first_round_result(
+                values,
+                expr.lhs(),
+                expr.rhs(),
+                alloc,
+                table,
+                params,
+                |lhs_present, lhs_value, rhs_present, rhs_value| {
+                    (lhs_present && rhs_present)
+                        || (lhs_present && !lhs_value)
+                        || (rhs_present && !rhs_value)
+                },
+            )?,
+            Self::Or(expr) => Self::nullable_boolean_first_round_result(
+                values,
+                expr.lhs(),
+                expr.rhs(),
+                alloc,
+                table,
+                params,
+                |lhs_present, lhs_value, rhs_present, rhs_value| {
+                    (lhs_present && rhs_present)
+                        || (lhs_present && lhs_value)
+                        || (rhs_present && rhs_value)
+                },
+            )?,
         };
         Ok(result)
     }
@@ -242,6 +260,50 @@ impl DynProofExpr {
                 NullableColumn::try_new(values, input.presence())
                     .expect("Nullable expression values and presence should match")
             }))
+    }
+
+    fn nullable_boolean_first_round_result<'a, S: Scalar>(
+        values: Column<'a, S>,
+        lhs: &Self,
+        rhs: &Self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+        is_present: impl Fn(bool, bool, bool, bool) -> bool,
+    ) -> PlaceholderResult<Option<NullableColumn<'a, S>>> {
+        let Some(lhs) = lhs.first_round_evaluate_nullable_propagating(alloc, table, params)? else {
+            return Ok(None);
+        };
+        let Some(rhs) = rhs.first_round_evaluate_nullable_propagating(alloc, table, params)? else {
+            return Ok(None);
+        };
+
+        assert_eq!(lhs.len(), rhs.len(), "Boolean operand lengths should match");
+        assert_eq!(
+            values.len(),
+            lhs.len(),
+            "Boolean expression values and operand lengths should match"
+        );
+        let lhs_values = lhs.values().as_boolean().expect("lhs is not boolean");
+        let rhs_values = rhs.values().as_boolean().expect("rhs is not boolean");
+
+        let presence: Option<&'a [bool]> = if lhs.presence().is_none() && rhs.presence().is_none() {
+            None
+        } else {
+            Some(&*alloc.alloc_slice_fill_iter(
+                lhs_values.iter().zip(rhs_values.iter()).enumerate().map(
+                    |(i, (lhs_value, rhs_value))| {
+                        let lhs_present = lhs.presence().map_or(true, |presence| presence[i]);
+                        let rhs_present = rhs.presence().map_or(true, |presence| presence[i]);
+                        is_present(lhs_present, *lhs_value, rhs_present, *rhs_value)
+                    },
+                ),
+            ))
+        };
+
+        Ok(Some(NullableColumn::try_new(values, presence).expect(
+            "Nullable boolean expression values and presence should match",
+        )))
     }
 
     /// Create a SQL `IS NULL` expression for a column reference.
@@ -562,7 +624,7 @@ mod tests {
     }
 
     #[test]
-    fn nullable_first_round_evaluation_does_not_guess_and_or_nullability() {
+    fn nullable_first_round_evaluation_handles_boolean_and_or_presence() {
         let alloc = Bump::new();
         let table = nullable_test_table(&alloc);
         let flag_ref = ColumnRef::new_nullable(
@@ -570,17 +632,47 @@ mod tests {
             "flag".into(),
             ColumnType::Boolean,
         );
-        let expression = DynProofExpr::try_new_and(
+        let and_true = DynProofExpr::try_new_and(
+            DynProofExpr::new_column(flag_ref.clone()),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        )
+        .unwrap()
+        .first_round_evaluate_nullable_propagating(&alloc, &table, &[])
+        .unwrap()
+        .unwrap();
+        let and_false = DynProofExpr::try_new_and(
+            DynProofExpr::new_column(flag_ref.clone()),
+            DynProofExpr::new_literal(LiteralValue::Boolean(false)),
+        )
+        .unwrap()
+        .first_round_evaluate_nullable_propagating(&alloc, &table, &[])
+        .unwrap()
+        .unwrap();
+        let or_false = DynProofExpr::try_new_or(
+            DynProofExpr::new_column(flag_ref.clone()),
+            DynProofExpr::new_literal(LiteralValue::Boolean(false)),
+        )
+        .unwrap()
+        .first_round_evaluate_nullable_propagating(&alloc, &table, &[])
+        .unwrap()
+        .unwrap();
+        let or_true = DynProofExpr::try_new_or(
             DynProofExpr::new_column(flag_ref),
             DynProofExpr::new_literal(LiteralValue::Boolean(true)),
         )
+        .unwrap()
+        .first_round_evaluate_nullable_propagating(&alloc, &table, &[])
+        .unwrap()
         .unwrap();
 
-        let result = expression
-            .first_round_evaluate_nullable_propagating(&alloc, &table, &[])
-            .unwrap();
-
-        assert!(result.is_none());
+        assert_eq!(and_true.values(), Column::Boolean(&[true, true, false]));
+        assert_eq!(and_true.presence(), Some([true, false, true].as_slice()));
+        assert_eq!(and_false.values(), Column::Boolean(&[false, false, false]));
+        assert_eq!(and_false.presence(), Some([true, true, true].as_slice()));
+        assert_eq!(or_false.values(), Column::Boolean(&[true, true, false]));
+        assert_eq!(or_false.presence(), Some([true, false, true].as_slice()));
+        assert_eq!(or_true.values(), Column::Boolean(&[true, true, true]));
+        assert_eq!(or_true.presence(), Some([true, true, true].as_slice()));
     }
 
     #[test]
@@ -605,7 +697,7 @@ mod tests {
     }
 
     #[test]
-    fn nullable_result_fields_do_not_claim_and_or_result_nullability() {
+    fn nullable_result_fields_mark_and_or_outputs_nullable() {
         let flag_ref = ColumnRef::new_nullable(
             TableRef::new("sxt", "orders"),
             "flag".into(),
@@ -621,7 +713,7 @@ mod tests {
 
         assert_eq!(field.name(), "flag_and_true".into());
         assert_eq!(field.data_type(), ColumnType::Boolean);
-        assert!(!field.is_nullable());
+        assert!(field.is_nullable());
     }
 
     fn nullable_test_table<'a>(alloc: &'a Bump) -> Table<'a, TestScalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -107,6 +107,118 @@ impl DynProofExpr {
         )
     }
 
+    /// Return a proof expression for this nullable-propagating result's row presence.
+    ///
+    /// `None` means the expression is statically non-nullable.
+    #[must_use]
+    pub(crate) fn nullable_result_presence_expr(&self) -> Option<Self> {
+        match self {
+            Self::Column(column) => column
+                .column_ref()
+                .is_nullable()
+                .then(|| Self::new_column(column.column_ref().presence_column_ref())),
+            Self::Literal(_) | Self::Placeholder(_) => None,
+            Self::Add(expr) => Self::nullable_binary_result_presence_expr(expr.lhs(), expr.rhs()),
+            Self::Subtract(expr) => {
+                Self::nullable_binary_result_presence_expr(expr.lhs(), expr.rhs())
+            }
+            Self::Multiply(expr) => {
+                Self::nullable_binary_result_presence_expr(expr.lhs(), expr.rhs())
+            }
+            Self::Equals(expr) => {
+                Self::nullable_binary_result_presence_expr(expr.lhs(), expr.rhs())
+            }
+            Self::Inequality(expr) => {
+                Self::nullable_binary_result_presence_expr(expr.lhs(), expr.rhs())
+            }
+            Self::Not(expr) => expr.input().nullable_result_presence_expr(),
+            Self::Cast(expr) => expr.get_from_expr().nullable_result_presence_expr(),
+            Self::ScalingCast(expr) => expr.get_from_expr().nullable_result_presence_expr(),
+            Self::And(expr) => {
+                Self::nullable_boolean_and_result_presence_expr(expr.lhs(), expr.rhs())
+            }
+            Self::Or(expr) => {
+                Self::nullable_boolean_or_result_presence_expr(expr.lhs(), expr.rhs())
+            }
+        }
+    }
+
+    fn nullable_binary_result_presence_expr(lhs: &Self, rhs: &Self) -> Option<Self> {
+        match (
+            lhs.nullable_result_presence_expr(),
+            rhs.nullable_result_presence_expr(),
+        ) {
+            (None, None) => None,
+            (Some(presence), None) | (None, Some(presence)) => Some(presence),
+            (Some(lhs_presence), Some(rhs_presence)) => Some(
+                Self::try_new_and(lhs_presence, rhs_presence)
+                    .expect("Nullable binary presence expressions are boolean"),
+            ),
+        }
+    }
+
+    fn nullable_boolean_and_result_presence_expr(lhs: &Self, rhs: &Self) -> Option<Self> {
+        let lhs_presence = lhs.nullable_result_presence_expr();
+        let rhs_presence = rhs.nullable_result_presence_expr();
+        if lhs_presence.is_none() && rhs_presence.is_none() {
+            return None;
+        }
+
+        let lhs_present = Self::presence_expr_or_true(lhs_presence);
+        let rhs_present = Self::presence_expr_or_true(rhs_presence);
+        let both_present = Self::try_new_and(lhs_present.clone(), rhs_present.clone())
+            .expect("Nullable boolean presence expressions are boolean");
+        let lhs_present_and_lhs_false = Self::try_new_and(
+            lhs_present,
+            Self::try_new_not(lhs.clone()).expect("AND operands are boolean"),
+        )
+        .expect("Nullable boolean presence expressions are boolean");
+        let rhs_present_and_rhs_false = Self::try_new_and(
+            rhs_present,
+            Self::try_new_not(rhs.clone()).expect("AND operands are boolean"),
+        )
+        .expect("Nullable boolean presence expressions are boolean");
+
+        Some(
+            Self::try_new_or(
+                Self::try_new_or(both_present, lhs_present_and_lhs_false)
+                    .expect("Nullable boolean presence expressions are boolean"),
+                rhs_present_and_rhs_false,
+            )
+            .expect("Nullable boolean presence expressions are boolean"),
+        )
+    }
+
+    fn nullable_boolean_or_result_presence_expr(lhs: &Self, rhs: &Self) -> Option<Self> {
+        let lhs_presence = lhs.nullable_result_presence_expr();
+        let rhs_presence = rhs.nullable_result_presence_expr();
+        if lhs_presence.is_none() && rhs_presence.is_none() {
+            return None;
+        }
+
+        let lhs_present = Self::presence_expr_or_true(lhs_presence);
+        let rhs_present = Self::presence_expr_or_true(rhs_presence);
+        let both_present = Self::try_new_and(lhs_present.clone(), rhs_present.clone())
+            .expect("Nullable boolean presence expressions are boolean");
+        let lhs_present_and_lhs_true = Self::try_new_and(lhs_present, lhs.clone())
+            .expect("Nullable boolean presence expressions are boolean");
+        let rhs_present_and_rhs_true = Self::try_new_and(rhs_present, rhs.clone())
+            .expect("Nullable boolean presence expressions are boolean");
+
+        Some(
+            Self::try_new_or(
+                Self::try_new_or(both_present, lhs_present_and_lhs_true)
+                    .expect("Nullable boolean presence expressions are boolean"),
+                rhs_present_and_rhs_true,
+            )
+            .expect("Nullable boolean presence expressions are boolean"),
+        )
+    }
+
+    fn presence_expr_or_true(expr: Option<Self>) -> Self {
+        expr.unwrap_or_else(|| Self::new_literal(LiteralValue::Boolean(true)))
+    }
+
     /// Evaluate expressions whose SQL nullability can be derived from local operands.
     pub fn first_round_evaluate_nullable_propagating<'a, S: Scalar>(
         &self,
@@ -714,6 +826,65 @@ mod tests {
         assert_eq!(field.name(), "flag_and_true".into());
         assert_eq!(field.data_type(), ColumnType::Boolean);
         assert!(field.is_nullable());
+    }
+
+    #[test]
+    fn nullable_presence_expression_ands_binary_operand_presence() {
+        let amount_ref = nullable_amount_ref();
+        let discount_ref = ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "discount".into(),
+            ColumnType::BigInt,
+        );
+        let expression = DynProofExpr::try_new_add(
+            DynProofExpr::new_column(amount_ref.clone()),
+            DynProofExpr::new_column(discount_ref.clone()),
+        )
+        .unwrap();
+
+        let presence_expr = expression.nullable_result_presence_expr().unwrap();
+
+        assert_eq!(
+            presence_expr,
+            DynProofExpr::try_new_and(
+                DynProofExpr::new_column(amount_ref.presence_column_ref()),
+                DynProofExpr::new_column(discount_ref.presence_column_ref()),
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn nullable_boolean_presence_expression_matches_sql_short_circuit_presence() {
+        let alloc = Bump::new();
+        let table = nullable_test_table(&alloc);
+        let flag_ref = ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "flag".into(),
+            ColumnType::Boolean,
+        );
+
+        let and_false_presence = DynProofExpr::try_new_and(
+            DynProofExpr::new_column(flag_ref.clone()),
+            DynProofExpr::new_literal(LiteralValue::Boolean(false)),
+        )
+        .unwrap()
+        .nullable_result_presence_expr()
+        .unwrap()
+        .first_round_evaluate(&alloc, &table, &[])
+        .unwrap();
+        let or_true_presence = DynProofExpr::try_new_or(
+            DynProofExpr::new_column(flag_ref),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        )
+        .unwrap()
+        .nullable_result_presence_expr()
+        .unwrap()
+        .first_round_evaluate(&alloc, &table, &[])
+        .unwrap();
+
+        assert_eq!(and_false_presence, Column::Boolean(&[true, true, true]));
+        assert_eq!(or_true_presence, Column::Boolean(&[true, true, true]));
     }
 
     fn nullable_test_table<'a>(alloc: &'a Bump) -> Table<'a, TestScalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -111,7 +111,7 @@ impl DynProofExpr {
     ///
     /// `None` means the expression is statically non-nullable.
     #[must_use]
-    pub(crate) fn nullable_result_presence_expr(&self) -> Option<Self> {
+    pub fn nullable_result_presence_expr(&self) -> Option<Self> {
         match self {
             Self::Column(column) => column
                 .column_ref()

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -108,6 +108,29 @@ impl DynProofExpr {
         }
     }
 
+    /// Create a SQL `IS FALSE` expression for a boolean column reference.
+    ///
+    /// Nullable boolean columns are false only when the value is false and the
+    /// row is present. Non-nullable boolean columns are already two-valued.
+    pub fn try_new_is_false(column_ref: ColumnRef) -> AnalyzeResult<Self> {
+        if column_ref.column_type() != &ColumnType::Boolean {
+            return Err(AnalyzeError::DataTypeMismatch {
+                left_type: column_ref.column_type().to_string(),
+                right_type: ColumnType::Boolean.to_string(),
+            });
+        }
+
+        let value_expr = Self::try_new_not(Self::new_column(column_ref.clone()))?;
+        if column_ref.is_nullable() {
+            Self::try_new_and(
+                value_expr,
+                Self::new_column(column_ref.presence_column_ref()),
+            )
+        } else {
+            Ok(value_expr)
+        }
+    }
+
     /// Create logical AND expression
     pub fn try_new_and(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         AndExpr::try_new(Box::new(lhs), Box::new(rhs)).map(DynProofExpr::And)
@@ -257,5 +280,48 @@ mod tests {
         );
 
         assert!(DynProofExpr::try_new_is_true(column_ref).is_err());
+    }
+
+    #[test]
+    fn is_false_builder_ands_negated_value_with_presence_for_nullable_boolean_refs() {
+        let column_ref = ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "is_paid".into(),
+            ColumnType::Boolean,
+        );
+
+        assert_eq!(
+            DynProofExpr::try_new_is_false(column_ref.clone()).unwrap(),
+            DynProofExpr::try_new_and(
+                DynProofExpr::try_new_not(DynProofExpr::new_column(column_ref.clone())).unwrap(),
+                DynProofExpr::new_column(column_ref.presence_column_ref()),
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn is_false_builder_keeps_non_nullable_boolean_refs_direct() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            "is_paid".into(),
+            ColumnType::Boolean,
+        );
+
+        assert_eq!(
+            DynProofExpr::try_new_is_false(column_ref.clone()).unwrap(),
+            DynProofExpr::try_new_not(DynProofExpr::new_column(column_ref)).unwrap()
+        );
+    }
+
+    #[test]
+    fn is_false_builder_rejects_non_boolean_refs() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            "amount".into(),
+            ColumnType::BigInt,
+        );
+
+        assert!(DynProofExpr::try_new_is_false(column_ref).is_err());
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -4,7 +4,9 @@ use super::{
 };
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table},
+        database::{
+            Column, ColumnField, ColumnRef, ColumnType, LiteralValue, NullableColumn, Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -56,6 +58,56 @@ impl DynProofExpr {
     #[must_use]
     pub fn new_column(column_ref: ColumnRef) -> Self {
         Self::Column(ColumnExpr::new(column_ref))
+    }
+
+    /// Return the output field for expressions whose nullability is simple presence propagation.
+    ///
+    /// `AND` / `OR` are deliberately not marked nullable here because their
+    /// PostgreSQL three-valued result nullability depends on values as well as
+    /// operand presence.
+    #[must_use]
+    pub(crate) fn nullable_propagating_result_field(&self, alias: Ident) -> ColumnField {
+        if self
+            .nullable_propagating_result_is_nullable()
+            .unwrap_or(false)
+        {
+            ColumnField::new_nullable(alias, self.data_type())
+        } else {
+            ColumnField::new(alias, self.data_type())
+        }
+    }
+
+    fn nullable_propagating_result_is_nullable(&self) -> Option<bool> {
+        match self {
+            Self::Column(column) => Some(column.column_ref().is_nullable()),
+            Self::Literal(_) | Self::Placeholder(_) => Some(false),
+            Self::Add(expr) => Self::nullable_binary_result_is_nullable(expr.lhs(), expr.rhs()),
+            Self::Subtract(expr) => {
+                Self::nullable_binary_result_is_nullable(expr.lhs(), expr.rhs())
+            }
+            Self::Multiply(expr) => {
+                Self::nullable_binary_result_is_nullable(expr.lhs(), expr.rhs())
+            }
+            Self::Equals(expr) => Self::nullable_binary_result_is_nullable(expr.lhs(), expr.rhs()),
+            Self::Inequality(expr) => {
+                Self::nullable_binary_result_is_nullable(expr.lhs(), expr.rhs())
+            }
+            Self::Not(expr) => expr.input().nullable_propagating_result_is_nullable(),
+            Self::Cast(expr) => expr
+                .get_from_expr()
+                .nullable_propagating_result_is_nullable(),
+            Self::ScalingCast(expr) => expr
+                .get_from_expr()
+                .nullable_propagating_result_is_nullable(),
+            Self::And(_) | Self::Or(_) => None,
+        }
+    }
+
+    fn nullable_binary_result_is_nullable(lhs: &Self, rhs: &Self) -> Option<bool> {
+        Some(
+            lhs.nullable_propagating_result_is_nullable()?
+                || rhs.nullable_propagating_result_is_nullable()?,
+        )
     }
 
     /// Evaluate expressions whose SQL nullability is simple operand-presence propagation.
@@ -529,6 +581,47 @@ mod tests {
             .unwrap();
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn nullable_result_fields_mark_presence_propagating_outputs() {
+        let amount_ref = nullable_amount_ref();
+        let fee_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            "fee".into(),
+            ColumnType::BigInt,
+        );
+        let expression = DynProofExpr::try_new_add(
+            DynProofExpr::new_column(amount_ref),
+            DynProofExpr::new_column(fee_ref),
+        )
+        .unwrap();
+
+        let field = expression.nullable_propagating_result_field("total".into());
+
+        assert_eq!(field.name(), "total".into());
+        assert_eq!(field.data_type(), expression.data_type());
+        assert!(field.is_nullable());
+    }
+
+    #[test]
+    fn nullable_result_fields_do_not_claim_and_or_result_nullability() {
+        let flag_ref = ColumnRef::new_nullable(
+            TableRef::new("sxt", "orders"),
+            "flag".into(),
+            ColumnType::Boolean,
+        );
+        let expression = DynProofExpr::try_new_and(
+            DynProofExpr::new_column(flag_ref),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        )
+        .unwrap();
+
+        let field = expression.nullable_propagating_result_field("flag_and_true".into());
+
+        assert_eq!(field.name(), "flag_and_true".into());
+        assert_eq!(field.data_type(), ColumnType::Boolean);
+        assert!(!field.is_nullable());
     }
 
     fn nullable_test_table<'a>(alloc: &'a Bump) -> Table<'a, TestScalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -8,17 +8,15 @@ use sqlparser::ast::Ident;
 
 pub fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> ColumnRef {
     let name: Ident = name.into();
-    let type_col = accessor.lookup_column(tab, &name).unwrap();
-    ColumnRef::new(tab.clone(), name, type_col)
+    let field = accessor.lookup_column_field(tab, &name).unwrap();
+    ColumnRef::from_field(tab.clone(), &field)
 }
 
 /// # Panics
 /// Panics if:
 /// - `accessor.lookup_column()` returns `None`, indicating the column is not found.
 pub fn column(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> DynProofExpr {
-    let name: Ident = name.into();
-    let type_col = accessor.lookup_column(tab, &name).unwrap();
-    DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(tab.clone(), name, type_col)))
+    DynProofExpr::Column(ColumnExpr::new(col_ref(tab, name, accessor)))
 }
 
 /// # Panics

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -180,7 +180,7 @@ impl DynProofPlan {
     pub(crate) fn get_column_result_fields_as_references(&self) -> IndexSet<ColumnRef> {
         self.get_column_result_fields()
             .into_iter()
-            .map(|f| ColumnRef::new(TableRef::from_names(None, ""), f.name(), f.data_type()))
+            .map(|f| ColumnRef::from_field(TableRef::from_names(None, ""), &f))
             .collect()
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -135,9 +135,7 @@ impl ProofPlan for FilterExec {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         self.aliased_results
             .iter()
-            .map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
-            })
+            .map(AliasedDynProofExpr::result_field)
             .collect()
     }
 
@@ -267,5 +265,66 @@ impl ProverEvaluate for FilterExec {
         log::log_memory_usage("End");
 
         Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{ColumnField, ColumnRef, ColumnType, LiteralValue},
+            math::decimal::Precision,
+        },
+        sql::{
+            proof::ProofPlan,
+            proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+        },
+    };
+
+    #[test]
+    fn filter_result_schema_preserves_nullable_propagating_fields() {
+        let table_ref = TableRef::new("sxt", "orders");
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), "amount".into(), ColumnType::BigInt);
+        let fee_ref = ColumnRef::new(table_ref.clone(), "fee".into(), ColumnType::BigInt);
+        let total = DynProofExpr::try_new_add(
+            DynProofExpr::new_column(amount_ref.clone()),
+            DynProofExpr::new_column(fee_ref),
+        )
+        .unwrap();
+        let plan = FilterExec::new(
+            vec![
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_column(amount_ref),
+                    alias: "amount".into(),
+                },
+                AliasedDynProofExpr {
+                    expr: total,
+                    alias: "total".into(),
+                },
+            ],
+            Box::new(DynProofPlan::new_table(
+                table_ref,
+                vec![
+                    ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                    ColumnField::new("fee".into(), ColumnType::BigInt),
+                ],
+            )),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+
+        let column_fields = plan.get_column_result_fields();
+
+        assert_eq!(
+            column_fields,
+            vec![
+                ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                ColumnField::new_nullable(
+                    "total".into(),
+                    ColumnType::Decimal75(Precision::new(20).unwrap(), 0)
+                ),
+            ]
+        );
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -148,12 +148,10 @@ impl ProofPlan for FilterExec {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        let mut columns = self.input.get_column_references();
-        self.where_clause.get_column_references(&mut columns);
-        for aliased_expr in self.physical_aliased_results() {
-            aliased_expr.expr.get_column_references(&mut columns);
-        }
-        columns
+        // Filter results and predicates can reference intermediate columns produced by child
+        // plans. Source commitments should come from the input plan, whose physical result schema
+        // already includes generated nullable presence columns when needed.
+        self.input.get_column_references()
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -327,4 +327,52 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn filter_physical_result_schema_adds_presence_fields_for_nullable_results() {
+        let table_ref = TableRef::new("sxt", "orders");
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), "amount".into(), ColumnType::BigInt);
+        let fee_ref = ColumnRef::new(table_ref.clone(), "fee".into(), ColumnType::BigInt);
+        let total = DynProofExpr::try_new_add(
+            DynProofExpr::new_column(amount_ref.clone()),
+            DynProofExpr::new_column(fee_ref),
+        )
+        .unwrap();
+        let plan = FilterExec::new(
+            vec![
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_column(amount_ref),
+                    alias: "amount".into(),
+                },
+                AliasedDynProofExpr {
+                    expr: total,
+                    alias: "total".into(),
+                },
+            ],
+            Box::new(DynProofPlan::new_table(
+                table_ref,
+                vec![
+                    ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                    ColumnField::new("fee".into(), ColumnType::BigInt),
+                ],
+            )),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+
+        let column_fields = plan.get_column_result_fields_with_presence();
+
+        assert_eq!(
+            column_fields,
+            vec![
+                ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                ColumnField::new("__posql_presence_amount".into(), ColumnType::Boolean),
+                ColumnField::new_nullable(
+                    "total".into(),
+                    ColumnType::Decimal75(Precision::new(20).unwrap(), 0)
+                ),
+                ColumnField::new("__posql_presence_total".into(), ColumnType::Boolean),
+            ]
+        );
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -64,6 +64,13 @@ impl FilterExec {
     pub fn where_clause(&self) -> &DynProofExpr {
         &self.where_clause
     }
+
+    fn physical_aliased_results(&self) -> Vec<AliasedDynProofExpr> {
+        self.aliased_results
+            .iter()
+            .flat_map(AliasedDynProofExpr::physical_result_exprs)
+            .collect()
+    }
 }
 
 impl ProofPlan for FilterExec {
@@ -83,7 +90,7 @@ impl ProofPlan for FilterExec {
         let input_chi_eval = input_eval.chi();
 
         // Build new accessors
-        let input_schema = self.input.get_column_result_fields();
+        let input_schema = self.input.get_column_result_fields_with_presence();
         let accessor = input_schema
             .iter()
             .map(ColumnField::name)
@@ -95,8 +102,9 @@ impl ProofPlan for FilterExec {
             self.where_clause
                 .verifier_evaluate(builder, &accessor, input_chi_eval.0, params)?;
         // 2. columns
+        let physical_results = self.physical_aliased_results();
         let columns_evals = Vec::from_iter(
-            self.aliased_results
+            physical_results
                 .iter()
                 .map(|aliased_expr| {
                     aliased_expr.expr.verifier_evaluate(
@@ -110,8 +118,8 @@ impl ProofPlan for FilterExec {
         );
         // 3. filtered_columns
         let filtered_columns_evals =
-            builder.try_consume_first_round_mle_evaluations(self.aliased_results.len())?;
-        assert!(filtered_columns_evals.len() == self.aliased_results.len());
+            builder.try_consume_first_round_mle_evaluations(physical_results.len())?;
+        assert!(filtered_columns_evals.len() == physical_results.len());
 
         let output_chi_eval = builder.try_consume_chi_evaluation()?;
 
@@ -140,7 +148,12 @@ impl ProofPlan for FilterExec {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        self.input.get_column_references()
+        let mut columns = self.input.get_column_references();
+        self.where_clause.get_column_references(&mut columns);
+        for aliased_expr in self.physical_aliased_results() {
+            aliased_expr.expr.get_column_references(&mut columns);
+        }
+        columns
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
@@ -173,8 +186,8 @@ impl ProverEvaluate for FilterExec {
         let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
-        let columns: Vec<_> = self
-            .aliased_results
+        let physical_results = self.physical_aliased_results();
+        let columns: Vec<_> = physical_results
             .iter()
             .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr
@@ -190,7 +203,7 @@ impl ProverEvaluate for FilterExec {
             builder.produce_intermediate_mle(column);
         });
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.aliased_results
+            physical_results
                 .iter()
                 .map(|expr| expr.alias.clone())
                 .zip(filtered_columns),
@@ -230,8 +243,8 @@ impl ProverEvaluate for FilterExec {
         let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
-        let columns: Vec<_> = self
-            .aliased_results
+        let physical_results = self.physical_aliased_results();
+        let columns: Vec<_> = physical_results
             .iter()
             .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr
@@ -254,7 +267,7 @@ impl ProverEvaluate for FilterExec {
             result_len,
         );
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.aliased_results
+            physical_results
                 .iter()
                 .map(|expr| expr.alias.clone())
                 .zip(filtered_columns),
@@ -273,8 +286,9 @@ mod tests {
     use super::*;
     use crate::{
         base::{
-            database::{ColumnField, ColumnRef, ColumnType, LiteralValue},
+            database::{table_utility::*, ColumnField, ColumnRef, ColumnType, LiteralValue},
             math::decimal::Precision,
+            scalar::test_scalar::TestScalar,
         },
         sql::{
             proof::ProofPlan,
@@ -373,6 +387,56 @@ mod tests {
                 ),
                 ColumnField::new("__posql_presence_total".into(), ColumnType::Boolean),
             ]
+        );
+    }
+
+    #[test]
+    fn filter_first_round_evaluates_physical_nullable_results() {
+        let alloc = Bump::new();
+        let table_ref = TableRef::new("sxt", "orders");
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), "amount".into(), ColumnType::BigInt);
+        let plan = FilterExec::new(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(amount_ref),
+                alias: "amount".into(),
+            }],
+            Box::new(DynProofPlan::new_table(
+                table_ref.clone(),
+                vec![ColumnField::new_nullable(
+                    "amount".into(),
+                    ColumnType::BigInt,
+                )],
+            )),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+        let table_map = IndexMap::from_iter([(
+            table_ref,
+            table([
+                borrowed_bigint("amount", [10_i64, 0, 30], &alloc),
+                borrowed_boolean("__posql_presence_amount", [true, false, true], &alloc),
+            ]),
+        )]);
+        let mut builder = FirstRoundBuilder::new(3);
+
+        let result: Table<TestScalar> = plan
+            .first_round_evaluate(&mut builder, &alloc, &table_map, &[])
+            .unwrap();
+
+        assert_eq!(
+            result.inner_table().keys().cloned().collect::<Vec<_>>(),
+            vec!["amount".into(), "__posql_presence_amount".into()]
+        );
+        assert_eq!(
+            *result.inner_table().get(&Ident::new("amount")).unwrap(),
+            Column::BigInt(&[10_i64, 0, 30])
+        );
+        assert_eq!(
+            *result
+                .inner_table()
+                .get(&Ident::new("__posql_presence_amount"))
+                .unwrap(),
+            Column::Boolean(&[true, false, true])
         );
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
@@ -137,9 +137,7 @@ where
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         self.aliased_results
             .iter()
-            .map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
-            })
+            .map(AliasedDynProofExpr::result_field)
             .collect()
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
@@ -69,6 +69,13 @@ impl<H: ProverHonestyMarker> OstensibleLegacyFilterExec<H> {
     pub fn where_clause(&self) -> &DynProofExpr {
         &self.where_clause
     }
+
+    fn physical_aliased_results(&self) -> Vec<AliasedDynProofExpr> {
+        self.aliased_results
+            .iter()
+            .flat_map(AliasedDynProofExpr::physical_result_exprs)
+            .collect()
+    }
 }
 
 impl<H: ProverHonestyMarker> ProofPlan for OstensibleLegacyFilterExec<H>
@@ -97,8 +104,9 @@ where
             self.where_clause
                 .verifier_evaluate(builder, &accessor, input_chi_eval.0, params)?;
         // 2. columns
+        let physical_results = self.physical_aliased_results();
         let columns_evals = Vec::from_iter(
-            self.aliased_results
+            physical_results
                 .iter()
                 .map(|aliased_expr| {
                     aliased_expr.expr.verifier_evaluate(
@@ -112,8 +120,8 @@ where
         );
         // 3. filtered_columns
         let filtered_columns_evals =
-            builder.try_consume_first_round_mle_evaluations(self.aliased_results.len())?;
-        assert!(filtered_columns_evals.len() == self.aliased_results.len());
+            builder.try_consume_first_round_mle_evaluations(physical_results.len())?;
+        assert!(filtered_columns_evals.len() == physical_results.len());
 
         let output_chi_eval = builder.try_consume_chi_evaluation()?;
 
@@ -144,7 +152,7 @@ where
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         let mut columns = IndexSet::default();
 
-        for aliased_expr in &self.aliased_results {
+        for aliased_expr in self.physical_aliased_results() {
             aliased_expr.expr.get_column_references(&mut columns);
         }
 
@@ -189,8 +197,8 @@ impl ProverEvaluate for LegacyFilterExec {
         let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
-        let columns: Vec<_> = self
-            .aliased_results
+        let physical_results = self.physical_aliased_results();
+        let columns: Vec<_> = physical_results
             .iter()
             .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr.expr.first_round_evaluate(alloc, table, params)
@@ -204,7 +212,7 @@ impl ProverEvaluate for LegacyFilterExec {
             builder.produce_intermediate_mle(column);
         });
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.aliased_results
+            physical_results
                 .iter()
                 .map(|expr| expr.alias.clone())
                 .zip(filtered_columns),
@@ -248,8 +256,8 @@ impl ProverEvaluate for LegacyFilterExec {
         let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
-        let columns: Vec<_> = self
-            .aliased_results
+        let physical_results = self.physical_aliased_results();
+        let columns: Vec<_> = physical_results
             .iter()
             .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr
@@ -272,7 +280,7 @@ impl ProverEvaluate for LegacyFilterExec {
             result_len,
         );
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.aliased_results
+            physical_results
                 .iter()
                 .map(|expr| expr.alias.clone())
                 .zip(filtered_columns),

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -50,6 +50,13 @@ impl ProjectionExec {
     pub fn aliased_results(&self) -> &[AliasedDynProofExpr] {
         &self.aliased_results
     }
+
+    fn physical_aliased_results(&self) -> Vec<AliasedDynProofExpr> {
+        self.aliased_results
+            .iter()
+            .flat_map(AliasedDynProofExpr::physical_result_exprs)
+            .collect()
+    }
 }
 
 impl ProofPlan for ProjectionExec {
@@ -68,14 +75,14 @@ impl ProofPlan for ProjectionExec {
         // Build new accessors
         // TODO: Make this work with inputs with multiple tables such as join
         // and union results
-        let input_schema = self.input.get_column_result_fields();
+        let input_schema = self.input.get_column_result_fields_with_presence();
         let current_accessor = input_schema
             .iter()
             .zip(input_eval.column_evals())
             .map(|(field, eval)| (field.name().clone(), *eval))
             .collect::<IndexMap<_, _>>();
         let output_column_evals = self
-            .aliased_results
+            .physical_aliased_results()
             .iter()
             .map(|aliased_expr| {
                 aliased_expr
@@ -94,8 +101,11 @@ impl ProofPlan for ProjectionExec {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        // For projections any output column reference is a reference to an input column
-        self.input.get_column_references()
+        let mut columns = self.input.get_column_references();
+        for aliased_expr in self.physical_aliased_results() {
+            aliased_expr.expr.get_column_references(&mut columns);
+        }
+        columns
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
@@ -123,7 +133,7 @@ impl ProverEvaluate for ProjectionExec {
             .first_round_evaluate(builder, alloc, table_map, params)?;
 
         let cols = self
-            .aliased_results
+            .physical_aliased_results()
             .iter()
             .map(
                 |aliased_expr| -> PlaceholderResult<(Ident, Column<'a, S>)> {
@@ -166,7 +176,7 @@ impl ProverEvaluate for ProjectionExec {
 
         // Evaluate result expressions
         let cols = self
-            .aliased_results
+            .physical_aliased_results()
             .iter()
             .map(
                 |aliased_expr| -> PlaceholderResult<(Ident, Column<'a, S>)> {
@@ -195,8 +205,9 @@ mod tests {
     use super::*;
     use crate::{
         base::{
-            database::{ColumnField, ColumnRef, ColumnType},
+            database::{table_utility::*, ColumnField, ColumnRef, ColumnType},
             math::decimal::Precision,
+            scalar::test_scalar::TestScalar,
         },
         sql::{
             proof::ProofPlan,
@@ -293,6 +304,66 @@ mod tests {
                 ),
                 ColumnField::new("__posql_presence_total".into(), ColumnType::Boolean),
             ]
+        );
+    }
+
+    #[test]
+    fn projection_first_round_evaluates_physical_nullable_results() {
+        let alloc = Bump::new();
+        let table_ref = TableRef::new("sxt", "orders");
+        let flag_ref =
+            ColumnRef::new_nullable(table_ref.clone(), "flag".into(), ColumnType::Boolean);
+        let flag_and_false = DynProofExpr::try_new_and(
+            DynProofExpr::new_column(flag_ref.clone()),
+            DynProofExpr::new_literal(LiteralValue::Boolean(false)),
+        )
+        .unwrap();
+        let plan = ProjectionExec::new(
+            vec![AliasedDynProofExpr {
+                expr: flag_and_false,
+                alias: "flag_known_false".into(),
+            }],
+            Box::new(DynProofPlan::new_table(
+                table_ref.clone(),
+                vec![ColumnField::new_nullable(
+                    "flag".into(),
+                    ColumnType::Boolean,
+                )],
+            )),
+        );
+        let table_map = IndexMap::from_iter([(
+            table_ref,
+            table([
+                borrowed_boolean("flag", [true, true, false], &alloc),
+                borrowed_boolean("__posql_presence_flag", [true, false, true], &alloc),
+            ]),
+        )]);
+        let mut builder = FirstRoundBuilder::new(3);
+
+        let result: Table<TestScalar> = plan
+            .first_round_evaluate(&mut builder, &alloc, &table_map, &[])
+            .unwrap();
+
+        assert_eq!(
+            result.inner_table().keys().cloned().collect::<Vec<_>>(),
+            vec![
+                "flag_known_false".into(),
+                "__posql_presence_flag_known_false".into(),
+            ]
+        );
+        assert_eq!(
+            *result
+                .inner_table()
+                .get(&Ident::new("flag_known_false"))
+                .unwrap(),
+            Column::Boolean(&[false, false, false])
+        );
+        assert_eq!(
+            *result
+                .inner_table()
+                .get(&Ident::new("__posql_presence_flag_known_false"))
+                .unwrap(),
+            Column::Boolean(&[true, true, true])
         );
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -89,9 +89,7 @@ impl ProofPlan for ProjectionExec {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         self.aliased_results
             .iter()
-            .map(|aliased_expr| {
-                ColumnField::new(aliased_expr.alias.clone(), aliased_expr.expr.data_type())
-            })
+            .map(AliasedDynProofExpr::result_field)
             .collect()
     }
 
@@ -189,5 +187,65 @@ impl ProverEvaluate for ProjectionExec {
         log::log_memory_usage("End");
 
         Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{ColumnField, ColumnRef, ColumnType},
+            math::decimal::Precision,
+        },
+        sql::{
+            proof::ProofPlan,
+            proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+        },
+    };
+
+    #[test]
+    fn projection_result_schema_preserves_nullable_propagating_fields() {
+        let table_ref = TableRef::new("sxt", "orders");
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), "amount".into(), ColumnType::BigInt);
+        let fee_ref = ColumnRef::new(table_ref.clone(), "fee".into(), ColumnType::BigInt);
+        let total = DynProofExpr::try_new_add(
+            DynProofExpr::new_column(amount_ref.clone()),
+            DynProofExpr::new_column(fee_ref),
+        )
+        .unwrap();
+        let provable_ast = ProjectionExec::new(
+            vec![
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_column(amount_ref),
+                    alias: "amount".into(),
+                },
+                AliasedDynProofExpr {
+                    expr: total,
+                    alias: "total".into(),
+                },
+            ],
+            Box::new(DynProofPlan::new_table(
+                table_ref,
+                vec![
+                    ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                    ColumnField::new("fee".into(), ColumnType::BigInt),
+                ],
+            )),
+        );
+
+        let column_fields = provable_ast.get_column_result_fields();
+
+        assert_eq!(
+            column_fields,
+            vec![
+                ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                ColumnField::new_nullable(
+                    "total".into(),
+                    ColumnType::Decimal75(Precision::new(20).unwrap(), 0)
+                ),
+            ]
+        );
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -101,11 +101,10 @@ impl ProofPlan for ProjectionExec {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        let mut columns = self.input.get_column_references();
-        for aliased_expr in self.physical_aliased_results() {
-            aliased_expr.expr.get_column_references(&mut columns);
-        }
-        columns
+        // Projection results can reference intermediate columns produced by child plans. Source
+        // commitments should come from the input plan, whose physical result schema already
+        // includes generated nullable presence columns when needed.
+        self.input.get_column_references()
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -248,4 +248,51 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn projection_physical_result_schema_adds_presence_fields_for_nullable_results() {
+        let table_ref = TableRef::new("sxt", "orders");
+        let amount_ref =
+            ColumnRef::new_nullable(table_ref.clone(), "amount".into(), ColumnType::BigInt);
+        let fee_ref = ColumnRef::new(table_ref.clone(), "fee".into(), ColumnType::BigInt);
+        let total = DynProofExpr::try_new_add(
+            DynProofExpr::new_column(amount_ref.clone()),
+            DynProofExpr::new_column(fee_ref),
+        )
+        .unwrap();
+        let provable_ast = ProjectionExec::new(
+            vec![
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_column(amount_ref),
+                    alias: "amount".into(),
+                },
+                AliasedDynProofExpr {
+                    expr: total,
+                    alias: "total".into(),
+                },
+            ],
+            Box::new(DynProofPlan::new_table(
+                table_ref,
+                vec![
+                    ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                    ColumnField::new("fee".into(), ColumnType::BigInt),
+                ],
+            )),
+        );
+
+        let column_fields = provable_ast.get_column_result_fields_with_presence();
+
+        assert_eq!(
+            column_fields,
+            vec![
+                ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+                ColumnField::new("__posql_presence_amount".into(), ColumnType::Boolean),
+                ColumnField::new_nullable(
+                    "total".into(),
+                    ColumnType::Decimal75(Precision::new(20).unwrap(), 0)
+                ),
+                ColumnField::new("__posql_presence_total".into(), ColumnType::Boolean),
+            ]
+        );
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -79,7 +79,7 @@ impl ProofPlan for TableExec {
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         self.schema
             .iter()
-            .map(|field| ColumnRef::new(self.table_ref.clone(), field.name(), field.data_type()))
+            .map(|field| ColumnRef::from_field(self.table_ref.clone(), field))
             .collect()
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -44,6 +44,19 @@ impl TableExec {
     pub fn schema(&self) -> &[ColumnField] {
         &self.schema
     }
+
+    fn physical_schema(&self) -> Vec<ColumnField> {
+        let mut fields = Vec::new();
+        for field in ColumnField::value_and_presence_fields(self.schema.clone()) {
+            if fields
+                .iter()
+                .all(|existing: &ColumnField| existing.name() != field.name())
+            {
+                fields.push(field);
+            }
+        }
+        fields
+    }
 }
 
 impl ProofPlan for TableExec {
@@ -56,7 +69,7 @@ impl ProofPlan for TableExec {
         params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         let column_evals = self
-            .schema
+            .physical_schema()
             .iter()
             .map(|field| {
                 *accessor
@@ -76,8 +89,12 @@ impl ProofPlan for TableExec {
         self.schema.clone()
     }
 
+    fn get_column_result_fields_with_presence(&self) -> Vec<ColumnField> {
+        self.physical_schema()
+    }
+
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        self.schema
+        self.physical_schema()
             .iter()
             .map(|field| ColumnRef::from_field(self.table_ref.clone(), field))
             .collect()

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
@@ -4,7 +4,7 @@ use crate::{
         owned_table_utility::*, table_utility::*, ColumnField, ColumnType, TableRef,
         TableTestAccessor,
     },
-    sql::proof::{exercise_verification, VerifiableQueryResult},
+    sql::proof::{exercise_verification, ProofPlan, VerifiableQueryResult},
 };
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
@@ -31,6 +31,26 @@ fn we_can_create_and_prove_an_empty_table_exec() {
         .table;
     let expected = owned_table([bigint("a", [0_i64; 0])]);
     assert_eq!(res, expected);
+}
+
+#[test]
+fn table_exec_physical_schema_adds_nullable_presence_once() {
+    let table_ref = TableRef::new("namespace", "table_name");
+    let plan = table_exec(
+        table_ref,
+        vec![
+            ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+            ColumnField::new("__posql_presence_amount".into(), ColumnType::Boolean),
+        ],
+    );
+
+    assert_eq!(
+        plan.get_column_result_fields_with_presence(),
+        vec![
+            ColumnField::new_nullable("amount".into(), ColumnType::BigInt),
+            ColumnField::new("__posql_presence_amount".into(), ColumnType::Boolean),
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
/claim #183

Claiming #183 for maintainer review as a substantial nullable-column implementation and proof-of-concept. The value+presence representation, nullable-result API, and split strategy are ready for maintainer shape feedback before any requested final polish.

What changed:
- added nullable metadata to `ColumnField` / `ColumnRef` with backward-compatible serde defaults
- added `NullableColumn`, `NullableOwnedColumn`, `NullableTable`, and `NullableOwnedTable` wrappers that model nullable data as backing values plus optional row-presence bits
- added borrowed and owned nullable add/sub/mul/eq/lt/gt operations that reuse existing value-column operations and propagate presence
- added Arrow `ArrayRef` / `RecordBatch` conversions that preserve Arrow nulls as value+presence data and nullable Arrow fields
- added nullable accessors and generated `__posql_presence_*` value/commitment plumbing so existing proof plans can read nullable data through the current non-null proof engine
- added generated `IS NULL`, `IS NOT NULL`, `IS TRUE`, and `IS FALSE` proof-expression builders for nullable refs, folding non-nullable refs to constants where possible
- propagated nullable metadata through DataFusion planner context, table scans, projections, filters, aggregates, and proof-plan result schemas
- expanded nullable logical result fields into physical value plus generated presence fields, and added nullable proof-result reassembly back into `NullableOwnedTable`
- added nullable first-round expression evaluation for columns, literals, placeholders, arithmetic, comparisons, `NOT`, casts, and boolean `AND` / `OR`
- added PostgreSQL-style value-dependent `AND` / `OR` nullable result presence, so short-circuiting `false` / `true` cases can produce present results even when the other operand is `NULL`
- guarded nullable boolean/comparison filters with generated presence expressions so nullable backing values cannot leak through `WHERE`, `WHERE NOT`, nested `AND` / `OR`, or expression-level null checks
- emits physical value+presence result columns through `TableExec`, `ProjectionExec`, `FilterExec`, and legacy filter proof evaluation, so `QueryProof` verifies nullable result presence rather than only describing it in schema
- keeps source commitment discovery on input plans for projection/filter nodes so aggregate/intermediate output refs are not treated as source table columns
- added `VerifiableQueryResult::verify_nullable()` for reassembling verified physical results into `NullableOwnedTable`, while keeping `verify()` compatible with the value-only `OwnedTable` return shape
- added query-proof PoCs for nullable `IS NULL`, `IS NOT NULL AND amount > 15`, nullable boolean filters, nullable comparison filters, nullable expression null checks, nullable result schema expansion, nullable result reassembly, verified physical nullable result output, and SQL `SELECT` results that preserve nulls through `verify_nullable()`
- added proof-scheme coverage for verified nullable result reassembly under both `DoryEvaluationProof` and `InnerProductProof` (`blitzar`)

Validation on this head:
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p proof-of-sql --no-default-features --features std`
- `cargo check -p proof-of-sql-planner`
- `cargo test -p proof-of-sql --no-default-features --features "std test" physical_nullable_results --lib`
- `cargo test -p proof-of-sql --no-default-features --features "std test" nullable_projection_query_result_can_reassemble_presence_after_verification --lib`
- `cargo test -p proof-of-sql --no-default-features --features "std test" --lib` (1017 passed)
- `cargo test -p proof-of-sql-planner --lib` (127 passed)
- `cargo test -p proof-of-sql-planner --test e2e_tests test_nullable_select_results_can_round_trip_nulls` (1 passed)
- `cargo test -p proof-of-sql-planner --test e2e_tests` (15 passed)
- `cargo test -p proof-of-sql --no-default-features --features "std test" nullable_projection_query_result` (2 passed)
- `cargo test -p proof-of-sql --no-default-features --features "std test" nullable --lib` (55 passed)
- Linux/amd64 Docker with `BLITZAR_BACKEND=cpu`: `cargo check -p proof-of-sql --features blitzar` passed
- Linux/amd64 Docker with `BLITZAR_BACKEND=cpu`: `cargo test -p proof-of-sql --features blitzar --lib nullable_projection_query_result_can_reassemble_presence_after_verification` passed
- Linux/amd64 Docker with `BLITZAR_BACKEND=cpu`: `cargo test -p proof-of-sql --features blitzar --lib nullable_projection_query_result_verifies_with_inner_product_proof` passed

Not included / review ask:
- Claim submitted via `/claim #183`; I still expect maintainer-directed API naming/shape adjustments and any preferred split strategy before final merge.
- `verify()` intentionally remains value-only compatibility output; nullable-preserving callers should use `verify_nullable()`.
- I expect the remaining work to be maintainer-directed API naming/shape adjustments and any preferred split strategy.

