### PR TITLE
Reject nullable RecordBatch schemas during Arrow conversions

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -20,7 +20,7 @@ use crate::base::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError},
     scalar::Scalar,
 };
-use alloc::sync::Arc;
+use alloc::{string::String, sync::Arc};
 use arrow::{
     array::{
         ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
@@ -58,6 +58,12 @@ pub enum OwnedArrowConversionError {
     /// This error occurs when trying to convert from an Arrow array with nulls.
     #[snafu(display("null values are not supported in OwnedColumn yet"))]
     NullNotSupportedYet,
+    /// This error occurs when trying to convert from an Arrow field marked nullable.
+    #[snafu(display("nullable Arrow field {field_name} is not supported in OwnedTable yet"))]
+    NullableFieldNotSupportedYet {
+        /// The nullable field name.
+        field_name: String,
+    },
     /// Using `TimeError` to handle all time-related errors
     #[snafu(transparent)]
     TimestampConversionError {
@@ -314,6 +320,11 @@ impl<S: Scalar> TryFrom<RecordBatch> for OwnedTable<S> {
             .iter()
             .zip(value.columns())
             .map(|(field, array_ref)| {
+                if field.is_nullable() {
+                    return Err(OwnedArrowConversionError::NullableFieldNotSupportedYet {
+                        field_name: field.name().clone(),
+                    });
+                }
                 let owned_column = OwnedColumn::try_from(array_ref)?;
                 let identifier = Ident::new(field.name());
                 Ok((identifier, owned_column))

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -101,6 +101,23 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
     ));
 }
 
+#[test]
+fn we_reject_nullable_record_batch_fields_even_when_values_are_present() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "nullable_int64",
+        DataType::Int64,
+        true,
+    )]));
+    let batch =
+        RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1, 2, 3]))]).unwrap();
+
+    assert!(matches!(
+        OwnedTable::<TestScalar>::try_from(batch),
+        Err(OwnedArrowConversionError::NullableFieldNotSupportedYet { field_name })
+            if field_name == "nullable_int64"
+    ));
+}
+
 fn we_can_convert_between_owned_table_and_record_batch_impl(
     owned_table: &OwnedTable<TestScalar>,
     record_batch: &RecordBatch,

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -16,6 +16,7 @@ use sqlparser::ast::Ident;
 
 /// This function will return an error if:
 /// - The field name cannot be parsed into an [`Identifier`].
+/// - A field is marked nullable, which is not represented in [`Column`] yet.
 /// - The conversion of an Arrow array to a [`Column`] fails.
 pub fn batch_to_columns<'a, S: Scalar + 'a>(
     batch: &'a RecordBatch,
@@ -28,6 +29,11 @@ pub fn batch_to_columns<'a, S: Scalar + 'a>(
         .zip(batch.columns())
         .map(|(field, array)| {
             let identifier: Ident = field.name().as_str().into();
+            if field.is_nullable() {
+                return Err(RecordBatchToColumnsError::NullableFieldNotSupportedYet {
+                    field_name: field.name().clone(),
+                });
+            }
             let column: Column<S> = array.to_column(alloc, &(0..array.len()), None)?;
             Ok((identifier, column))
         })
@@ -96,6 +102,35 @@ impl<C: Commitment> TableCommitment<C> {
                 panic!("RecordBatches cannot have duplicate identifiers")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod batch_to_columns_tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::sync::Arc;
+    use arrow::{
+        array::Int64Array,
+        datatypes::{DataType, Field, Schema},
+    };
+
+    #[test]
+    fn we_reject_nullable_record_batch_fields_when_converting_to_columns() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "nullable_int64",
+            DataType::Int64,
+            true,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1, 2, 3]))]).unwrap();
+        let alloc = Bump::new();
+
+        assert!(matches!(
+            batch_to_columns::<TestScalar>(&batch, &alloc),
+            Err(RecordBatchToColumnsError::NullableFieldNotSupportedYet { field_name })
+                if field_name == "nullable_int64"
+        ));
     }
 }
 

--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -1,10 +1,19 @@
 use super::arrow_array_to_column_conversion::ArrowArrayToColumnConversionError;
 use crate::base::commitment::ColumnCommitmentsMismatch;
+use alloc::string::String;
 use snafu::Snafu;
 
 /// Errors that can occur when trying to create or extend a [`TableCommitment`] from a record batch.
 #[derive(Debug, Snafu)]
 pub enum RecordBatchToColumnsError {
+    /// This error occurs when trying to convert from an Arrow field marked nullable.
+    #[snafu(display(
+        "nullable Arrow field {field_name} is not supported in record batch conversion yet"
+    ))]
+    NullableFieldNotSupportedYet {
+        /// The nullable field name.
+        field_name: String,
+    },
     /// Error converting from arrow array
     #[snafu(transparent)]
     ArrowArrayToColumnConversionError {


### PR DESCRIPTION
## Summary
- Reject nullable Arrow fields before converting `RecordBatch` values into Proof-of-SQL owned columns.
- Add explicit conversion errors for nullable Arrow schema fields.
- Add regression coverage for nullable schema fields, including the case where the actual values contain no nulls.

## Why
Proof-of-SQL owned columns are non-nullable today. Before this change, a nullable Arrow field could be accepted when the concrete array had no null values, silently dropping the schema-level nullability bit during conversion.

Refs #183.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `scripts/check_commits.sh`
- `cargo test -p proof-of-sql --no-default-features --features="arrow test" --lib` (1055 passed)

## Bounty claim
/claim #183

This claims a partial, productive slice of the nullable column bounty: it adds an explicit guard for nullable Arrow RecordBatch inputs so unsupported nullable data cannot be silently converted into non-nullable columns, with tests covering the new rejection path.
