### PR TITLE
test: reduce query commitment setup size

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -319,9 +319,12 @@ mod tests {
     #[expect(clippy::similar_names)]
     #[test]
     fn we_can_get_query_commitments_from_accessor() {
-        let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
+        const QUERY_COMMITMENTS_DORY_SETUP_NU: usize = 3;
+
+        let public_parameters =
+            PublicParameters::test_rand(QUERY_COMMITMENTS_DORY_SETUP_NU, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
-        let setup = DoryProverPublicSetup::new(&prover_setup, 3);
+        let setup = DoryProverPublicSetup::new(&prover_setup, QUERY_COMMITMENTS_DORY_SETUP_NU);
 
         let column_a_id: Ident = "column_a".into();
         let column_b_id: Ident = "column_b".into();


### PR DESCRIPTION
/claim #557

## Summary

- reduce the `QueryCommitments::from_accessor_with_max_bounds` test's generated Dory public-parameter size from `max_nu = 4` to `max_nu = 3`
- keep the existing `DoryProverPublicSetup` `sigma = 3` surface, fixtures, accessor path, and assertions unchanged
- avoid generating unused Dory setup rows for this test while preserving the same query-commitment behavior being checked

## Rationale

The test constructs `DoryProverPublicSetup` with `sigma = 3`, so `PublicParameters::test_rand(3, ...)` provides the exact `1 << sigma` `Gamma_1`/`Gamma_2` setup surface used by the Dory commitment path. The fixture tables are shorter than that setup width and use offset `0`, so the previous `max_nu = 4` generation was larger than the test needs.

## Validation

- `git diff --check`
- static verification of the `sigma`/`max_nu` relationship in `dory_public_setup.rs` and the Dory commitment helper indexing path

I could not run `cargo fmt` or `cargo test` in this Windows environment because neither `cargo` nor `rustfmt` is installed, and Docker Desktop is not running.
