### PR TITLE
test: run table test accessor without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -113,7 +113,7 @@ mod owned_table_test_accessor_test;
 
 mod table_test_accessor;
 pub use table_test_accessor::TableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod table_test_accessor_test;
 
 /// Module providing utilities for filtering columns based on selection vectors.

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -116,7 +116,7 @@ mod owned_table_test_accessor_test;
 
 mod table_test_accessor;
 pub use table_test_accessor::TableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod table_test_accessor_test;
 
 /// Module providing utilities for filtering columns based on selection vectors.


### PR DESCRIPTION
/claim #560

## Summary
- run the existing `table_test_accessor_test` module under plain `#[cfg(test)]` so it contributes to the no-default `test` coverage path
- keeps `owned_table_test_accessor_test` behind `feature = "blitzar"` because that slice is already claimed separately

## Coverage
- `crates/proof-of-sql/src/base/database/table_test_accessor.rs`: 72/88 covered lines in the no-default LCOV run

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" table_test_accessor`
- `LLVM_COV=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov LLVM_PROFDATA=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --lcov --output-path target/table-test-accessor-no-blitzar.lcov`
- `cargo fmt --all -- --check`
- `git diff --check`

AI-assisted with OpenAI Codex; I reviewed and validated the diff before submitting.