### PR TITLE
test: cover metadata map and decimal parsing slices

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -141,6 +141,7 @@ mod tests {
     use crate::base::{
         commitment::{column_bounds::Bounds, ColumnBounds},
         database::{owned_table_utility::*, ColumnType, OwnedTable},
+        math::decimal::Precision,
         scalar::test_scalar::TestScalar,
     };
     use alloc::vec::Vec;
@@ -156,6 +157,49 @@ mod tests {
             .unzip();
 
         ColumnCommitmentMetadataMap::from_columns(identifiers.into_iter().zip(columns.iter()))
+    }
+
+    #[test]
+    fn we_can_construct_metadata_map_from_column_fields_with_max_bounds() {
+        let decimal_type = ColumnType::Decimal75(Precision::new(12).unwrap(), 4);
+        let metadata_map = ColumnCommitmentMetadataMap::from_column_fields_with_max_bounds(&[
+            ColumnField::new("bigint_column".into(), ColumnType::BigInt),
+            ColumnField::new("smallint_column".into(), ColumnType::SmallInt),
+            ColumnField::new("varchar_column".into(), ColumnType::VarChar),
+            ColumnField::new("decimal_column".into(), decimal_type),
+        ]);
+
+        assert_eq!(metadata_map.len(), 4);
+
+        let (bigint_ident, bigint_metadata) = metadata_map.get_index(0).unwrap();
+        assert_eq!(bigint_ident.value.as_str(), "bigint_column");
+        assert_eq!(bigint_metadata.column_type(), &ColumnType::BigInt);
+        if let ColumnBounds::BigInt(Bounds::Bounded(bounds)) = bigint_metadata.bounds() {
+            assert_eq!(bounds.min(), &i64::MIN);
+            assert_eq!(bounds.max(), &i64::MAX);
+        } else {
+            panic!("BigInt field should receive maximum BigInt bounds");
+        }
+
+        let (smallint_ident, smallint_metadata) = metadata_map.get_index(1).unwrap();
+        assert_eq!(smallint_ident.value.as_str(), "smallint_column");
+        assert_eq!(smallint_metadata.column_type(), &ColumnType::SmallInt);
+        if let ColumnBounds::SmallInt(Bounds::Bounded(bounds)) = smallint_metadata.bounds() {
+            assert_eq!(bounds.min(), &i16::MIN);
+            assert_eq!(bounds.max(), &i16::MAX);
+        } else {
+            panic!("SmallInt field should receive maximum SmallInt bounds");
+        }
+
+        let (varchar_ident, varchar_metadata) = metadata_map.get_index(2).unwrap();
+        assert_eq!(varchar_ident.value.as_str(), "varchar_column");
+        assert_eq!(varchar_metadata.column_type(), &ColumnType::VarChar);
+        assert_eq!(varchar_metadata.bounds(), &ColumnBounds::NoOrder);
+
+        let (decimal_ident, decimal_metadata) = metadata_map.get_index(3).unwrap();
+        assert_eq!(decimal_ident.value.as_str(), "decimal_column");
+        assert_eq!(decimal_metadata.column_type(), &decimal_type);
+        assert_eq!(decimal_metadata.bounds(), &ColumnBounds::NoOrder);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,25 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn we_only_collect_decimal_columns_with_precision_above_thirty_eight_and_scale() {
+        let sql = "CREATE TABLE ledger.settlements(
+            id BIGINT NOT NULL,
+            exact_value DECIMAL(39, 6),
+            standard_value DECIMAL(38, 6),
+            unscaled_value DECIMAL(60),
+            display_value VARCHAR
+        );
+
+        SELECT * FROM ledger.settlements;";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("ledger.settlements").unwrap(),
+            &[("exact_value".to_string(), 39, 6)]
+        );
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add a focused test for `ColumnCommitmentMetadataMap::from_column_fields_with_max_bounds` covering ordered max bounds and unordered metadata
- add parser coverage proving only DECIMAL columns with precision above 38 and explicit scale are collected
- keep the patch test-only and scoped to two small, non-overlapping coverage slices

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test column_commitment_metadata_map -- --nocapture` -> 6 passed
- `cargo test -p proof-of-sql --lib --no-default-features --features test utils::parse -- --nocapture` -> 2 passed
- `cargo fmt --all -- --check` -> passed
- `git diff --check` -> passed

Coverage accounting note: `cargo llvm-cov` is not installed in my local environment, so final covered-line accounting is left to the maintainer baseline. The default-feature test path on macOS arm64 also hits the existing `halo2curves` asm restriction, so validation used the project's no-default targeted test pattern.

Manual payment fallback if needed: PayPal `aa.631@hotmail.com`.