### PR TITLE
test: cover query error conversions

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,35 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_errors_convert_to_display_strings() {
+        let invalid_timezone: String = PoSQLTimestampError::InvalidTimezone {
+            timezone: "Mars/Phobos".to_string(),
+        }
+        .into();
+        assert_eq!(invalid_timezone, "invalid timezone string: Mars/Phobos");
+
+        let invalid_offset: String = PoSQLTimestampError::InvalidTimezoneOffset.into();
+        assert_eq!(invalid_offset, "invalid timezone offset");
+
+        let invalid_unit: String = PoSQLTimestampError::InvalidTimeUnit {
+            error: "fortnight".to_string(),
+        }
+        .into();
+        assert_eq!(invalid_unit, "Invalid time unit");
+
+        let unsupported_precision: String = PoSQLTimestampError::UnsupportedPrecision {
+            error: "weeks".to_string(),
+        }
+        .into();
+        assert_eq!(
+            unsupported_precision,
+            "Unsupported precision for timestamp: weeks"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,37 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn analyze_errors_convert_to_display_strings() {
+        let text: String = AnalyzeError::DataTypeMismatch {
+            left_type: "BIGINT".to_string(),
+            right_type: "VARCHAR".to_string(),
+        }
+        .into();
+
+        assert_eq!(
+            text,
+            "Left side has 'BIGINT' type but right side has 'VARCHAR' type"
+        );
+    }
+
+    #[test]
+    fn intermediate_decimal_errors_convert_to_analyze_errors() {
+        let err = AnalyzeError::from(IntermediateDecimalError::LossyCast);
+
+        assert!(matches!(
+            err,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::LossyCast
+                }
+            }
+        ));
+        assert_eq!(err.to_string(), "Fractional part of decimal is non-zero");
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,51 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_coercion_errors_map_to_query_errors() {
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCoercionError {
+                source: ColumnCoercionError::Overflow,
+            }),
+            QueryError::Overflow
+        ));
+
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCoercionError {
+                source: ColumnCoercionError::InvalidTypeCoercion,
+            }),
+            QueryError::ProofError {
+                source: ProofError::InvalidTypeCoercion
+            }
+        ));
+
+        assert!(matches!(
+            QueryError::from(TableCoercionError::NameMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldNamesMismatch
+            }
+        ));
+
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCountMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldCountMismatch
+            }
+        ));
+    }
+
+    #[test]
+    fn query_error_display_messages_are_stable() {
+        assert_eq!(QueryError::Overflow.to_string(), "Overflow error");
+        assert_eq!(QueryError::InvalidString.to_string(), "String decode error");
+        assert_eq!(
+            QueryError::InvalidColumnCount.to_string(),
+            "Invalid number of columns"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add no-default unit coverage for `PoSQLTimestampError` string conversion
- add no-default unit coverage for `AnalyzeError` display/conversion paths
- add no-default unit coverage for `QueryError` display messages and `TableCoercionError` mapping

## Coverage
Full no-default LCOV spot-check after the change:
- `crates/proof-of-sql/src/base/posql_time/error.rs`: 22/22 covered lines
- `crates/proof-of-sql/src/sql/error.rs`: 23/23 covered lines
- `crates/proof-of-sql/src/sql/proof/query_result.rs`: 28/28 covered lines

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" error`
- `LLVM_COV=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov LLVM_PROFDATA=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-profdata cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --lcov --output-path target/query-errors-no-default.lcov`
- `cargo fmt --all -- --check`
- `git diff --check`

AI-assisted with OpenAI Codex; I reviewed and validated the diff before submitting.