### PR TITLE
test: cover table evaluation accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,22 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_read_table_evaluation_parts() {
+        let column_evals = vec![TestScalar::from(2), TestScalar::from(3)];
+        let chi = (TestScalar::from(5), 7);
+        let table_evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+        assert_eq!(table_evaluation.column_evals(), column_evals.as_slice());
+        assert_eq!(table_evaluation.chi_eval(), chi.0);
+        assert_eq!(table_evaluation.chi(), chi);
+        assert_eq!(table_evaluation.clone(), table_evaluation);
+        assert!(format!("{table_evaluation:?}").contains("column_evals"));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused unit coverage for `TableEvaluation` construction and accessor behavior
- verify `column_evals`, `chi_eval`, `chi`, clone/equality, and debug output without changing production behavior

## Non-overlap
I checked current open PRs for `table_evaluation` / `TableEvaluation` and did not find an overlapping active claim before opening this PR.

## Coverage
Using the existing local baseline LCOV from this bounty scan, `crates/proof-of-sql/src/base/database/table_evaluation.rs` had 12 uncovered production lines: 16-18, 22-24, 28-30, and 34-36.

The focused LCOV run for this branch reports `table_evaluation.rs` at `22 / 22` instrumented lines covered, including those 12 production lines.

## Validation
- `rustfmt --check --edition 2021 crates\proof-of-sql\src\base\database\table_evaluation.rs`
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test table_evaluation -- --nocapture` (1 passed)
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target\table-evaluation-coverage.lcov -- table_evaluation` (1 passed; `table_evaluation.rs` 22/22 instrumented lines)
- `git diff --check`