### PR TITLE
test(planner): add df_util helper coverage

### DIFF
--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -25,3 +25,36 @@ pub(crate) fn df_schema(table_name: &str, pairs: Vec<(&str, DataType)>) -> DFSch
     );
     DFSchema::try_from_qualified_schema(table_name, &arrow_schema).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn df_column_builds_qualified_column_expr() {
+        let expr = df_column("users", "id");
+        let Expr::Column(column) = expr else {
+            panic!("expected Expr::Column");
+        };
+        assert_eq!(column.name, "id");
+        assert_eq!(
+            column.relation.as_ref().map(|r| r.to_string()),
+            Some("users".to_string())
+        );
+    }
+
+    #[test]
+    fn df_schema_builds_non_nullable_fields_with_expected_types() {
+        let schema = df_schema(
+            "orders",
+            vec![("order_id", DataType::Int64), ("amount", DataType::Float64)],
+        );
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).name(), "order_id");
+        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
+        assert!(!schema.field(0).is_nullable());
+        assert_eq!(schema.field(1).name(), "amount");
+        assert_eq!(schema.field(1).data_type(), &DataType::Float64);
+        assert!(!schema.field(1).is_nullable());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `df_column` to verify qualified `Expr::Column` construction
- add unit tests for `df_schema` to verify field names, datatypes, and non-nullability
- keep scope test-only and non-overlapping with prior planner error coverage PR

## Validation
- `cargo test -p proof-of-sql-planner df_util::tests -- --nocapture`

/claim #560