### PR TITLE
ci: cache solhint npm downloads

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -304,9 +304,14 @@ jobs:
         run: solidity/scripts/check_coverage.sh
       - name: Check fmt
         run: solidity/scripts/pre_forge.sh fmt --check
+      - name: Cache npm downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: solhint-npm-${{ runner.os }}
       - name: Run solhint
         run: |
-          npm install -g solhint
+          npm install -g solhint --prefer-offline --no-audit --no-fund
           cd solidity
           solhint '**/*.sol' -w 0
           cd ..


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimefdn/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist

- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

Issue #557 accepts CI runtime improvements. The `foundrycheck` job currently runs `npm install -g solhint` every time it reaches the Solidity lint step. This PR adds an npm cache restore/save step immediately before that install, then asks npm to prefer the restored cache and skip audit/fund network calls. The actual `solhint` lint command is unchanged.

/claim #557

# What changes are included in this PR?

- Add `actions/cache@v4` for `~/.npm` in `.github/workflows/lint-and-test.yml`.
- Scope the cache key to the solhint/npm path and runner OS.
- Use `--prefer-offline --no-audit --no-fund` for the global solhint install so the restored npm cache is used where possible and unrelated network checks are skipped.
- Leave the existing Solidity lint command unchanged:
  - `npm install -g solhint --prefer-offline --no-audit --no-fund`
  - `cd solidity`
  - `solhint '**/*.sol' -w 0`

# Are these changes tested?

Local/static validation:

- YAML parse of `.github/workflows/lint-and-test.yml` succeeded.
- `git diff --check` passed.
- `bash scripts/check_commits.sh` passed.

Limitations:

- I did not run `source scripts/run_ci_checks.sh` because this is a GitHub Actions workflow-only CI cache change and the full CI path is the target runtime surface.
- I attempted a local workspace cargo check, but it failed before reaching this YAML-only change because `blitzar-sys` panics on macOS with `Unsupported OS. Only Linux is supported`.
