### PR TITLE
test: cover column ref accessors and serde

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,47 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_create_and_read_column_refs() {
+        let table_ref = TableRef::new("analytics", "orders");
+        let column_ref = ColumnRef::new(
+            table_ref.clone(),
+            Ident::new("order_id"),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id().value.as_str(), "order_id");
+        assert_eq!(*column_ref.column_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn we_can_clone_and_compare_column_refs() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("analytics", "orders"),
+            Ident::new("amount"),
+            ColumnType::Int128,
+        );
+
+        assert_eq!(column_ref.clone(), column_ref);
+    }
+
+    #[test]
+    fn we_can_serialize_and_deserialize_column_refs() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("analytics", "orders"),
+            Ident::new("is_paid"),
+            ColumnType::Boolean,
+        );
+
+        let encoded = serde_json::to_string(&column_ref).unwrap();
+        let decoded = serde_json::from_str::<ColumnRef>(&encoded).unwrap();
+
+        assert_eq!(decoded, column_ref);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for `ColumnRef` construction and accessor methods.
- Cover clone/equality behavior.
- Cover serde round-tripping for column references.

## Test plan
- `git diff --check`
- Not run locally: `cargo` is not installed in this environment.
