### PR TITLE
test: cover memory usage trace logging

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -67,7 +67,7 @@ merlin = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["std"] }
 rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -30,3 +30,65 @@ pub fn log_memory_usage(name: &str) {
         );
     }
 }
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::log_memory_usage;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tracing::subscriber::Interest;
+    use tracing::{
+        span::{Attributes, Id, Record},
+        Event, Metadata, Subscriber,
+    };
+
+    struct TraceSubscriber {
+        events: Arc<AtomicUsize>,
+    }
+
+    impl Subscriber for TraceSubscriber {
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            *metadata.level() == tracing::Level::TRACE
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            if *event.metadata().level() == tracing::Level::TRACE {
+                self.events.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+
+        fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+            if *metadata.level() == tracing::Level::TRACE {
+                Interest::always()
+            } else {
+                Interest::never()
+            }
+        }
+    }
+
+    #[test]
+    fn log_memory_usage_emits_trace_event_when_trace_is_enabled() {
+        let events = Arc::new(AtomicUsize::new(0));
+        let subscriber = TraceSubscriber {
+            events: Arc::clone(&events),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_memory_usage("coverage-marker");
+        });
+
+        assert_eq!(events.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
﻿Fixes #560

## Summary
- add focused coverage for `utils::log::log_memory_usage` when TRACE logging is enabled
- use a minimal test subscriber to exercise the std-only memory sampling and trace event path
- enable the `tracing/std` dev-dependency feature needed by the subscriber test helper only

## Validation
- `cargo fmt --all -- --check` - passed
- `cargo test -p proof-of-sql --lib --no-default-features --features std log_memory_usage -- --nocapture` - passed, 1 test
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features std --lcov --output-path target\log-coverage.lcov -- log_memory_usage` - passed; focused LCOV shows `crates/proof-of-sql/src/utils/log.rs` at `LH:30 / LF:42`

/claim #560
