### PR TITLE
test: cover TableRef parsing and serde

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,92 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_ref_new_omits_empty_schema() {
+        let table_ref = TableRef::new("", "orders");
+
+        assert!(table_ref.schema_id().is_none());
+        assert_eq!(table_ref.table_id().value, "orders");
+        assert_eq!(table_ref.to_string(), "orders");
+    }
+
+    #[test]
+    fn table_ref_constructors_preserve_schema_and_table() {
+        let from_names = TableRef::from_names(Some("sxt"), "orders");
+        let from_idents = TableRef::from_idents(Some(Ident::new("sxt")), Ident::new("orders"));
+
+        assert_eq!(from_names, from_idents);
+        assert_eq!(from_names.schema_id().unwrap().value, "sxt");
+        assert_eq!(from_names.table_id().value, "orders");
+        assert_eq!(from_names.to_string(), "sxt.orders");
+    }
+
+    #[test]
+    fn table_ref_from_strs_accepts_one_or_two_components() {
+        let table_only = TableRef::from_strs(&["orders"]).unwrap();
+        let schema_and_table = TableRef::from_strs(&["sxt", "orders"]).unwrap();
+
+        assert_eq!(table_only, TableRef::from_names(None, "orders"));
+        assert_eq!(schema_and_table, TableRef::new("sxt", "orders"));
+    }
+
+    #[test]
+    fn table_ref_from_strs_rejects_invalid_component_count() {
+        let error = TableRef::from_strs(&["sxt", "analytics", "orders"]).unwrap_err();
+
+        assert_eq!(
+            error,
+            ParseError::InvalidTableReference {
+                table_reference: "sxt,analytics,orders".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn table_ref_try_from_rejects_more_than_one_separator() {
+        let error = TableRef::try_from("sxt.analytics.orders").unwrap_err();
+
+        assert_eq!(
+            error,
+            ParseError::InvalidTableReference {
+                table_reference: "sxt.analytics.orders".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn borrowed_table_ref_compares_equivalently_to_owned_key() {
+        let key = TableRef::new("sxt", "orders");
+        let borrowed = &TableRef::new("sxt", "orders");
+        let different = &TableRef::new("sxt", "customers");
+
+        assert!(Equivalent::equivalent(&borrowed, &key));
+        assert!(!Equivalent::equivalent(&different, &key));
+    }
+
+    #[test]
+    fn table_ref_serializes_as_display_string() {
+        let table_ref = TableRef::new("sxt", "orders");
+
+        let serialized = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(serialized, "\"sxt.orders\"");
+        assert_eq!(
+            serde_json::from_str::<TableRef>(&serialized).unwrap(),
+            table_ref
+        );
+    }
+
+    #[test]
+    fn table_ref_deserialization_rejects_invalid_display_string() {
+        let error = serde_json::from_str::<TableRef>("\"sxt.analytics.orders\"").unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Invalid table reference: sxt.analytics.orders"));
+    }
+}


### PR DESCRIPTION
## Summary

/claim #560

Adds direct unit coverage for `TableRef` behavior in `crates/proof-of-sql/src/base/database/table_ref.rs`, including:

- empty-schema constructor behavior and display output
- schema/table constructors and accessors
- `from_strs` success and invalid component counts
- dot-separated parsing failures
- `Equivalent<TableRef>` borrowed-key comparison
- serde string serialization and invalid deserialization errors

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test table_ref -- --nocapture` (8 passed)
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path coverage-table-ref-after.info -- table_ref` (8 passed; focused `table_ref.rs` LCOV: `LH:124 / LF:125`)
- `cargo fmt --all -- --check`
- `git diff --check`

Before this change, the focused `table_ref` test filter ran 0 tests.