### PR TITLE
test: reduce dynamic Dory serialization setup

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
@@ -128,7 +128,7 @@ mod tests {
     fn commitment_serialization_does_not_change() {
         let expected_serialization =
             include_bytes!("./test_table_commitmet_do_not_modify.bin").to_vec();
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
         let setup = ProverSetup::from(&public_parameters);
 
         let base_table: OwnedTable<DoryScalar> = owned_table([


### PR DESCRIPTION
## Summary
- shrink the `DynamicDoryCommitment` serialization regression test setup from `max_nu = 5` to `max_nu = 2`
- keep the same four-row table, expected serialized bytes, and round-trip assertion
- avoid generating unused Dory public/prover setup entries for this focused test

Note: bounty claim consolidated on #1771 to avoid duplicate claims.
## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" commitment_serialization_does_not_change`
- `cargo fmt --all -- --check`
- `git diff --check`
