### PR TITLE
test: cover HyperKZG commitment paths

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -218,7 +218,11 @@ mod tests {
     use super::*;
     #[cfg(feature = "hyperkzg_proof")]
     use crate::base::database::OwnedColumn;
-    use crate::base::{try_standard_binary_deserialization, try_standard_binary_serialization};
+    use crate::base::{
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        try_standard_binary_deserialization, try_standard_binary_serialization,
+    };
     #[cfg(feature = "hyperkzg_proof")]
     use crate::proof_primitive::hyperkzg::nova_commitment_key_to_hyperkzg_public_setup;
     #[cfg(feature = "hyperkzg_proof")]
@@ -231,6 +235,31 @@ mod tests {
     #[cfg(feature = "hyperkzg_proof")]
     use proptest::prelude::*;
 
+    fn generator_commitment() -> HyperKZGCommitment {
+        (&G1Affine::generator()).into()
+    }
+
+    fn setup_for_testing(len: usize) -> Vec<G1Affine> {
+        let generator = G1Projective::from(G1Affine::generator());
+        (1..=len)
+            .map(|multiplier| G1Affine::from(generator * BNScalar::from(multiplier as u64).0))
+            .collect()
+    }
+
+    fn expected_commitment<T: Copy + Into<BNScalar>>(
+        setup: &[G1Affine],
+        offset: usize,
+        values: &[T],
+    ) -> HyperKZGCommitment {
+        HyperKZGCommitment {
+            commitment: values
+                .iter()
+                .zip(&setup[offset..offset + values.len()])
+                .map(|(value, setup_point)| *setup_point * Into::<BNScalar>::into(*value).0)
+                .sum(),
+        }
+    }
+
     #[test]
     fn we_can_convert_default_point_to_a_hyperkzg_commitment_from_ark_bn254_g1_affine() {
         let commitment: HyperKZGCommitment = HyperKZGCommitment::from(&G1Affine::default());
@@ -242,6 +271,144 @@ mod tests {
         let commitment: HyperKZGCommitment = (&G1Affine::generator()).into();
         let expected: HyperKZGCommitment = HyperKZGCommitment::from(&G1Affine::generator());
         assert_eq!(commitment.commitment, expected.commitment);
+    }
+
+    #[test]
+    fn we_can_multiply_hyperkzg_commitments_by_scalars() {
+        let commitment = generator_commitment();
+
+        let by_value = BNScalar::from(3_u64) * commitment;
+        let by_reference = BNScalar::from(3_u64) * &commitment;
+        let expected_commitment =
+            G1Projective::from(G1Affine::generator()) * BNScalar::from(3_u64).0;
+
+        assert_eq!(by_value, by_reference);
+        assert_eq!(by_value.commitment, expected_commitment);
+    }
+
+    #[test]
+    fn we_can_add_and_subtract_hyperkzg_commitments() {
+        let commitment = generator_commitment();
+        let mut doubled = commitment;
+
+        doubled += commitment;
+
+        assert_eq!(doubled, BNScalar::from(2_u64) * commitment);
+
+        let mut back_to_generator = doubled;
+        back_to_generator -= commitment;
+
+        assert_eq!(back_to_generator, commitment);
+        assert_eq!(doubled - commitment, commitment);
+    }
+
+    #[test]
+    fn we_can_negate_hyperkzg_commitments() {
+        let commitment = generator_commitment();
+        let mut identity = -commitment;
+
+        identity += commitment;
+
+        assert_eq!(identity, HyperKZGCommitment::default());
+    }
+
+    #[test]
+    fn we_can_get_transcript_bytes_for_hyperkzg_commitments() {
+        let commitment = generator_commitment();
+        let transcript_bytes = commitment.to_transcript_bytes();
+        let mut expected_bytes = Vec::new();
+
+        commitment
+            .commitment
+            .serialize_compressed(&mut expected_bytes)
+            .unwrap();
+
+        assert_eq!(transcript_bytes, expected_bytes);
+        assert_eq!(
+            transcript_bytes.len(),
+            commitment.commitment.compressed_size()
+        );
+    }
+
+    #[test]
+    fn we_can_compute_commitments_with_mixed_column_types() {
+        let setup = setup_for_testing(8);
+        let offset = 1;
+        let decimal_values = [[10, 0, 0, 0], [11, 0, 0, 0]];
+        let scalar_values = [[12, 0, 0, 0], [13, 0, 0, 0]];
+        let varchar_values = [[14, 0, 0, 0], [15, 0, 0, 0]];
+        let varbinary_values = [[16, 0, 0, 0], [17, 0, 0, 0]];
+        let timestamp_values = [18, 19];
+        let columns = vec![
+            CommittableColumn::Boolean(&[true, false]),
+            CommittableColumn::Uint8(&[2, 3]),
+            CommittableColumn::TinyInt(&[-4, 5]),
+            CommittableColumn::SmallInt(&[-6, 7]),
+            CommittableColumn::Int(&[-8, 9]),
+            CommittableColumn::BigInt(&[-10, 11]),
+            CommittableColumn::Int128(&[-12, 13]),
+            CommittableColumn::Decimal75(Precision::new(2).unwrap(), 0, decimal_values.to_vec()),
+            CommittableColumn::Scalar(scalar_values.to_vec()),
+            CommittableColumn::VarChar(varchar_values.to_vec()),
+            CommittableColumn::VarBinary(varbinary_values.to_vec()),
+            CommittableColumn::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                &timestamp_values,
+            ),
+        ];
+
+        let commitments = HyperKZGCommitment::compute_commitments(&columns, offset, &&setup[..]);
+
+        assert_eq!(commitments.len(), columns.len());
+        assert_eq!(
+            commitments[0],
+            expected_commitment(&setup, offset, &[true, false])
+        );
+        assert_eq!(
+            commitments[1],
+            expected_commitment(&setup, offset, &[2_u8, 3])
+        );
+        assert_eq!(
+            commitments[2],
+            expected_commitment(&setup, offset, &[-4_i8, 5])
+        );
+        assert_eq!(
+            commitments[3],
+            expected_commitment(&setup, offset, &[-6_i16, 7])
+        );
+        assert_eq!(
+            commitments[4],
+            expected_commitment(&setup, offset, &[-8_i32, 9])
+        );
+        assert_eq!(
+            commitments[5],
+            expected_commitment(&setup, offset, &[-10_i64, 11])
+        );
+        assert_eq!(
+            commitments[6],
+            expected_commitment(&setup, offset, &[-12_i128, 13])
+        );
+        assert_eq!(
+            commitments[7],
+            expected_commitment(&setup, offset, &decimal_values)
+        );
+        assert_eq!(
+            commitments[8],
+            expected_commitment(&setup, offset, &scalar_values)
+        );
+        assert_eq!(
+            commitments[9],
+            expected_commitment(&setup, offset, &varchar_values)
+        );
+        assert_eq!(
+            commitments[10],
+            expected_commitment(&setup, offset, &varbinary_values)
+        );
+        assert_eq!(
+            commitments[11],
+            expected_commitment(&setup, offset, &timestamp_values)
+        );
     }
 
     #[cfg(feature = "hyperkzg_proof")]


### PR DESCRIPTION
## Summary

/claim #560

- add focused HyperKZG commitment tests for scalar multiplication, add/subtract, negation, and transcript bytes
- cover CPU commitment computation across mixed `CommittableColumn` variants
- contributes to #560 by covering 73 previously uncovered production lines in `proof_primitive/hyperkzg/commitment.rs`

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::hyperkzg::commitment::tests -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --summary-only` (965 passed; total line coverage 81.40%; `hyperkzg/commitment.rs` line coverage 99.26%)
- `cargo llvm-cov report --lcov --output-path target/proof-of-sql-hyperkzg.lcov`
- `git diff --check`