### PR TITLE
test: cover table evaluation accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,22 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_read_table_evaluation_fields() {
+        let column_evals = vec![TestScalar::from(3), TestScalar::from(5)];
+        let chi = (TestScalar::from(8), 4);
+
+        let evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+        assert_eq!(evaluation.column_evals(), column_evals.as_slice());
+        assert_eq!(evaluation.chi_eval(), chi.0);
+        assert_eq!(evaluation.chi(), chi);
+        assert_eq!(evaluation.clone(), evaluation);
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope

Covers the `TableEvaluation` value object directly in its implementation module.

- Constructs a populated `TableEvaluation` with `TableEvaluation::new`.
- Checks `column_evals`, `chi_eval`, and `chi` against the stored values.
- Verifies the derived clone/equality behavior on the same evaluation payload.

The change is intentionally small: it covers the currently uncovered accessors without adding a separate test module or touching database module wiring.

## Validation

Windows:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" table_evaluation
1 passed

cargo test -p proof-of-sql --lib --no-default-features --features "test"
961 passed
```

WSL Ubuntu-26.04:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" table_evaluation --quiet
1 passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" --quiet
961 passed
```

