### PR TITLE
test: shrink dynamic Dory helper setup size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn we_can_compute_dynamic_T_vec_prime() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
 
         let a: Vec<F> = (100..109).map(Into::into).collect();


### PR DESCRIPTION
/claim #557

## Summary
- reduce the `we_can_compute_dynamic_T_vec_prime` test setup from `PublicParameters::test_rand(5, ...)` to `test_rand(3, ...)`
- keep the fixed `nu = 3` case and all expected `Gamma_1[3][0..3]` assertions unchanged
- avoid generating unused larger Dory setup data in this helper test

## Verification
- `cargo test -p proof-of-sql --lib --no-default-features --features test dynamic_dory_helper::tests::we_can_compute_dynamic_T_vec_prime -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test dynamic_dory_helper -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Notes: the default-feature test path still hits the existing upstream `halo2curves` asm target gate on macOS arm64, so I used the project pattern already used for focused local validation here.