### PR TITLE
test: cover rho 256 MLE evaluation

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
@@ -48,3 +48,48 @@ fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
         expected_eval
     );
 }
+
+#[test]
+fn we_can_compute_rho_256_evaluation_for_large_evaluation_points() {
+    let evaluation_point = [
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(2u64),
+        Curve25519Scalar::from(3u64),
+        Curve25519Scalar::from(4u64),
+        Curve25519Scalar::from(5u64),
+        Curve25519Scalar::from(6u64),
+        Curve25519Scalar::from(7u64),
+        Curve25519Scalar::from(8u64),
+        Curve25519Scalar::from(9u64),
+    ];
+    let random_scalars = evaluation_point;
+
+    let sumcheck_random_scalars =
+        SumcheckRandomScalars::new(&random_scalars, 4, evaluation_point.len());
+
+    let evals = SumcheckMleEvaluations::new(
+        4,
+        [],
+        [],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &[],
+        &[],
+    );
+
+    let expected_rho_256_prefix = evaluation_point
+        .iter()
+        .take(8)
+        .rev()
+        .fold(Curve25519Scalar::from(0u64), |acc, &x| {
+            acc * Curve25519Scalar::from(2u64) + x
+        });
+    let expected_rho_256 = evaluation_point
+        .iter()
+        .skip(8)
+        .fold(expected_rho_256_prefix, |acc, &x| {
+            acc * (Curve25519Scalar::one() - x)
+        });
+
+    assert_eq!(evals.rho_256_evaluation, Some(expected_rho_256));
+}


### PR DESCRIPTION
## Summary
- add direct coverage for `SumcheckMleEvaluations::new` when the evaluation point has at least eight variables
- assert the computed `rho_256_evaluation` including the post-8-variable folding path

/claim #560

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" sumcheck_mle_evaluations -- --nocapture`
- `LLVM_COV=/opt/homebrew/Cellar/llvm/22.1.4/bin/llvm-cov LLVM_PROFDATA=/opt/homebrew/Cellar/llvm/22.1.4/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --lcov --output-path /tmp/sxt-proof-sumcheck-mle-rho256.lcov`
- `rustfmt --edition 2021 --check crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs`
- `git diff --check`

The full lcov run moved `crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations.rs` from `LH:46/58` to `LH:56/58`, covering the previously uncovered `rho_256_evaluation` branch lines 65-69 and 71-74.
