### PR TITLE
test: cover vec commitment extension

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -171,7 +171,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{


### PR DESCRIPTION
## Summary
- enable the existing vec commitment extension tests under the arrow-only test configuration
- covers NaiveCommitment-backed conversion, append, extend, add, subtract, and mismatch paths

/claim #560

## Coverage
- Previously uncovered lines now covered in `crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs`: 223
- Coverage artifact: `target/vec-commitment-ext.lcov`

## Tests
- `cargo test -p proof-of-sql --no-default-features --features="arrow" vec_commitment_ext -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features="arrow" --lcov --output-path target/vec-commitment-ext.lcov -- vec_commitment_ext`
- `cargo test -p proof-of-sql --no-default-features --features="arrow"`