### PR TITLE
ci: cache coverage apt dependencies

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -20,8 +20,11 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
-    - name: Install Dependencies
-      run: sudo apt-get update && sudo apt-get install -y clang lld
+    - name: Install cached apt dependencies
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+      with:
+        packages: clang lld
+        version: 1.0
     - uses: taiki-e/install-action@cargo-llvm-cov
     - name: Clean Previous Coverage Artifacts
       run: cargo llvm-cov clean --workspace


### PR DESCRIPTION
## Summary
/claim #557

This applies apt package caching to the code coverage workflow's `clang lld` install step. The coverage job currently installs those packages from apt on every run before `cargo llvm-cov`; using the same cached apt install pattern keeps the dependency set unchanged while avoiding repeated apt downloads on cache hits.

This is scoped to `.github/workflows/code-coverage.yml` and does not overlap with the existing lint-and-test apt-cache slice.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/code-coverage.yml"); puts "yaml ok"'`\n