### PR TITLE
test: cover posql time unit helpers

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -81,4 +81,29 @@ mod time_unit_tests {
             ));
         }
     }
+
+    #[test]
+    fn we_can_convert_time_units_to_precision_values() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn we_can_display_time_units_with_precision() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
 }


### PR DESCRIPTION
/claim #560

## Scope

Covers the `PoSQLTimeUnit` helper surface in `base::posql_time`.

- Checks the precision value exposed for seconds, milliseconds, microseconds, and nanoseconds.
- Checks the user-facing `Display` strings for the same units.

These assertions sit beside the existing serde coverage for the enum and keep the test focused on the helper behavior that was not otherwise exercised.

## Validation

Windows:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" time_unit_tests
4 passed

cargo test -p proof-of-sql --lib --no-default-features --features "test"
962 passed
```

WSL Ubuntu-26.04:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" time_unit_tests --quiet
4 passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" --quiet
962 passed
```

