### PR TITLE
ci: cache preprocessor test dependencies

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -361,10 +361,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          cache: pip
+          cache-dependency-path: solidity/preprocessor/requirements-ci.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black pytest
+          pip install -r solidity/preprocessor/requirements-ci.txt
       - name: Run black
         run: black --check solidity/preprocessor/
       - name: Run pytest

--- a/solidity/preprocessor/requirements-ci.txt
+++ b/solidity/preprocessor/requirements-ci.txt
@@ -1,0 +1,2 @@
+black
+pytest


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

The `check-yul-preprocessor` job currently installs `black` and `pytest` directly every run, but the job has no dependency file for `actions/setup-python` to cache against.

This PR moves those CI-only Python packages into `solidity/preprocessor/requirements-ci.txt` and enables `setup-python`'s pip cache for that file. The formatter and test commands stay unchanged; the job can now reuse pip downloads across CI runs instead of fetching the same tools from scratch.

/claim #557

# What changes are included in this PR?

- Add `solidity/preprocessor/requirements-ci.txt` with the existing `black` and `pytest` CI dependencies.
- Enable `cache: pip` in the `check-yul-preprocessor` Python setup step.
- Install the same tools through `pip install -r solidity/preprocessor/requirements-ci.txt`.

# Are these changes tested?

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lint-and-test.yml"); puts "yaml ok"'`\n- `git diff --check`\n- `docker run --rm -v "$PWD":/work -w /work python:3.12-slim sh -lc 'python -m pip install -q -r solidity/preprocessor/requirements-ci.txt && black --check solidity/preprocessor/ && pytest solidity/preprocessor/'`\n- `source scripts/check_commits.sh`\n\nI did not run the full CI wrapper locally because this patch only changes GitHub Actions dependency setup for a single Python job; the affected formatter and test commands are covered above.