### PR TITLE
ci: cache slither install

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -282,6 +282,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          cache: pip
+          cache-dependency-path: solidity/slither-requirements-ci.txt
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -311,7 +313,7 @@ jobs:
           solhint '**/*.sol' -w 0
           cd ..
       - name: Install Slither
-        run: pip install slither-analyzer
+        run: pip install -r solidity/slither-requirements-ci.txt
 
       - name: Run slither on verifier
         run: slither solidity/src/verifier/Verifier.post.sol --config-file solidity/slither.config.json

--- a/solidity/slither-requirements-ci.txt
+++ b/solidity/slither-requirements-ci.txt
@@ -1,0 +1,1 @@
+slither-analyzer


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

The `foundrycheck` job currently installs `slither-analyzer` directly with pip on every run. This PR moves that existing dependency into a CI requirements file and enables the built-in `actions/setup-python` pip cache for that install path.

This keeps the Slither version policy the same as today because `slither-analyzer` remains unpinned, and it keeps all Foundry, coverage, formatting, solhint, and Slither commands unchanged. The only runtime change is that GitHub Actions can restore cached Python packages for the repeated Slither install.

/claim #557

# What changes are included in this PR?

- Add `solidity/slither-requirements-ci.txt` containing the existing `slither-analyzer` dependency.
- Enable `cache: pip` in the `foundrycheck` Python setup step, keyed by that requirements file.
- Install Slither from the requirements file instead of repeating the package name inline.

# Are these changes tested?

Local/static validation on Windows:

- `git diff --check HEAD~1..HEAD`
- `py -3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint-and-test.yml', encoding='utf-8')); print('yaml ok')"`
- `py -3 -m pip install --dry-run -r solidity\slither-requirements-ci.txt`
- `bash -c "tr -d '\r' < scripts/check_commits.sh | bash"`

Limitations:

- I did not run `source scripts/run_ci_checks.sh` locally because this is a workflow-only Linux CI setup change and the full wrapper is not faithful on this Windows host.

Disclosure: prepared with AI assistance in Codex and reviewed before submission.