### PR TITLE
test: cover helper edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::base::{
+    proof::ProofError,
     scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
     try_standard_binary_deserialization, try_standard_binary_serialization,
 };
@@ -211,6 +212,23 @@ fn we_can_get_leading_bit_eval_while_constant_and_non_zero() {
 // leading_bit_eval functions start
 
 // leading_bit_eval functions end
+
+#[test]
+#[should_panic(expected = "No lead bit available despite variable lead bit.")]
+fn converting_missing_lead_bit_error_panics() {
+    let _proof_error: ProofError = BitDistributionError::NoLeadBit.into();
+}
+
+#[test]
+fn converting_bit_verification_error_preserves_context() {
+    let proof_error = ProofError::from(BitDistributionError::Verification);
+    assert!(matches!(
+        proof_error,
+        ProofError::VerificationError {
+            error: "invalid bit_decomposition"
+        }
+    ));
+}
 
 #[test]
 fn we_can_compute_the_bit_distribution_of_an_empty_slice() {

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -111,6 +111,14 @@ mod tests {
     }
 
     #[test]
+    fn mont_scalar_hashing_masks_non_empty_input() {
+        type Scalar = MontScalar<ark_curve25519::FrConfig>;
+        let scalar = Scalar::from_byte_slice_via_hash(b"abc");
+        assert_ne!(scalar, Scalar::ZERO);
+        assert!(scalar.into_u256_wrapping() <= Scalar::CHALLENGE_MASK);
+    }
+
+    #[test]
     fn we_can_compute_powers_of_10() {
         for i in 0..=u128::MAX.ilog10() {
             assert_eq!(

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
+    dynamic_dory_commitment_evaluation_proof::DoryError, test_rng, DoryScalar,
+    DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -56,6 +57,68 @@ fn test_random_ipa_with_various_lengths() {
             &&verifier_setup,
         );
     }
+}
+
+#[test]
+fn new_returns_default_proof_for_nonzero_generator_offset() {
+    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let mut transcript = Transcript::new(b"evaluation_proof");
+
+    let proof = DynamicDoryEvaluationProof::new(
+        &mut transcript,
+        &[DoryScalar::from(1u64)],
+        &[],
+        1,
+        &&prover_setup,
+    );
+
+    assert_eq!(proof, DynamicDoryEvaluationProof::default());
+}
+
+#[test]
+fn verify_reports_invalid_generator_offset() {
+    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let mut transcript = Transcript::new(b"evaluation_proof");
+
+    let error = DynamicDoryEvaluationProof::default()
+        .verify_batched_proof(&mut transcript, &[], &[], &[], &[], 7, 0, &&verifier_setup)
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        DoryError::InvalidGeneratorsOffset { offset: 7 }
+    ));
+}
+
+#[test]
+fn verify_reports_small_setup_for_large_evaluation_points() {
+    let public_parameters = PublicParameters::test_rand(1, &mut test_rng());
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let b_point = vec![DoryScalar::from(0u64); 8];
+    let mut transcript = Transcript::new(b"evaluation_proof");
+
+    let error = DynamicDoryEvaluationProof::default()
+        .verify_batched_proof(
+            &mut transcript,
+            &[],
+            &[],
+            &[],
+            &b_point,
+            0,
+            0,
+            &&verifier_setup,
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        DoryError::SmallSetup {
+            actual: 1,
+            required: _
+        }
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Cover `BitDistributionError` conversion branches, including the missing lead-bit panic path
- Exercise `ScalarExt::from_byte_slice_via_hash` with a concrete `MontScalar` implementation
- Cover Dynamic Dory generator-offset and small-setup edge cases directly

## Coverage
From a full `cargo llvm-cov` lib run against the no-default `test` feature:
- `base/bit/bit_distribution.rs`: 65/66 -> 66/66 lines
- `base/scalar/scalar_ext.rs`: 83/84 -> 88/89 lines
- `proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs`: 73/75 -> 74/75 lines

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" converting_missing_lead_bit_error_panics -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" converting_bit_verification_error_preserves_context -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" mont_scalar_hashing_masks_non_empty_input -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" new_returns_default_proof_for_nonzero_generator_offset -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" verify_reports_invalid_generator_offset -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features="test" verify_reports_small_setup_for_large_evaluation_points -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --summary-only --json --output-path /tmp/sxt-small-helper-coverage.json` (966 passed)

/claim #560