### PR TITLE
test: improve planner coverage

### DIFF
--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -140,6 +140,14 @@ mod tests {
             table_source.as_any().type_id(),
             TypeId::of::<PoSqlTableSource>()
         );
+        assert_eq!(
+            table_source
+                .supports_filters_pushdown(&[&Expr::Literal(
+                    datafusion::common::ScalarValue::Boolean(Some(true))
+                )])
+                .unwrap(),
+            vec![TableProviderFilterPushDown::Exact]
+        );
 
         // Non-empty
         let column_fields = vec![
@@ -181,6 +189,10 @@ mod tests {
         assert_eq!(context_provider.get_function_meta(""), None);
         assert_eq!(context_provider.get_aggregate_meta(""), None);
         assert_eq!(context_provider.get_window_meta(""), None);
+        assert!(core::ptr::addr_eq(
+            context_provider.options(),
+            &context_provider.options
+        ));
 
         // Non-empty
         let accessor = SchemaAccessorImpl::new(indexmap_with_default! {AHasher;

--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -168,6 +168,18 @@ AND s.salary > (
     }
 
     #[test]
+    fn we_cannot_get_catalog_table_references() {
+        let statement = Parser::parse_sql(
+            &GenericDialect {},
+            "SELECT * FROM catalog.management.projects;",
+        )
+        .unwrap()[0]
+            .clone();
+
+        assert!(get_table_refs_from_statement(&statement).is_err());
+    }
+
+    #[test]
     fn we_can_use_abs() {
         let statements = Parser::parse_sql(&GenericDialect {}, "SELECT ABS(-1-1);").unwrap();
         sql_to_posql_plans(

--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -113,7 +113,10 @@ pub fn get_table_refs_from_statement(
 #[cfg(test)]
 mod tests {
     use super::get_table_refs_from_statement;
-    use crate::{conversion::sql_to_posql_plans, PlannerResult};
+    use crate::{
+        conversion::{sql_to_posql_plans, sql_to_proof_plans},
+        PlannerResult,
+    };
     use datafusion::{config::ConfigOptions, logical_expr::LogicalPlan};
     use indexmap::IndexSet;
     use proof_of_sql::{
@@ -172,6 +175,18 @@ AND s.salary > (
             &TableTestAccessor::<DynamicDoryEvaluationProof>::default(),
             &ConfigOptions::default(),
             |a, _| -> PlannerResult<LogicalPlan> { Ok(a.clone()) },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn we_can_convert_sql_to_proof_plans() {
+        let statements = Parser::parse_sql(&GenericDialect {}, "SELECT 1 AS one;").unwrap();
+
+        sql_to_proof_plans(
+            &statements,
+            &TableTestAccessor::<DynamicDoryEvaluationProof>::default(),
+            &ConfigOptions::default(),
         )
         .unwrap();
     }

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -2224,6 +2224,73 @@ mod tests {
         );
     }
 
+    #[test]
+    fn we_can_convert_inner_join_plan_to_proof_plan() {
+        let left_source = Arc::new(PoSqlTableSource::new(vec![
+            ColumnField::new("id".into(), ColumnType::BigInt),
+            ColumnField::new("left_value".into(), ColumnType::Int),
+        ]));
+        let right_source = Arc::new(PoSqlTableSource::new(vec![
+            ColumnField::new("id".into(), ColumnType::BigInt),
+            ColumnField::new("right_value".into(), ColumnType::VarChar),
+        ]));
+        let left = LogicalPlan::TableScan(
+            TableScan::try_new("left_table", left_source, Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+        let right = LogicalPlan::TableScan(
+            TableScan::try_new("right_table", right_source, Some(vec![0, 1]), vec![], None)
+                .unwrap(),
+        );
+        let plan = LogicalPlan::Join(Join {
+            left: Arc::new(left),
+            right: Arc::new(right),
+            on: vec![(
+                df_column("left_table", "id"),
+                df_column("right_table", "id"),
+            )],
+            filter: None,
+            join_type: JoinType::Inner,
+            join_constraint: JoinConstraint::On,
+            schema: Arc::new(DFSchema::empty()),
+            null_equals_null: false,
+        });
+        let schemas = SchemaAccessorImpl::new(indexmap_with_default! {AHasher;
+            TableRef::new("", "left_table") => vec![
+                ("id".into(), ColumnType::BigInt),
+                ("left_value".into(), ColumnType::Int),
+            ],
+            TableRef::new("", "right_table") => vec![
+                ("id".into(), ColumnType::BigInt),
+                ("right_value".into(), ColumnType::VarChar),
+            ],
+        });
+
+        let result = logical_plan_to_proof_plan(&plan, &schemas).unwrap();
+
+        let expected_left = DynProofPlan::new_table(
+            TableRef::new("", "left_table"),
+            vec![
+                ColumnField::new("id".into(), ColumnType::BigInt),
+                ColumnField::new("left_value".into(), ColumnType::Int),
+            ],
+        );
+        let expected_right = DynProofPlan::new_table(
+            TableRef::new("", "right_table"),
+            vec![
+                ColumnField::new("id".into(), ColumnType::BigInt),
+                ColumnField::new("right_value".into(), ColumnType::VarChar),
+            ],
+        );
+        let expected = DynProofPlan::SortMergeJoin(SortMergeJoinExec::new(
+            Box::new(expected_left),
+            Box::new(expected_right),
+            vec![0],
+            vec![0],
+            vec!["id".into(), "left_value".into(), "right_value".into()],
+        ));
+        assert_eq!(result, expected);
+    }
+
     // Filter (LogicalPlan::Filter) tests - Happy paths
     #[test]
     fn we_can_convert_simple_nested_filters() {

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1299,6 +1299,95 @@ mod tests {
     }
 
     #[test]
+    fn we_cannot_aggregate_if_aggregate_alias_is_missing() {
+        let group_expr = vec![df_column("table", "a")];
+        let aggr_expr = vec![SUM_B(), COUNT_1()];
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "table.a".to_string() => "a".to_string(),
+            "COUNT(Int64(1))".to_string() => "count_1".to_string(),
+        };
+
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_with_non_aggregate_expression_after_group_alias_resolution() {
+        let group_expr = vec![df_column("table", "a")];
+        let aggr_expr = vec![Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(df_column("table", "b")),
+            Operator::Plus,
+            Box::new(df_column("table", "b")),
+        ))];
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "table.a".to_string() => "a".to_string(),
+        };
+
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_with_multiple_group_columns_after_alias_resolution() {
+        let group_expr = vec![df_column("table", "a"), df_column("table", "c")];
+        let aggr_expr = vec![SUM_B(), COUNT_1()];
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "table.a".to_string() => "a".to_string(),
+            "table.c".to_string() => "c".to_string(),
+            "SUM(table.b)".to_string() => "sum_b".to_string(),
+            "COUNT(Int64(1))".to_string() => "count_1".to_string(),
+        };
+
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
     fn we_cannot_aggregate_with_non_sum_aggregate_function() {
         // Setup group expression
         let group_expr = vec![df_column("table", "a")];
@@ -2289,6 +2378,55 @@ mod tests {
             vec!["id".into(), "left_value".into(), "right_value".into()],
         ));
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_cannot_convert_inner_join_with_different_join_column_names() {
+        let left_source = Arc::new(PoSqlTableSource::new(vec![
+            ColumnField::new("id".into(), ColumnType::BigInt),
+            ColumnField::new("left_value".into(), ColumnType::Int),
+        ]));
+        let right_source = Arc::new(PoSqlTableSource::new(vec![
+            ColumnField::new("right_id".into(), ColumnType::BigInt),
+            ColumnField::new("right_value".into(), ColumnType::VarChar),
+        ]));
+        let left = LogicalPlan::TableScan(
+            TableScan::try_new("left_table", left_source, Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+        let right = LogicalPlan::TableScan(
+            TableScan::try_new("right_table", right_source, Some(vec![0, 1]), vec![], None)
+                .unwrap(),
+        );
+        let plan = LogicalPlan::Join(Join {
+            left: Arc::new(left),
+            right: Arc::new(right),
+            on: vec![(
+                df_column("left_table", "id"),
+                df_column("right_table", "right_id"),
+            )],
+            filter: None,
+            join_type: JoinType::Inner,
+            join_constraint: JoinConstraint::On,
+            schema: Arc::new(DFSchema::empty()),
+            null_equals_null: false,
+        });
+        let schemas = SchemaAccessorImpl::new(indexmap_with_default! {AHasher;
+            TableRef::new("", "left_table") => vec![
+                ("id".into(), ColumnType::BigInt),
+                ("left_value".into(), ColumnType::Int),
+            ],
+            TableRef::new("", "right_table") => vec![
+                ("right_id".into(), ColumnType::BigInt),
+                ("right_value".into(), ColumnType::VarChar),
+            ],
+        });
+
+        let result = logical_plan_to_proof_plan(&plan, &schemas);
+
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
     }
 
     // Filter (LogicalPlan::Filter) tests - Happy paths

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -236,6 +236,18 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn we_cannot_convert_placeholder_with_unsupported_type() {
+        let placeholder = Placeholder {
+            id: "$1".to_string(),
+            data_type: Some(DataType::UInt16),
+        };
+        assert!(matches!(
+            placeholder_to_placeholder_expr(&placeholder),
+            Err(PlannerError::UnsupportedDataType { .. })
+        ));
+    }
+
     // TableReference to TableRef
     #[test]
     fn we_can_convert_table_reference_to_table_ref() {


### PR DESCRIPTION
## Summary
- cover planner context option and filter pushdown paths
- cover SQL-to-proof-plan conversion and catalog table-reference error handling
- cover successful and unsupported join/aggregate planner branches
- cover unsupported placeholder data-type conversion

/claim #560

## Coverage Evidence
Local planner LCOV comparison across the touched production files:

| File | Before missed lines | After missed lines | Delta |
| --- | ---: | ---: | ---: |
| `crates/proof-of-sql-planner/src/context.rs` | 9 | 0 | 9 |
| `crates/proof-of-sql-planner/src/conversion.rs` | 8 | 0 | 8 |
| `crates/proof-of-sql-planner/src/plan.rs` | 63 | 1 | 62 |
| `crates/proof-of-sql-planner/src/util.rs` | 2 | 0 | 2 |
| Total | 82 | 1 | 81 |

Final covered-line accounting is left to the maintainer/Algora baseline.

## Tests
- `cargo test -p proof-of-sql-planner we_can_create_a_posql_table_source`
- `cargo test -p proof-of-sql-planner we_can_convert_sql_to_proof_plans`
- `cargo test -p proof-of-sql-planner we_can_convert_inner_join_plan_to_proof_plan`
- `cargo test -p proof-of-sql-planner we_cannot_`
- `LLVM_COV=/usr/bin/llvm-cov LLVM_PROFDATA=/usr/bin/llvm-profdata cargo llvm-cov -p proof-of-sql-planner --lib --lcov --output-path target/planner-more.lcov`
- `git diff --check`
