### PR TITLE
test: add planner conversion coverage

### DIFF
--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -112,8 +112,8 @@ pub fn get_table_refs_from_statement(
 
 #[cfg(test)]
 mod tests {
-    use super::get_table_refs_from_statement;
-    use crate::{conversion::sql_to_posql_plans, PlannerResult};
+    use super::{get_table_refs_from_statement, optimizer};
+    use crate::{conversion::sql_to_posql_plans, sql_to_proof_plans, PlannerResult};
     use datafusion::{config::ConfigOptions, logical_expr::LogicalPlan};
     use indexmap::IndexSet;
     use proof_of_sql::{
@@ -165,6 +165,24 @@ AND s.salary > (
     }
 
     #[test]
+    fn we_do_not_get_table_references_from_tableless_statement() {
+        let statement =
+            Parser::parse_sql(&GenericDialect {}, "SELECT ABS(-1-1);").unwrap()[0].clone();
+        let table_refs = get_table_refs_from_statement(&statement).unwrap();
+        assert!(table_refs.is_empty());
+    }
+
+    #[test]
+    fn optimizer_excludes_common_subexpression_eliminate_rule() {
+        let optimizer = optimizer();
+        assert!(!optimizer.rules.is_empty());
+        assert!(optimizer
+            .rules
+            .iter()
+            .all(|rule| rule.name() != "common_sub_expression_eliminate"));
+    }
+
+    #[test]
     fn we_can_use_abs() {
         let statements = Parser::parse_sql(&GenericDialect {}, "SELECT ABS(-1-1);").unwrap();
         sql_to_posql_plans(
@@ -174,5 +192,18 @@ AND s.salary > (
             |a, _| -> PlannerResult<LogicalPlan> { Ok(a.clone()) },
         )
         .unwrap();
+    }
+
+    #[test]
+    fn we_can_convert_multiple_sql_statements_to_proof_plans() {
+        let statements =
+            Parser::parse_sql(&GenericDialect {}, "SELECT 1; SELECT ABS(-1-1);").unwrap();
+        let plans = sql_to_proof_plans(
+            &statements,
+            &TableTestAccessor::<DynamicDoryEvaluationProof>::default(),
+            &ConfigOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(plans.len(), 2);
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

/claim #560

Adds a small set of focused tests for planner conversion coverage.

# What changes are included in this PR?

- Covers table reference extraction for tableless SQL statements.
- Verifies the custom optimizer excludes `common_sub_expression_eliminate`.
- Covers `sql_to_proof_plans` with multiple SQL statements.

# Are these changes tested?

Yes.

- `cargo fmt --check`
- `cargo test -p proof-of-sql-planner --lib`

The full CI shell scripts were not run locally because this Windows environment does not have `bash` available.