### PR TITLE
test: cover decimal precision errors

### DIFF
--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -216,6 +216,26 @@ mod scale_adjust_test {
     }
 
     #[test]
+    fn we_can_validate_precision_conversion_and_decimal_errors() {
+        assert_eq!(
+            Precision::try_from(75_u64).unwrap(),
+            Precision::new(75).unwrap()
+        );
+
+        let precision_err = Precision::try_from(u64::from(u8::MAX) + 1).unwrap_err();
+        assert_eq!(
+            precision_err,
+            DecimalError::InvalidPrecision {
+                error: "256".to_string()
+            }
+        );
+
+        let precision_err = Precision::try_from(0_u64).unwrap_err();
+        let precision_err_as_string = String::from(precision_err);
+        assert_eq!(precision_err_as_string, "Decimal precision is not valid: 0");
+    }
+
+    #[test]
     fn we_can_match_integers_with_negative_scale() {
         let decimal = "12300".parse().unwrap();
         let target_scale = -2;


### PR DESCRIPTION
/claim #560

## Summary
- add deterministic coverage for Precision::try_from(u64)
- cover DecimalError -> String conversion for invalid precision

## Newly covered production lines
- crates/proof-of-sql/src/base/math/decimal.rs: 84-86, 116-122, 124
- 11 lines that were previously uncovered in the local baseline LCOV

## Validation
- cargo fmt --all -- --check
- cargo test -p proof-of-sql --no-default-features --features="arrow" we_can_validate_precision_conversion_and_decimal_errors -- --nocapture
- cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow" --lcov --output-path target/decimal-precision-errors.lcov -- we_can_validate_precision_conversion_and_decimal_errors
- cargo test -p proof-of-sql --no-default-features --features="arrow"

Note: workspace-level arrow/blitzar test attempts on this Apple Silicon machine can fail because halo2curves enables asm only for x86_64.