### PR TITLE
test: cover Curve25519 Ristretto multiplication

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
@@ -7,6 +7,7 @@ use crate::{
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
 };
 use byte_slice_cast::AsByteSlice;
+use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use num_bigint::BigInt;
 use num_traits::{Inv, One, Zero};
 use rand::{
@@ -36,6 +37,18 @@ fn test_dalek_interop_m1() {
     let mxp = -xp;
     assert_eq!(mxp, Curve25519Scalar::from(-123i64));
     assert_eq!(curve25519_dalek::scalar::Scalar::from(mxp), mx);
+}
+
+#[test]
+fn test_curve25519_scalar_ristretto_multiplication_interop() {
+    let scalar = Curve25519Scalar::from(7u64);
+    let point = RISTRETTO_BASEPOINT_POINT;
+    let expected = curve25519_dalek::scalar::Scalar::from(scalar) * point;
+
+    assert_eq!(scalar * point, expected);
+    assert_eq!(scalar * &point, expected);
+    assert_eq!(point * scalar, expected);
+    assert_eq!(&point * scalar, expected);
 }
 
 #[test]


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for `Curve25519Scalar` multiplication with owned and borrowed `RistrettoPoint` values
- assert all wrapper multiplication paths match direct `curve25519_dalek::Scalar` multiplication
- keep the change test-only and scoped to the existing Curve25519 inner-product tests

## Coverage
Using full `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov`:

- `crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_scalar.rs`: 7/19 -> 19/19 executable lines covered, +12 production lines

## Validation
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib --no-default-features --features test test_curve25519_scalar_ristretto_multiplication_interop -- --nocapture`
- `BLITZAR_BACKEND=cpu cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path /tmp/sxt-curve25519-interop.lcov -- test_curve25519_scalar_ristretto_multiplication_interop`
- `BLITZAR_BACKEND=cpu cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path /tmp/sxt-curve25519-interop-full.lcov` (961 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
