### PR TITLE
fix: reject nullable Arrow arrays before owned conversion

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -23,7 +23,7 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
+        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
         Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
         TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
     },
@@ -148,6 +148,10 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
     /// - `Decimal256Array` when converting from `DataType::Decimal256` if precision is less than or equal to 75.
     /// - `StringArray` when converting from `DataType::Utf8`.
     fn try_from(value: &ArrayRef) -> Result<Self, Self::Error> {
+        if value.null_count() > 0 {
+            return Err(OwnedArrowConversionError::NullNotSupportedYet);
+        }
+
         match &value.data_type() {
             // Arrow uses a bit-packed representation for booleans.
             // Hence we need to unpack the bits to get the actual boolean values.

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -7,10 +7,12 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
-        StringArray,
+        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Float32Array, Int16Array,
+        Int32Array, Int64Array, Int8Array, LargeBinaryArray, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt8Array,
     },
-    datatypes::{DataType, Field, Schema},
+    datatypes::{i256, DataType, Field, Schema},
     record_batch::RecordBatch,
 };
 use proptest::prelude::*;
@@ -99,6 +101,51 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
         OwnedColumn::<TestScalar>::try_from(array_ref),
         Err(OwnedArrowConversionError::UnsupportedType { .. })
     ));
+}
+
+fn assert_null_array_is_rejected(array_ref: ArrayRef) {
+    assert!(matches!(
+        OwnedColumn::<TestScalar>::try_from(array_ref),
+        Err(OwnedArrowConversionError::NullNotSupportedYet)
+    ));
+}
+
+#[test]
+fn we_reject_nulls_for_all_arrow_types_before_reading_backing_values() {
+    assert_null_array_is_rejected(Arc::new(BooleanArray::from(vec![Some(true), None])));
+    assert_null_array_is_rejected(Arc::new(UInt8Array::from(vec![Some(1), None])));
+    assert_null_array_is_rejected(Arc::new(Int8Array::from(vec![Some(1), None])));
+    assert_null_array_is_rejected(Arc::new(Int16Array::from(vec![Some(1), None])));
+    assert_null_array_is_rejected(Arc::new(Int32Array::from(vec![Some(1), None])));
+    assert_null_array_is_rejected(Arc::new(Int64Array::from(vec![Some(1), None])));
+    assert_null_array_is_rejected(Arc::new(
+        Decimal128Array::from(vec![Some(1), None])
+            .with_precision_and_scale(38, 0)
+            .unwrap(),
+    ));
+    assert_null_array_is_rejected(Arc::new(
+        Decimal256Array::from(vec![Some(i256::from_i128(1)), None])
+            .with_precision_and_scale(75, 0)
+            .unwrap(),
+    ));
+    assert_null_array_is_rejected(Arc::new(StringArray::from(vec![Some("a"), None])));
+    assert_null_array_is_rejected(Arc::new(LargeBinaryArray::from_opt_vec(vec![
+        Some(b"a".as_slice()),
+        None,
+    ])));
+    assert_null_array_is_rejected(Arc::new(TimestampSecondArray::from(vec![Some(1), None])));
+    assert_null_array_is_rejected(Arc::new(TimestampMillisecondArray::from(vec![
+        Some(1),
+        None,
+    ])));
+    assert_null_array_is_rejected(Arc::new(TimestampMicrosecondArray::from(vec![
+        Some(1),
+        None,
+    ])));
+    assert_null_array_is_rejected(Arc::new(TimestampNanosecondArray::from(vec![
+        Some(1),
+        None,
+    ])));
 }
 
 fn we_can_convert_between_owned_table_and_record_batch_impl(


### PR DESCRIPTION
/claim #183

## Summary
- reject Arrow arrays with null values before converting them into OwnedColumn
- add coverage for boolean, integer, decimal, string, binary, and timestamp arrays with nulls
- preserve existing non-null conversion behavior

## Why
OwnedColumn does not support nullable columns yet. Some Arrow conversion paths used the backing alues() buffer directly, which can ignore Arrow's null bitmap and treat null slots as real values. This makes null handling inconsistent and can silently ingest invalid data while nullable-column support is still being built.

## Tests
- cargo test -p proof-of-sql --no-default-features --features arrow,test we_reject_nulls_for_all_arrow_types_before_reading_backing_values
- cargo test -p proof-of-sql --no-default-features --features arrow,test we_can_convert_between_owned_column_and_array_ref
- git diff --check

Note: default Windows test build pulls litzar-sys, which only supports Linux, so these were run with --no-default-features --features arrow,test.