### PR TITLE
test: expand no-default coverage slices

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,6 +1,48 @@
 use super::MultilinearExtension;
-use crate::base::{database::Column, scalar::test_scalar::TestScalar};
+use crate::base::{
+    database::Column,
+    math::decimal::Precision,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    scalar::{test_scalar::TestScalar, Scalar},
+};
 use bumpalo::Bump;
+
+fn exercise_column_methods(column: Column<'_, TestScalar>, expected_values: &[TestScalar]) {
+    let evaluation_vec: Vec<TestScalar> = (1..=expected_values.len())
+        .map(|value| TestScalar::from(value as u64))
+        .collect();
+    let expected_inner_product = expected_values
+        .iter()
+        .zip(&evaluation_vec)
+        .map(|(&value, &eval)| value * eval)
+        .sum();
+    assert_eq!(
+        column.inner_product(&evaluation_vec),
+        expected_inner_product
+    );
+
+    let mut res = vec![TestScalar::from(3); expected_values.len()];
+    column.mul_add(&mut res, &TestScalar::from(2));
+    assert_eq!(
+        res,
+        expected_values
+            .iter()
+            .map(|&value| TestScalar::from(3) + TestScalar::from(2) * value)
+            .collect::<Vec<_>>()
+    );
+
+    let mut expected_term = expected_values.to_vec();
+    expected_term.resize(8, TestScalar::ZERO);
+    assert_eq!(
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&column, 3),
+        expected_term
+    );
+
+    assert_eq!(
+        MultilinearExtension::<TestScalar>::id(&column).1,
+        expected_values.len()
+    );
+}
 
 #[test]
 fn allocated_slices_must_have_different_ids_even_when_one_is_empty() {
@@ -113,4 +155,141 @@ fn we_can_use_multilinear_extension_methods_for_i64_vec() {
         MultilinearExtension::<TestScalar>::id(&slice),
         MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
+}
+
+#[test]
+fn we_can_use_multilinear_extension_methods_for_i64_array() {
+    let array = [2_i64, 3, 4, 5];
+    let evaluation_vec: Vec<TestScalar> = vec![101.into(), 102.into(), 103.into(), 104.into()];
+    assert_eq!(
+        (&array).inner_product(&evaluation_vec),
+        (2 * 101 + 3 * 102 + 4 * 103 + 5 * 104).into()
+    );
+    let mut res = evaluation_vec.clone();
+    (&array).mul_add(&mut res, &10.into());
+    assert_eq!(res, vec![121.into(), 132.into(), 143.into(), 154.into()]);
+    assert_eq!(
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&&array, 2),
+        vec![2.into(), 3.into(), 4.into(), 5.into()]
+    );
+}
+
+#[test]
+fn we_can_use_multilinear_extension_methods_for_all_column_variants() {
+    let bool_values = [true, false, true];
+    exercise_column_methods(
+        Column::Boolean(&bool_values),
+        &[TestScalar::ONE, TestScalar::ZERO, TestScalar::ONE],
+    );
+
+    let u8_values = [2_u8, 3, 4];
+    exercise_column_methods(
+        Column::Uint8(&u8_values),
+        &[
+            TestScalar::from(2),
+            TestScalar::from(3),
+            TestScalar::from(4),
+        ],
+    );
+
+    let i8_values = [-2_i8, 0, 4];
+    exercise_column_methods(
+        Column::TinyInt(&i8_values),
+        &[
+            TestScalar::from(-2_i64),
+            TestScalar::ZERO,
+            TestScalar::from(4),
+        ],
+    );
+
+    let i16_values = [-200_i16, 0, 400];
+    exercise_column_methods(
+        Column::SmallInt(&i16_values),
+        &[
+            TestScalar::from(-200_i64),
+            TestScalar::ZERO,
+            TestScalar::from(400),
+        ],
+    );
+
+    let i32_values = [-20_000_i32, 0, 40_000];
+    exercise_column_methods(
+        Column::Int(&i32_values),
+        &[
+            TestScalar::from(-20_000_i64),
+            TestScalar::ZERO,
+            TestScalar::from(40_000),
+        ],
+    );
+
+    let i128_values = [-20_000_000_000_i128, 0, 40_000_000_000];
+    exercise_column_methods(
+        Column::Int128(&i128_values),
+        &[
+            TestScalar::from(-20_000_000_000_i64),
+            TestScalar::ZERO,
+            TestScalar::from(40_000_000_000_i64),
+        ],
+    );
+
+    let scalar_values = [
+        TestScalar::from(5),
+        TestScalar::from(8),
+        TestScalar::from(13),
+    ];
+    exercise_column_methods(Column::Scalar(&scalar_values), &scalar_values);
+    exercise_column_methods(
+        Column::Decimal75(Precision::new(20).unwrap(), 4, &scalar_values),
+        &scalar_values,
+    );
+
+    let string_values = ["a", "b", "c"];
+    let string_scalars = [
+        TestScalar::from(17),
+        TestScalar::from(19),
+        TestScalar::from(23),
+    ];
+    exercise_column_methods(
+        Column::VarChar((&string_values, &string_scalars)),
+        &string_scalars,
+    );
+
+    let binary_values: [&[u8]; 3] = [b"a".as_slice(), b"b".as_slice(), b"c".as_slice()];
+    let binary_scalars = [
+        TestScalar::from(29),
+        TestScalar::from(31),
+        TestScalar::from(37),
+    ];
+    exercise_column_methods(
+        Column::VarBinary((&binary_values, &binary_scalars)),
+        &binary_scalars,
+    );
+
+    let timestamp_values = [-3_i64, 0, 9];
+    exercise_column_methods(
+        Column::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            &timestamp_values,
+        ),
+        &[
+            TestScalar::from(-3_i64),
+            TestScalar::ZERO,
+            TestScalar::from(9),
+        ],
+    );
+}
+
+#[test]
+fn we_can_evaluate_multilinear_extension_at_a_point() {
+    let values = [2_i64, 4, 6, 8];
+    let point = [TestScalar::from(3), TestScalar::from(5)];
+    let one_minus_x = TestScalar::ONE - point[0];
+    let one_minus_y = TestScalar::ONE - point[1];
+    let expected = TestScalar::from(2) * one_minus_x * one_minus_y
+        + TestScalar::from(4) * point[0] * one_minus_y
+        + TestScalar::from(6) * one_minus_x * point[1]
+        + TestScalar::from(8) * point[0] * point[1];
+
+    assert_eq!((&values).evaluate_at_point(&point), expected);
 }

--- a/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/matrix_structure.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/matrix_structure.rs
@@ -273,4 +273,11 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn we_can_reject_explicit_invalid_row_column_edges() {
+        assert_eq!(index_from_row_and_column(1, 0), None);
+        assert_eq!(index_from_row_and_column(0, 1), None);
+        assert_eq!(index_from_row_and_column(3, 4), None);
+    }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/standard_basis_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/standard_basis_helper.rs
@@ -707,6 +707,13 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Values in point cannot be 1.")]
+    fn we_cannot_compute_dynamic_vecs_when_point_contains_one() {
+        let point = vec![DoryScalar::ONE];
+        let _ = compute_dynamic_vecs(&point);
+    }
+
+    #[test]
     fn we_can_compute_dynamic_vecs_that_matches_evaluation_vec() {
         use ark_std::UniformRand;
         let mut rng = ark_std::test_rng();

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -69,3 +69,129 @@ impl<'a, T: ProvableResultElement<'a>, const N: usize> ProvableResultColumn for 
         (&self[..]).write(out, length)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProvableResultColumn;
+    use crate::base::{
+        database::Column,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
+    use alloc::vec::Vec;
+
+    fn encoded(column: &impl ProvableResultColumn, length: u64) -> Vec<u8> {
+        let mut out = vec![0_u8; column.num_bytes(length)];
+        let written = column.write(&mut out, length);
+        assert_eq!(written, out.len());
+        out
+    }
+
+    #[test]
+    fn we_can_serialize_array_result_columns_like_slices() {
+        let values = [3_i64, -5, 8];
+        assert_eq!(encoded(&values, 3), encoded(&values.as_slice(), 3));
+    }
+
+    #[test]
+    fn we_can_serialize_numeric_database_columns_like_their_slices() {
+        let bool_values = [true, false, true];
+        assert_eq!(
+            encoded(&Column::<TestScalar>::Boolean(&bool_values), 3),
+            encoded(&bool_values.as_slice(), 3)
+        );
+
+        let u8_values = [1_u8, 127, 255];
+        assert_eq!(
+            encoded(&Column::<TestScalar>::Uint8(&u8_values), 3),
+            encoded(&u8_values.as_slice(), 3)
+        );
+
+        let i8_values = [-2_i8, 0, 5];
+        assert_eq!(
+            encoded(&Column::<TestScalar>::TinyInt(&i8_values), 3),
+            encoded(&i8_values.as_slice(), 3)
+        );
+
+        let i16_values = [-300_i16, 0, 700];
+        assert_eq!(
+            encoded(&Column::<TestScalar>::SmallInt(&i16_values), 3),
+            encoded(&i16_values.as_slice(), 3)
+        );
+
+        let i32_values = [-70_000_i32, 0, 90_000];
+        assert_eq!(
+            encoded(&Column::<TestScalar>::Int(&i32_values), 3),
+            encoded(&i32_values.as_slice(), 3)
+        );
+
+        let i64_values = [-9_000_000_000_i64, 0, 9_000_000_000];
+        assert_eq!(
+            encoded(&Column::<TestScalar>::BigInt(&i64_values), 3),
+            encoded(&i64_values.as_slice(), 3)
+        );
+        assert_eq!(
+            encoded(
+                &Column::<TestScalar>::TimestampTZ(
+                    PoSQLTimeUnit::Second,
+                    PoSQLTimeZone::utc(),
+                    &i64_values,
+                ),
+                3,
+            ),
+            encoded(&i64_values.as_slice(), 3)
+        );
+
+        let i128_values = [-100_000_000_000_i128, 0, 100_000_000_000];
+        assert_eq!(
+            encoded(&Column::<TestScalar>::Int128(&i128_values), 3),
+            encoded(&i128_values.as_slice(), 3)
+        );
+    }
+
+    #[test]
+    fn we_can_serialize_scalar_backed_database_columns_like_their_slices() {
+        let scalars = [
+            TestScalar::from(7),
+            TestScalar::from(11),
+            TestScalar::from(13),
+        ];
+        assert_eq!(
+            encoded(&Column::Scalar(&scalars), 3),
+            encoded(&scalars.as_slice(), 3)
+        );
+        assert_eq!(
+            encoded(
+                &Column::Decimal75(Precision::new(20).unwrap(), 4, &scalars),
+                3,
+            ),
+            encoded(&scalars.as_slice(), 3)
+        );
+    }
+
+    #[test]
+    fn we_can_serialize_variable_width_database_columns_like_their_values() {
+        let strings = ["alpha", "", "gamma"];
+        let string_scalars = [
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+        ];
+        assert_eq!(
+            encoded(&Column::VarChar((&strings, &string_scalars)), 3),
+            encoded(&strings.as_slice(), 3)
+        );
+
+        let binary_values: [&[u8]; 3] = [b"abc".as_slice(), b"".as_slice(), b"\x00\xff".as_slice()];
+        let binary_scalars = [
+            TestScalar::from(4),
+            TestScalar::from(5),
+            TestScalar::from(6),
+        ];
+        assert_eq!(
+            encoded(&Column::VarBinary((&binary_values, &binary_scalars)), 3),
+            encoded(&binary_values.as_slice(), 3)
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -119,3 +119,128 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         })
     }
 }
+
+#[cfg(test)]
+mod no_blitzar_tests {
+    use super::VerifiableQueryResult;
+    use crate::{
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof,
+            database::{
+                owned_table_utility::{bigint, owned_table},
+                table_utility::{borrowed_bigint, table_with_row_count},
+                ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTableTestAccessor, Table,
+                TableEvaluation, TableRef,
+            },
+            map::{indexset, IndexMap, IndexSet},
+            proof::{PlaceholderResult, ProofError},
+            scalar::Scalar,
+        },
+        sql::proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, QueryData,
+            VerificationBuilder,
+        },
+    };
+    use bumpalo::Bump;
+    use serde::Serialize;
+    use sqlparser::ast::Ident;
+
+    #[derive(Debug, Serialize, Default)]
+    struct EmptyTestQueryExpr {
+        length: usize,
+        columns: usize,
+    }
+
+    impl ProverEvaluate for EmptyTestQueryExpr {
+        fn first_round_evaluate<'a, S: Scalar>(
+            &self,
+            builder: &mut FirstRoundBuilder<'a, S>,
+            alloc: &'a Bump,
+            _table_map: &IndexMap<TableRef, Table<'a, S>>,
+            _params: &[LiteralValue],
+        ) -> PlaceholderResult<Table<'a, S>> {
+            let zeros = vec![0_i64; self.length];
+            builder.produce_chi_evaluation_length(self.length);
+            Ok(table_with_row_count(
+                (1..=self.columns)
+                    .map(|i| borrowed_bigint(format!("a{i}").as_str(), zeros.clone(), alloc)),
+                self.length,
+            ))
+        }
+
+        fn final_round_evaluate<'a, S: Scalar>(
+            &self,
+            builder: &mut FinalRoundBuilder<'a, S>,
+            alloc: &'a Bump,
+            _table_map: &IndexMap<TableRef, Table<'a, S>>,
+            _params: &[LiteralValue],
+        ) -> PlaceholderResult<Table<'a, S>> {
+            let zeros = vec![0_i64; self.length];
+            let res: &[_] = alloc.alloc_slice_copy(&zeros);
+            core::iter::repeat_with(|| builder.produce_intermediate_mle(res))
+                .take(self.columns)
+                .for_each(drop);
+            Ok(table_with_row_count(
+                (1..=self.columns)
+                    .map(|i| borrowed_bigint(format!("a{i}").as_str(), zeros.clone(), alloc)),
+                self.length,
+            ))
+        }
+    }
+
+    impl ProofPlan for EmptyTestQueryExpr {
+        fn verifier_evaluate<S: Scalar>(
+            &self,
+            builder: &mut impl VerificationBuilder<S>,
+            _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+            _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
+            _params: &[LiteralValue],
+        ) -> Result<TableEvaluation<S>, ProofError> {
+            assert_eq!(
+                builder.try_consume_final_round_mle_evaluations(self.columns)?,
+                vec![S::ZERO; self.columns]
+            );
+            Ok(TableEvaluation::new(
+                vec![S::ZERO; self.columns],
+                builder.try_consume_chi_evaluation()?,
+            ))
+        }
+
+        fn get_column_result_fields(&self) -> Vec<ColumnField> {
+            (1..=self.columns)
+                .map(|i| ColumnField::new(format!("a{i}").as_str().into(), ColumnType::BigInt))
+                .collect()
+        }
+
+        fn get_column_references(&self) -> IndexSet<ColumnRef> {
+            indexset! {}
+        }
+
+        fn get_table_references(&self) -> IndexSet<TableRef> {
+            indexset![TableRef::new("sxt", "test")]
+        }
+    }
+
+    #[test]
+    fn we_can_create_and_verify_empty_query_result_without_blitzar() {
+        let expr = EmptyTestQueryExpr {
+            columns: 1,
+            ..Default::default()
+        };
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            TableRef::new("sxt", "test"),
+            owned_table([bigint("a1", [0_i64; 0])]),
+            0,
+            (),
+        );
+
+        let res =
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
+        let QueryData {
+            verification_hash: _,
+            table,
+        } = res.verify(&expr, &accessor, &(), &[]).unwrap();
+
+        assert_eq!(table, owned_table([bigint("a1", [0_i64; 0])]));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
@@ -132,3 +132,172 @@ pub(crate) fn verify_membership_check<S: Scalar>(
 
     Ok(multiplicity_eval)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        final_round_evaluate_membership_check, first_round_evaluate_membership_check,
+        verify_membership_check,
+    };
+    use crate::{
+        base::{
+            database::{table_utility::*, Column},
+            polynomial::MultilinearExtension,
+            proof::ProofError,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::{
+            mock_verification_builder::{run_verify_for_each_row, MockVerificationBuilder},
+            FinalRoundBuilder, FirstRoundBuilder,
+        },
+    };
+    use alloc::{collections::VecDeque, vec, vec::Vec};
+    use bumpalo::Bump;
+
+    #[test]
+    fn we_can_verify_membership_check_without_blitzar() {
+        let alloc = Bump::new();
+        let source_column = borrowed_bigint::<TestScalar>("a", [1, 2, 3], &alloc).1;
+        let candidate_column =
+            borrowed_bigint::<TestScalar>("candidate_a", [1, 2, 2, 1, 2], &alloc).1;
+        let source_columns = [source_column];
+        let candidate_columns = [candidate_column];
+        let source_len = source_columns[0].len();
+        let candidate_len = candidate_columns[0].len();
+        let source_chi = alloc.alloc_slice_fill_copy(source_len, true) as &[bool];
+        let candidate_chi = alloc.alloc_slice_fill_copy(candidate_len, true) as &[bool];
+
+        let mut first_round_builder = FirstRoundBuilder::new(candidate_len);
+        let multiplicities = first_round_evaluate_membership_check(
+            &mut first_round_builder,
+            &alloc,
+            &source_columns,
+            &candidate_columns,
+        );
+        assert_eq!(multiplicities, &[2, 3, 0]);
+        assert_eq!(first_round_builder.pcs_proof_mles().len(), 1);
+
+        let alpha = TestScalar::from(7);
+        let beta = TestScalar::from(19);
+        let mut final_round_builder = FinalRoundBuilder::new(candidate_len, VecDeque::new());
+        let final_multiplicities = final_round_evaluate_membership_check(
+            &mut final_round_builder,
+            &alloc,
+            alpha,
+            beta,
+            source_chi,
+            candidate_chi,
+            &source_columns,
+            &candidate_columns,
+        );
+        assert_eq!(final_multiplicities, multiplicities);
+        assert_eq!(final_round_builder.num_sumcheck_subpolynomials(), 3);
+
+        let verification_builder = run_verify_for_each_row(
+            source_len,
+            &first_round_builder,
+            &final_round_builder,
+            vec![],
+            3,
+            |builder, chi_n_eval, evaluation_point| {
+                let chi_m_eval = candidate_chi.inner_product(evaluation_point);
+                let column_evals = eval_columns(&source_columns, evaluation_point);
+                let candidate_evals = eval_columns(&candidate_columns, evaluation_point);
+                let multiplicity_eval = verify_membership_check(
+                    builder,
+                    alpha,
+                    beta,
+                    chi_n_eval,
+                    chi_m_eval,
+                    &column_evals,
+                    &candidate_evals,
+                )
+                .unwrap();
+                assert_eq!(
+                    multiplicity_eval,
+                    multiplicities.inner_product(evaluation_point)
+                );
+            },
+        );
+
+        assert!(verification_builder
+            .get_zero_sum_results()
+            .iter()
+            .all(|result| *result));
+    }
+
+    #[test]
+    fn we_can_reject_membership_check_with_mismatched_column_counts() {
+        let mut builder: MockVerificationBuilder<TestScalar> = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            Vec::new(),
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        let err = verify_membership_check(
+            &mut builder,
+            TestScalar::from(7),
+            TestScalar::from(19),
+            TestScalar::ONE,
+            TestScalar::ONE,
+            &[TestScalar::from(1), TestScalar::from(2)],
+            &[TestScalar::from(1)],
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, ProofError::VerificationError { .. }));
+    }
+
+    #[test]
+    #[should_panic(expected = "The number of source and candidate columns should be equal")]
+    fn we_cannot_first_round_membership_check_with_mismatched_column_counts() {
+        let alloc = Bump::new();
+        let source_columns = [
+            borrowed_bigint::<TestScalar>("a", [1, 2, 3], &alloc).1,
+            borrowed_bigint::<TestScalar>("b", [4, 5, 6], &alloc).1,
+        ];
+        let candidate_columns = [borrowed_bigint::<TestScalar>("candidate_a", [1, 2, 3], &alloc).1];
+        let mut builder = FirstRoundBuilder::new(3);
+
+        let _ = first_round_evaluate_membership_check(
+            &mut builder,
+            &alloc,
+            &source_columns,
+            &candidate_columns,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "The number of source columns should be greater than 0")]
+    fn we_cannot_final_round_membership_check_without_columns() {
+        let alloc = Bump::new();
+        let mut builder = FinalRoundBuilder::new(1, VecDeque::new());
+        let columns: [Column<'_, TestScalar>; 0] = [];
+        let candidate_columns: [Column<'_, TestScalar>; 0] = [];
+
+        let _ = final_round_evaluate_membership_check(
+            &mut builder,
+            &alloc,
+            TestScalar::from(7),
+            TestScalar::from(19),
+            &[true],
+            &[true],
+            &columns,
+            &candidate_columns,
+        );
+    }
+
+    fn eval_columns(
+        columns: &[Column<'_, TestScalar>],
+        evaluation_point: &[TestScalar],
+    ) -> Vec<TestScalar> {
+        columns
+            .iter()
+            .map(|column| column.inner_product(evaluation_point))
+            .collect()
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -201,6 +201,203 @@ pub(crate) fn verify_shift<S: Scalar>(
     Ok((shifted_column_eval, chi_n_plus_1_eval))
 }
 
+#[cfg(test)]
+mod no_blitzar_tests {
+    use super::{
+        final_round_evaluate_shift, final_round_evaluate_shift_base, first_round_evaluate_shift,
+        verify_shift,
+    };
+    use crate::{
+        base::{
+            polynomial::MultilinearExtension,
+            proof::{ProofError, ProofSizeMismatch},
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::{
+            mock_verification_builder::{run_verify_for_each_row, MockVerificationBuilder},
+            FinalRoundBuilder, FirstRoundBuilder,
+        },
+    };
+    use alloc::{collections::VecDeque, vec, vec::Vec};
+    use bumpalo::Bump;
+
+    #[test]
+    fn we_can_verify_shift_without_blitzar() {
+        let alloc = Bump::new();
+        let column_values = [
+            TestScalar::from(5),
+            TestScalar::from(7),
+            -TestScalar::from(11),
+        ];
+        let column = alloc.alloc_slice_copy(&column_values) as &[TestScalar];
+        let expected_shifted_column = [
+            TestScalar::ZERO,
+            TestScalar::from(5),
+            TestScalar::from(7),
+            -TestScalar::from(11),
+        ];
+
+        let mut first_round_builder = FirstRoundBuilder::new(0);
+        first_round_evaluate_shift(&mut first_round_builder, &alloc, column);
+        assert_eq!(first_round_builder.chi_evaluation_lengths(), &[4]);
+        assert_eq!(first_round_builder.rho_evaluation_lengths(), &[3, 4]);
+        assert_eq!(first_round_builder.range_length(), 4);
+
+        let shifted_first_round_values =
+            evaluate_first_round_mle_rows(&first_round_builder, first_round_builder.range_length());
+        assert_eq!(shifted_first_round_values, expected_shifted_column);
+
+        let alpha = TestScalar::from(3);
+        let beta = TestScalar::from(17);
+        let mut final_round_builder = FinalRoundBuilder::new(4, VecDeque::new());
+        let shifted_column =
+            final_round_evaluate_shift(&mut final_round_builder, &alloc, alpha, beta, column);
+        assert_eq!(shifted_column, expected_shifted_column);
+        assert_eq!(final_round_builder.pcs_proof_mles().len(), 2);
+        assert_eq!(final_round_builder.num_sumcheck_subpolynomials(), 3);
+
+        let verification_builder = run_verify_for_each_row(
+            column.len(),
+            &first_round_builder,
+            &final_round_builder,
+            vec![],
+            3,
+            |builder, chi_eval, evaluation_point| {
+                let column_eval = column.inner_product(evaluation_point);
+                let (shifted_column_eval, chi_n_plus_1_eval) =
+                    verify_shift(builder, alpha, beta, column_eval, chi_eval).unwrap();
+                assert_eq!(
+                    shifted_column_eval,
+                    shifted_column.inner_product(evaluation_point)
+                );
+                assert_eq!(chi_n_plus_1_eval, TestScalar::ONE);
+            },
+        );
+
+        assert!(verification_builder
+            .get_identity_results()
+            .iter()
+            .flatten()
+            .all(|result| *result));
+        assert!(verification_builder
+            .get_zero_sum_results()
+            .iter()
+            .all(|result| *result));
+    }
+
+    #[test]
+    fn we_can_detect_invalid_shift_witness_without_blitzar() {
+        let alloc = Bump::new();
+        let column_values = [
+            TestScalar::from(2),
+            TestScalar::from(4),
+            TestScalar::from(8),
+        ];
+        let column = alloc.alloc_slice_copy(&column_values) as &[TestScalar];
+        let invalid_shifted_column = alloc.alloc_slice_copy(&[
+            TestScalar::ZERO,
+            TestScalar::from(2),
+            TestScalar::from(99),
+            TestScalar::from(8),
+        ]) as &[TestScalar];
+
+        let mut first_round_builder = FirstRoundBuilder::new(0);
+        first_round_evaluate_shift(&mut first_round_builder, &alloc, column);
+
+        let alpha = TestScalar::from(13);
+        let beta = TestScalar::from(19);
+        let mut final_round_builder = FinalRoundBuilder::new(4, VecDeque::new());
+        final_round_evaluate_shift_base(
+            &mut final_round_builder,
+            &alloc,
+            alpha,
+            beta,
+            column,
+            invalid_shifted_column,
+        );
+
+        let verification_builder = run_verify_for_each_row(
+            column.len(),
+            &first_round_builder,
+            &final_round_builder,
+            vec![],
+            3,
+            |builder, chi_eval, evaluation_point| {
+                let column_eval = column.inner_product(evaluation_point);
+                let _ = verify_shift(builder, alpha, beta, column_eval, chi_eval).unwrap();
+            },
+        );
+
+        assert!(verification_builder
+            .get_identity_results()
+            .iter()
+            .flatten()
+            .any(|result| !*result));
+    }
+
+    #[test]
+    #[should_panic(expected = "Shifted column length mismatch")]
+    fn we_cannot_final_round_evaluate_shift_with_wrong_length() {
+        let alloc = Bump::new();
+        let column =
+            alloc.alloc_slice_copy(&[TestScalar::from(1), TestScalar::from(2)]) as &[TestScalar];
+        let shifted_column =
+            alloc.alloc_slice_copy(&[TestScalar::ZERO, TestScalar::from(1)]) as &[TestScalar];
+        let mut builder = FinalRoundBuilder::new(3, VecDeque::new());
+
+        final_round_evaluate_shift_base(
+            &mut builder,
+            &alloc,
+            TestScalar::from(3),
+            TestScalar::from(5),
+            column,
+            shifted_column,
+        );
+    }
+
+    #[test]
+    fn we_get_shift_verification_error_when_inputs_are_missing() {
+        let mut builder: MockVerificationBuilder<TestScalar> = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            Vec::new(),
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        let err = verify_shift(
+            &mut builder,
+            TestScalar::from(3),
+            TestScalar::from(5),
+            TestScalar::from(7),
+            TestScalar::ONE,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewChiLengths
+            }
+        ));
+    }
+
+    fn evaluate_first_round_mle_rows(
+        builder: &FirstRoundBuilder<'_, TestScalar>,
+        range_length: usize,
+    ) -> Vec<TestScalar> {
+        (0..range_length)
+            .map(|row| {
+                let mut evaluation_vec = vec![TestScalar::ZERO; range_length];
+                evaluation_vec[row] = TestScalar::ONE;
+                builder.evaluate_pcs_proof_mles(&evaluation_vec)[0]
+            })
+            .collect()
+    }
+}
+
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::{final_round_evaluate_shift_base, verify_shift};

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -162,14 +162,18 @@ mod tests {
             scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
         },
         sql::{
-            proof::mock_verification_builder::MockVerificationBuilder,
-            proof_gadgets::verifier_evaluate_sign,
+            proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
+            proof_gadgets::{
+                final_round_evaluate_sign, first_round_evaluate_sign, verifier_evaluate_sign,
+            },
         },
     };
+    use alloc::collections::VecDeque;
     use bnum::{
         cast::As,
         types::{I256, U256},
     };
+    use bumpalo::Bump;
     use core::ops::Shl;
 
     fn evaluate_matrix(matrix: &[&[I256]], terms: &[TestScalar]) -> Vec<TestScalar> {
@@ -191,6 +195,51 @@ mod tests {
                 }
             })
             .sum()
+    }
+
+    #[test]
+    fn we_can_prove_signs_without_blitzar() {
+        let raw_data = [123_i64, -452, 0, 789, -910];
+        let data: Vec<TestScalar> = raw_data.into_iter().map(TestScalar::from).collect();
+        let alloc = Bump::new();
+
+        let first_round_signs = first_round_evaluate_sign(data.len(), &alloc, &data);
+        assert_eq!(first_round_signs, [false, true, false, false, true]);
+
+        let mut builder = FinalRoundBuilder::new(3, VecDeque::new());
+        let final_round_signs = final_round_evaluate_sign(&mut builder, &alloc, &data);
+        assert_eq!(final_round_signs, first_round_signs);
+        assert_eq!(
+            builder.bit_distributions(),
+            [BitDistribution::new::<TestScalar, _>(&raw_data)]
+        );
+        assert!(!builder.pcs_proof_mles().is_empty());
+        assert!(builder.num_sumcheck_subpolynomials() > 0);
+    }
+
+    #[test]
+    fn we_can_prove_constant_signs_without_blitzar() {
+        let raw_data = [-123_i64, -123, -123];
+        let data: Vec<TestScalar> = raw_data.into_iter().map(TestScalar::from).collect();
+        let alloc = Bump::new();
+        let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+
+        let signs = final_round_evaluate_sign(&mut builder, &alloc, &data);
+        assert_eq!(signs, [true; 3]);
+        assert_eq!(
+            builder.bit_distributions(),
+            [BitDistribution::new::<TestScalar, _>(&raw_data)]
+        );
+        assert!(builder.pcs_proof_mles().is_empty());
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed")]
+    fn we_cannot_first_round_evaluate_sign_with_wrong_length() {
+        let alloc = Bump::new();
+        let data = [TestScalar::from(1), TestScalar::from(2)];
+        first_round_evaluate_sign(data.len() + 1, &alloc, &data);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,38 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn find_bigdecimals_only_returns_precision_and_scale_above_38() {
+        let sql = "CREATE TABLE TYPES(
+            DECIMAL_38 DECIMAL(38, 2),
+            DECIMAL_39 DECIMAL(39, 2),
+            DECIMAL_PRECISION_ONLY DECIMAL(39),
+            DECIMAL_WITHOUT_PRECISION DECIMAL,
+            INTEGER_VALUE INT
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(
+            bigdecimals.get("TYPES").unwrap(),
+            &[("DECIMAL_39".to_string(), 39, 2)]
+        );
+    }
+
+    #[test]
+    fn find_bigdecimals_ignores_non_create_table_statements() {
+        let sql = "SELECT 1;
+        CREATE TABLE BIG_TABLE(
+            VALUE DECIMAL(40, 1)
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("BIG_TABLE").unwrap(),
+            &[("VALUE".to_string(), 40, 1)]
+        );
+    }
 }


### PR DESCRIPTION
/claim #560

## Claim note
This PR supersedes #1819, which was closed unmerged. Please treat #1835 as the active claim PR for @evoesco on #560.

## Summary
- add no-Blitzar coverage for the `shift`, `membership_check`, and `sign_expr` proof gadgets
- add serialization coverage for `ProvableResultColumn` across fixed-width, scalar-backed, timestamp, varchar, and varbinary columns
- add no-default coverage for `MultilinearExtension` slice/array/column delegation and point evaluation
- add a no-Blitzar `VerifiableQueryResult` smoke path using `NaiveEvaluationProof`
- keep the previous parser and dynamic matrix helper coverage from this branch

## Local coverage accounting
Compared a clean `upstream/main` run with this branch using:

`cargo llvm-cov -p proof-of-sql --lib --no-default-features --features std,test --json --summary-only`

- baseline: `28742/35432` covered lines, `81.1188%`
- this branch: `30147/36050` covered lines, `83.6255%`
- existing source lines that were previously uncovered and are now covered in the local JSON comparison: `626`

Largest local newly-covered existing slices:
- `sql/proof/query_proof.rs`: 160 lines, reached transitively by the no-Blitzar `VerifiableQueryResult` smoke path
- `sql/proof_gadgets/shift.rs`: 104 lines
- `sql/proof_gadgets/membership_check.rs`: 48 lines
- `sql/proof/provable_result_column.rs`: 43 lines
- `base/polynomial/multilinear_extension.rs`: 40 lines
- `sql/proof_gadgets/sign_expr.rs`: 38 lines
- `sql/proof_gadgets/fold_log_expr.rs`: 28 lines, reached transitively
- `sql/proof/{first_round_builder,final_round_builder,verification_builder}.rs`: 77 combined lines, reached transitively

Final payable-line accounting is left to the maintainer/Algora baseline, especially for any lines that overlap with already rewarded coverage PRs.

## Testing
- `cargo test -p proof-of-sql --lib --no-default-features --features std,test shift -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features std,test membership_check -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features std,test provable_result_column -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features std,test multilinear_extension -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features std,test sign_expr -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features std,test verifiable_query_result -- --nocapture`
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One`
- `git diff --check`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features std,test --json --summary-only --output-path /tmp/sxt-coverage-branch-final-summary.json` (`983 passed; 0 failed`)
