### PR TITLE
ci: scope dory testother commands

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -182,8 +182,8 @@ jobs:
         run: cargo test -p proof-of-sql --no-run --no-default-features --features="std"
       - name: Run cargo test (proof primitives - Dory) (std feature only - i.e. not using blitzar)
         run: |
-            cargo test proof_primitive::dory::dory_compute_commitments_test --no-default-features --features="std" && \
-            cargo test proof_primitive::dory::dynamic_dory_compute_commitments_test --no-default-features --features="std"
+            cargo test -p proof-of-sql --lib proof_primitive::dory::dory_compute_commitments_test --no-default-features --features="std" && \
+            cargo test -p proof-of-sql --lib proof_primitive::dory::dynamic_dory_compute_commitments_test --no-default-features --features="std"
 
   examples:
       name: Run Examples (${{ matrix.rust }})


### PR DESCRIPTION
﻿Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

/claim #557

The `testother` job already runs `cargo test -p proof-of-sql --no-run --no-default-features --features="std"` before the focused Dory std-only tests. The next two commands are intended to run proof-of-sql library test modules, but they currently invoke `cargo test` with only a filter. That leaves Cargo to resolve a broader workspace test surface than this step needs.

This PR scopes those two Dory commands to the same package/library target with `-p proof-of-sql --lib`. The test filters and feature set stay unchanged.

# What changes are included in this PR?

- Scope `proof_primitive::dory::dory_compute_commitments_test` to `cargo test -p proof-of-sql --lib`.
- Scope `proof_primitive::dory::dynamic_dory_compute_commitments_test` to `cargo test -p proof-of-sql --lib`.
- Keep the existing `--no-default-features --features="std"` arguments unchanged.

# Are these changes tested?

Yes, focused validation passed locally:

- `cargo test -p proof-of-sql --lib proof_primitive::dory::dory_compute_commitments_test --no-default-features --features="std"` - 20 passed.
- `cargo test -p proof-of-sql --lib proof_primitive::dory::dynamic_dory_compute_commitments_test --no-default-features --features="std"` - 10 passed.
- `git diff --check` - passed; Git only reported the existing workflow line-ending warning.
- `bash -lc "tr -d '\r' < scripts/check_commits.sh | bash"` - passed.

I did not run the full `source scripts/run_ci_checks.sh` on this Windows checkout because the full workspace/CI path is Linux-oriented here; the PR changes workflow command scoping and the two affected commands are covered above.
