### PR TITLE
test: cover arrow schema utility

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,55 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_convert_empty_schema_to_posql_compatible_schema() {
+        let schema = Arc::new(Schema::empty());
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert!(converted.fields().is_empty());
+    }
+
+    #[test]
+    fn we_can_convert_float_fields_to_posql_compatible_decimals() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("float16", DataType::Float16, true),
+            Field::new("float32", DataType::Float32, false),
+            Field::new("float64", DataType::Float64, true),
+            Field::new("int64", DataType::Int64, false),
+            Field::new("varchar", DataType::Utf8, true),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(converted.field(0).name(), "float16");
+        assert_eq!(
+            converted.field(0).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert!(converted.field(0).is_nullable());
+        assert_eq!(converted.field(1).name(), "float32");
+        assert_eq!(
+            converted.field(1).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert!(!converted.field(1).is_nullable());
+        assert_eq!(converted.field(2).name(), "float64");
+        assert_eq!(
+            converted.field(2).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert!(converted.field(2).is_nullable());
+        assert_eq!(converted.field(3).name(), "int64");
+        assert_eq!(converted.field(3).data_type(), &DataType::Int64);
+        assert!(!converted.field(3).is_nullable());
+        assert_eq!(converted.field(4).name(), "varchar");
+        assert_eq!(converted.field(4).data_type(), &DataType::Utf8);
+        assert!(converted.field(4).is_nullable());
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add unit coverage for empty Arrow schemas in `get_posql_compatible_schema`
- cover Float16, Float32, and Float64 conversion to `Decimal256(20, 10)`
- assert non-float fields preserve their data type and nullability

## Tests
- `cargo test -p proof-of-sql --lib --no-default-features --features=arrow base::database::arrow_schema_utility`
- `cargo fmt --check`
- `git diff --check`