### PR TITLE
test: cover PoSQL time parsing helpers

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -104,6 +104,27 @@ mod timezone_parsing_tests {
     }
 
     #[test]
+    fn we_can_parse_positive_time_zone() {
+        let timezone_as_str: Option<Arc<str>> = Some("+05:45".into());
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+        let expected_time_zone = PoSQLTimeZone::new(20_700);
+        assert_eq!(timezone, expected_time_zone);
+    }
+
+    #[test]
+    fn we_can_parse_utc_aliases() {
+        let utc_aliases = ["Z", "z", "UTC", "utc", "00:00", "+00:00", "0:00", "+0:00"];
+
+        for alias in utc_aliases {
+            let timezone_as_str: Option<Arc<str>> = Some(alias.into());
+            assert_eq!(
+                PoSQLTimeZone::try_from(&timezone_as_str),
+                Ok(PoSQLTimeZone::utc())
+            );
+        }
+    }
+
+    #[test]
     fn we_can_parse_none_time_zone() {
         let timezone = PoSQLTimeZone::try_from(&None).unwrap();
         let expected_time_zone = PoSQLTimeZone::utc();
@@ -117,6 +138,16 @@ mod timezone_parsing_tests {
         assert!(matches!(
             timezone_err,
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
+        ));
+    }
+
+    #[test]
+    fn we_cannot_parse_malformed_numeric_time_zone() {
+        let timezone_as_str: Option<Arc<str>> = Some("+AA:00".into());
+        let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();
+        assert!(matches!(
+            timezone_err,
+            PoSQLTimestampError::InvalidTimezoneOffset
         ));
     }
 }

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -69,6 +69,31 @@ mod time_unit_tests {
     }
 
     #[test]
+    fn test_precision_as_u64() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
+
+    #[test]
     fn test_invalid_precision() {
         let invalid_precisions = [
             "1", "2", "4", "5", "7", "8", "10", "zero", "three", "cat", "-1", "-2",


### PR DESCRIPTION
/claim #560

## Summary

Contributes to #560 by adding targeted unit coverage for the PoSQL timestamp helper types:

- covers `PoSQLTimeUnit` precision conversion via `From<PoSQLTimeUnit> for u64`
- covers `PoSQLTimeUnit` display formatting
- covers positive timezone offsets, UTC aliases, and malformed numeric timezone offsets for `PoSQLTimeZone`

## Tests

- `cargo fmt --check`
- `cargo test -p proof-of-sql posql_time --no-default-features --features="test"`

Both commands passed locally on Rust 1.91.1.