### PR TITLE
test: cover rho eval against evaluation vector

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
@@ -379,6 +379,35 @@ fn compute_truncated_lagrange_basis_sum_matches_sum_of_result_from_compute_evalu
 }
 
 #[test]
+fn compute_rho_eval_matches_weighted_sum_of_result_from_compute_evaluation_vector() {
+    use ark_std::rand::{
+        distributions::{Distribution, Uniform},
+        rngs::StdRng,
+        SeedableRng,
+    };
+
+    let mut rng = StdRng::from_seed([0u8; 32]);
+    let dist = Uniform::new(2, 10);
+    for _ in 0..20 {
+        let variables = dist.sample(&mut rng);
+        let length = Uniform::new((1 << (variables - 1)) + 1, 1 << variables).sample(&mut rng);
+        let point: Vec<_> = iter::repeat_with(|| TestScalar::rand(&mut rng))
+            .take(variables)
+            .collect();
+        let mut eval_vec = vec![TestScalar::zero(); length];
+        compute_evaluation_vector(&mut eval_vec, &point);
+        let expected = eval_vec
+            .into_iter()
+            .enumerate()
+            .map(|(index, eval)| TestScalar::from(index as u64) * eval)
+            .sum();
+        // ---------------- This is the actual test --------------------
+        assert_eq!(compute_rho_eval(length, &point), expected);
+        // -----------------------------------------------------------
+    }
+}
+
+#[test]
 fn compute_truncated_lagrange_basis_inner_product_matches_inner_product_of_results_compute_evaluation_vector(
 ) {
     use ark_std::rand::{


### PR DESCRIPTION
## Summary
- add deterministic coverage for `compute_rho_eval`
- compare the rho evaluation against the weighted sum produced from `compute_evaluation_vector`

/claim #560

## Validation
- `rustfmt --check crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs`
- `git diff --check`
- `BLITZAR_BACKEND=cpu CARGO_HOME=/private/tmp/sxt-cargo-home CARGO_TARGET_DIR=/private/tmp/sxt-proof-target cargo test -p proof-of-sql --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel" --lib compute_rho_eval_matches_weighted_sum_of_result_from_compute_evaluation_vector`