### PR TITLE
test: cover record batch conversion without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -99,18 +99,160 @@ impl<C: Commitment> TableCommitment<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(all(test, feature = "arrow"))]
 mod tests {
     use super::*;
     use crate::base::{
+        arrow::arrow_array_to_column_conversion::ArrowArrayToColumnConversionError,
         commitment::naive_commitment::NaiveCommitment, scalar::test_scalar::TestScalar,
     };
     use arrow::{
-        array::{Int64Array, StringArray},
+        array::{BooleanArray, Int64Array, StringArray, UInt8Array},
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
     use std::sync::Arc;
+
+    #[test]
+    fn we_can_convert_record_batches_to_columns_without_blitzar() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("flag", DataType::Boolean, false),
+            Field::new("small_count", DataType::UInt8, false),
+            Field::new("label", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(BooleanArray::from(vec![true, false, true])),
+                Arc::new(UInt8Array::from(vec![3, 5, 8])),
+                Arc::new(StringArray::from(vec!["alpha", "beta", "gamma"])),
+            ],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+
+        let columns = batch_to_columns::<TestScalar>(&batch, &alloc).unwrap();
+        let expected_labels = ["alpha", "beta", "gamma"];
+        let expected_label_scalars: Vec<TestScalar> = expected_labels
+            .iter()
+            .map(core::convert::Into::into)
+            .collect();
+
+        assert_eq!(columns.len(), 3);
+        assert_eq!(columns[0].0.value, "flag");
+        assert_eq!(columns[0].1, Column::Boolean(&[true, false, true]));
+        assert_eq!(columns[1].0.value, "small_count");
+        assert_eq!(columns[1].1, Column::Uint8(&[3, 5, 8]));
+        assert_eq!(columns[2].0.value, "label");
+        assert_eq!(
+            columns[2].1,
+            Column::VarChar((&expected_labels, expected_label_scalars.as_slice()))
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_record_batches_with_nullable_values() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, true)]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int64Array::from(vec![Some(1), None, Some(3)]))],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+
+        let result = batch_to_columns::<TestScalar>(&batch, &alloc);
+
+        assert!(matches!(
+            result,
+            Err(
+                RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                    source: ArrowArrayToColumnConversionError::ArrayContainsNulls
+                }
+            )
+        ));
+    }
+
+    #[test]
+    fn we_can_create_table_commitments_from_record_batches_with_offset_without_blitzar() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![10, 20, 30]))])
+                .unwrap();
+
+        let commitment =
+            TableCommitment::<NaiveCommitment>::try_from_record_batch_with_offset(&batch, 7, &())
+                .unwrap();
+
+        assert_eq!(commitment.range(), &(7..10));
+        assert_eq!(commitment.num_rows(), 3);
+        assert_eq!(commitment.num_columns(), 1);
+    }
+
+    #[test]
+    fn we_cannot_append_record_batch_with_mismatched_column_type() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let initial_batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1, 2, 3]))]).unwrap();
+        let mut commitment =
+            TableCommitment::<NaiveCommitment>::try_from_record_batch(&initial_batch, &()).unwrap();
+
+        let append_schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, false)]));
+        let append_batch =
+            RecordBatch::try_new(append_schema, vec![Arc::new(StringArray::from(vec!["1"]))])
+                .unwrap();
+
+        let result = commitment.try_append_record_batch(&append_batch, &());
+
+        assert!(matches!(
+            result,
+            Err(AppendRecordBatchTableCommitmentError::ColumnCommitmentsMismatch { .. })
+        ));
+        assert_eq!(commitment.range(), &(0..3));
+    }
+
+    #[test]
+    #[should_panic(expected = "RecordBatches cannot have duplicate identifiers")]
+    fn we_cannot_create_table_commitments_from_record_batches_with_duplicate_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("a", DataType::UInt8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(UInt8Array::from(vec![3, 5, 8])),
+            ],
+        )
+        .unwrap();
+
+        let _ = TableCommitment::<NaiveCommitment>::try_from_record_batch(&batch, &());
+    }
+
+    #[test]
+    #[should_panic(expected = "RecordBatches cannot have duplicate identifiers")]
+    fn we_cannot_append_record_batches_with_duplicate_fields() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let initial_batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1, 2, 3]))]).unwrap();
+        let mut commitment =
+            TableCommitment::<NaiveCommitment>::try_from_record_batch(&initial_batch, &()).unwrap();
+
+        let append_schema = Arc::new(Schema::new(vec![
+            Field::new("b", DataType::Int64, false),
+            Field::new("b", DataType::UInt8, false),
+        ]));
+        let append_batch = RecordBatch::try_new(
+            append_schema,
+            vec![
+                Arc::new(Int64Array::from(vec![4, 5, 6])),
+                Arc::new(UInt8Array::from(vec![7, 8, 9])),
+            ],
+        )
+        .unwrap();
+
+        let _ = commitment.try_append_record_batch(&append_batch, &());
+    }
 
     #[test]
     fn we_can_create_and_append_table_commitments_with_record_batches() {


### PR DESCRIPTION
/claim #560

## Scope

Exercises the Arrow record batch conversion paths that are available without the `blitzar` feature.

- Runs the existing record batch commitment path under the `arrow` feature gate instead of tying it to `blitzar`.
- Covers `batch_to_columns` for Boolean, UInt8, and Utf8 arrays, including field-name preservation.
- Covers nullable Arrow values returning `RecordBatchToColumnsError`.
- Covers offset-aware table commitment creation from a record batch.
- Checks append-time type mismatch handling and verifies the existing commitment range is left unchanged.
- Covers duplicate field-name handling for both initial table commitment creation and record batch append.

The mixed-length panic branches remain unreachable through Arrow's safe `RecordBatch` constructor because Arrow validates equal column lengths before the commitment layer sees the batch.

## Validation

Windows:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "arrow test" record_batch_conversion
7 passed

cargo test -p proof-of-sql --lib --no-default-features --features "arrow test"
1060 passed
```

WSL Ubuntu-26.04:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "arrow test" record_batch_conversion --quiet
7 passed

cargo test -p proof-of-sql --lib --no-default-features --features "arrow test" --quiet
1060 passed
```

