### PR TITLE
test: cover table accessor helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -1,5 +1,5 @@
 use crate::base::{
-    database::{table_utility::*, Column, Table, TableError, TableOptions},
+    database::{table_utility::*, Column, ColumnField, ColumnType, Table, TableError, TableOptions},
     map::{indexmap, IndexMap},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
@@ -101,6 +101,36 @@ fn we_cannot_create_a_table_with_no_columns_without_specified_row_count() {
         Table::<TestScalar>::try_new(IndexMap::default()),
         Err(TableError::EmptyTableWithoutSpecifiedRowCount)
     ));
+}
+
+#[test]
+fn we_can_inspect_table_schema_and_columns_in_order() {
+    let table = Table::<TestScalar>::try_new(indexmap! {
+        "a".into() => Column::BigInt(&[10, 20]),
+        "b".into() => Column::Boolean(&[true, false]),
+    })
+    .unwrap();
+
+    assert!(!table.is_empty());
+    assert_eq!(
+        table.schema(),
+        vec![
+            ColumnField::new(Ident::new("a"), ColumnType::BigInt),
+            ColumnField::new(Ident::new("b"), ColumnType::Boolean),
+        ]
+    );
+    assert_eq!(
+        table
+            .column_names()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+    assert_eq!(table.columns().count(), 2);
+    assert_eq!(table.column(0), Some(&Column::BigInt(&[10, 20])));
+    assert_eq!(table.column(1), Some(&Column::Boolean(&[true, false])));
+    assert_eq!(table.column(2), None);
+    assert_eq!(table.inner_table().len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add coverage for `Table` schema and column accessor helpers
- verify column order is preserved through `schema()`, `column_names()`, `columns()`, `column()`, and `inner_table()`
- keep the change test-only and limited to `crates/proof-of-sql/src/base/database/table_test.rs`

/claim #560

## Coverage delta
Compared the full crate LCOV report for this branch against `origin/main` using:

- `cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-arrow-current.lcov`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-arrow-main.lcov`

The new test adds non-overlapping coverage in `crates/proof-of-sql/src/base/database/table.rs`, including previously uncovered helper lines:

- `is_empty()` lines 108-110: 0 -> 1 hits
- `column_names()` lines 130-132: 0 -> 1 hits
- `columns()` lines 134-136: 0 -> 1 hits

It also increases exercised hits for related table construction/schema/accessor paths:

- `try_new` / `try_new_with_options` lines 51-60, 64-68, 79: +1 to +2 hits depending on line
- `inner_table()` lines 118-120: 42 -> 43 hits
- `schema()` lines 123-128: +1 to +2 hits
- `column()` lines 139-141: 31 -> 34 hits

## Verification
- `cargo test -p proof-of-sql --no-default-features --features arrow table_test::we_can_inspect_table_schema_and_columns_in_order`
- `cargo test -p proof-of-sql --no-default-features --features arrow table_test`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-arrow-current.lcov` (1054 passed)
- baseline comparison on `origin/main` with the same llvm-cov command (1053 passed)

## Note
I replaced the earlier placeholder-type test scope after noticing #1306/#1836 already cover that branch. This PR now targets a non-overlapping table accessor/schema coverage slice.