### PR TITLE
test: reduce VMV state setup size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/vmv_state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/vmv_state_test.rs
@@ -99,10 +99,10 @@ fn we_can_create_correct_vmv_states_from_a_small_fixed_vmv() {
 #[test]
 fn we_can_create_vmv_states_from_random_vmv_and_get_correct_sizes() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
-    for nu in 0..max_nu {
+    for nu in 0..=max_nu {
         let vmv = VMV::rand(nu, &mut rng);
 
         assert_eq!(vmv.L.len(), 1 << nu);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist

- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

This is a small, non-overlapping test-runtime cleanup for #557. `we_can_create_vmv_states_from_random_vmv_and_get_correct_sizes` generates Dory public parameters with `max_nu = 5`, but the loop only tests `nu = 0, 1, 2, 3, 4`.

This PR reduces the generated setup to `max_nu = 4` and changes the loop to `0..=max_nu`, preserving the exact same tested `nu` range and all existing assertions while avoiding unused `nu = 5` setup generation.

/claim #557

# What changes are included in this PR?

- Generate VMV state test public parameters with `max_nu = 4` instead of `5`.
- Preserve coverage of `nu = 0..4` by switching the loop to `0..=max_nu`.

# Are these changes tested?

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `source scripts/check_commits.sh`
- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::dory::vmv_state -- --nocapture`

Focused timing on this machine: before `4.983s total`; after `2.848s total`.

Disclosure: prepared with AI assistance in Codex and reviewed before submission.