### PR TITLE
test: cover not expr without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -99,3 +99,96 @@ impl ProofExpr for NotExpr {
         self.expr.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{
+                table_utility::{borrowed_boolean, table},
+                TableRef,
+            },
+            scalar::test_scalar::TestScalar,
+        },
+        sql::proof::mock_verification_builder::MockVerificationBuilder,
+    };
+    use alloc::{collections::VecDeque, vec};
+
+    fn boolean_column_ref(name: &str) -> ColumnRef {
+        ColumnRef::new(
+            TableRef::new("sxt", "not_inputs"),
+            Ident::new(name),
+            ColumnType::Boolean,
+        )
+    }
+
+    #[test]
+    fn not_expr_evaluates_rounds_without_blitzar() {
+        let alloc = Bump::new();
+        let table =
+            table::<TestScalar>([borrowed_boolean("flag", [false, true, true, false], &alloc)]);
+        let flag_ref = boolean_column_ref("flag");
+        let not_expr =
+            NotExpr::try_new(Box::new(DynProofExpr::new_column(flag_ref.clone()))).unwrap();
+
+        assert_eq!(not_expr.data_type(), ColumnType::Boolean);
+        assert_eq!(not_expr.input().data_type(), ColumnType::Boolean);
+
+        let first_round = not_expr.first_round_evaluate(&alloc, &table, &[]).unwrap();
+        assert_eq!(first_round, Column::Boolean(&[true, false, false, true]));
+
+        let mut final_round_builder = FinalRoundBuilder::new(0, VecDeque::new());
+        let final_round = not_expr
+            .final_round_evaluate(&mut final_round_builder, &alloc, &table, &[])
+            .unwrap();
+        assert_eq!(final_round, Column::Boolean(&[true, false, false, true]));
+
+        let mut column_refs = IndexSet::default();
+        not_expr.get_column_references(&mut column_refs);
+        assert_eq!(column_refs.len(), 1);
+        assert!(column_refs.contains(&flag_ref));
+    }
+
+    #[test]
+    fn not_expr_verifier_evaluate_subtracts_inner_eval_without_blitzar() {
+        let not_true = NotExpr::try_new(Box::new(DynProofExpr::new_literal(
+            LiteralValue::Boolean(true),
+        )))
+        .unwrap();
+        let not_false = NotExpr::try_new(Box::new(DynProofExpr::new_literal(
+            LiteralValue::Boolean(false),
+        )))
+        .unwrap();
+        let mut verifier = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            0,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        assert_eq!(
+            not_true
+                .verifier_evaluate(&mut verifier, &IndexMap::default(), 7_i64.into(), &[])
+                .unwrap(),
+            TestScalar::ZERO
+        );
+        assert_eq!(
+            not_false
+                .verifier_evaluate(&mut verifier, &IndexMap::default(), 7_i64.into(), &[])
+                .unwrap(),
+            TestScalar::from(7_i64)
+        );
+    }
+
+    #[test]
+    fn not_expr_rejects_non_boolean_operands_without_blitzar() {
+        let error = NotExpr::try_new(Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(1))))
+            .unwrap_err();
+
+        assert!(matches!(error, AnalyzeError::InvalidDataType { .. }));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add no-default `test` feature coverage for `NotExpr` construction/accessor and column-reference forwarding.
- Cover first/final round NOT evaluation, verifier-side NOT evaluation, and unsupported operand type errors without requiring `blitzar`.
- Keep the existing `blitzar` proof-flow tests unchanged.

## Validation
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p proof-of-sql --lib --no-default-features --features="test" not_expr -- --nocapture` (6 passed)
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all -- --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --json --summary-only --output-path /tmp/sxt-not-expr-coverage.json -- not_expr` (`not_expr.rs`: lines 114/114, functions 13/13)