### PR TITLE
test: cover table test accessor

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -113,7 +113,7 @@ mod owned_table_test_accessor_test;
 
 mod table_test_accessor;
 pub use table_test_accessor::TableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod table_test_accessor_test;
 
 /// Module providing utilities for filtering columns based on selection vectors.


### PR DESCRIPTION
/claim #560

## Summary
- run the existing `TableTestAccessor` tests in the standard Arrow-profile test build instead of requiring `blitzar`
- cover accessor creation, borrowed-table insertion, column access, commitments, metadata, schema lookup, and offset updates
- keep production behavior unchanged; test cfg only

## Newly covered production lines
- crates/proof-of-sql/src/base/database/table_test_accessor.rs: 20-25, 40-42, 44-46, 52-60, 66-68, 78-87, 97-106, 113-115, 120-122, 125, 127-134, 139-148, 153-157
- 72 lines that were previously uncovered in the local baseline LCOV

## Validation
- cargo fmt --all -- --check
- cargo test -p proof-of-sql --no-default-features --features="arrow" table_test_accessor -- --nocapture
- cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow" --lcov --output-path target/table-test-accessor.lcov -- table_test_accessor
- cargo test -p proof-of-sql --no-default-features --features="arrow"

Note: workspace-level arrow/blitzar test attempts on this Apple Silicon machine can fail because halo2curves enables asm only for x86_64.