### PR TITLE
test: shrink Dory state setup without dropping cases

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_state_test.rs
@@ -9,10 +9,10 @@ use ark_ff::Fp;
 #[test]
 pub fn we_can_create_an_extended_verifier_state_from_an_extended_prover_state() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
-    for nu in 0..max_nu {
+    for nu in 0..=max_nu {
         let (v1, v2) = rand_G_vecs(nu, &mut rng);
         let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
         let mut s1 = vec![Fp::default(); 1 << nu];

--- a/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
@@ -4,10 +4,10 @@ use ark_ec::pairing::Pairing;
 #[test]
 pub fn we_can_create_a_verifier_state_from_a_prover_state() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
-    for nu in 0..max_nu {
+    for nu in 0..=max_nu {
         let (v1, v2) = rand_G_vecs(nu, &mut rng);
         let prover_state = ProverState::new(v1.clone(), v2.clone(), nu);
         let verifier_state = prover_state.calculate_verifier_state(&prover_setup);


### PR DESCRIPTION
## Summary
- reduce over-provisioned Dory public parameter setup generation in the state and extended-state multi-nu tests from max_nu=5 to max_nu=4
- preserve the exact tested nu values by changing the loops from 0..max_nu to 0..=max_nu
- keep all assertions and verifier-state checks unchanged

/claim #557

## Validation
- cargo fmt -- --check
- cargo test -p proof-of-sql --no-default-features --features="test" proof_primitive::dory::state_test
- cargo test -p proof-of-sql --no-default-features --features="test" proof_primitive::dory::extended_state_test
- git diff --check
