### PR TITLE
test: reuse HyperKZG public setup in tests

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment_evaluation_proof.rs
@@ -173,12 +173,13 @@ mod tests {
     fn we_can_create_small_hyperkzg_evaluation_proofs() {
         let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32);
         let (_, vk) = EvaluationEngine::setup(&ck);
+        let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
         test_simple_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_commitment_evaluation_proof_with_length_1::<HyperKZGCommitmentEvaluationProof>(
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
     }
@@ -187,82 +188,83 @@ mod tests {
     fn we_can_create_hyperkzg_evaluation_proofs_with_various_lengths() {
         let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128);
         let (_, vk) = EvaluationEngine::setup(&ck);
+        let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             2,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             3,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             4,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             5,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             8,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             10,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             16,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             20,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             32,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             50,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             64,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             100,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             128,
             0,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
             &&vk,
         );
     }

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
@@ -122,6 +122,7 @@ mod tests {
     #[test]
     fn we_can_compute_a_commitment_with_only_one_column() {
         let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6);
+        let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
 
         let committable_columns = vec![CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7])];
 
@@ -130,7 +131,7 @@ mod tests {
         let res = HyperKZGCommitment::compute_commitments(
             &committable_columns,
             offset,
-            &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+            &&public_setup[..],
         )
         .into_iter()
         .map(ark_to_nova_commitment)
@@ -143,6 +144,7 @@ mod tests {
     #[test]
     fn we_can_compute_commitments_with_a_single_empty_column() {
         let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32);
+        let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
 
         let committable_columns = vec![CommittableColumn::BigInt(&[0; 0])];
 
@@ -150,7 +152,7 @@ mod tests {
             let res = HyperKZGCommitment::compute_commitments(
                 &committable_columns,
                 offset,
-                &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+                &&public_setup[..],
             )
             .into_iter()
             .map(ark_to_nova_commitment)
@@ -164,6 +166,7 @@ mod tests {
     #[test]
     fn we_can_compute_commitments_with_a_multiple_mixed_empty_columns() {
         let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32);
+        let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
 
         let committable_columns = vec![
             CommittableColumn::TinyInt(&[0; 0]),
@@ -178,7 +181,7 @@ mod tests {
             let res = HyperKZGCommitment::compute_commitments(
                 &committable_columns,
                 offset,
-                &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+                &&public_setup[..],
             )
             .into_iter()
             .map(ark_to_nova_commitment)
@@ -192,6 +195,7 @@ mod tests {
     #[test]
     fn we_can_compute_a_commitment_with_mixed_columns_of_different_sizes_and_offsets() {
         let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128);
+        let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
 
         let committable_columns = vec![
             CommittableColumn::BigInt(&[0, 1]),
@@ -219,7 +223,7 @@ mod tests {
             let res = HyperKZGCommitment::compute_commitments(
                 &committable_columns,
                 offset,
-                &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+                &&public_setup[..],
             )
             .into_iter()
             .map(ark_to_nova_commitment)
@@ -233,6 +237,7 @@ mod tests {
     #[test]
     fn we_can_compute_a_commitment_with_mixed_signed_columns_of_different_sizes_and_offsets() {
         let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128);
+        let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
 
         let committable_columns = vec![
             CommittableColumn::BigInt(&[-1, -2, -3]),
@@ -245,7 +250,7 @@ mod tests {
             let res = HyperKZGCommitment::compute_commitments(
                 &committable_columns,
                 offset,
-                &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
+                &&public_setup[..],
             )
             .into_iter()
             .map(ark_to_nova_commitment)


### PR DESCRIPTION
/claim #557

## Summary
- Reuse the HyperKZG public setup within commitment evaluation proof tests instead of converting the same Nova commitment key for every case.
- Reuse the same public setup across repeated `compute_commitments` offset loops in HyperKZG Nova commitment tests.
- Keeps the same lengths, offsets, input columns, fixtures, and assertions; this is test-only setup reuse.

## Local validation
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features hyperkzg_proof proof_primitive::hyperkzg -- --nocapture`
  - 30 passed, 3 ignored, 0 failed

## Focused timing check
Using the test harness reported runtimes after local compilation:
- `proof_primitive::hyperkzg::commitment_evaluation_proof::tests`: 8.78s on `origin/main` -> 4.76s on this branch
- `proof_primitive::hyperkzg::nova_commitment::tests`: 45.31s on `origin/main` -> 17.46s on this branch