### PR TITLE
test: cover record batch error wrappers

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -29,3 +29,45 @@ pub enum AppendRecordBatchTableCommitmentError {
         source: RecordBatchToColumnsError,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{AppendRecordBatchTableCommitmentError, RecordBatchToColumnsError};
+    use crate::base::{
+        arrow::arrow_array_to_column_conversion::ArrowArrayToColumnConversionError,
+        commitment::ColumnCommitmentsMismatch,
+    };
+    use alloc::string::ToString;
+
+    #[test]
+    fn record_batch_to_columns_error_preserves_arrow_conversion_error_display() {
+        let error = RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+            source: ArrowArrayToColumnConversionError::ArrayContainsNulls,
+        };
+
+        assert_eq!(error.to_string(), "arrow array must not contain nulls");
+    }
+
+    #[test]
+    fn append_record_batch_error_preserves_commitment_mismatch_display() {
+        let error = AppendRecordBatchTableCommitmentError::ColumnCommitmentsMismatch {
+            source: ColumnCommitmentsMismatch::NumColumns,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "commitments with different column counts cannot operate with each other"
+        );
+    }
+
+    #[test]
+    fn append_record_batch_error_preserves_nested_record_batch_conversion_display() {
+        let error = AppendRecordBatchTableCommitmentError::ArrowBatchToColumnError {
+            source: RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                source: ArrowArrayToColumnConversionError::ArrayContainsNulls,
+            },
+        };
+
+        assert_eq!(error.to_string(), "arrow array must not contain nulls");
+    }
+}


### PR DESCRIPTION
/claim #560

# Rationale for this change

`RecordBatchToColumnsError` and `AppendRecordBatchTableCommitmentError` are the public record-batch conversion error surfaces for Arrow record batch conversion and table commitment appends. This adds focused coverage for their transparent wrapper behavior so source conversion and commitment mismatch errors keep their expected display text.

# What changes are included in this PR?

- Cover `RecordBatchToColumnsError` forwarding an `ArrowArrayToColumnConversionError` display string.
- Cover `AppendRecordBatchTableCommitmentError` forwarding a `ColumnCommitmentsMismatch` display string.
- Cover nested record-batch conversion errors propagated through append-record-batch errors.
- Keep production code unchanged.

# Are these changes tested?

- `cargo test -p proof-of-sql --lib --no-default-features --features arrow record_batch_errors`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: this is a small non-overlapping coverage slice. I did not run local `cargo llvm-cov` because `cargo-llvm-cov` is not installed in this environment, so final covered-line accounting is left to the maintainer/CI baseline.

Disclosure: prepared with AI assistance in Codex and reviewed before submission.