### PR TITLE
test: cover parse and permutation helpers

### DIFF
--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -29,7 +29,7 @@ pub struct Permutation {
 
 impl Permutation {
     /// Create a new permutation from a comparison function with the given length
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn unchecked_new_from_cmp<F>(length: usize, cmp: F) -> Self
     where
         F: Fn(&usize, &usize) -> Ordering + Sync,
@@ -99,6 +99,23 @@ mod test {
         assert_eq!(
             permutation.try_apply(&["and", "Space", "Time"]).unwrap(),
             vec!["Space", "and", "Time"]
+        );
+    }
+
+    #[test]
+    fn test_unchecked_new_from_cmp_orders_indexes_by_comparator() {
+        let words = ["ccc", "a", "bb", "dd"];
+        let permutation = Permutation::unchecked_new_from_cmp(words.len(), |left, right| {
+            words[*left]
+                .len()
+                .cmp(&words[*right].len())
+                .then_with(|| words[*left].cmp(words[*right]))
+        });
+
+        assert_eq!(permutation.size(), words.len());
+        assert_eq!(
+            permutation.try_apply(&words).unwrap(),
+            vec!["a", "bb", "dd", "ccc"]
         );
     }
 

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,31 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn test_find_bigdecimals_filters_precision_and_statement_types() {
+        let sql = "SELECT 1;
+
+        CREATE TABLE metrics(
+            ID BIGINT NOT NULL,
+            SMALL_AMOUNT DECIMAL(38, 4),
+            BIG_AMOUNT DECIMAL(39, 4),
+            UNSCALED_AMOUNT DECIMAL(78),
+            DESCRIPTION VARCHAR
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("metrics").unwrap(),
+            &[("BIG_AMOUNT".to_string(), 39, 4)]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Failed to parse SQL")]
+    fn test_find_bigdecimals_panics_on_invalid_sql() {
+        let _ = find_bigdecimals("CREATE TABLE");
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add edge-case coverage for `find_bigdecimals` to ignore non-CREATE statements, skip decimal precision <= 38, and ignore unscaled decimals
- cover invalid SQL panic behavior for the DDL parser helper
- cover `Permutation::unchecked_new_from_cmp` ordering and application behavior

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test test_find_bigdecimals`
- `cargo test -p proof-of-sql --lib --no-default-features --features test permutation`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: default-feature test builds enable `halo2curves` asm, which only builds on x86_64; local validation was run with no default features on Apple Silicon.