### PR TITLE
test: cover owned table accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -101,6 +101,49 @@ fn we_can_create_an_owned_table_with_data() {
     );
     assert_eq!(owned_table.into_inner(), table);
 }
+
+#[test]
+fn we_can_inspect_owned_table_rows_columns_and_values() {
+    let owned_table: OwnedTable<TestScalar> = owned_table([
+        bigint("bigint", [1, 2, 3]),
+        varchar("varchar", ["a", "b", "c"]),
+    ]);
+
+    assert_eq!(owned_table.num_rows(), 3);
+    assert!(!owned_table.is_empty());
+    assert_eq!(
+        owned_table
+            .column_names()
+            .map(|ident| ident.value.as_str())
+            .collect::<Vec<_>>(),
+        vec!["bigint", "varchar"]
+    );
+    assert_eq!(
+        owned_table.column_by_index(0),
+        Some(&OwnedColumn::BigInt(vec![1, 2, 3]))
+    );
+    assert_eq!(
+        owned_table.column_by_index(1),
+        Some(&OwnedColumn::VarChar(vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string()
+        ]))
+    );
+    assert_eq!(owned_table.column_by_index(2), None);
+    assert_eq!(owned_table["bigint"], OwnedColumn::BigInt(vec![1, 2, 3]));
+}
+
+#[test]
+fn we_can_inspect_owned_table_with_no_columns() {
+    let owned_table = OwnedTable::<TestScalar>::try_new(IndexMap::default()).unwrap();
+
+    assert_eq!(owned_table.num_rows(), 0);
+    assert!(owned_table.is_empty());
+    assert_eq!(owned_table.column_names().count(), 0);
+    assert_eq!(owned_table.column_by_index(0), None);
+}
+
 #[test]
 fn we_get_inequality_between_tables_with_differing_column_order() {
     let owned_table_a: OwnedTable<TestScalar> = owned_table([


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for `OwnedTable` row/empty-state accessors
- cover column-name iteration, indexed column lookup, out-of-range lookup, and test-only string indexing
- keep production behavior unchanged; tests only

## Newly covered production lines
- crates/proof-of-sql/src/base/database/owned_table.rs: 107-109, 111, 113, 130-132, 135-137, 165-167
- 14 lines that were previously uncovered in the local baseline LCOV

## Validation
- cargo fmt --all -- --check
- cargo test -p proof-of-sql --no-default-features --features="arrow" we_can_inspect_owned_table -- --nocapture
- cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow" --lcov --output-path target/owned-table-accessors.lcov -- we_can_inspect_owned_table
- cargo test -p proof-of-sql --no-default-features --features="arrow"

Note: workspace-level arrow/blitzar test attempts on this Apple Silicon machine can fail because halo2curves enables asm only for x86_64.