### PR TITLE
test: cover table commitments without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -374,20 +374,24 @@ fn num_rows_of_columns<'a>(
     Ok(num_rows)
 }
 
-#[cfg(all(test, feature = "arrow", feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "arrow")]
+    use crate::base::database::Column;
     use crate::base::{
         commitment::naive_commitment::NaiveCommitment,
-        database::{owned_table_utility::*, Column, OwnedColumn},
+        database::{owned_table_utility::*, OwnedColumn},
         map::IndexMap,
         scalar::test_scalar::TestScalar,
     };
+    #[cfg(feature = "arrow")]
     use arrow::{
         array::{Int64Array, StringArray},
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
+    #[cfg(feature = "arrow")]
     use std::sync::Arc;
 
     #[test]
@@ -1151,6 +1155,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "arrow")]
     #[test]
     fn we_can_create_and_append_table_commitments_with_record_batches() {
         let schema = Arc::new(Schema::new(vec![


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a focused coverage slice for #560.

The `table_commitment` unit tests were gated behind both `arrow` and `blitzar`, but most of the module's tests only exercise `NaiveCommitment` and owned-table helpers. As a result, those tests were not run in the no-default `test` feature coverage mode used by several #560 slices.

This PR makes the non-Arrow `table_commitment` tests available under `cfg(test)` and keeps only the RecordBatch-specific test/imports behind `feature = "arrow"`.

# What changes are included in this PR?

- Loosen `table_commitment` test module gating from `all(test, feature = "arrow", feature = "blitzar")` to `test`.
- Gate the Arrow-only `Column`, Arrow imports, `Arc`, and RecordBatch test behind `feature = "arrow"`.
- No production behavior changes.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql --lib --no-default-features --features test table_commitment -- --nocapture`
  - 16 passed, 0 failed
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/codex-table-commitment-focused.lcov -- table_commitment`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/codex-table-commitment-full.lcov`
  - 976 passed, 0 failed
  - Production-only `table_commitment.rs` coverage moved from `LH:10/172` in the local baseline to `LH:152/172` in the full no-default LCOV run.
- `cargo test -p proof-of-sql --lib --no-default-features --features "test arrow" table_commitment -- --nocapture`
  - 17 passed, 0 failed
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
