### PR TITLE
ci: cache soldeer dependencies

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -286,6 +286,11 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: v1.0.0
+      - name: Restore Soldeer dependency cache
+        uses: actions/cache@v4
+        with:
+          path: solidity/dependencies
+          key: ${{ runner.os }}-soldeer-${{ hashFiles('solidity/soldeer.lock') }}
       - name: Install dependencies
         run: solidity/scripts/install_deps.sh
       - name: Run tests without via-ir or optimization


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

The `foundrycheck` job runs `forge soldeer install` before the Solidity test, coverage, fmt, solhint, and Slither steps. The Foundry dependency directory is generated under `solidity/dependencies`, already ignored by git, and its inputs are recorded in `solidity/soldeer.lock`.

This PR restores that generated dependency directory from `actions/cache` using the lockfile hash before the existing install step. The install command still runs, so a cold cache or changed lockfile keeps the current behavior; a warm cache avoids repeatedly downloading and unpacking the same Soldeer dependency payload.

/claim #557

# What changes are included in this PR?

- Add an `actions/cache@v4` restore step for `solidity/dependencies`.
- Key the cache with `${{ runner.os }}-soldeer-${{ hashFiles('solidity/soldeer.lock') }}`.
- Leave all Foundry, coverage, formatting, solhint, Slither, and dependency-install commands unchanged.

# Are these changes tested?

Local/static validation on Windows:

- `git diff --check HEAD~1..HEAD`
- `py -3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint-and-test.yml', encoding='utf-8')); print('yaml ok')"`
- `bash -c "tr -d '\r' < scripts/check_commits.sh | bash"`

Limitations:

- I did not run `source scripts/run_ci_checks.sh` locally because this is a workflow-only Linux CI setup change and the full wrapper is not faithful on this Windows host.

Disclosure: prepared with AI assistance in Codex and reviewed before submission.