### PR TITLE
test: cover RefInto reference conversion

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,44 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Source {
+        value: usize,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Converted {
+        value: usize,
+        was_from_ref: bool,
+    }
+
+    impl From<&Source> for Converted {
+        fn from(source: &Source) -> Self {
+            Self {
+                value: source.value,
+                was_from_ref: true,
+            }
+        }
+    }
+
+    #[test]
+    fn ref_into_uses_reference_conversion_without_consuming_source() {
+        let source = Source { value: 37 };
+
+        let converted: Converted = source.ref_into();
+
+        assert_eq!(
+            converted,
+            Converted {
+                value: 37,
+                was_from_ref: true,
+            }
+        );
+        assert_eq!(source.value, 37);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add direct unit coverage for the blanket `RefInto` implementation
- verify that `ref_into` dispatches through `From<&Source>` and does not consume the source value
- keep production code unchanged

## Validation
- `cargo fmt --check --package proof-of-sql`
- `git diff --check`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS='' cargo test -p proof-of-sql --lib --no-default-features --features test ref_into::tests::ref_into_uses_reference_conversion_without_consuming_source -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS='' cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --summary-only --json --output-path /tmp/refinto-coverage.json -- ref_into::tests::ref_into_uses_reference_conversion_without_consuming_source --nocapture`

Coverage summary for `crates/proof-of-sql/src/base/ref_into.rs` from the targeted llvm-cov run: 15/15 lines, 3/3 functions, 17/17 regions.