### PR TITLE
test: cover table operation error formatting

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,70 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_format_union_schema_errors() {
+        let error = TableOperationError::UnionIncompatibleSchemas {
+            correct_schema: vec![ColumnField::new(Ident::new("id"), ColumnType::BigInt)],
+            actual_schema: vec![ColumnField::new(Ident::new("id"), ColumnType::Int)],
+        };
+        let message = error.to_string();
+
+        assert!(message.contains("Cannot union tables with incompatible schemas"));
+        assert!(message.contains("BigInt"));
+        assert!(message.contains("Int"));
+    }
+
+    #[test]
+    fn we_can_format_join_errors() {
+        let column_count_error = TableOperationError::JoinWithDifferentNumberOfColumns {
+            left_num_columns: 2,
+            right_num_columns: 3,
+        };
+        let type_error = TableOperationError::JoinIncompatibleTypes {
+            left_type: ColumnType::BigInt,
+            right_type: ColumnType::VarChar,
+        };
+
+        assert_eq!(
+            column_count_error.to_string(),
+            "Cannot join tables with different numbers of columns: 2 and 3"
+        );
+        assert_eq!(
+            type_error.to_string(),
+            "Cannot join tables on columns with incompatible types: BigInt and VarChar"
+        );
+    }
+
+    #[test]
+    fn we_can_format_column_lookup_errors() {
+        let missing_column_error = TableOperationError::ColumnDoesNotExist {
+            column_ident: Ident::new("missing_column"),
+        };
+        let index_error = TableOperationError::ColumnIndexOutOfBounds { column_index: 7 };
+
+        let missing_column_message = missing_column_error.to_string();
+
+        assert!(missing_column_message.starts_with("Column Ident"));
+        assert!(missing_column_message.contains("missing_column"));
+        assert!(missing_column_message.ends_with("does not exist in table"));
+        assert_eq!(index_error.to_string(), "Column index out of bounds: 7");
+    }
+
+    #[test]
+    fn we_can_format_simple_table_operation_errors() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for `TableOperationError` display messages.
- Cover union schema, join, column lookup, index, duplicate-column, and insufficient-table errors.
- Use partial matching where debug-rendered identifiers can include parser span details.

## Test plan
- `git diff --check`
- Not run locally: `cargo` is not installed in this environment.
