### PR TITLE
test: cover query commitments accessors

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -122,6 +122,117 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
     }
 }
 
+#[cfg(test)]
+mod no_blitzar_tests {
+    use super::*;
+    use crate::base::{
+        commitment::{
+            naive_commitment::NaiveCommitment, naive_evaluation_proof::NaiveEvaluationProof,
+        },
+        database::{owned_table_utility::*, OwnedTable, OwnedTableTestAccessor, TestAccessor},
+        scalar::test_scalar::TestScalar,
+    };
+
+    #[test]
+    fn query_commitments_expose_metadata_commitments_and_schema() {
+        let column_a_id: Ident = "column_a".into();
+        let column_b_id: Ident = "column_b".into();
+        let missing_column_id: Ident = "missing".into();
+
+        let table_a: OwnedTable<TestScalar> = owned_table([
+            bigint(column_a_id.value.as_str(), [1, 2, 3, 4]),
+            varchar(
+                column_b_id.value.as_str(),
+                ["Lorem", "ipsum", "dolor", "sit"],
+            ),
+        ]);
+        let table_b: OwnedTable<TestScalar> =
+            owned_table([scalar(column_a_id.value.as_str(), [5, 6])]);
+
+        let table_a_commitment =
+            TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_a, 2, &());
+        let table_a_id = TableRef::new("table", "a");
+        let table_b_commitment =
+            TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_b, 0, &());
+        let table_b_id = TableRef::new("table", "b");
+
+        let query_commitments = QueryCommitments::from_iter([
+            (table_a_id.clone(), table_a_commitment.clone()),
+            (table_b_id.clone(), table_b_commitment.clone()),
+        ]);
+
+        assert_eq!(query_commitments.get_offset(&table_a_id), 2);
+        assert_eq!(query_commitments.get_length(&table_a_id), 4);
+        assert_eq!(query_commitments.get_offset(&table_b_id), 0);
+        assert_eq!(query_commitments.get_length(&table_b_id), 2);
+
+        assert_eq!(
+            query_commitments.get_commitment(&table_a_id, &column_a_id),
+            table_a_commitment.column_commitments().commitments()[0]
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_a_id, &column_b_id),
+            table_a_commitment.column_commitments().commitments()[1]
+        );
+
+        assert_eq!(
+            query_commitments.lookup_column(&table_a_id, &column_a_id),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            query_commitments.lookup_column(&table_a_id, &missing_column_id),
+            None
+        );
+        assert_eq!(
+            query_commitments.lookup_schema(&table_a_id),
+            vec![
+                (column_a_id.clone(), ColumnType::BigInt),
+                (column_b_id.clone(), ColumnType::VarChar)
+            ]
+        );
+    }
+
+    #[test]
+    fn query_commitments_from_accessor_groups_columns_by_table_in_schema_order() {
+        let column_a_id: Ident = "column_a".into();
+        let column_b_id: Ident = "column_b".into();
+        let table_id = TableRef::new("table", "ordered");
+        let table = owned_table([
+            bigint(column_a_id.value.as_str(), [1, 2, 3]),
+            scalar(column_b_id.value.as_str(), [4, 5, 6]),
+        ]);
+
+        let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+        accessor.add_table(table_id.clone(), table, 7);
+
+        let query_commitments = QueryCommitments::<NaiveCommitment>::from_accessor_with_max_bounds(
+            [
+                ColumnRef::new(table_id.clone(), column_b_id.clone(), ColumnType::Scalar),
+                ColumnRef::new(table_id.clone(), column_a_id.clone(), ColumnType::BigInt),
+            ],
+            &accessor,
+        );
+
+        assert_eq!(query_commitments.get_offset(&table_id), 7);
+        assert_eq!(query_commitments.get_length(&table_id), 3);
+        assert_eq!(
+            query_commitments.lookup_schema(&table_id),
+            vec![
+                (column_a_id.clone(), ColumnType::BigInt),
+                (column_b_id.clone(), ColumnType::Scalar)
+            ]
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_id, &column_a_id),
+            accessor.get_commitment(&table_id, &column_a_id)
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_id, &column_b_id),
+            accessor.get_commitment(&table_id, &column_b_id)
+        );
+    }
+}
+
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;


### PR DESCRIPTION
/claim #560

## Summary
- add non-blitzar Arrow-profile coverage for `QueryCommitments` metadata, commitment, and schema accessors
- cover `from_accessor_with_max_bounds` grouping selected columns by table while preserving accessor schema order
- keep production behavior unchanged; tests only

## Newly covered production lines
- crates/proof-of-sql/src/base/commitment/query_commitments.rs: 33-47, 49-64, 66-69, 73-76, 78-81, 88-95, 99-106, 111-122
- 68 lines that were previously uncovered in the local baseline LCOV

## Validation
- cargo fmt --all -- --check
- cargo test -p proof-of-sql --no-default-features --features="arrow" query_commitments -- --nocapture
- cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow" --lcov --output-path target/query-commitments-accessors.lcov -- query_commitments
- cargo test -p proof-of-sql --no-default-features --features="arrow"

Note: workspace-level arrow/blitzar test attempts on this Apple Silicon machine can fail because halo2curves enables asm only for x86_64.