### PR TITLE
test: cover column index operation variants

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -120,7 +120,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::ColumnOperationError, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        database::ColumnOperationError,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn test_apply_index_op() {
@@ -188,5 +193,84 @@ mod tests {
         let expected = Column::VarBinary((expected_bytes.as_slice(), expected_scalars.as_slice()));
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_apply_index_op_fixed_width_variants() {
+        let bump = Bump::new();
+        let indexes = [2, 0, 2];
+
+        let column: Column<TestScalar> = Column::Boolean(&[true, false, true]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::Boolean(&[true, true, true]));
+
+        let column: Column<TestScalar> = Column::TinyInt(&[-5, 0, 7]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::TinyInt(&[7, -5, 7]));
+
+        let column: Column<TestScalar> = Column::Uint8(&[1, 2, 3]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::Uint8(&[3, 1, 3]));
+
+        let column: Column<TestScalar> = Column::SmallInt(&[-10, 20, 30]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::SmallInt(&[30, -10, 30]));
+
+        let column: Column<TestScalar> = Column::BigInt(&[-1_000_000_000, 0, 1_000_000_000]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(
+            result,
+            Column::BigInt(&[1_000_000_000, -1_000_000_000, 1_000_000_000])
+        );
+
+        let column: Column<TestScalar> =
+            Column::Int128(&[-1_000_000_000_000, 0, 1_000_000_000_000]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(
+            result,
+            Column::Int128(&[1_000_000_000_000, -1_000_000_000_000, 1_000_000_000_000])
+        );
+    }
+
+    #[test]
+    fn test_apply_index_op_decimal_and_timestamp_variants() {
+        let bump = Bump::new();
+        let indexes = [1, 2, 1, 0];
+
+        let decimal_values = [101, -202, 303]
+            .iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let column: Column<TestScalar> =
+            Column::Decimal75(Precision::new(10).unwrap(), 2, &decimal_values);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        let expected_decimal_values = [-202, 303, -202, 101]
+            .iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            result,
+            Column::Decimal75(Precision::new(10).unwrap(), 2, &expected_decimal_values)
+        );
+
+        let time_unit = PoSQLTimeUnit::Millisecond;
+        let timezone = PoSQLTimeZone::new(19_800);
+        let column: Column<TestScalar> =
+            Column::TimestampTZ(time_unit, timezone, &[1_000, 2_000, 3_000]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(
+            result,
+            Column::TimestampTZ(time_unit, timezone, &[2_000, 3_000, 2_000, 1_000])
+        );
+    }
+
+    #[test]
+    fn test_apply_index_op_empty_indexes() {
+        let bump = Bump::new();
+        let indexes = [];
+
+        let column: Column<TestScalar> = Column::Boolean(&[true, false]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::Boolean(&[]));
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for `apply_column_to_indexes` across boolean, remaining integer-width, decimal, and timestamp columns
- cover empty index selection preserving the column variant
- keep the change test-only and scoped to `column_index_operation.rs`

## Non-overlap
I checked the active #560 claim PR file list before opening this and did not find `crates/proof-of-sql/src/base/database/column_index_operation.rs` in those open changes.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --lib column_index_operation` in WSL Ubuntu: 6 passed, 0 failed

Note: the same targeted test could not run on the Windows MSVC target in this local environment because `link.exe`/Visual Studio Build Tools is not installed.