### PR TITLE
test: cover database metadata and error helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,29 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnField, ColumnType};
+    use alloc::string::ToString;
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn new_preserves_column_name_and_type() {
+        let field = ColumnField::new(Ident::new("amount".to_string()), ColumnType::BigInt);
+
+        assert_eq!(field.name().value, "amount");
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn serde_round_trips_column_metadata() {
+        let field = ColumnField::new(Ident::new("is_active".to_string()), ColumnType::Boolean);
+
+        let serialized = serde_json::to_string(&field).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ColumnField>(&serialized).unwrap(),
+            field
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,39 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnRef, ColumnType, TableRef};
+    use alloc::string::ToString;
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn new_preserves_table_column_and_type() {
+        let table_ref = TableRef::new("sxt", "orders");
+        let column_ref = ColumnRef::new(
+            table_ref.clone(),
+            Ident::new("amount".to_string()),
+            ColumnType::Int128,
+        );
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id().value, "amount");
+        assert_eq!(column_ref.column_type(), &ColumnType::Int128);
+    }
+
+    #[test]
+    fn serde_round_trips_column_reference() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            Ident::new("created_at".to_string()),
+            ColumnType::BigInt,
+        );
+
+        let serialized = serde_json::to_string(&column_ref).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ColumnRef>(&serialized).unwrap(),
+            column_ref
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -13,7 +13,7 @@ pub enum OwnedColumnError {
         /// The type to which we are trying to cast.
         to_type: ColumnType,
     },
-    /// Error in converting scalars to a given column type.   
+    /// Error in converting scalars to a given column type.
     #[snafu(display("Error in converting scalars to a given column type: {error}"))]
     ScalarConversionError {
         /// The underlying error
@@ -40,3 +40,50 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnCoercionError, OwnedColumnError};
+    use crate::base::database::ColumnType;
+    use alloc::string::ToString;
+
+    #[test]
+    fn owned_column_errors_render_context() {
+        assert_eq!(
+            OwnedColumnError::TypeCastError {
+                from_type: ColumnType::Scalar,
+                to_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Can not perform type casting from Scalar to VarChar"
+        );
+
+        assert_eq!(
+            OwnedColumnError::ScalarConversionError {
+                error: "Overflow in scalar conversions".into(),
+            }
+            .to_string(),
+            "Error in converting scalars to a given column type: Overflow in scalar conversions"
+        );
+
+        assert_eq!(
+            OwnedColumnError::Unsupported {
+                error: "Null values are not supported".into(),
+            }
+            .to_string(),
+            "Unsupported operation: Null values are not supported"
+        );
+    }
+
+    #[test]
+    fn column_coercion_errors_render_cause() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,21 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableEvaluation;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::vec;
+
+    #[test]
+    fn new_preserves_column_and_chi_evaluations() {
+        let column_evals = vec![TestScalar::from(2_u64), TestScalar::from(3_u64)];
+        let chi = (TestScalar::from(5_u64), 8);
+        let evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+        assert_eq!(evaluation.column_evals(), column_evals.as_slice());
+        assert_eq!(evaluation.chi_eval(), chi.0);
+        assert_eq!(evaluation.chi(), chi);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,50 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::TableOperationError;
+    use crate::base::database::{ColumnOperationError, ColumnType};
+    use alloc::string::ToString;
+
+    #[test]
+    fn table_operation_errors_render_context() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+
+        assert_eq!(
+            TableOperationError::JoinWithDifferentNumberOfColumns {
+                left_num_columns: 1,
+                right_num_columns: 2,
+            }
+            .to_string(),
+            "Cannot join tables with different numbers of columns: 1 and 2"
+        );
+
+        assert_eq!(
+            TableOperationError::JoinIncompatibleTypes {
+                left_type: ColumnType::Int,
+                right_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Cannot join tables on columns with incompatible types: Int and BigInt"
+        );
+
+        assert_eq!(
+            TableOperationError::ColumnIndexOutOfBounds { column_index: 4 }.to_string(),
+            "Column index out of bounds: 4"
+        );
+    }
+
+    #[test]
+    fn table_operation_errors_forward_column_operation_context() {
+        let error = TableOperationError::ColumnOperationError {
+            source: ColumnOperationError::DifferentColumnLength { len_a: 2, len_b: 3 },
+        };
+
+        assert_eq!(error.to_string(), "Columns have different lengths: 2 != 3");
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,73 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ParseError, TableRef};
+    use alloc::{string::ToString, vec};
+
+    #[test]
+    fn new_omits_empty_schema_names() {
+        let table_ref = TableRef::new("", "orders");
+
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "orders");
+        assert_eq!(table_ref.to_string(), "orders");
+    }
+
+    #[test]
+    fn from_names_preserves_optional_schema() {
+        let table_ref = TableRef::from_names(Some("sxt"), "orders");
+
+        assert_eq!(table_ref.schema_id().unwrap().value, "sxt");
+        assert_eq!(table_ref.table_id().value, "orders");
+        assert_eq!(table_ref.to_string(), "sxt.orders");
+    }
+
+    #[test]
+    fn try_from_accepts_bare_and_schema_qualified_names() {
+        assert_eq!(
+            TableRef::try_from("orders").unwrap(),
+            TableRef::new("", "orders")
+        );
+        assert_eq!(
+            TableRef::try_from("sxt.orders").unwrap(),
+            TableRef::new("sxt", "orders")
+        );
+    }
+
+    #[test]
+    fn from_strs_rejects_references_with_too_many_components() {
+        let components = vec!["database", "schema", "orders"];
+
+        assert_eq!(
+            TableRef::from_strs(&components),
+            Err(ParseError::InvalidTableReference {
+                table_reference: "database,schema,orders".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn try_from_rejects_dot_separated_references_with_too_many_components() {
+        assert_eq!(
+            TableRef::try_from("database.schema.orders"),
+            Err(ParseError::InvalidTableReference {
+                table_reference: "database.schema.orders".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn serde_round_trips_through_display_form() {
+        let table_ref = TableRef::new("sxt", "orders");
+
+        let serialized = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(serialized, r#""sxt.orders""#);
+        assert_eq!(
+            serde_json::from_str::<TableRef>(&serialized).unwrap(),
+            table_ref
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds focused coverage for `TableRef` construction, parsing, display serialization, invalid refs, and serde.
- Adds coverage for `ColumnRef` and `ColumnField` constructors/getters plus serde round trips.
- Adds coverage for `TableEvaluation` construction and accessors.
- Adds coverage for database error display behavior in `OwnedColumnError`, `ColumnCoercionError`, and `TableOperationError`.
- Contributes to #560 with a small, reviewable database coverage slice.

## Validation
- `cargo fmt --check`
- `cargo test -p proof-of-sql table_ref --no-default-features --features=std`
- `cargo test -p proof-of-sql column_ref --no-default-features --features=std`
- `cargo test -p proof-of-sql column_field --no-default-features --features=std`
- `cargo test -p proof-of-sql table_evaluation --no-default-features --features=std`
- `cargo test -p proof-of-sql owned_column_error --no-default-features --features=std`
- `cargo test -p proof-of-sql table_operation_error --no-default-features --features=std`