### PR TITLE
test: reduce eval VMV setup size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re_test.rs
@@ -35,12 +35,12 @@ fn we_can_prove_and_verify_an_eval_vmv_re() {
 #[test]
 fn we_can_prove_and_verify_an_eval_vmv_re_for_multiple_nu_values() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
     let verifier_setup = (&pp).into();
 
-    for nu in 0..max_nu {
+    for nu in 0..=max_nu {
         let vmv = VMV::rand(nu, &mut rng);
         let prover_state = vmv.calculate_prover_state(&prover_setup);
         let verifier_state = vmv.calculate_verifier_state(&prover_setup);


### PR DESCRIPTION
/claim #557

## Summary
- reduce the multi-`nu` eval VMV test setup from `PublicParameters::test_rand(5, ...)` to `test_rand(4, ...)`
- preserve the same tested `nu` cases by changing `0..max_nu` to `0..=max_nu`
- keep production code and assertions unchanged

## Validation
- `cargo fmt --check --package proof-of-sql`
- `git diff --check`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS='' cargo test -p proof-of-sql --lib --no-default-features --features test eval_vmv_re_test -- --nocapture`