### PR TITLE
test: cover dory reduce edge cases

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce.rs
@@ -53,3 +53,100 @@ pub fn dory_reduce_verify(
     state.nu -= 1;
     true
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{rand_G_vecs, test_rng, PublicParameters};
+    use super::*;
+    use merlin::Transcript as MerlinTranscript;
+
+    #[test]
+    fn we_can_prove_and_verify_one_dory_reduce_round_directly() {
+        let mut rng = test_rng();
+        let nu = 3;
+        let pp = PublicParameters::test_rand(nu, &mut rng);
+        let prover_setup = (&pp).into();
+        let verifier_setup = (&pp).into();
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let mut prover_state = ProverState::new(v1, v2, nu);
+        let mut verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+
+        let mut transcript = MerlinTranscript::new(b"dory_reduce_test");
+        let mut messages = DoryMessages::default();
+        dory_reduce_prove(&mut messages, &mut transcript, &mut prover_state, &prover_setup);
+
+        assert_eq!(prover_state.nu, nu - 1);
+
+        let mut transcript = MerlinTranscript::new(b"dory_reduce_test");
+        assert!(dory_reduce_verify(
+            &mut messages,
+            &mut transcript,
+            &mut verifier_state,
+            &verifier_setup
+        ));
+        assert_eq!(verifier_state.nu, nu - 1);
+    }
+
+    #[test]
+    fn we_fail_to_verify_one_dory_reduce_round_when_gt_messages_are_missing() {
+        let mut rng = test_rng();
+        let nu = 3;
+        let pp = PublicParameters::test_rand(nu, &mut rng);
+        let prover_setup = (&pp).into();
+        let verifier_setup = (&pp).into();
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let mut prover_state = ProverState::new(v1, v2, nu);
+        let mut verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+
+        let mut transcript = MerlinTranscript::new(b"dory_reduce_test");
+        let mut messages = DoryMessages::default();
+        dory_reduce_prove(&mut messages, &mut transcript, &mut prover_state, &prover_setup);
+        messages.GT_messages.pop();
+
+        let mut transcript = MerlinTranscript::new(b"dory_reduce_test");
+        assert!(!dory_reduce_verify(
+            &mut messages,
+            &mut transcript,
+            &mut verifier_state,
+            &verifier_setup
+        ));
+        assert_eq!(verifier_state.nu, nu);
+    }
+
+    #[test]
+    #[should_panic]
+    fn dory_reduce_prove_requires_positive_nu() {
+        let mut rng = test_rng();
+        let nu = 0;
+        let pp = PublicParameters::test_rand(nu, &mut rng);
+        let prover_setup = (&pp).into();
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let mut prover_state = ProverState::new(v1, v2, nu);
+
+        let mut transcript = MerlinTranscript::new(b"dory_reduce_test");
+        let mut messages = DoryMessages::default();
+        dory_reduce_prove(&mut messages, &mut transcript, &mut prover_state, &prover_setup);
+    }
+
+    #[test]
+    #[should_panic]
+    fn dory_reduce_verify_requires_positive_nu() {
+        let mut rng = test_rng();
+        let nu = 0;
+        let pp = PublicParameters::test_rand(nu, &mut rng);
+        let prover_setup = (&pp).into();
+        let verifier_setup = (&pp).into();
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let prover_state = ProverState::new(v1, v2, nu);
+        let mut verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+
+        let mut transcript = MerlinTranscript::new(b"dory_reduce_test");
+        let mut messages = DoryMessages::default();
+        dory_reduce_verify(
+            &mut messages,
+            &mut transcript,
+            &mut verifier_state,
+            &verifier_setup,
+        );
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
@@ -111,3 +111,125 @@ pub fn extended_dory_reduce_verify(
 
     true
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{rand_F_tensors, rand_G_vecs, test_rng, PublicParameters};
+    use super::*;
+    use merlin::Transcript as MerlinTranscript;
+
+    #[test]
+    fn we_can_prove_and_verify_one_extended_dory_reduce_round_directly() {
+        let mut rng = test_rng();
+        let nu = 3;
+        let pp = PublicParameters::test_rand(nu, &mut rng);
+        let prover_setup = (&pp).into();
+        let verifier_setup = (&pp).into();
+        let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let mut prover_state =
+            ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
+        let mut verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+
+        let mut transcript = MerlinTranscript::new(b"extended_dory_reduce_test");
+        let mut messages = DoryMessages::default();
+        extended_dory_reduce_prove(
+            &mut messages,
+            &mut transcript,
+            &mut prover_state,
+            &prover_setup,
+        );
+
+        assert_eq!(prover_state.base_state.nu, nu - 1);
+        assert_eq!(prover_state.s1.len(), 1 << (nu - 1));
+        assert_eq!(prover_state.s2.len(), 1 << (nu - 1));
+
+        let mut transcript = MerlinTranscript::new(b"extended_dory_reduce_test");
+        assert!(extended_dory_reduce_verify(
+            &mut messages,
+            &mut transcript,
+            &mut verifier_state,
+            &verifier_setup
+        ));
+        assert_eq!(verifier_state.base_state.nu, nu - 1);
+    }
+
+    #[test]
+    fn we_fail_to_verify_one_extended_dory_reduce_round_when_g2_messages_are_missing() {
+        let mut rng = test_rng();
+        let nu = 3;
+        let pp = PublicParameters::test_rand(nu, &mut rng);
+        let prover_setup = (&pp).into();
+        let verifier_setup = (&pp).into();
+        let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let mut prover_state =
+            ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
+        let mut verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+
+        let mut transcript = MerlinTranscript::new(b"extended_dory_reduce_test");
+        let mut messages = DoryMessages::default();
+        extended_dory_reduce_prove(
+            &mut messages,
+            &mut transcript,
+            &mut prover_state,
+            &prover_setup,
+        );
+        messages.G2_messages.pop();
+
+        let mut transcript = MerlinTranscript::new(b"extended_dory_reduce_test");
+        assert!(!extended_dory_reduce_verify(
+            &mut messages,
+            &mut transcript,
+            &mut verifier_state,
+            &verifier_setup
+        ));
+        assert_eq!(verifier_state.base_state.nu, nu);
+    }
+
+    #[test]
+    #[should_panic]
+    fn extended_dory_reduce_prove_requires_positive_nu() {
+        let mut rng = test_rng();
+        let nu = 0;
+        let pp = PublicParameters::test_rand(nu, &mut rng);
+        let prover_setup = (&pp).into();
+        let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let mut prover_state =
+            ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
+
+        let mut transcript = MerlinTranscript::new(b"extended_dory_reduce_test");
+        let mut messages = DoryMessages::default();
+        extended_dory_reduce_prove(
+            &mut messages,
+            &mut transcript,
+            &mut prover_state,
+            &prover_setup,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn extended_dory_reduce_verify_requires_positive_nu() {
+        let mut rng = test_rng();
+        let nu = 0;
+        let pp = PublicParameters::test_rand(nu, &mut rng);
+        let prover_setup = (&pp).into();
+        let verifier_setup = (&pp).into();
+        let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let prover_state =
+            ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
+        let mut verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+
+        let mut transcript = MerlinTranscript::new(b"extended_dory_reduce_test");
+        let mut messages = DoryMessages::default();
+        extended_dory_reduce_verify(
+            &mut messages,
+            &mut transcript,
+            &mut verifier_state,
+            &verifier_setup,
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add direct one-round tests for `dory_reduce_prove` / `dory_reduce_verify`
- add direct one-round tests for `extended_dory_reduce_prove` / `extended_dory_reduce_verify`
- cover malformed message queues returning `false` before verifier state mutation
- cover positive-`nu` panic guards on prover and verifier paths

## Tests
- `git diff --check`
- Not run locally: `cargo test -p proof-of-sql dory_reduce` because this Windows Codex environment does not have `cargo` or `rustc` installed