### PR TITLE
test: cover inner product ref cast

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -162,3 +162,28 @@ fn test_inner_product_testscalar_uneven() {
     ];
     assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
+
+#[test]
+fn test_inner_product_ref_cast_with_integer_inputs() {
+    let a = vec![1_u8, 2, 3, 4];
+    let b = vec![
+        TestScalar::from(2),
+        TestScalar::from(3),
+        TestScalar::from(4),
+        TestScalar::from(5),
+    ];
+
+    assert_eq!(TestScalar::from(40), inner_product_ref_cast(&a, &b));
+}
+
+#[test]
+fn test_inner_product_ref_cast_truncates_to_shorter_input() {
+    let a = vec![true, false, true, true];
+    let b = vec![
+        TestScalar::from(5),
+        TestScalar::from(7),
+        TestScalar::from(11),
+    ];
+
+    assert_eq!(TestScalar::from(16), inner_product_ref_cast(&a, &b));
+}


### PR DESCRIPTION
/claim #560

## Scope

Adds direct coverage for `inner_product_ref_cast` in the slice helpers.

- Covers ref-cast inner products for integer inputs against `TestScalar` values.
- Covers Boolean inputs with uneven slice lengths, preserving the current zip/truncation behavior.

The tests extend the existing inner-product test file and do not change the helper implementation.

## Validation

Windows:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" inner_product_ref_cast
2 passed

cargo test -p proof-of-sql --lib --no-default-features --features "test"
962 passed
```

WSL Ubuntu-26.04:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" inner_product_ref_cast --quiet
2 passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" --quiet
962 passed
```

