### PR TITLE
test: cover uint8 column bounds operations

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -590,6 +590,13 @@ mod tests {
         let no_order = ColumnBounds::NoOrder;
         assert_eq!(no_order.try_union(no_order).unwrap(), no_order);
 
+        let uint8_a = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
+        let uint8_b = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
+        assert_eq!(
+            uint8_a.try_union(uint8_b).unwrap(),
+            ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 6 }))
+        );
+
         let tinyint_a = ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let tinyint_b = ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
         assert_eq!(
@@ -677,6 +684,13 @@ mod tests {
     fn we_can_difference_column_bounds_with_matching_variant() {
         let no_order = ColumnBounds::NoOrder;
         assert_eq!(no_order.try_difference(no_order).unwrap(), no_order);
+
+        let uint8_a = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 4 }));
+        let uint8_b = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 3, max: 6 }));
+        assert_eq!(
+            uint8_a.try_difference(uint8_b).unwrap(),
+            ColumnBounds::Uint8(Bounds::Bounded(BoundsInner { min: 1, max: 4 }))
+        );
 
         let tinyint_a = ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let tinyint_b = ColumnBounds::TinyInt(Bounds::Empty);


### PR DESCRIPTION
## Summary
- add focused coverage for Uint8 ColumnBounds union and difference branches
- extend existing matching-variant tests without changing production behavior
- keep the change test-only in crates/proof-of-sql/src/base/commitment/column_bounds.rs

/claim #560

## Validation
- cargo fmt --all -- --check
- cargo test -p proof-of-sql --no-default-features --features arrow base::commitment::column_bounds::tests::we_can (12 passed)
- cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-column-bounds-uint8-ops.lcov -- base::commitment::column_bounds::tests::we_can (12 passed)
- cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-column-bounds-uint8-ops-full.lcov (1053 passed)

## Coverage
- crates/proof-of-sql/src/base/commitment/column_bounds.rs gained newly covered production lines for Uint8 ColumnBounds operations: 252-253, 287-288.