### PR TITLE
test: cover numerical helpers and empty exec

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -662,8 +662,8 @@ pub fn cast_column_with_scaling<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::{
-        cast_bool_column_to_signed_int_column, cast_column, cast_int_slice_to_int_column,
-        divide_columns, divide_integer_columns,
+        add_subtract_columns, cast_bool_column_to_signed_int_column, cast_column,
+        cast_int_slice_to_int_column, divide_columns, divide_integer_columns, multiply_columns,
     };
     use crate::{
         base::{
@@ -1363,6 +1363,80 @@ mod tests {
                 ColumnType::BigInt
             ),
             Column::BigInt(&[1, 10, supported_bigint])
+        );
+    }
+
+    #[test]
+    fn we_can_add_subtract_and_multiply_numeric_columns() {
+        let alloc = Bump::new();
+        let lhs = Column::<TestScalar>::Int(&[10, -2, 0]);
+        let rhs = Column::<TestScalar>::Int(&[3, 4, -5]);
+
+        let added = add_subtract_columns(lhs, rhs, &alloc, false);
+        let expected_added = [
+            TestScalar::from(13_i64),
+            TestScalar::from(2_i64),
+            TestScalar::from(-5_i64),
+        ];
+        assert_eq!(added, expected_added.as_slice());
+
+        let subtracted = add_subtract_columns(lhs, rhs, &alloc, true);
+        let expected_subtracted = [
+            TestScalar::from(7_i64),
+            TestScalar::from(-6_i64),
+            TestScalar::from(5_i64),
+        ];
+        assert_eq!(subtracted, expected_subtracted.as_slice());
+
+        let multiplied = multiply_columns(&lhs, &rhs, &alloc);
+        let expected_multiplied = [
+            TestScalar::from(30_i64),
+            TestScalar::from(-8_i64),
+            TestScalar::ZERO,
+        ];
+        assert_eq!(multiplied, expected_multiplied.as_slice());
+    }
+
+    #[test]
+    fn we_can_cast_integer_columns_to_decimal_columns_without_scaling() {
+        let alloc = Bump::new();
+        let int_values = [123, -456, 0];
+        let precision = Precision::new(10).unwrap();
+        let int_column = Column::<TestScalar>::Int(&int_values);
+        let decimal_values = int_values.map(TestScalar::from);
+
+        assert_eq!(
+            cast_column(
+                &alloc,
+                int_column,
+                ColumnType::Int,
+                ColumnType::Decimal75(precision, 0),
+            ),
+            Column::Decimal75(precision, 0, &decimal_values)
+        );
+    }
+
+    #[test]
+    fn we_can_scale_cast_timestamp_to_finer_unit() {
+        let alloc = Bump::new();
+        let timestamp_values = [2_i64, -3_i64, 0_i64];
+        let timestamp_column = Column::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            &timestamp_values,
+        );
+
+        assert_eq!(
+            cast_column_with_scaling(
+                &alloc,
+                timestamp_column,
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc()),
+            ),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Microsecond,
+                PoSQLTimeZone::utc(),
+                &[2_000, -3_000, 0]
+            )
         );
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -28,6 +28,92 @@ impl Default for EmptyExec {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::EmptyExec;
+    use crate::{
+        base::{
+            database::{Table, TableRef},
+            map::IndexMap,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
+            SumcheckMleEvaluations, VerificationBuilderImpl,
+        },
+    };
+    use alloc::collections::VecDeque;
+    use bumpalo::Bump;
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn we_can_create_default_empty_exec() {
+        assert_eq!(EmptyExec::default(), EmptyExec::new());
+    }
+
+    #[test]
+    fn we_can_get_empty_exec_references_and_fields() {
+        let empty_exec = EmptyExec::new();
+
+        assert!(empty_exec.get_column_result_fields().is_empty());
+        assert!(empty_exec.get_column_references().is_empty());
+        assert!(empty_exec.get_table_references().is_empty());
+    }
+
+    #[test]
+    fn we_can_evaluate_empty_exec_verifier_result() {
+        let expected_chi = TestScalar::from(17_i64);
+        let mle_evaluations = SumcheckMleEvaluations {
+            chi_evaluations: IndexMap::default(),
+            rho_evaluations: IndexMap::default(),
+            singleton_chi_evaluation: expected_chi,
+            random_evaluation: TestScalar::ZERO,
+            first_round_pcs_proof_evaluations: &[],
+            final_round_pcs_proof_evaluations: &[],
+            rho_256_evaluation: None,
+        };
+        let mut builder = VerificationBuilderImpl::new(
+            mle_evaluations,
+            &[],
+            &[],
+            VecDeque::new(),
+            Vec::new(),
+            Vec::new(),
+            0,
+        );
+        let accessor: IndexMap<TableRef, IndexMap<Ident, TestScalar>> = IndexMap::default();
+        let chi_eval_map: IndexMap<TableRef, (TestScalar, usize)> = IndexMap::default();
+
+        let table_evaluation = EmptyExec::new()
+            .verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[])
+            .unwrap();
+
+        assert!(table_evaluation.column_evals().is_empty());
+        assert_eq!(table_evaluation.chi(), (expected_chi, 1));
+    }
+
+    #[test]
+    fn we_can_evaluate_empty_exec_prover_rounds() {
+        let empty_exec = EmptyExec::new();
+        let alloc = Bump::new();
+        let table_map: IndexMap<TableRef, Table<'_, TestScalar>> = IndexMap::default();
+        let mut first_round_builder = FirstRoundBuilder::new(1);
+        let mut final_round_builder = FinalRoundBuilder::new(1, VecDeque::new());
+
+        let first_round_table = empty_exec
+            .first_round_evaluate(&mut first_round_builder, &alloc, &table_map, &[])
+            .unwrap();
+        assert!(first_round_table.is_empty());
+        assert_eq!(first_round_table.num_rows(), 1);
+
+        let final_round_table = empty_exec
+            .final_round_evaluate(&mut final_round_builder, &alloc, &table_map, &[])
+            .unwrap();
+        assert!(final_round_table.is_empty());
+        assert_eq!(final_round_table.num_rows(), 1);
+    }
+}
+
 impl EmptyExec {
     /// Creates a new empty plan.
     #[must_use]


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage for numerical add/subtract/multiply helper paths.
- Covers integer-to-decimal casting without scaling and timestamp scale casting to a finer unit.
- Adds focused `EmptyExec` coverage for construction, metadata/reference accessors, verifier evaluation, and prover first/final round evaluation.

## Coverage
Using the local Windows-compatible coverage command:

```bash
cargo llvm-cov --no-default-features --features test -p proof-of-sql --ignore-filename-regex evm_tests --lcov --output-path lcov.info
```

Measured uncovered-line deltas in changed files:
- `crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs`: 53 -> 13 remaining uncovered lines
- `crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs`: 52 -> 0 remaining uncovered lines
- Total measured improvement: 92 newly covered lines

## Checks
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test numerical_util -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test empty_exec -- --nocapture`
- `cargo llvm-cov --no-default-features --features test -p proof-of-sql --ignore-filename-regex evm_tests --lcov --output-path lcov.info` (967 passed)
- `git diff --check`