### PR TITLE
test: cover table ref parsing and serialization

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,57 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_create_table_refs_from_names_and_components() {
+        let table_ref = TableRef::new("", "orders");
+
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value.as_str(), "orders");
+        assert_eq!(table_ref.to_string(), "orders");
+
+        let table_ref = TableRef::from_strs(&["analytics", "orders"]).unwrap();
+
+        assert_eq!(table_ref.schema_id().unwrap().value.as_str(), "analytics");
+        assert_eq!(table_ref.table_id().value.as_str(), "orders");
+        assert_eq!(table_ref.to_string(), "analytics.orders");
+    }
+
+    #[test]
+    fn we_can_parse_and_serialize_table_refs() {
+        let table_ref = TableRef::try_from("analytics.orders").unwrap();
+        let encoded = serde_json::to_string(&table_ref).unwrap();
+
+        assert_eq!(encoded, "\"analytics.orders\"");
+        assert_eq!(serde_json::from_str::<TableRef>(&encoded).unwrap(), table_ref);
+    }
+
+    #[test]
+    fn we_reject_invalid_table_reference_component_counts() {
+        assert_eq!(
+            TableRef::from_strs(&["one", "two", "three"]).unwrap_err(),
+            ParseError::InvalidTableReference {
+                table_reference: "one,two,three".into()
+            }
+        );
+
+        assert_eq!(
+            TableRef::try_from("one.two.three").unwrap_err(),
+            ParseError::InvalidTableReference {
+                table_reference: "one.two.three".into()
+            }
+        );
+    }
+
+    #[test]
+    fn borrowed_table_refs_are_equivalent_to_matching_keys() {
+        let table_ref = TableRef::from_names(Some("analytics"), "orders");
+
+        assert!((&table_ref).equivalent(&TableRef::new("analytics", "orders")));
+        assert!(!(&table_ref).equivalent(&TableRef::new("warehouse", "orders")));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for `TableRef` construction from names and string components.
- Cover parse/display/serde round-tripping.
- Cover invalid component-count errors and `Equivalent` matching behavior.

## Test plan
- `git diff --check`
- Not run locally: `cargo` is not installed in this environment.
