### PR TITLE
test(planner): cover join conversion and context helpers

### DIFF
--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -140,6 +140,10 @@ mod tests {
             table_source.as_any().type_id(),
             TypeId::of::<PoSqlTableSource>()
         );
+        assert_eq!(
+            table_source.supports_filters_pushdown(&[]).unwrap(),
+            Vec::<TableProviderFilterPushDown>::new()
+        );
 
         // Non-empty
         let column_fields = vec![
@@ -157,6 +161,11 @@ mod tests {
         assert_eq!(
             table_source.as_any().type_id(),
             TypeId::of::<PoSqlTableSource>()
+        );
+        let filter = Expr::Literal(datafusion::common::ScalarValue::Boolean(Some(true)));
+        assert_eq!(
+            table_source.supports_filters_pushdown(&[&filter]).unwrap(),
+            vec![TableProviderFilterPushDown::Exact]
         );
     }
 
@@ -181,6 +190,15 @@ mod tests {
         assert_eq!(context_provider.get_function_meta(""), None);
         assert_eq!(context_provider.get_aggregate_meta(""), None);
         assert_eq!(context_provider.get_window_meta(""), None);
+        assert_eq!(
+            context_provider
+                .options()
+                .sql_parser
+                .enable_ident_normalization,
+            ConfigOptions::default()
+                .sql_parser
+                .enable_ident_normalization
+        );
 
         // Non-empty
         let accessor = SchemaAccessorImpl::new(indexmap_with_default! {AHasher;

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -613,6 +613,20 @@ mod tests {
     }
 
     #[expect(non_snake_case)]
+    fn JOIN_SCHEMAS() -> impl SchemaAccessor {
+        SchemaAccessorImpl::new(indexmap_with_default! {AHasher;
+            TableRef::new("", "left_table") => vec![
+                ("id".into(), ColumnType::BigInt),
+                ("left_value".into(), ColumnType::Int),
+            ],
+            TableRef::new("", "right_table") => vec![
+                ("id".into(), ColumnType::BigInt),
+                ("right_value".into(), ColumnType::VarChar),
+            ],
+        })
+    }
+
+    #[expect(non_snake_case)]
     fn EMPTY_SCHEMAS() -> impl SchemaAccessor {
         SchemaAccessorImpl::new(indexmap_with_default! {AHasher;})
     }
@@ -2221,6 +2235,50 @@ mod tests {
         .unwrap_err();
         assert!(
             matches!(join_err, PlannerError::UnsupportedLogicalPlan { plan: logical_plan } if *logical_plan == plan )
+        );
+    }
+
+    #[test]
+    fn we_can_convert_inner_join_plan_to_proof_plan() {
+        let left_source = Arc::new(PoSqlTableSource::new(vec![
+            ColumnField::new("id".into(), ColumnType::BigInt),
+            ColumnField::new("left_value".into(), ColumnType::Int),
+        ]));
+        let right_source = Arc::new(PoSqlTableSource::new(vec![
+            ColumnField::new("id".into(), ColumnType::BigInt),
+            ColumnField::new("right_value".into(), ColumnType::VarChar),
+        ]));
+        let left_plan = LogicalPlan::TableScan(
+            TableScan::try_new("left_table", left_source, Some(vec![0, 1]), vec![], None).unwrap(),
+        );
+        let right_plan = LogicalPlan::TableScan(
+            TableScan::try_new("right_table", right_source, Some(vec![0, 1]), vec![], None)
+                .unwrap(),
+        );
+        let plan = LogicalPlan::Join(Join {
+            left: Arc::new(left_plan),
+            right: Arc::new(right_plan),
+            on: vec![(
+                df_column("left_table", "id"),
+                df_column("right_table", "id"),
+            )],
+            filter: None,
+            join_type: JoinType::Inner,
+            join_constraint: JoinConstraint::On,
+            schema: Arc::new(DFSchema::empty()),
+            null_equals_null: false,
+        });
+
+        let result = logical_plan_to_proof_plan(&plan, &JOIN_SCHEMAS()).unwrap();
+
+        assert!(matches!(result, DynProofPlan::SortMergeJoin(_)));
+        assert_eq!(
+            result.get_column_result_fields(),
+            vec![
+                ColumnField::new("id".into(), ColumnType::BigInt),
+                ColumnField::new("left_value".into(), ColumnType::Int),
+                ColumnField::new("right_value".into(), ColumnType::VarChar),
+            ]
         );
     }
 


### PR DESCRIPTION
/claim #560

## Summary
- add coverage for successful planner conversion of an inner join into `DynProofPlan::SortMergeJoin`
- assert the resulting join column/result schema ordering
- cover planner context options and table-source filter pushdown behavior

## Coverage note
Using `cargo llvm-cov -p proof-of-sql-planner --lib --text --show-missing-lines` before/after this branch:
- `crates/proof-of-sql-planner/src/context.rs` production missing lines: 9 -> 0
- `crates/proof-of-sql-planner/src/plan.rs` production missing lines: 63 -> 13
- net newly covered production lines in these files: 59

## Verification
- `cargo test -p proof-of-sql-planner context::tests`
- `cargo test -p proof-of-sql-planner plan::tests::we_can_convert_inner_join_plan_to_proof_plan`
- `cargo llvm-cov -p proof-of-sql-planner --lib --json --summary-only --output-path target/planner-summary-after-context-join.json`
- `cargo test -p proof-of-sql-planner --lib`
- `cargo fmt --all -- --check`
- `git diff --check`

## Limitations
- This is test-only coverage; it does not change planner behavior.