### PR TITLE
test: reduce slow proof test verification work

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -27,10 +27,12 @@ pub fn exercise_verification(
     expr: &(impl ProofPlan + Serialize),
     accessor: &impl TestAccessor<RistrettoPoint>,
     table_ref: &TableRef,
-) {
-    res.clone()
+) -> OwnedTable<Curve25519Scalar> {
+    let verified_table = res
+        .clone()
         .verify(expr, accessor, &(), &[])
-        .expect("Verification failed");
+        .expect("Verification failed")
+        .table;
 
     // try changing the result
     let mut res_p = res.clone();
@@ -80,6 +82,8 @@ pub fn exercise_verification(
         fake_accessor.update_offset(table_ref, offset_generators + 1);
         assert!(res.clone().verify(expr, &fake_accessor, &(), &[]).is_err());
     }
+
+    verified_table
 }
 
 fn tampered_table<S: Scalar>(table: &OwnedTable<S>) -> OwnedTable<S> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -58,11 +58,7 @@ fn we_can_prove_a_typical_add_subtract_query() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         smallint("a", [3_i16, 4]),
         bigint("c", [2_i16, 0]),
@@ -129,11 +125,7 @@ fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         decimal75("a", 12, 1, [4_i64, 2]),
         decimal75("c", 17, 3, [1040_i64, 477]),
@@ -205,11 +197,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res
-            .verify(&ast, &accessor, &(), &[])
-            .unwrap()
-            .table;
+        let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
 
         // Calculate/compare expected result
         let (expected_f, expected_d): (Vec<_>, Vec<_>) = multizip((

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -61,11 +61,7 @@ fn we_can_prove_a_simple_and_query() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("a", [2]), varchar("d", ["t"])]);
     assert_eq!(res, expected_res);
 }
@@ -101,11 +97,7 @@ fn we_can_prove_a_simple_and_query_with_128_bits() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([int128("a", [2]), varchar("d", ["t"])]);
     assert_eq!(res, expected_res);
 }
@@ -161,11 +153,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res
-            .verify(&ast, &accessor, &(), &[])
-            .unwrap()
-            .table;
+        let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
 
         // Calculate/compare expected result
         let (expected_a, expected_d): (Vec<_>, Vec<_>) = multizip((

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
@@ -84,11 +84,7 @@ fn we_can_prove_a_simple_cast_expr() {
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         tinyint("a_cast", [0i8, 1, 0, 1]),
         smallint("b_cast", [1i16, 1, 0, 1]),
@@ -169,11 +165,7 @@ fn we_can_prove_a_simple_cast_expr_from_int_to_other_numeric_type() {
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         smallint("a_cast", [1i16]),
         uint8("b_cast", [1u8]),

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
@@ -26,11 +26,7 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([boolean("a", [true, false])]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -160,11 +160,7 @@ fn we_can_prove_an_equality_query_with_a_single_selected_row() {
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([varchar("d", ["abc"]), bigint("a", [123_i64])]);
     assert_eq!(res, expected_res);
 }
@@ -194,11 +190,7 @@ fn we_can_prove_another_equality_query_with_a_single_selected_row() {
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([varchar("d", ["abc"]), bigint("a", [123_i64])]);
     assert_eq!(res, expected_res);
 }
@@ -228,11 +220,7 @@ fn we_can_prove_an_equality_query_with_a_single_non_selected_row() {
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [0; 0]),
         varchar("d", [""; 0]),
@@ -276,11 +264,7 @@ fn we_can_prove_an_equality_query_with_multiple_rows() {
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [1, 3]),
         varchar("c", ["t", "jj"]),
@@ -329,11 +313,7 @@ fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [1, 2]),
         varchar("c", ["t", "ghi"]),
@@ -378,11 +358,7 @@ fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
         equal(column(&t, "b", &accessor), const_bigint(123_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [1, 3]),
         varchar("c", ["t", "jj"]),
@@ -428,11 +404,7 @@ fn we_can_prove_an_equality_query_with_a_string_comparison() {
         equal(column(&t, "c", &accessor), const_varchar("ghi")),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [2, 5]),
         bigint("b", [5, 0]),
@@ -488,11 +460,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res
-            .verify(&ast, &accessor, &(), &[])
-            .unwrap()
-            .table;
+        let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
 
         // Calculate/compare expected result
         let (expected_a, expected_d): (Vec<_>, Vec<_>) = multizip((

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -215,11 +215,7 @@ fn we_can_compare_columns_with_extreme_values() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("bigint_b", [i64::MAX, i64::MIN])]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -140,11 +140,7 @@ fn we_can_compare_a_constant_column() {
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [0; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -167,11 +163,7 @@ fn we_can_compare_a_varying_column_with_constant_sign() {
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [0; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -247,11 +239,7 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
         lte(column(&t, "e", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [25]),
         varchar("d", ["de"]),
@@ -296,11 +284,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [123]),
         varchar("d", ["abc"]),
@@ -346,11 +330,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [25]),
         varchar("d", ["de"]),
@@ -391,11 +371,7 @@ fn we_can_compare_columns_returning_extreme_decimal_values() {
         lte(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [25]),
         varchar("d", ["de"]),
@@ -449,11 +425,7 @@ fn we_can_compare_two_columns() {
         lte(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [1_i64, 7])]);
     assert_eq!(res, expected_res);
 }
@@ -479,11 +451,7 @@ fn we_can_compare_a_varying_column_with_constant_absolute_value() {
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [1_i64, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -509,11 +477,7 @@ fn we_can_compare_a_constant_column_of_negative_columns() {
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -539,11 +503,7 @@ fn we_can_compare_a_varying_column_with_negative_only_signs() {
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -566,11 +526,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs() {
         lte(column(&t, "a", &accessor), const_bigint(1)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [1_i64, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -593,11 +549,7 @@ fn we_can_compare_column_with_greater_than_or_equal() {
         gte(column(&t, "a", &accessor), const_bigint(1)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [2_i64])]);
     assert_eq!(res, expected_res);
 }
@@ -628,11 +580,7 @@ fn we_can_run_nested_comparison() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [1_i64, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -655,11 +603,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs_and_a_constant
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [1_i64])]);
     assert_eq!(res, expected_res);
 }
@@ -682,11 +626,7 @@ fn we_can_compare_a_constant_column_of_zeros() {
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -709,11 +649,7 @@ fn the_sign_can_be_0_or_1_for_a_constant_column_of_zeros() {
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected);
 }
@@ -755,11 +691,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             lte(column(&t, "a", &accessor), const_bigint(filter_val)),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res
-            .verify(&ast, &accessor, &(), &[])
-            .unwrap()
-            .table;
+        let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
 
         // Calculate/compare expected result
         let (expected_a, expected_b): (Vec<_>, Vec<_>) =

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -60,11 +60,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             const_bool(lit),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res
-            .verify(&ast, &accessor, &(), &[])
-            .unwrap()
-            .table;
+        let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
 
         // Calculate/compare expected result
         let (expected_a, expected_b, expected_c): (Vec<bool>, Vec<String>, Vec<i64>) = if lit {
@@ -109,11 +105,7 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
         const_bool(true),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     assert_eq!(res, expected_res);
 }
 
@@ -129,11 +121,7 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
         const_bool(false),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("a", [1_i64; 0])]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -69,11 +69,7 @@ fn we_can_prove_a_typical_multiply_query() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         decimal75("a", 16, 0, [2_i32, 6]),
         bigint("c", [0_i64, 2]),
@@ -136,11 +132,7 @@ fn where_clause_can_wrap_around() {
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         bigint(
             "a",
@@ -221,11 +213,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res
-            .verify(&ast, &accessor, &(), &[])
-            .unwrap()
-            .table;
+        let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
 
         // Calculate/compare expected result
         let (expected_f, expected_d): (Vec<_>, Vec<_>) = multizip((

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -45,11 +45,7 @@ fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {
         not(equal(column(&t, "b", &accessor), const_bigint(1))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("a", [123]), varchar("d", ["alfa"])]);
     assert_eq!(res, expected_res);
 }
@@ -98,11 +94,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             )),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res
-            .verify(&ast, &accessor, &(), &[])
-            .unwrap()
-            .table;
+        let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
 
         // Calculate/compare expected result
         let (expected_a, expected_b): (Vec<_>, Vec<_>) =

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -47,11 +47,7 @@ fn we_can_prove_a_simple_or_query() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("a", [2_i64, 3]), varchar("d", ["t", "g"])]);
     assert_eq!(res, expected_res);
 }
@@ -82,11 +78,7 @@ fn we_can_prove_a_simple_or_query_with_variable_integer_types() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([int128("a", [2_i64, 3]), varchar("d", ["t", "g"])]);
     assert_eq!(res, expected_res);
 }
@@ -119,11 +111,7 @@ fn we_can_prove_an_or_query_where_both_lhs_and_rhs_are_true() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("a", [2_i64, 3, 4]), varchar("d", ["t", "g", "efg"])]);
     assert_eq!(res, expected_res);
 }
@@ -179,11 +167,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res
-            .verify(&ast, &accessor, &(), &[])
-            .unwrap()
-            .table;
+        let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
 
         // Calculate/compare expected result
         let (expected_a, expected_d): (Vec<_>, Vec<_>) = multizip((

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
@@ -92,11 +92,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         decimal75("a_cast", 4, 1, [10]),
         decimal75("b_cast", 4, 1, [10]),
@@ -153,11 +149,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_decimal_to_decimal() {
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([
         decimal75("a_cast", 5, -1, [100]),
         decimal75("b_cast", 5, 2, [10]),
@@ -195,11 +187,7 @@ fn we_can_prove_a_simple_scale_cast_expr_from_timestamp_to_timestamp() {
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([timestamptz(
         "a_cast",
         PoSQLTimeUnit::Millisecond,

--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
@@ -42,8 +42,7 @@ fn we_can_prove_aggregation_without_group_by() {
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("sum_c", [101 + 104 + 102 + 103]),
         bigint("__count__", [4]),
@@ -77,8 +76,7 @@ fn we_can_prove_a_simple_aggregate_with_bigint_columns() {
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("a", [1, 2]),
         bigint("sum_c", [101 + 104, 102 + 103]),
@@ -119,8 +117,7 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("a", [1, 2]),
         decimal75("sum_c", 40, 0, [(101 + 104) * 2 + 2, (102 + 103) * 2 + 2]),
@@ -307,8 +304,7 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
         ),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("sum_int", [1406 + 927 + 637]),
         decimal75("sum_128", 59, 0, [(1342 + 1262 + 513) * 4]),
@@ -378,8 +374,7 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
     );
 
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         decimal75("one_plus_double_a", 40, 0, [3, 5, 7]),
         bigint("sum_b", [50, 60, 30]),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -81,8 +81,7 @@ fn we_can_correctly_filter_data_with_filter() {
     );
 
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected_res = owned_table([bigint("b", [3_i64, 5])]);
     assert_eq!(res, expected_res);
 }
@@ -121,8 +120,7 @@ fn we_can_correctly_filter_with_complex_condition() {
     );
 
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [4_i64, 5]),
         bigint("b", [2, 3]),
@@ -168,8 +166,7 @@ fn we_can_compose_multiple_filters() {
     );
 
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected_res = owned_table([
         bigint("a", [4_i64, 5]),
         bigint("b", [2, 3]),
@@ -238,8 +235,7 @@ fn we_can_compose_complex_filters() {
         ),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected_res = owned_table([
         decimal75("sum", 11, 0, [15, 19]), // a+b values for rows 3,4
         int("a", [7, 9]),                  // a values for rows 3,4

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
@@ -31,8 +31,7 @@ fn we_can_prove_aggregation_without_group_by() {
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("sum_c", [101 + 104 + 102 + 103]),
         bigint("__count__", [4]),
@@ -59,8 +58,7 @@ fn we_can_prove_a_simple_group_by_with_bigint_columns() {
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("a", [1, 2]),
         bigint("sum_c", [101 + 104, 102 + 103]),
@@ -94,8 +92,7 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("a", [1, 2]),
         decimal75("sum_c", 40, 0, [(101 + 104) * 2 + 2, (102 + 103) * 2 + 2]),
@@ -252,8 +249,7 @@ fn we_cannot_prove_a_complex_group_by_query_with_many_columns() {
         ),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("sum_int", [1406 + 927 + 637]),
         decimal75("sum_128", 59, 0, [(1342 + 1262 + 513) * 4]),

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
@@ -164,11 +164,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_filter() {
     let where_clause = equal(column(&t, "a", &accessor), const_int128(5_i128));
     let ast = legacy_filter(cols_expr_plan(&t, &["b"], &accessor), tab(&t), where_clause);
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("b", [3_i64, 5])]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec_test.rs
@@ -392,8 +392,7 @@ fn we_can_prove_a_filter_with_empty_results() {
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("b", [3; 0]),
         int128("c", [3; 0]),
@@ -431,8 +430,7 @@ fn we_can_prove_a_filter() {
         equal(column(&t, "a", &accessor), const_int128(105)),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("b", [3, 7]),
         int128("c", [3, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -132,11 +132,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_projection() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected = owned_table([bigint("b", [1_i64, 2, 3, 4, 5, 1, 2, 3, 4, 5])]);
     assert_eq!(res, expected);
 }
@@ -167,11 +163,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected = owned_table([
         decimal75("b", 20, 0, [2_i64, 3, 4, 5, 6]),
         decimal75("prod", 39, 0, [1_i64, 8, 15, 8, 25]),
@@ -229,11 +221,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected = owned_table([
         decimal75("b", 21, 0, [5_i64, 7]),
         decimal75("prod", 41, 0, [32_i64, 60]),

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -472,8 +472,7 @@ fn we_can_prove_a_projection() {
         ),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("b", [1, 2, 3, 4, 7]),
         int128("c", [1, 3, 3, 4, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -44,11 +44,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
         Some(2),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("a", [2_i64, 3]), varchar("b", ["2", "3"])]);
     assert_eq!(res, expected_res);
 }
@@ -80,11 +76,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
         Some(2),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let expected_res = owned_table([bigint("a", [0_i64; 0]), varchar("b", [""; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -366,8 +358,7 @@ fn we_can_prove_a_slice_exec() {
         Some(1),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("b", [4]),
         int128("c", [4]),
@@ -425,8 +416,7 @@ fn we_can_prove_a_nested_slice_exec() {
         Some(1),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("b", [4]),
         int128("c", [4]),
@@ -484,8 +474,7 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         None,
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -543,8 +532,7 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         None,
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
+    let res = exercise_verification(&res, &expr, &accessor, &t);
     let expected = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -596,11 +584,7 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         (),
     );
     let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
-    let res = verifiable_res
-        .verify(&plan, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let expected = owned_table([
         bigint("language_rank", [1_i64, 2, 3]),
         varchar("language_name", ["Español", "Português", "Français"]),
@@ -645,11 +629,7 @@ fn we_can_prove_a_slice_exec_if_it_has_groupby_with_provable_uniqueness_as_input
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
         VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &plan, &accessor, &t);
-    let res = verifiable_res
-        .verify(&plan, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &plan, &accessor, &t);
     let expected = owned_table([
         bigint("a", [2]),
         bigint("sum_c", [205]),

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -58,11 +58,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let expected_res = owned_table([
         bigint("id", [1_i64, 1, 2, 2, 4]),
         varchar("name", ["Chloe", "Chloe", "Margaret", "Margaret", "Lucy"]),
@@ -136,11 +132,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let expected_res = owned_table([
         bigint("id", [2_i64, 2]),
         varchar("name", ["Margaret", "Margaret"]),
@@ -316,11 +308,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let expected_res = owned_table([
         bigint("id", [0_i64; 0]),
         varchar("name", [""; 0]),
@@ -369,11 +357,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_right);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &table_right);
     let expected_res = owned_table([
         bigint("id", [0_i64; 0]),
         varchar("name", [""; 0]),
@@ -420,11 +404,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let expected_res = owned_table([
         bigint("id", [0_i64; 0]),
         varchar("name", [""; 0]),

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -155,46 +155,32 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
     let alloc = Bump::new();
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let cats = table([
-        borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 10, 29, 20, 21], &alloc),
+        borrowed_bigint("id", [1_i64, 2, 10, 20, 21], &alloc),
         borrowed_varchar(
             "name",
-            [
-                "Chloe", "Margaret", "Prudence", "Lucy", "Pepper", "Rocky", "Nova", "Whiskers",
-                "Mittens", "Felix",
-            ],
+            ["Chloe", "Margaret", "Nova", "Mittens", "Felix"],
             &alloc,
         ),
     ]);
     let table_cats: TableRef = "sxt.cats".parse().unwrap();
     let cat_human = table([
-        borrowed_bigint("id", [1_i64, 2, 98, 4, 10, 1, 2, 7, 5, 6], &alloc),
+        borrowed_bigint("id", [1_i64, 1, 2, 2, 4, 7, 10], &alloc),
         borrowed_varchar(
             "human",
-            [
-                "Cassia", "Cassia", "Gretta", "Gretta", "Trevor", "Ian", "Ian", "Erik", "Gretta",
-                "Gretta",
-            ],
+            ["Cassia", "Ian", "Cassia", "Ian", "Gretta", "Erik", "Trevor"],
             &alloc,
         ),
-        borrowed_varchar(
-            "state",
-            ["TX", "TX", "NC", "NC", "CO", "NC", "NC", "ND", "NC", "NC"],
-            &alloc,
-        ),
+        borrowed_varchar("state", ["TX", "NC", "TX", "NC", "NC", "ND", "CO"], &alloc),
     ]);
     let table_cat_human: TableRef = "sxt.cat_human".parse().unwrap();
     let cat_vet = table([
-        borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 9, 8, 10], &alloc),
+        borrowed_bigint("id", [1_i64, 2, 3, 5, 10], &alloc),
         borrowed_varchar(
             "hospital",
             [
                 "Mint Hill",
                 "Mint Hill",
                 "Brown Creek",
-                "Brown Creek",
-                "Brown Creek",
-                "Brown Creek",
-                "Clear Creek",
                 "Clear Creek",
                 "Rock Creek",
             ],
@@ -269,11 +255,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
 
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let expected_res = owned_table([
         bigint("id", [1_i64, 1, 2, 2, 10]),
         varchar("name", ["Chloe", "Chloe", "Margaret", "Margaret", "Nova"]),

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
@@ -69,11 +69,7 @@ fn we_can_create_and_prove_a_table_exec() {
         (),
     );
     let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
-    let res = verifiable_res
-        .verify(&plan, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let expected = owned_table([
         bigint("language_rank", [0, 1, 2, 3]),
         varchar(

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -114,11 +114,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
         ),
     ]);
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t0);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let expected_res = owned_table([
         bigint("a0", [1_i64, 2, 3, 4, 5, 2, 3, 4, 5, 6]),
         varchar("b0", ["1", "2", "3", "4", "5", "2", "3", "4", "5", "6"]),
@@ -255,11 +251,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
         ),
     ]);
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t0);
-    let res = verifiable_res
-        .verify(&ast, &accessor, &(), &[])
-        .unwrap()
-        .table;
+    let res = exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let expected_res = owned_table([
         bigint("a0", [5_i64, 2, 3, 4, 5, 6, 7, 105, 5, 6, 7, 7, 8, 9, 10]),
         varchar(


### PR DESCRIPTION
/claim #557

## Summary
- make `exercise_verification` return the already verified result table so targeted slow tests do not immediately repeat the same successful verification
- reuse that verified table across additional proof expression and proof plan tests that were verifying twice only to assert the table
- shrink the two-sort-merge-join fixture while preserving the same expected output, duplicate join rows, filtered rows, and nonmatching rows

## Coverage preserved
The `exercise_verification` helper still performs the successful verification and all existing tamper checks. The changed tests now reuse the table from that successful verification instead of immediately running an identical second verification just to read the table.

The reduced two-sort-merge-join fixture still covers the behavior the test was asserting:
- two nested sort-merge joins
- duplicate output rows from duplicate matching IDs
- rows filtered out by `human != "Gretta"`
- rows filtered out by `hospital != "Clear Creek"`
- left-side rows that pass the first filter but do not survive the joins
- right-side rows that do not join
- the same expected result table as before

Follow-up commit `2677bb6a` extends the same verified-table reuse to more duplicated-verification tests in inequality, projection, slice, union, table, legacy filter, and sort-merge join coverage.

Follow-up commit `a56bc26d` removes more duplicated successful verification passes from filter, AND, and OR tests, including the random-table loops; those tests still assert the same expected tables using the successful verification result returned by the helper.

Follow-up commit `3d4552c1` applies the same helper-table reuse across add/subtract, cast, column, equality, literal, multiply, NOT, and scaling-cast expression tests. This removes another 25 duplicate successful verification calls while preserving the existing expected-table assertions.

Follow-up commit `7d225283` applies the same proof-plan cleanup to aggregate, group-by, legacy filter, and projection tests, removing 12 more duplicate successful verification passes while keeping the same expected-table assertions.

## Local timing
Measured with `BLITZAR_BACKEND=cpu` in a Docker Rust 1.91.1 environment with clang/lld, using warm focused runs after the initial compile:

| Test | Before | After |
| --- | ---: | ---: |
| `we_can_compare_columns_with_extreme_values` | 18.3s | 12.9s |
| `we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_sort_merge_joins` | 19.1s | 9.6s |

## Validation
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib we_can_compare_columns_with_extreme_values`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_sort_merge_joins`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib sort_merge_join_exec_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib we_can_prove_and_get_the_correct_result_from_a_sort_merge_join`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib slice_exec_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib inequality_expr_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib and_expr_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib or_expr_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib filter_exec_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib proof_exprs`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib aggregate_exec_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib group_by_exec_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib projection_exec_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib legacy_filter_exec_test`
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib proof_plans`
- `cargo fmt --all -- --check`
- `git diff --check`