### PR TITLE
test: reduce Dory compute setup sizes

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -12,9 +12,11 @@ use ark_ec::pairing::Pairing;
 use ark_std::test_rng;
 use num_traits::Zero;
 
+const TEST_MAX_NU: usize = 4;
+
 #[test]
 fn we_can_compute_a_dory_commitment_with_varbinary_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
 
@@ -34,7 +36,7 @@ fn we_can_compute_a_dory_commitment_with_varbinary_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_int128_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::Int128(&[0, -1, 2])], 0, &setup);
@@ -48,7 +50,7 @@ fn we_can_compute_a_dory_commitment_with_int128_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_boolean_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -66,7 +68,7 @@ fn we_can_compute_a_dory_commitment_with_boolean_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2])], 0, &setup);
@@ -80,7 +82,7 @@ fn we_can_compute_a_dory_commitment_with_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3])], 0, &setup);
@@ -95,7 +97,7 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[2, 3])], 2, &setup);
@@ -108,7 +110,7 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with_signed_data() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
@@ -121,7 +123,7 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -146,7 +148,7 @@ fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -182,7 +184,7 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1])], 5, &setup);
@@ -195,7 +197,7 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -220,7 +222,7 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns()
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -256,7 +258,7 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
 
 #[test]
 fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -342,7 +344,7 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
 
 #[test]
 fn we_can_compute_an_empty_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
@@ -385,7 +387,7 @@ fn we_can_compute_an_empty_dory_commitment() {
 
 #[test]
 fn test_compute_dory_commitment_when_sigma_is_zero() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 0, &setup);
@@ -401,7 +403,7 @@ fn test_compute_dory_commitment_when_sigma_is_zero() {
 
 #[test]
 fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 5, &setup);
@@ -417,7 +419,7 @@ fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -494,7 +496,7 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_fewer_rows_than_columns(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -570,7 +572,7 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
@@ -659,7 +661,7 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
@@ -11,9 +11,11 @@ use crate::{
 use ark_ec::pairing::Pairing;
 use num_traits::Zero;
 
+const TEST_MAX_NU: usize = 3;
+
 #[test]
 fn we_can_handle_calling_with_an_empty_committable_column() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(&[], 0, &setup);
 
@@ -22,7 +24,7 @@ fn we_can_handle_calling_with_an_empty_committable_column() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(
         &[CommittableColumn::BigInt(&[
@@ -57,7 +59,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(
         &[CommittableColumn::BigInt(&[
@@ -92,7 +94,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_o
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_signed_bigint_values_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
     let Gamma_1 = public_parameters.Gamma_1;
@@ -104,7 +106,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_signed_bigint_values_and_an_off
 
 #[test]
 fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(
         &[
@@ -189,7 +191,7 @@ fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset
 
 #[test]
 fn we_can_compute_an_empty_dynamic_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
     assert_eq!(res[0].0, GT::zero());
@@ -231,7 +233,7 @@ fn we_can_compute_an_empty_dynamic_dory_commitment() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(
         &[
@@ -306,7 +308,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(
         &[
@@ -381,7 +383,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(
         &[
@@ -469,7 +471,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(TEST_MAX_NU, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);
     let res = compute_dynamic_dory_commitments(
         &[


### PR DESCRIPTION
## Summary

/claim #557

This trims the generated Dory public-parameter sizes used by the compute commitment test modules without removing any cases or assertions.

- `dory_compute_commitments_test` now uses `max_nu = 4`, which still covers the largest asserted static Gamma index (`Gamma_2[9]`).
- `dynamic_dory_compute_commitments_test` now uses `max_nu = 3`, which still covers the largest asserted dynamic Gamma indices (`Gamma_1[7]`, `Gamma_2[6]`).

## Timing

Focused hot-run command before this change:

```sh
cargo test -p proof-of-sql --lib --no-default-features --features="test" dory_compute_commitments
```

- before: test binary finished in 12.99s; `time` real 13.30s
- after: test binary finished in 8.74s; `time` real 9.03s

## Verification

```sh
cargo test -p proof-of-sql --lib --no-default-features --features="test" dory_compute_commitments
cargo fmt --all -- --check
git diff --check
```