### PR TITLE
test: cover posql time conversions

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/error_test.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error_test.rs
@@ -1,0 +1,27 @@
+use super::PoSQLTimestampError;
+
+#[test]
+fn we_can_convert_timestamp_errors_to_strings() {
+    assert_eq!(
+        String::from(PoSQLTimestampError::InvalidTimezone {
+            timezone: "Mars/Phobos".to_string()
+        }),
+        "invalid timezone string: Mars/Phobos"
+    );
+    assert_eq!(
+        String::from(PoSQLTimestampError::InvalidTimezoneOffset),
+        "invalid timezone offset"
+    );
+    assert_eq!(
+        String::from(PoSQLTimestampError::InvalidTimeUnit {
+            error: "fortnight".to_string()
+        }),
+        "Invalid time unit"
+    );
+    assert_eq!(
+        String::from(PoSQLTimestampError::UnsupportedPrecision {
+            error: "42".to_string()
+        }),
+        "Unsupported precision for timestamp: 42"
+    );
+}

--- a/crates/proof-of-sql/src/base/posql_time/mod.rs
+++ b/crates/proof-of-sql/src/base/posql_time/mod.rs
@@ -1,4 +1,6 @@
 mod error;
+#[cfg(test)]
+mod error_test;
 /// Errors related to time operations, including timezone and timestamp conversions.
 pub use error::PoSQLTimestampError;
 mod timezone;

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -81,4 +81,29 @@ mod time_unit_tests {
             ));
         }
     }
+
+    #[test]
+    fn test_precision_conversion_values() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn test_display_values() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add focused coverage for PoSQLTimeUnit precision conversion values
- cover PoSQLTimeUnit display strings for all supported timestamp precisions
- cover PoSQLTimestampError to String conversion for all error variants

/claim #560

## Validation
- cargo fmt --all -- --check
- cargo test -p proof-of-sql --no-default-features --features arrow base::posql_time (11 passed)
- cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-posql-time-unit-errors.lcov -- base::posql_time (11 passed)
- cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-posql-time-unit-errors-full.lcov (1056 passed)

## Coverage
- crates/proof-of-sql/src/base/posql_time/unit.rs gained newly covered production lines for PoSQLTimeUnit -> u64 conversion and Display arms: 19-24, 26, 45-50, 52.
- crates/proof-of-sql/src/base/posql_time/error.rs gained newly covered production lines for PoSQLTimestampError -> String conversion: 37-39.