### PR TITLE
test: precompute EVM verifier arguments

### DIFF
--- a/crates/proof-of-sql-planner/tests/evm_tests.rs
+++ b/crates/proof-of-sql-planner/tests/evm_tests.rs
@@ -30,14 +30,22 @@ use proof_of_sql::{
 use proof_of_sql_planner::sql_to_proof_plans;
 use sqlparser::{ast::Ident, dialect::GenericDialect, parser::Parser};
 
+struct EvmVerifierArgs {
+    result_hex: String,
+    query_hex: String,
+    params: String,
+    proof_hex: String,
+    table_lengths: String,
+    commitments: String,
+}
+
 #[expect(clippy::missing_panics_doc)]
-fn evm_verifier_with_extra_args(
+fn evm_verifier_args(
     plan: &DynProofPlan,
     params: &str,
     verifiable_result: &VerifiableQueryResult<HyperKZGCommitmentEvaluationProof>,
     accessor: &impl CommitmentAccessor<HyperKZGCommitment>,
-    extra_args: &[&'static str],
-) -> bool {
+) -> EvmVerifierArgs {
     let commitments = plan
         .get_column_references()
         .into_iter()
@@ -67,6 +75,21 @@ fn evm_verifier_with_extra_args(
     let result_bytes =
         bincode::serde::encode_to_vec(&verifiable_result.result, bincode_options).unwrap();
 
+    EvmVerifierArgs {
+        result_hex: hex::encode(result_bytes),
+        query_hex: hex::encode(query_bytes),
+        params: params.to_string(),
+        proof_hex: hex::encode(proof_bytes),
+        table_lengths: format!("[{table_lengths}]"),
+        commitments: format!("[{commitments}]"),
+    }
+}
+
+#[expect(clippy::missing_panics_doc)]
+fn evm_verifier_with_extra_args(
+    verifier_args: &EvmVerifierArgs,
+    extra_args: &[&'static str],
+) -> bool {
     std::process::Command::new("../../solidity/scripts/pre_forge.sh")
         .arg("script")
         .arg("-vvvvv")
@@ -78,13 +101,13 @@ fn evm_verifier_with_extra_args(
         ])
         .arg("./test/verifier/Verifier.t.post.sol")
         .args([
-            dbg!(hex::encode(&result_bytes)),
-            dbg!(hex::encode(&query_bytes)),
-            dbg!(params.to_string()),
-            dbg!(hex::encode(&proof_bytes)),
+            &verifier_args.result_hex,
+            &verifier_args.query_hex,
+            &verifier_args.params,
+            &verifier_args.proof_hex,
         ])
-        .arg(dbg!(format!("[{table_lengths}]")))
-        .arg(dbg!(format!("[{commitments}]")))
+        .arg(&verifier_args.table_lengths)
+        .arg(&verifier_args.commitments)
         .output()
         .unwrap()
         .status
@@ -96,16 +119,11 @@ fn evm_verifier_all(
     verifiable_result: &VerifiableQueryResult<HyperKZGCommitmentEvaluationProof>,
     accessor: &impl CommitmentAccessor<HyperKZGCommitment>,
 ) -> bool {
-    evm_verifier_with_extra_args(plan, params, verifiable_result, accessor, &[])
-        && evm_verifier_with_extra_args(plan, params, verifiable_result, accessor, &["--via-ir"])
-        && evm_verifier_with_extra_args(plan, params, verifiable_result, accessor, &["--optimize"])
-        && evm_verifier_with_extra_args(
-            plan,
-            params,
-            verifiable_result,
-            accessor,
-            &["--optimize", "--via-ir"],
-        )
+    let verifier_args = evm_verifier_args(plan, params, verifiable_result, accessor);
+    evm_verifier_with_extra_args(&verifier_args, &[])
+        && evm_verifier_with_extra_args(&verifier_args, &["--via-ir"])
+        && evm_verifier_with_extra_args(&verifier_args, &["--optimize"])
+        && evm_verifier_with_extra_args(&verifier_args, &["--optimize", "--via-ir"])
 }
 
 #[expect(clippy::missing_panics_doc)]


### PR DESCRIPTION
/claim #557

## Summary
- precompute the serialized EVM verifier arguments once per `evm_verifier_all` call
- reuse the same result/query/params/proof/table-length/commitment values across the four forge variants
- remove unconditional `dbg!` formatting from the hot verifier path

## Expected effect
- avoids repeating plan column/table scans, `EVMProofPlan::new(plan.clone())`, bincode serialization, hex encoding, and captured stderr formatting four times per EVM verifier case
- preserves all four forge invocations (`plain`, `--via-ir`, `--optimize`, and both) and does not remove native verification assertions
- effect is intentionally limited to Rust-side pre-forge setup; forge execution still dominates, so CI/maintainer timing should be the source of truth for bounty accounting

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --package proof-of-sql-planner --test evm_tests --no-run`
- `cargo test --package proof-of-sql-planner --test evm_tests we_can_verify_a_slice_exec_using_the_evm -- --ignored --nocapture`
- `bash scripts/check_commits.sh`

## Notes
- `cargo test --package proof-of-sql-planner --all-features --test evm_tests --no-run` is not runnable on this Apple Silicon environment because `halo2curves/asm` only supports x86_64.
- The real Foundry-based EVM smoke path currently fails locally on both this branch and a clean `origin/main`, so I did not use local forge timings as evidence; CI/maintainer timing is the source of truth.