### PR TITLE
test: cover reference conversion helper

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,35 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct RefSource {
+        value: usize,
+    }
+
+    impl From<&RefSource> for usize {
+        fn from(source: &RefSource) -> Self {
+            source.value
+        }
+    }
+
+    #[test]
+    fn ref_into_uses_reference_based_conversion() {
+        let source = RefSource { value: 42 };
+
+        assert_eq!(source.ref_into(), 42);
+        assert_eq!(source, RefSource { value: 42 });
+    }
+
+    #[test]
+    fn ref_into_allows_explicit_target_types() {
+        let source = RefSource { value: 7 };
+        let converted: usize = source.ref_into();
+
+        assert_eq!(converted, 7);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for the `RefInto` blanket implementation.
- Verify that reference-based conversion does not consume the source value.
- Cover explicit target type inference for `ref_into()`.

## Test plan
- `git diff --check`
- Not run locally: `cargo` is not installed in this environment.
