### PR TITLE
test: cover timestamp scale cast branches

### DIFF
--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -73,7 +73,10 @@ pub fn scale_cast_binary_op(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::{ColumnRef, TableRef};
+    use crate::base::{
+        database::{ColumnRef, TableRef},
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    };
 
     #[expect(non_snake_case)]
     fn COLUMN1_BOOLEAN() -> DynProofExpr {
@@ -138,6 +141,24 @@ mod tests {
                 Precision::new(25).expect("Precision is definitely valid"),
                 5,
             ),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN1_TIMESTAMP_SECOND() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN2_TIMESTAMP_MILLISECOND() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column2".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
         ))
     }
 
@@ -226,6 +247,30 @@ mod tests {
                 )
             );
         }
+    }
+
+    #[test]
+    fn we_can_convert_scale_cast_binary_op_upcasting_left_timestamp() {
+        let left = COLUMN1_TIMESTAMP_SECOND();
+        let right = COLUMN2_TIMESTAMP_MILLISECOND();
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+        assert_eq!(
+            proof_exprs,
+            (
+                DynProofExpr::try_new_scaling_cast(left, right.data_type()).unwrap(),
+                right
+            )
+        );
+    }
+
+    #[test]
+    fn we_can_convert_scale_cast_binary_op_upcasting_right_timestamp() {
+        let left = COLUMN2_TIMESTAMP_MILLISECOND();
+        let right = COLUMN1_TIMESTAMP_SECOND();
+        let expected_right =
+            DynProofExpr::try_new_scaling_cast(right.clone(), left.data_type()).unwrap();
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+        assert_eq!(proof_exprs, (left, expected_right));
     }
 
     #[test]


### PR DESCRIPTION
/claim #560

## Scope

Covers the timestamp-specific branches in `scale_cast_binary_op`.

- Builds second- and millisecond-precision `TimestampTZ` column expressions.
- Verifies the left-hand timestamp branch wraps the lower-precision operand in a scaling cast.
- Verifies the right-hand timestamp branch does the same when the lower-precision operand is on the right.

The assertions compare against `DynProofExpr::try_new_scaling_cast` directly, so the test exercises the timestamp path rather than the decimal scaling helper.

## Validation

Windows:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" scale_cast_binary_op
5 passed

cargo test -p proof-of-sql --lib --no-default-features --features "test"
962 passed
```

WSL Ubuntu-26.04:

```text
cargo fmt --all -- --check
passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" scale_cast_binary_op --quiet
5 passed

cargo test -p proof-of-sql --lib --no-default-features --features "test" --quiet
962 passed
```

