### PR TITLE
ci: cache apt package installs

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -42,8 +42,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.rust }}
-      - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld     
+      - name: Install cached apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: clang lld
+          version: 1.0
       - name: Run cargo check (no features, exclude examples)
         run: cargo check --no-default-features
       - name: Run cargo check (default features)
@@ -114,8 +117,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.rust }}
-      - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+      - name: Install cached apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: clang lld
+          version: 1.0
       - run: cargo test --all-features
 
   testnorayon:
@@ -142,8 +148,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.rust }}
-      - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+      - name: Install cached apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: clang lld
+          version: 1.0
       - run: cargo test --no-default-features --features="arrow blitzar"
 
   testother:
@@ -170,8 +179,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.rust }}
-      - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+      - name: Install cached apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: clang lld
+          version: 1.0
       - name: Dry run cargo test (proof-of-sql) (test feature only)
         run: cargo test -p proof-of-sql --no-run --no-default-features --features="test"
       - name: Dry run cargo test (proof-of-sql) (arrow feature only)
@@ -209,8 +221,11 @@ jobs:
           uses: Swatinem/rust-cache@v2
           with:
             key: ${{ matrix.rust }}
-        - name: Install Dependencies
-          run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+        - name: Install cached apt dependencies
+          uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+          with:
+            packages: clang lld
+            version: 1.0
         - name: Run hello_world example (With Blitzar)
           run: cargo run --example hello_world --features="proof-of-sql/test"
         - name: Run hello_world example (Without Blitzar and With Rayon)
@@ -240,8 +255,11 @@ jobs:
           rustup component add clippy
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
-      - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+      - name: Install cached apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: clang lld
+          version: 1.0
       - name: Run clippy
         run: cargo cl -- -D warnings
         
@@ -298,8 +316,11 @@ jobs:
         run: solidity/scripts/pre_forge.sh test --via-ir --optimize
       - name: Remove preprocessor test files (for they are already tested in the check-yul-preprocessor job)
         run: rm -rf solidity/preprocessor/test_files
-      - name: Install lcov
-        run: sudo apt-get update && sudo apt-get install -y lcov
+      - name: Install cached lcov
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: lcov
+          version: 1.0
       - name: Check code coverage
         run: solidity/scripts/check_coverage.sh
       - name: Check fmt
@@ -333,8 +354,11 @@ jobs:
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
-      - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+      - name: Install cached apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: clang lld
+          version: 1.0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

Issue #557 includes broad CI runtime improvements. The main lint/test workflow repeatedly installs the same apt packages with `apt-get update && apt-get install` across the Rust matrix jobs, clippy, Rust EVM tests, and the Foundry coverage path.

This PR replaces those repeated package-install shell steps with `awalsh128/cache-apt-pkgs-action@v1.6.0`, which installs the packages on cold cache and restores them from the GitHub Actions cache on warm runs. The build/test commands stay unchanged; this only changes how `clang`, `lld`, and `lcov` are made available to the runner.

/claim #557

# What changes are included in this PR?

- Cache/install `clang lld` in the Rust check, test, no-rayon test, test-other, examples, clippy, and Rust EVM test jobs.
- Cache/install `lcov` in the Foundry job before the existing coverage check.
- Pin the apt cache action to `v1.6.0` and use `version: 1.0` cache namespaces for the package groups.

# Are these changes tested?

Static validation on the VPS workspace:

- `python3 - <<PY ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `rg -n "apt-get|Install Dependencies|Install lcov|cache-apt-pkgs-action" .github/workflows/lint-and-test.yml`
- `source scripts/check_commits.sh`

- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS="" source scripts/run_ci_checks.sh`

The CI check script completed successfully on the VPS after applying the same gcc linker override used for non-default local validation in this repo. The runtime cache benefit still depends on GitHub Actions cache behavior.
