### PR TITLE
test: cover slice right-upcast helper

### DIFF
--- a/crates/proof-of-sql/src/base/database/slice_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_operation.rs
@@ -397,6 +397,12 @@ mod test {
         let actual = slice_binary_op_left_upcast(&lhs, &rhs, PartialEq::eq);
         let expected = vec![true, false, true];
         assert_eq!(expected, actual);
+
+        let lhs = [1_i32, 2, 3];
+        let rhs = [1_i16, 3, 3];
+        let actual = slice_binary_op_right_upcast(&lhs, &rhs, PartialEq::eq);
+        let expected = vec![true, false, true];
+        assert_eq!(expected, actual);
     }
 
     // <=


### PR DESCRIPTION
## Summary
- add a direct assertion for `slice_binary_op_right_upcast`
- cover the right-hand upcast path alongside the existing left-upcast equality test
- keep the change test-only with no production behavior changes

## Coverage
Focused LCOV for `crates/proof-of-sql/src/base/database/slice_operation.rs`:
- before: 497/504 executable lines
- after: 509/509 executable lines

## Validation
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS= BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib --no-default-features --features="test" slice_operation -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS= BLITZAR_BACKEND=cpu cargo llvm-cov -p proof-of-sql --lib --no-default-features --features="test" --lcov --output-path /tmp/sxt-slice-pr.lcov -- slice_operation`
- `cargo fmt --check`
- `git diff --check`

/claim #560
