### PR TITLE
test: cover query and analyze errors

### DIFF
--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,56 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_and_analyze_error_we_can_convert_analyze_errors_to_strings() {
+        let error = AnalyzeError::InvalidDataType {
+            expr_type: ColumnType::Boolean,
+        };
+        assert_eq!(
+            String::from(error),
+            "Expression has datatype BOOLEAN, which was not valid"
+        );
+
+        let error = AnalyzeError::DataTypeMismatch {
+            left_type: "INT".to_string(),
+            right_type: "VARCHAR".to_string(),
+        };
+        assert_eq!(
+            String::from(error),
+            "Left side has 'INT' type but right side has 'VARCHAR' type"
+        );
+
+        let error = AnalyzeError::DifferentColumnLength { len_a: 2, len_b: 3 };
+        assert_eq!(
+            String::from(error),
+            "Columns have different lengths: 2 != 3"
+        );
+
+        assert_eq!(
+            String::from(AnalyzeError::NotEnoughInputPlans),
+            "Not enough input plans"
+        );
+    }
+
+    #[test]
+    fn query_and_analyze_error_we_can_convert_intermediate_decimal_error_to_analyze_error() {
+        let error = AnalyzeError::from(IntermediateDecimalError::LossyCast);
+        assert_eq!(
+            error,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::LossyCast
+                }
+            }
+        );
+        assert_eq!(
+            String::from(error),
+            "Fractional part of decimal is non-zero"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,72 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_and_analyze_error_we_can_convert_table_coercion_errors_to_query_errors() {
+        let error = QueryError::from(TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::Overflow,
+        });
+        assert!(matches!(error, QueryError::Overflow));
+        assert_eq!(error.to_string(), "Overflow error");
+
+        let error = QueryError::from(TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::InvalidTypeCoercion,
+        });
+        assert!(matches!(
+            error,
+            QueryError::ProofError {
+                source: ProofError::InvalidTypeCoercion
+            }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Result does not match query: type mismatch"
+        );
+
+        let error = QueryError::from(TableCoercionError::NameMismatch);
+        assert!(matches!(
+            error,
+            QueryError::ProofError {
+                source: ProofError::FieldNamesMismatch
+            }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+
+        let error = QueryError::from(TableCoercionError::ColumnCountMismatch);
+        assert!(matches!(
+            error,
+            QueryError::ProofError {
+                source: ProofError::FieldCountMismatch
+            }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+
+    #[test]
+    fn query_and_analyze_error_we_can_display_direct_query_error_variants() {
+        assert_eq!(QueryError::InvalidString.to_string(), "String decode error");
+        assert_eq!(
+            QueryError::MiscellaneousDecodingError.to_string(),
+            "Miscellaneous decoding error"
+        );
+        assert_eq!(
+            QueryError::MiscellaneousEvaluationError.to_string(),
+            "Miscellaneous evaluation error"
+        );
+        assert_eq!(
+            QueryError::InvalidColumnCount.to_string(),
+            "Invalid number of columns"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add deterministic coverage for TableCoercionError -> QueryError mapping
- cover direct QueryError displays and AnalyzeError string/decimal conversions

## Newly covered production lines
- crates/proof-of-sql/src/sql/proof/query_result.rs: 43-44, 47, 50-52, 54
- crates/proof-of-sql/src/sql/error.rs: 59-61, 65-69
- 15 lines that were previously uncovered in the local baseline LCOV

## Validation
- cargo fmt --all -- --check
- cargo test -p proof-of-sql --no-default-features --features="arrow" query_and_analyze_error -- --nocapture
- cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow" --lcov --output-path target/query-and-analyze-errors.lcov -- query_and_analyze_error
- cargo test -p proof-of-sql --no-default-features --features="arrow"

Note: workspace-level arrow/blitzar test attempts on this Apple Silicon machine can fail because halo2curves enables asm only for x86_64.