### PR TITLE
test: cover standard limb serialization

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,51 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use crate::base::standard_serializations::binary::{
+        try_standard_binary_deserialization, try_standard_binary_serialization,
+    };
+    use alloc::vec::Vec;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct LimbSerde {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn we_serialize_limbs_in_reverse_order() {
+        let value = LimbSerde {
+            limbs: [1, 2, 3, 4],
+        };
+
+        let serialized = try_standard_binary_serialization(value).unwrap();
+        let expected = [4_u64, 3, 2, 1]
+            .into_iter()
+            .flat_map(u64::to_be_bytes)
+            .collect::<Vec<_>>();
+
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn we_round_trip_reversed_limbs() {
+        let value = LimbSerde {
+            limbs: [u64::MIN, 1, u64::MAX - 1, u64::MAX],
+        };
+        let serialized = try_standard_binary_serialization(&value).unwrap();
+
+        let (deserialized, bytes_read): (LimbSerde, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, value);
+        assert_eq!(bytes_read, serialized.len());
+    }
+}


### PR DESCRIPTION
# Please go through the following checklist

- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

This is a focused, non-overlapping coverage slice for #560. `crates/proof-of-sql/src/base/standard_serializations/limbs.rs` had no direct unit coverage in the focused `standard_serializations` run, even though the helper is responsible for preserving the canonical reversed limb order used by serde wrappers.

/claim #560

# What changes are included in this PR?

- Add a test wrapper that uses the existing `serialize_limbs` / `deserialize_to_limbs` serde hooks.
- Assert the exact standard binary byte order for `[1, 2, 3, 4]`, which must serialize as limbs `[4, 3, 2, 1]` in big-endian fixed-width encoding.
- Add a round-trip test with boundary limb values to exercise both helper functions.

# Are these changes tested?

- `cargo test -p proof-of-sql --lib --no-default-features --features test standard_serializations -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path coverage-standard-after.info -- standard_serializations`

Focused coverage evidence for `crates/proof-of-sql/src/base/standard_serializations/limbs.rs`:

| Run | Covered existing lines |
| --- | ---: |
| before | 0 / 12 |
| after | 12 / 12 |

Local limitation: `bash scripts/check_commits.sh` could not run because this Windows machine's WSL/Docker backing disk is missing (`ERROR_PATH_NOT_FOUND`). The commit itself is a single conventional `test:` commit.

Disclosure: prepared with AI assistance in Codex and reviewed before submission.