### PR TITLE
test: cover bigdecimal DDL parsing

### DIFF
--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,38 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn find_bigdecimals_only_returns_precision_and_scale_above_38() {
+        let sql = "CREATE TABLE TYPES(
+            DECIMAL_38 DECIMAL(38, 2),
+            DECIMAL_39 DECIMAL(39, 2),
+            DECIMAL_PRECISION_ONLY DECIMAL(39),
+            DECIMAL_WITHOUT_PRECISION DECIMAL,
+            INTEGER_VALUE INT
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(
+            bigdecimals.get("TYPES").unwrap(),
+            &[("DECIMAL_39".to_string(), 39, 2)]
+        );
+    }
+
+    #[test]
+    fn find_bigdecimals_ignores_non_create_table_statements() {
+        let sql = "SELECT 1;
+        CREATE TABLE BIG_TABLE(
+            VALUE DECIMAL(40, 1)
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("BIG_TABLE").unwrap(),
+            &[("VALUE".to_string(), 40, 1)]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add focused coverage for `utils::parse::find_bigdecimals`
- cover the `DECIMAL(38, scale)` boundary versus supported `DECIMAL(39, scale)`
- cover precision-only/no-precision decimals and non-`CREATE TABLE` statements being ignored

## Testing
- `cargo test -p proof-of-sql --lib --no-default-features --features std,test utils::parse -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features std,test --summary-only -- utils::parse`
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One`
- `git diff --check`
- `scripts/check_commits.sh`

Focused coverage result: `utils/parse.rs` reports 100.00% line and region coverage.

/claim #560