### PR TITLE
test: cover DecimalProofExpr precision and scale

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -78,3 +78,79 @@ pub(crate) trait DecimalProofExpr: ProofExpr {
         self.data_type().scale().expect("Scale should be valid")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{DecimalProofExpr, ProofExpr};
+    use crate::{
+        base::{
+            database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+            map::{IndexMap, IndexSet},
+            math::decimal::Precision,
+            proof::{PlaceholderResult, ProofError},
+            scalar::Scalar,
+        },
+        sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    };
+    use bumpalo::Bump;
+    use sqlparser::ast::Ident;
+
+    #[derive(Debug)]
+    struct TestDecimalExpr(ColumnType);
+
+    impl ProofExpr for TestDecimalExpr {
+        fn data_type(&self) -> ColumnType {
+            self.0
+        }
+
+        fn first_round_evaluate<'a, S: Scalar>(
+            &self,
+            _alloc: &'a Bump,
+            _table: &Table<'a, S>,
+            _params: &[LiteralValue],
+        ) -> PlaceholderResult<Column<'a, S>> {
+            unimplemented!("not needed for DecimalProofExpr accessors")
+        }
+
+        fn final_round_evaluate<'a, S: Scalar>(
+            &self,
+            _builder: &mut FinalRoundBuilder<'a, S>,
+            _alloc: &'a Bump,
+            _table: &Table<'a, S>,
+            _params: &[LiteralValue],
+        ) -> PlaceholderResult<Column<'a, S>> {
+            unimplemented!("not needed for DecimalProofExpr accessors")
+        }
+
+        fn verifier_evaluate<S: Scalar>(
+            &self,
+            _builder: &mut impl VerificationBuilder<S>,
+            _accessor: &IndexMap<Ident, S>,
+            _chi_eval: S,
+            _params: &[LiteralValue],
+        ) -> Result<S, ProofError> {
+            unimplemented!("not needed for DecimalProofExpr accessors")
+        }
+
+        fn get_column_references(&self, _columns: &mut IndexSet<ColumnRef>) {}
+    }
+
+    impl DecimalProofExpr for TestDecimalExpr {}
+
+    #[test]
+    fn decimal_proof_expr_uses_decimal75_precision_and_scale() {
+        let precision = Precision::new(18).unwrap();
+        let expr = TestDecimalExpr(ColumnType::Decimal75(precision, 6));
+
+        assert_eq!(expr.precision(), precision);
+        assert_eq!(expr.scale(), 6);
+    }
+
+    #[test]
+    fn decimal_proof_expr_uses_integer_precision_with_zero_scale() {
+        let expr = TestDecimalExpr(ColumnType::BigInt);
+
+        assert_eq!(expr.precision(), Precision::new(19).unwrap());
+        assert_eq!(expr.scale(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

/claim #560

Adds focused test coverage for the default `DecimalProofExpr` precision and scale accessors in `proof_expr.rs`. The tests cover both:

- `Decimal75(precision, scale)`, ensuring the explicit decimal precision/scale are returned
- integer-backed decimal behavior via `BigInt`, ensuring precision is derived from `ColumnType` and scale is zero

## Coverage notes

Before this slice, local LCOV showed `crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs` default accessor lines 64-71 and 77-79 uncovered:

```text
target/proof-of-sql.lcov 0/10 uncovered [64, 65, 66, 67, 68, 70, 71, 77, 78, 79]
```

After adding the focused tests, the `decimal_proof_expr` coverage run exercises those accessor paths:

```text
target/proof-expr-after.lcov 24/48
running 2 tests
test sql::proof_exprs::proof_expr::tests::decimal_proof_expr_uses_integer_precision_with_zero_scale ... ok
test sql::proof_exprs::proof_expr::tests::decimal_proof_expr_uses_decimal75_precision_and_scale ... ok
```

I checked the open #560 PR file list before starting and did not find another open PR touching `proof_expr.rs`.

## Validation

```bash
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --lib --no-default-features --features="test" --quiet
cargo fmt --all -- --check
git diff --check
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --lcov --output-path target/proof-expr-after.lcov -- decimal_proof_expr
```

Full local proof-of-sql lib test result: 962 passed, 0 failed.

Edit: repo doesn't look too active. closing this out.
