### PR TITLE
test: cover owned table test accessor

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -108,7 +108,7 @@ pub use test_accessor::TestAccessor;
 
 mod owned_table_test_accessor;
 pub use owned_table_test_accessor::OwnedTableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod owned_table_test_accessor_test;
 
 mod table_test_accessor;


### PR DESCRIPTION
/claim #560

## Summary
- run the existing `OwnedTableTestAccessor` tests in the standard Arrow-profile test build instead of requiring `blitzar`
- cover accessor creation, table insertion, column access, commitments, metadata, schema lookup, and offset updates
- keep production behavior unchanged; test cfg only

## Newly covered production lines
- crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs: 22-28, 46-48, 50-52, 58-66, 72-74, 84-92, 94, 99-100, 104-112, 129, 131, 141-150, 157-159, 164-166, 169, 171-178, 183-192, 197-201
- 86 lines that were previously uncovered in the local baseline LCOV

## Validation
- cargo fmt --all -- --check
- cargo test -p proof-of-sql --no-default-features --features="arrow" owned_table_test_accessor -- --nocapture
- cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow" --lcov --output-path target/owned-table-test-accessor.lcov -- owned_table_test_accessor
- cargo test -p proof-of-sql --no-default-features --features="arrow"

Note: workspace-level arrow/blitzar test attempts on this Apple Silicon machine can fail because halo2curves enables asm only for x86_64.