### PR TITLE
test: cover bit distribution no lead bit error

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -6,6 +6,12 @@ use crate::base::{
 use bnum::types::U256;
 use core::ops::Shl;
 
+#[test]
+#[should_panic(expected = "No lead bit available despite variable lead bit.")]
+fn we_panic_when_converting_no_lead_bit_to_proof_error() {
+    let _: crate::base::proof::ProofError = BitDistributionError::NoLeadBit.into();
+}
+
 // vary_mask function start
 
 #[test]


### PR DESCRIPTION
## Summary
- add a focused `BitDistributionError::NoLeadBit` conversion test
- assert the existing panic message when converting that impossible verifier state into `ProofError`

/claim #560

## Validation
- `cargo test -p proof-of-sql --no-default-features --features arrow base::bit::bit_distribution_test::we_panic_when_converting_no_lead_bit_to_proof_error`
- `cargo fmt --all -- --check`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-arrow-bit-distribution.lcov` (1054 passed)

## Coverage
- `crates/proof-of-sql/src/base/bit/bit_distribution.rs:49` moved from `0 -> 1` hit in local LCOV comparison against the previous arrow baseline.