### PR TITLE
test: cache seeded rand util fixtures

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/rand_util.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/rand_util.rs
@@ -5,6 +5,8 @@ use ark_std::{
     rand::{rngs::StdRng, Rng, SeedableRng},
     UniformRand,
 };
+#[cfg(test)]
+use std::sync::OnceLock;
 
 #[cfg(test)]
 /// Create a random number generator for testing.
@@ -52,13 +54,35 @@ where
         .unzip()
 }
 
+#[cfg(test)]
+fn seeded_G_vecs_from_seed_1() -> &'static [(Vec<G1Affine>, Vec<G2Affine>)] {
+    static SEEDED_G_VECS: OnceLock<Vec<(Vec<G1Affine>, Vec<G2Affine>)>> = OnceLock::new();
+    SEEDED_G_VECS
+        .get_or_init(|| {
+            let mut rng = test_seed_rng([1; 32]);
+            (0..5).map(|nu| rand_G_vecs(nu, &mut rng)).collect()
+        })
+        .as_slice()
+}
+
+#[cfg(test)]
+fn seeded_F_vecs_from_seed_1() -> &'static [(Vec<F>, Vec<F>)] {
+    static SEEDED_F_VECS: OnceLock<Vec<(Vec<F>, Vec<F>)>> = OnceLock::new();
+    SEEDED_F_VECS
+        .get_or_init(|| {
+            let mut rng = test_seed_rng([1; 32]);
+            (0..5).map(|nu| rand_F_vecs(nu, &mut rng)).collect()
+        })
+        .as_slice()
+}
+
 #[test]
 fn we_can_create_rand_G_vecs() {
     let mut rng = test_rng();
     for nu in 0..5 {
-        let (Gamma_1, Gamma_2) = rand_G_vecs(nu, &mut rng);
-        assert_eq!(Gamma_1.len(), 1 << nu);
-        assert_eq!(Gamma_2.len(), 1 << nu);
+        let (gamma_1, gamma_2) = rand_G_vecs(nu, &mut rng);
+        assert_eq!(gamma_1.len(), 1 << nu);
+        assert_eq!(gamma_2.len(), 1 << nu);
     }
 }
 
@@ -66,34 +90,30 @@ fn we_can_create_rand_G_vecs() {
 fn we_can_create_different_rand_G_vecs_consecutively_from_the_same_rng() {
     let mut rng = test_rng();
     for nu in 0..5 {
-        let (Gamma_1, Gamma_2) = rand_G_vecs(nu, &mut rng);
-        let (Gamma_1_2, Gamma_2_2) = rand_G_vecs(nu, &mut rng);
-        assert_ne!(Gamma_1, Gamma_1_2);
-        assert_ne!(Gamma_2, Gamma_2_2);
+        let (gamma_1, gamma_2) = rand_G_vecs(nu, &mut rng);
+        let (gamma_1_2, gamma_2_2) = rand_G_vecs(nu, &mut rng);
+        assert_ne!(gamma_1, gamma_1_2);
+        assert_ne!(gamma_2, gamma_2_2);
     }
 }
 
 #[test]
 fn we_can_create_the_same_rand_G_vecs_from_the_same_seed() {
-    let mut rng = test_seed_rng([1; 32]);
-    let mut rng_2 = test_seed_rng([1; 32]);
-    for nu in 0..5 {
-        let (Gamma_1, Gamma_2) = rand_G_vecs(nu, &mut rng);
-        let (Gamma_1_2, Gamma_2_2) = rand_G_vecs(nu, &mut rng_2);
-        assert_eq!(Gamma_1, Gamma_1_2);
-        assert_eq!(Gamma_2, Gamma_2_2);
+    let mut same_seed_rng = test_seed_rng([1; 32]);
+    for (nu, (gamma_1, gamma_2)) in seeded_G_vecs_from_seed_1().iter().enumerate() {
+        let (same_gamma_1, same_gamma_2) = rand_G_vecs(nu, &mut same_seed_rng);
+        assert_eq!(gamma_1, &same_gamma_1);
+        assert_eq!(gamma_2, &same_gamma_2);
     }
 }
 
 #[test]
 fn we_can_create_different_rand_G_vecs_from_different_seeds() {
-    let mut rng = test_seed_rng([1; 32]);
-    let mut rng_2 = test_seed_rng([2; 32]);
-    for nu in 0..5 {
-        let (Gamma_1, Gamma_2) = rand_G_vecs(nu, &mut rng);
-        let (Gamma_1_2, Gamma_2_2) = rand_G_vecs(nu, &mut rng_2);
-        assert_ne!(Gamma_1, Gamma_1_2);
-        assert_ne!(Gamma_2, Gamma_2_2);
+    let mut different_seed_rng = test_seed_rng([2; 32]);
+    for (nu, (gamma_1, gamma_2)) in seeded_G_vecs_from_seed_1().iter().enumerate() {
+        let (different_gamma_1, different_gamma_2) = rand_G_vecs(nu, &mut different_seed_rng);
+        assert_ne!(gamma_1, &different_gamma_1);
+        assert_ne!(gamma_2, &different_gamma_2);
     }
 }
 
@@ -121,24 +141,20 @@ fn we_can_create_different_rand_F_vecs_consecutively_from_the_same_rng() {
 
 #[test]
 fn we_can_create_the_same_rand_F_vecs_from_the_same_seed() {
-    let mut rng = test_seed_rng([1; 32]);
-    let mut rng_2 = test_seed_rng([1; 32]);
-    for nu in 0..5 {
-        let (s1, s2) = rand_F_vecs(nu, &mut rng);
-        let (s1_2, s2_2) = rand_F_vecs(nu, &mut rng_2);
-        assert_eq!(s1, s1_2);
-        assert_eq!(s2, s2_2);
+    let mut same_seed_rng = test_seed_rng([1; 32]);
+    for (nu, (s1, s2)) in seeded_F_vecs_from_seed_1().iter().enumerate() {
+        let (same_s1, same_s2) = rand_F_vecs(nu, &mut same_seed_rng);
+        assert_eq!(s1, &same_s1);
+        assert_eq!(s2, &same_s2);
     }
 }
 
 #[test]
 fn we_can_create_different_rand_F_vecs_from_different_seeds() {
-    let mut rng = test_seed_rng([1; 32]);
-    let mut rng_2 = test_seed_rng([2; 32]);
-    for nu in 0..5 {
-        let (s1, s2) = rand_F_vecs(nu, &mut rng);
-        let (s1_2, s2_2) = rand_F_vecs(nu, &mut rng_2);
-        assert_ne!(s1, s1_2);
-        assert_ne!(s2, s2_2);
+    let mut different_seed_rng = test_seed_rng([2; 32]);
+    for (nu, (s1, s2)) in seeded_F_vecs_from_seed_1().iter().enumerate() {
+        let (different_s1, different_s2) = rand_F_vecs(nu, &mut different_seed_rng);
+        assert_ne!(s1, &different_s1);
+        assert_ne!(s2, &different_s2);
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

This is a small, non-overlapping test-runtime cleanup for #557. The seeded `rand_G_vecs` and `rand_F_vecs` tests currently generate the same seed-1 vector sequence separately in both the same-seed and different-seed checks. That duplicates random group/field generation without adding coverage.

This PR caches the seed-1 fixture sequence once per vector type with `OnceLock`, then reuses it in the same-seed and different-seed assertions. The tests still cover every `nu` in the original `0..5` range and keep the existing checks for lengths, consecutive RNG freshness, same-seed determinism, and different-seed divergence.

/claim #557

# What changes are included in this PR?

- Add test-only cached seed-1 fixtures for Dory random G-vector and F-vector helpers.
- Reuse those fixtures in the seeded rand-util tests instead of regenerating the same seed-1 sequence twice.
- Rename local `Gamma_*` bindings to snake_case while touching the file; no production code changed.

# Are these changes tested?

- `cargo fmt --all -- --check`
- `git diff --check`
- `source scripts/check_commits.sh`
- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::dory::rand_util -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::dory::rand_util -- --nocapture --test-threads=1`

Disclosure: prepared with AI assistance in Codex and reviewed before submission.