### PR TITLE
test: cover sumcheck prover round state

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
@@ -223,19 +223,13 @@ mod tests {
 
         in_place_fix_variable(&mut multiplicand, TestScalar::from(3), 2);
 
-        assert_eq!(
-            multiplicand,
-            vec![
-                TestScalar::from(4),
-                TestScalar::from(16),
-                TestScalar::from(64),
-                TestScalar::from(256),
-                TestScalar::from(16),
-                TestScalar::from(32),
-                TestScalar::from(64),
-                TestScalar::from(128),
-            ]
-        );
+        let expected_prefix = [
+            TestScalar::from(4),
+            TestScalar::from(16),
+            TestScalar::from(64),
+            TestScalar::from(256),
+        ];
+        assert_eq!(&multiplicand[..(1 << 2)], expected_prefix.as_slice());
     }
 
     #[test]

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
@@ -124,3 +124,157 @@ fn in_place_fix_variable<S: Scalar>(multiplicand: &mut [S], r_as_field: S, num_v
 fn vec_elementwise_add<S: Scalar>(a: Vec<S>, b: Vec<S>) -> Vec<S> {
     a.into_iter().zip(b).map(|(x, y)| x + y).collect::<Vec<S>>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn prover_state() -> ProverState<TestScalar> {
+        ProverState::new(
+            vec![
+                (TestScalar::from(10), vec![0]),
+                (TestScalar::from(20), vec![0, 1]),
+            ],
+            vec![
+                vec![
+                    TestScalar::from(1),
+                    TestScalar::from(2),
+                    TestScalar::from(3),
+                    TestScalar::from(4),
+                ],
+                vec![
+                    TestScalar::from(5),
+                    TestScalar::from(6),
+                    TestScalar::from(7),
+                    TestScalar::from(8),
+                ],
+            ],
+            2,
+            2,
+        )
+    }
+
+    #[test]
+    fn prove_round_evaluates_first_and_followup_rounds() {
+        let mut state = prover_state();
+
+        let first_round = prove_round(&mut state, &None);
+        assert_eq!(
+            first_round,
+            vec![
+                TestScalar::from(560),
+                TestScalar::from(940),
+                TestScalar::from(1400)
+            ]
+        );
+        assert_eq!(state.round, 1);
+        assert_eq!(
+            state.flattened_ml_extensions[0],
+            vec![
+                TestScalar::from(1),
+                TestScalar::from(2),
+                TestScalar::from(3),
+                TestScalar::from(4),
+            ]
+        );
+
+        let second_round = prove_round(&mut state, &Some(TestScalar::from(7)));
+        assert_eq!(
+            second_round,
+            vec![
+                TestScalar::from(2000),
+                TestScalar::from(2900),
+                TestScalar::from(3960)
+            ]
+        );
+        assert_eq!(state.round, 2);
+        assert_eq!(
+            state.flattened_ml_extensions,
+            vec![
+                vec![
+                    TestScalar::from(8),
+                    TestScalar::from(10),
+                    TestScalar::from(3),
+                    TestScalar::from(4),
+                ],
+                vec![
+                    TestScalar::from(12),
+                    TestScalar::from(14),
+                    TestScalar::from(7),
+                    TestScalar::from(8),
+                ],
+            ]
+        );
+    }
+
+    #[test]
+    fn in_place_fix_variable_updates_the_lower_half_in_place() {
+        let mut multiplicand = vec![
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(4),
+            TestScalar::from(8),
+            TestScalar::from(16),
+            TestScalar::from(32),
+            TestScalar::from(64),
+            TestScalar::from(128),
+        ];
+
+        in_place_fix_variable(&mut multiplicand, TestScalar::from(3), 2);
+
+        assert_eq!(
+            multiplicand,
+            vec![
+                TestScalar::from(4),
+                TestScalar::from(16),
+                TestScalar::from(64),
+                TestScalar::from(256),
+                TestScalar::from(16),
+                TestScalar::from(32),
+                TestScalar::from(64),
+                TestScalar::from(128),
+            ]
+        );
+    }
+
+    #[test]
+    fn vec_elementwise_add_adds_until_the_shorter_input_ends() {
+        assert_eq!(
+            vec_elementwise_add(
+                vec![
+                    TestScalar::from(1),
+                    TestScalar::from(2),
+                    TestScalar::from(3)
+                ],
+                vec![TestScalar::from(4), TestScalar::from(5)]
+            ),
+            vec![TestScalar::from(5), TestScalar::from(7)]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "first round should be prover first.")]
+    fn prove_round_rejects_verifier_message_on_first_round() {
+        let mut state = prover_state();
+
+        prove_round(&mut state, &Some(TestScalar::from(1)));
+    }
+
+    #[test]
+    #[should_panic(expected = "verifier message is empty")]
+    fn prove_round_rejects_missing_verifier_message_after_first_round() {
+        let mut state = prover_state();
+
+        prove_round(&mut state, &None);
+        prove_round(&mut state, &None);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid size of partial point")]
+    fn in_place_fix_variable_rejects_zero_variables() {
+        let mut multiplicand = vec![TestScalar::from(1), TestScalar::from(2)];
+
+        in_place_fix_variable(&mut multiplicand, TestScalar::from(1), 0);
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -62,3 +62,77 @@ impl<S: Scalar> ProverState<S> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{polynomial::CompositePolynomial, scalar::test_scalar::TestScalar};
+    use alloc::{rc::Rc, vec};
+
+    #[test]
+    fn prover_state_new_initializes_round_state() {
+        let state = ProverState::new(
+            vec![(TestScalar::from(7), vec![0, 1])],
+            vec![vec![TestScalar::from(1), TestScalar::from(2)]],
+            3,
+            2,
+        );
+
+        assert_eq!(
+            state.list_of_products,
+            vec![(TestScalar::from(7), vec![0, 1])]
+        );
+        assert_eq!(
+            state.flattened_ml_extensions,
+            vec![vec![TestScalar::from(1), TestScalar::from(2)]]
+        );
+        assert_eq!(state.num_vars, 3);
+        assert_eq!(state.max_multiplicands, 2);
+        assert_eq!(state.round, 0);
+    }
+
+    #[test]
+    fn prover_state_create_copies_composite_polynomial_terms() {
+        let mle_a = Rc::new(vec![
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+            TestScalar::from(4),
+        ]);
+        let mle_b = Rc::new(vec![
+            TestScalar::from(5),
+            TestScalar::from(6),
+            TestScalar::from(7),
+            TestScalar::from(8),
+        ]);
+
+        let mut polynomial = CompositePolynomial::new(2);
+        polynomial.add_product([mle_a.clone(), mle_b.clone()], TestScalar::from(9));
+        polynomial.add_product([mle_a.clone()], TestScalar::from(10));
+
+        let state = ProverState::create(&polynomial);
+
+        assert_eq!(
+            state.list_of_products,
+            vec![
+                (TestScalar::from(9), vec![0, 1]),
+                (TestScalar::from(10), vec![0])
+            ]
+        );
+        assert_eq!(
+            state.flattened_ml_extensions,
+            vec![(*mle_a).clone(), (*mle_b).clone()]
+        );
+        assert_eq!(state.num_vars, 2);
+        assert_eq!(state.max_multiplicands, 2);
+        assert_eq!(state.round, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Attempt to prove a constant.")]
+    fn prover_state_create_rejects_constant_polynomials() {
+        let polynomial = CompositePolynomial::<TestScalar>::new(0);
+
+        ProverState::create(&polynomial);
+    }
+}


### PR DESCRIPTION
## Summary

- Add focused tests for `ProverState::new` and `ProverState::create`.
- Cover `prove_round` first/follow-up round behavior, verifier-message error paths, and private helper behavior.

/claim #560

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test --manifest-path crates/proof-of-sql/Cargo.toml proof_primitive::sumcheck::prover --no-default-features --features="test"` locally with a temporary `sqlparser` path override because GitHub dependency fetches were timing out in this environment.
