### PR TITLE
test: cover sumcheck random scalars

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -33,6 +33,8 @@ mod sumcheck_mle_evaluations_test;
 
 mod sumcheck_random_scalars;
 pub(crate) use sumcheck_random_scalars::SumcheckRandomScalars;
+#[cfg(test)]
+mod sumcheck_random_scalars_test;
 
 mod proof_plan;
 pub use proof_plan::ProofPlan;

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars_test.rs
@@ -1,0 +1,51 @@
+use super::SumcheckRandomScalars;
+use crate::base::scalar::test_scalar::TestScalar;
+use alloc::vec;
+use num_traits::One;
+
+#[test]
+fn we_split_sumcheck_random_scalars_into_multipliers_and_entrywise_point() {
+    let scalars = vec![
+        TestScalar::from(11u64),
+        TestScalar::from(12u64),
+        TestScalar::from(13u64),
+        TestScalar::from(3u64),
+        TestScalar::from(4u64),
+    ];
+
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 7, 2);
+
+    assert_eq!(random_scalars.subpolynomial_multipliers, &scalars[..3]);
+    assert_eq!(random_scalars.entrywise_point, &scalars[3..]);
+    assert_eq!(random_scalars.table_length, 7);
+}
+
+#[test]
+fn we_compute_entrywise_multipliers_from_the_entrywise_point() {
+    let three = TestScalar::from(3u64);
+    let four = TestScalar::from(4u64);
+    let scalars = vec![TestScalar::from(11u64), three, four];
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 3, 2);
+
+    let expected_multipliers = vec![
+        (TestScalar::one() - four) * (TestScalar::one() - three),
+        (TestScalar::one() - four) * three,
+        four * (TestScalar::one() - three),
+    ];
+
+    assert_eq!(
+        random_scalars.compute_entrywise_multipliers(),
+        expected_multipliers
+    );
+}
+
+#[test]
+fn we_compute_entrywise_multipliers_for_an_empty_entrywise_point() {
+    let scalars = vec![TestScalar::from(11u64), TestScalar::from(12u64)];
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 1, 0);
+
+    assert_eq!(
+        random_scalars.compute_entrywise_multipliers(),
+        vec![TestScalar::one()]
+    );
+}


### PR DESCRIPTION
/claim #560

# Rationale for this change

`SumcheckRandomScalars` splits verifier randomness into subpolynomial multipliers and the entrywise evaluation point, then turns that point into the entrywise multiplier vector used during sumcheck verification. This adds focused coverage for that helper without changing production behavior.

# What changes are included in this PR?

- Registers a dedicated `sumcheck_random_scalars_test` module.
- Covers the constructor split between `subpolynomial_multipliers` and `entrywise_point`.
- Covers `compute_entrywise_multipliers` for a truncated table length and for an empty entrywise point.

# Are these changes tested?

- `cargo test -p proof-of-sql --lib --no-default-features --features std sumcheck_random_scalars`
- `cargo fmt --check`
- `git diff --check`