### PR TITLE
test: cover equals expr without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_no_blitzar_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_no_blitzar_test.rs
@@ -1,0 +1,86 @@
+use super::equals_expr::{
+    final_round_evaluate_equals_zero, first_round_evaluate_equals_zero,
+    verifier_evaluate_equals_zero,
+};
+use super::{test_utility::*, EqualsExpr, ProofExpr};
+use crate::{
+    base::{
+        database::ColumnType,
+        scalar::{test_scalar::TestScalar, Scalar},
+    },
+    sql::{
+        proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
+        AnalyzeError,
+    },
+};
+use alloc::{collections::VecDeque, vec, vec::Vec};
+use bumpalo::Bump;
+
+#[test]
+fn we_can_create_equals_expr_and_access_children_without_blitzar() {
+    let expr = EqualsExpr::try_new(Box::new(const_bigint(1)), Box::new(const_bigint(2))).unwrap();
+
+    assert_eq!(expr.data_type(), ColumnType::Boolean);
+    assert_eq!(expr.lhs().data_type(), ColumnType::BigInt);
+    assert_eq!(expr.rhs().data_type(), ColumnType::BigInt);
+}
+
+#[test]
+fn equals_expr_rejects_mismatched_types_without_blitzar() {
+    let err =
+        EqualsExpr::try_new(Box::new(const_bigint(1)), Box::new(const_varchar("x"))).unwrap_err();
+
+    assert!(matches!(err, AnalyzeError::DataTypeMismatch { .. }));
+}
+
+#[test]
+fn we_can_evaluate_equals_zero_in_the_first_round_without_blitzar() {
+    let alloc = Bump::new();
+    let lhs = [
+        TestScalar::ZERO,
+        TestScalar::from(5),
+        TestScalar::from(-3),
+        TestScalar::ZERO,
+    ];
+
+    let selection = first_round_evaluate_equals_zero(lhs.len(), &alloc, &lhs);
+
+    assert_eq!(selection, &[true, false, false, true]);
+}
+
+#[test]
+fn we_can_evaluate_equals_zero_in_the_final_round_without_blitzar() {
+    let alloc = Bump::new();
+    let lhs = [
+        TestScalar::ZERO,
+        TestScalar::from(5),
+        TestScalar::from(-3),
+        TestScalar::ZERO,
+    ];
+    let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+
+    let selection = final_round_evaluate_equals_zero(lhs.len(), &mut builder, &alloc, &lhs);
+
+    assert_eq!(selection, &[true, false, false, true]);
+    assert_eq!(builder.pcs_proof_mles().len(), 2);
+    assert_eq!(builder.num_sumcheck_subpolynomials(), 2);
+}
+
+#[test]
+fn verifier_equals_zero_records_identity_constraints_without_blitzar() {
+    let mut builder = MockVerificationBuilder::new(
+        Vec::new(),
+        3,
+        Vec::new(),
+        vec![vec![TestScalar::ZERO, TestScalar::ONE]],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+
+    let selection_eval =
+        verifier_evaluate_equals_zero(&mut builder, TestScalar::ZERO, TestScalar::ONE).unwrap();
+
+    assert_eq!(selection_eval, TestScalar::ONE);
+    assert_eq!(builder.get_identity_results(), vec![vec![true, true]]);
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -60,6 +60,8 @@ pub(crate) use numerical_util::{divide_columns, modulo_columns};
 
 mod equals_expr;
 pub(crate) use equals_expr::EqualsExpr;
+#[cfg(test)]
+mod equals_expr_no_blitzar_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod equals_expr_test;
 


### PR DESCRIPTION
/claim #560

## Summary
- add a no-default/no-blitzar test module for `EqualsExpr` constructor/type handling
- cover first-round, final-round, and verifier equals-zero helper paths using `TestScalar` and `MockVerificationBuilder`

## Coverage
Compared against the local no-default `features="test"` baseline generated with `cargo llvm-cov`, the focused run moves `crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs` from `13/131` to `68/131`, covering 55 previously uncovered production lines. Final bounty accounting is left to the maintainer baseline.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" equals_expr_no_blitzar -- --nocapture` -> 5 passed
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --lcov --output-path target/codex-equals-focused.lcov -- equals_expr_no_blitzar` -> 5 passed, report generated
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --lcov --output-path target/codex-after.lcov` -> 963 passed, report generated before the final constructor/accessor test was added
- `cargo fmt --all -- --check` -> passed
- `git diff --check` -> passed