### PR TITLE
test: cover column commitments without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -349,7 +349,7 @@ impl<C> FromIterator<(Ident, ColumnCommitmentMetadata, C)> for ColumnCommitments
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{
@@ -669,10 +669,6 @@ mod tests {
             bigint("column_a", [5, 6, 7, 8]),
             varchar("b", ["amet", "ipsum", "dolor", "sit"]),
         ]);
-        println!(
-            "{:?}",
-            base_commitments.try_append_rows_with_offset(table_diff_id.inner_table(), 4, &())
-        );
         assert!(matches!(
             base_commitments.try_append_rows_with_offset(table_diff_id.inner_table(), 4, &()),
             Err(AppendColumnCommitmentsError::Mismatch {


### PR DESCRIPTION
/claim #560

## Summary
- run the existing `ColumnCommitments` tests without requiring the `blitzar` feature
- keep the tests on `NaiveCommitment`, which does not require Blitzar-specific setup
- remove a stale debug `println!` from one mismatch test now that the tests run in the no-default coverage configuration

## Coverage note
Using the same no-default coverage configuration as the baseline:

`cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov`

For `crates/proof-of-sql/src/base/commitment/column_commitments.rs`, counting production lines before the test module:
- production line coverage: `31/184 -> 165/184`
- net newly covered production lines: `134`
- estimated bounty at `$0.10/new covered production line`: about `$13.40`

## Verification
- `cargo test -p proof-of-sql --lib --no-default-features --features test column_commitments -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/codex-column-commitments-full.lcov`
- `cargo fmt --all -- --check`
- `git diff --check`

## Limitations
- test-only change; no production logic changed