### PR TITLE
test: reduce VMV state setup size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/vmv_state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/vmv_state_test.rs
@@ -99,10 +99,10 @@ fn we_can_create_correct_vmv_states_from_a_small_fixed_vmv() {
 #[test]
 fn we_can_create_vmv_states_from_random_vmv_and_get_correct_sizes() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
-    for nu in 0..max_nu {
+    for nu in 0..=max_nu {
         let vmv = VMV::rand(nu, &mut rng);
 
         assert_eq!(vmv.L.len(), 1 << nu);


### PR DESCRIPTION
## Summary
- Reduce the VMV state random test Dory setup from `max_nu = 5` to `max_nu = 4`.
- Preserve the exact tested `nu` range by changing the loop from `0..max_nu` to `0..=max_nu`, so the test still covers `nu = 0, 1, 2, 3, 4`.
- This halves the generated public-parameter vector size for this test from 32 entries to 16 entries without weakening assertions.

/claim #557

## Validation
- `cargo test -p proof-of-sql --no-default-features --features "test" proof_primitive::dory::vmv_state_test -- --nocapture`
- `cargo fmt --check`
- `git diff --check`