### PR TITLE
test: cover column metadata max bounds

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -293,6 +293,65 @@ mod tests {
     }
 
     #[test]
+    fn we_can_construct_metadata_with_max_bounds_for_column_type() {
+        assert_eq!(
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::SmallInt),
+            ColumnCommitmentMetadata {
+                column_type: ColumnType::SmallInt,
+                bounds: ColumnBounds::SmallInt(Bounds::Bounded(
+                    BoundsInner::try_new(i16::MIN, i16::MAX).unwrap()
+                )),
+            }
+        );
+        assert_eq!(
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::Int),
+            ColumnCommitmentMetadata {
+                column_type: ColumnType::Int,
+                bounds: ColumnBounds::Int(Bounds::Bounded(
+                    BoundsInner::try_new(i32::MIN, i32::MAX).unwrap()
+                )),
+            }
+        );
+        assert_eq!(
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::BigInt),
+            ColumnCommitmentMetadata {
+                column_type: ColumnType::BigInt,
+                bounds: ColumnBounds::BigInt(Bounds::Bounded(
+                    BoundsInner::try_new(i64::MIN, i64::MAX).unwrap()
+                )),
+            }
+        );
+        assert_eq!(
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc()
+            )),
+            ColumnCommitmentMetadata {
+                column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+                bounds: ColumnBounds::TimestampTZ(Bounds::Bounded(
+                    BoundsInner::try_new(i64::MIN, i64::MAX).unwrap()
+                )),
+            }
+        );
+        assert_eq!(
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::Int128),
+            ColumnCommitmentMetadata {
+                column_type: ColumnType::Int128,
+                bounds: ColumnBounds::Int128(Bounds::Bounded(
+                    BoundsInner::try_new(i128::MIN, i128::MAX).unwrap()
+                )),
+            }
+        );
+        assert_eq!(
+            ColumnCommitmentMetadata::from_column_type_with_max_bounds(ColumnType::Boolean),
+            ColumnCommitmentMetadata {
+                column_type: ColumnType::Boolean,
+                bounds: ColumnBounds::NoOrder,
+            }
+        );
+    }
+
+    #[test]
     fn we_cannot_construct_metadata_with_type_bounds_mismatch() {
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(


### PR DESCRIPTION
## Summary
- add focused coverage for ColumnCommitmentMetadata::from_column_type_with_max_bounds
- verify bounded metadata for ordered numeric/timestamp types and no-order metadata for unordered types
- keep the change test-only in crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs

/claim #560

## Validation
- cargo fmt --all -- --check
- cargo test -p proof-of-sql --no-default-features --features arrow base::commitment::column_commitment_metadata::tests::we_can_construct_metadata_with_max_bounds_for_column_type (1 passed)
- cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-column-metadata-max-bounds.lcov -- base::commitment::column_commitment_metadata::tests::we_can_construct_metadata_with_max_bounds_for_column_type (1 passed)
- cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-column-metadata-max-bounds-full.lcov (1054 passed)

## Coverage
- crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs gained newly covered production lines for ColumnCommitmentMetadata::from_column_type_with_max_bounds: 75-97, 99-100.