### PR TITLE
test: add PoSQL time coverage

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,42 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_timestamp_errors() {
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezone {
+                timezone: "MARS".into()
+            }
+            .to_string(),
+            "invalid timezone string: MARS"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezoneOffset.to_string(),
+            "invalid timezone offset"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimeUnit {
+                error: "weeks".into()
+            }
+            .to_string(),
+            "Invalid time unit"
+        );
+        assert_eq!(
+            PoSQLTimestampError::UnsupportedPrecision { error: "2".into() }.to_string(),
+            "Unsupported precision for timestamp: 2"
+        );
+    }
+
+    #[test]
+    fn we_can_convert_timestamp_errors_to_strings() {
+        let error = PoSQLTimestampError::UnsupportedPrecision { error: "12".into() };
+        let error_message: String = error.into();
+
+        assert_eq!(error_message, "Unsupported precision for timestamp: 12");
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -104,6 +104,27 @@ mod timezone_parsing_tests {
     }
 
     #[test]
+    fn we_can_parse_positive_time_zone() {
+        let timezone_as_str: Option<Arc<str>> = Some("+05:30".into());
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+        let expected_time_zone = PoSQLTimeZone::new(19_800);
+        assert_eq!(timezone, expected_time_zone);
+    }
+
+    #[test]
+    fn we_can_parse_utc_aliases() {
+        let utc_aliases = ["Z", "UTC", "00:00", "+00:00", "0:00", "+0:00", "utc"];
+
+        for alias in utc_aliases {
+            let timezone_as_str: Option<Arc<str>> = Some(alias.into());
+            assert_eq!(
+                PoSQLTimeZone::try_from(&timezone_as_str),
+                Ok(PoSQLTimeZone::utc())
+            );
+        }
+    }
+
+    #[test]
     fn we_can_parse_none_time_zone() {
         let timezone = PoSQLTimeZone::try_from(&None).unwrap();
         let expected_time_zone = PoSQLTimeZone::utc();
@@ -118,5 +139,12 @@ mod timezone_parsing_tests {
             timezone_err,
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
         ));
+    }
+
+    #[test]
+    fn we_cannot_parse_invalid_time_zone_offset() {
+        let timezone_as_str: Option<Arc<str>> = Some("+0A:00".into());
+        let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();
+        assert_eq!(timezone_err, PoSQLTimestampError::InvalidTimezoneOffset);
     }
 }

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -69,16 +69,43 @@ mod time_unit_tests {
     }
 
     #[test]
+    fn test_time_units_convert_to_precision() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn test_time_units_display_precision() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
+
+    #[test]
     fn test_invalid_precision() {
         let invalid_precisions = [
             "1", "2", "4", "5", "7", "8", "10", "zero", "three", "cat", "-1", "-2",
         ]; // Testing all your various invalid inputs
         for &value in &invalid_precisions {
             let result = PoSQLTimeUnit::try_from(value);
-            assert!(matches!(
+            assert_eq!(
                 result,
-                Err(PoSQLTimestampError::UnsupportedPrecision { .. })
-            ));
+                Err(PoSQLTimestampError::UnsupportedPrecision {
+                    error: value.into()
+                })
+            );
         }
     }
 }


### PR DESCRIPTION
# Proof of SQL #560: add PoSQL time coverage

## Summary

- Adds unit coverage for `From<PoSQLTimeUnit> for u64`.
- Adds unit coverage for the `PoSQLTimeUnit` `Display` implementation.
- Tightens the invalid precision test to assert the exact `UnsupportedPrecision` payload.
- Adds timezone parsing coverage for positive offsets, UTC aliases, and malformed numeric offsets.
- Adds timestamp error coverage for display strings and `String` conversion.

## Context

This is a small coverage-focused contribution related to:

- https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560
- Algora bounty board: https://algora.io/spaceandtimelabs/home

The issue explicitly says test coverage can be improved through smaller PRs that cover different parts of the codebase. This patch targets `crates/proof-of-sql/src/base/posql_time`.

Local branch prepared:

- `codex/posql-time-coverage`
- Commit: `b4f2811 test: add PoSQL time coverage`

## Validation

Ran in Docker because this Windows host does not have Rust/Cargo installed locally:

```bash
docker run --rm -v "${PWD}:/work" -w /work rust:1.89-slim sh -lc "apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y clang lld >/dev/null && /usr/local/cargo/bin/cargo test -p proof-of-sql base::posql_time::unit::time_unit_tests --lib"
```

Result:

- `4 passed; 0 failed; 0 ignored; 1398 filtered out`

After adding timezone and error tests, also ran:

```bash
docker run --rm -v "${PWD}:/work" -w /work rust:1.89-slim sh -lc "apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y clang lld >/dev/null && /usr/local/cargo/bin/cargo test -p proof-of-sql base::posql_time --lib"
```

Result:

- `15 passed; 0 failed; 0 ignored; 1392 filtered out`

Also ran:

```bash
docker run --rm -v "${PWD}:/work" -w /work rust:1.89-slim sh -lc "apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y clang lld >/dev/null && /usr/local/cargo/bin/rustup component add rustfmt >/dev/null && /usr/local/cargo/bin/cargo fmt --check"
git diff --check
```

Results:

- `cargo fmt --check` passed.
- `git diff --check` passed.
- Saved patch reverse-apply check passed.
