### PR TITLE
test: cover column field accessors and serde

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,33 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_create_and_read_column_fields() {
+        let column_field = ColumnField::new(Ident::new("order_id"), ColumnType::BigInt);
+
+        assert_eq!(column_field.name().value.as_str(), "order_id");
+        assert_eq!(column_field.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn we_can_clone_and_compare_column_fields() {
+        let column_field = ColumnField::new(Ident::new("amount"), ColumnType::Int128);
+
+        assert_eq!(column_field.clone(), column_field);
+    }
+
+    #[test]
+    fn we_can_serialize_and_deserialize_column_fields() {
+        let column_field = ColumnField::new(Ident::new("is_paid"), ColumnType::Boolean);
+
+        let encoded = serde_json::to_string(&column_field).unwrap();
+        let decoded = serde_json::from_str::<ColumnField>(&encoded).unwrap();
+
+        assert_eq!(decoded, column_field);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for `ColumnField` construction and accessor methods.
- Cover clone/equality behavior.
- Cover serde round-tripping for column field metadata.

## Test plan
- `git diff --check`
- Not run locally: `cargo` is not installed in this environment.
