### PR TITLE
test: cover parse and timestamp error formatting

### DIFF
--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,21 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_format_parse_errors() {
+        let error = ParseError::InvalidTableReference {
+            table_reference: "schema.table.extra".into(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Invalid table reference: schema.table.extra"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,46 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_format_timestamp_errors() {
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezone {
+                timezone: "Mars/Phobos".into()
+            }
+            .to_string(),
+            "invalid timezone string: Mars/Phobos"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezoneOffset.to_string(),
+            "invalid timezone offset"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimeUnit {
+                error: "weeks".into()
+            }
+            .to_string(),
+            "Invalid time unit"
+        );
+        assert_eq!(
+            PoSQLTimestampError::UnsupportedPrecision {
+                error: "picoseconds".into()
+            }
+            .to_string(),
+            "Unsupported precision for timestamp: picoseconds"
+        );
+    }
+
+    #[test]
+    fn we_can_convert_timestamp_errors_to_strings() {
+        let message = String::from(PoSQLTimestampError::InvalidTimezone {
+            timezone: "not-a-zone".into(),
+        });
+
+        assert_eq!(message, "invalid timezone string: not-a-zone");
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for database `ParseError` formatting.
- Add focused coverage for `PoSQLTimestampError` display messages.
- Cover conversion from timestamp errors into `String`.

## Test plan
- `git diff --check`
- Not run locally: `cargo` is not installed in this environment.
