### PR TITLE
test: cover monotonic proof gadget

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -124,7 +124,11 @@ impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
     }
 
     fn singleton_chi_evaluation(&self) -> S {
-        unimplemented!("No tests currently use this function")
+        if self.evaluation_row_index == 0 {
+            S::ONE
+        } else {
+            S::ZERO
+        }
     }
 
     fn rho_256_evaluation(&self) -> Option<S> {
@@ -407,10 +411,9 @@ mod tests {
         assert!(matches!(err, ProofSizeMismatch::TooFewMLEEvaluations));
     }
 
-    #[should_panic(expected = "No tests currently use this function")]
     #[test]
-    fn we_can_get_unimplemented_error_for_singleton_chi_evaluation() {
-        let verification_builder: MockVerificationBuilder<TestScalar> =
+    fn we_can_get_singleton_chi_evaluation() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
             MockVerificationBuilder::new(
                 Vec::new(),
                 2,
@@ -420,7 +423,15 @@ mod tests {
                 Vec::new(),
                 Vec::new(),
             );
-        verification_builder.singleton_chi_evaluation();
+        assert_eq!(
+            verification_builder.singleton_chi_evaluation(),
+            TestScalar::ONE
+        );
+        verification_builder.increment_row_index();
+        assert_eq!(
+            verification_builder.singleton_chi_evaluation(),
+            TestScalar::ZERO
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -134,3 +134,117 @@ pub(crate) fn verify_monotonic<S: Scalar, const STRICT: bool, const ASC: bool>(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic};
+    use crate::{
+        base::{
+            polynomial::MultilinearExtension,
+            proof::ProofError,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::{
+            mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
+            FirstRoundBuilder,
+        },
+    };
+    use bumpalo::Bump;
+    use core::cell::Cell;
+    use std::collections::VecDeque;
+
+    fn verify_column<const STRICT: bool, const ASC: bool>(column: &[i64]) -> (bool, bool, bool) {
+        let alloc = Bump::new();
+        let column = column
+            .iter()
+            .copied()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let column = &*alloc.alloc_slice_copy(&column);
+        let mut first_round_builder: FirstRoundBuilder<'_, TestScalar> =
+            FirstRoundBuilder::new(column.len());
+        first_round_evaluate_monotonic(&mut first_round_builder, &alloc, column);
+
+        let alpha = TestScalar::TWO;
+        let beta = TestScalar::from(7);
+        let mut final_round_builder =
+            FinalRoundBuilder::new(first_round_builder.range_length(), VecDeque::new());
+        final_round_evaluate_monotonic::<TestScalar, STRICT, ASC>(
+            &mut final_round_builder,
+            &alloc,
+            alpha,
+            beta,
+            column,
+        );
+
+        let saw_success = Cell::new(false);
+        let saw_error = Cell::new(false);
+        let verification_builder = run_verify_for_each_row(
+            column.len(),
+            &first_round_builder,
+            &final_round_builder,
+            Vec::new(),
+            3,
+            |builder, chi_eval, evaluation_point| {
+                let column_eval = column.inner_product(evaluation_point);
+                match verify_monotonic::<TestScalar, STRICT, ASC>(
+                    builder,
+                    alpha,
+                    beta,
+                    column_eval,
+                    chi_eval,
+                ) {
+                    Ok(()) => saw_success.set(true),
+                    Err(ProofError::VerificationError { .. }) => saw_error.set(true),
+                    Err(error) => panic!("unexpected monotonic verification error: {error:?}"),
+                }
+            },
+        );
+
+        let identity_constraints_hold = verification_builder
+            .get_identity_results()
+            .iter()
+            .all(|row| row.iter().all(|constraint| *constraint));
+        let zero_sum_constraints_hold = verification_builder
+            .get_zero_sum_results()
+            .iter()
+            .all(|constraint| *constraint);
+
+        (
+            saw_success.get(),
+            saw_error.get(),
+            identity_constraints_hold && zero_sum_constraints_hold,
+        )
+    }
+
+    #[test]
+    fn we_can_verify_monotonic_columns_without_blitzar() {
+        assert_eq!(
+            verify_column::<true, true>(&[1, 2, 3, 4]),
+            (true, false, true)
+        );
+        assert_eq!(
+            verify_column::<false, true>(&[1, 1, 2, 4]),
+            (true, false, true)
+        );
+        assert_eq!(
+            verify_column::<true, false>(&[4, 3, 2, 1]),
+            (true, false, true)
+        );
+        assert_eq!(
+            verify_column::<false, false>(&[4, 2, 2, 1]),
+            (true, false, true)
+        );
+    }
+
+    #[test]
+    fn we_can_verify_empty_monotonic_column_without_blitzar() {
+        assert_eq!(verify_column::<true, true>(&[]), (true, false, true));
+    }
+
+    #[test]
+    fn we_reject_non_monotonic_columns_without_blitzar() {
+        let (_, saw_error, _) = verify_column::<true, true>(&[1, 3, 2, 4]);
+        assert!(saw_error);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary

Adds no-default-feature coverage for the monotonic proof gadget by exercising:

- strict ascending verification
- non-strict ascending verification
- strict descending verification
- non-strict descending verification
- empty-column verification
- non-monotonic rejection

The PR also gives `MockVerificationBuilder::singleton_chi_evaluation` the row-local behavior needed by `verify_monotonic`, replacing the previous test-only `unimplemented!()` path.

## Coverage

Baseline no-default LCOV showed 62 uncovered production lines in `crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs`.

The targeted branch LCOV covers all 62 of those lines:

15-21, 29-36, 38, 40-44, 46, 48, 50, 52, 68-71, 73, 76-77, 79-85, 87-88, 90-92, 94-96, 106-109, 123-126, 130-136.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --no-default-features --features test sql::proof_gadgets::monotonic::tests -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features test we_can_get_singleton_chi_evaluation -- --nocapture`
- `cargo llvm-cov test -p proof-of-sql --no-default-features --features test --lib --lcov --output-path target/proof-of-sql-monotonic.lcov sql::proof_gadgets::monotonic::tests`
