### PR TITLE
test: cover proof expr helpers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
@@ -18,7 +18,7 @@ use ark_ff::{AdditiveGroup, Field};
 use blitzar::compute::ElementP2;
 #[cfg(feature = "blitzar")]
 use bytemuck::TransparentWrapper;
-use itertools::{Itertools, __std_iter::repeat};
+use itertools::{__std_iter::repeat, Itertools};
 
 /// Compute the evaluations of the columns of the matrix M that is derived from `a`.
 ///

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -116,3 +116,113 @@ impl ProofExpr for ColumnExpr {
         columns.insert(self.column_ref.clone());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{
+                table_utility::{borrowed_int, table},
+                Column, ColumnField, TableRef,
+            },
+            map::{IndexMap, IndexSet},
+            scalar::test_scalar::TestScalar,
+        },
+        sql::proof::mock_verification_builder::MockVerificationBuilder,
+    };
+    use alloc::collections::VecDeque;
+
+    fn column_expr() -> (ColumnExpr, ColumnRef) {
+        let column_ref = ColumnRef::new(
+            TableRef::new("sxt", "orders"),
+            "quantity".into(),
+            ColumnType::Int,
+        );
+        (ColumnExpr::new(column_ref.clone()), column_ref)
+    }
+
+    #[test]
+    fn we_can_inspect_column_expr_metadata_and_references() {
+        let (expr, column_ref) = column_expr();
+
+        assert_eq!(expr.get_column_reference(), column_ref);
+        assert_eq!(expr.column_ref(), &column_ref);
+        assert_eq!(
+            expr.get_column_field(),
+            ColumnField::new("quantity".into(), ColumnType::Int)
+        );
+        assert_eq!(expr.column_id(), "quantity".into());
+        assert_eq!(expr.data_type(), ColumnType::Int);
+
+        let mut columns = IndexSet::default();
+        expr.get_column_references(&mut columns);
+        assert_eq!(columns.len(), 1);
+        assert!(columns.contains(&column_ref));
+    }
+
+    #[test]
+    fn we_can_evaluate_column_expr_rounds() {
+        let alloc = Bump::new();
+        let data = table([borrowed_int("quantity", [3, 5, 8], &alloc)]);
+        let (expr, _) = column_expr();
+        let expected = Column::Int(&[3, 5, 8]);
+
+        assert_eq!(expr.fetch_column(&data), expected);
+        assert_eq!(
+            expr.first_round_evaluate(&alloc, &data, &[]).unwrap(),
+            expected
+        );
+
+        let mut builder = FinalRoundBuilder::<TestScalar>::new(2, VecDeque::new());
+        assert_eq!(
+            expr.final_round_evaluate(&mut builder, &alloc, &data, &[])
+                .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn we_can_verify_column_expr_from_accessor() {
+        let (expr, _) = column_expr();
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            0,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let mut accessor = IndexMap::default();
+        accessor.insert("quantity".into(), TestScalar::from(13_u64));
+
+        assert_eq!(
+            expr.verifier_evaluate(&mut builder, &accessor, TestScalar::from(7_u64), &[])
+                .unwrap(),
+            TestScalar::from(13_u64)
+        );
+    }
+
+    #[test]
+    fn we_cannot_verify_column_expr_without_accessor_value() {
+        let (expr, _) = column_expr();
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            0,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let accessor = IndexMap::default();
+
+        assert!(matches!(
+            expr.verifier_evaluate(&mut builder, &accessor, TestScalar::from(7_u64), &[]),
+            Err(ProofError::VerificationError {
+                error: "Column Not Found"
+            })
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -138,3 +138,114 @@ impl ProofExpr for MultiplyExpr {
 }
 
 impl DecimalProofExpr for MultiplyExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{
+                table_utility::{borrowed_int, table},
+                Column, ColumnRef, ColumnType, TableRef,
+            },
+            map::{IndexMap, IndexSet},
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::{
+            proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
+            proof_exprs::test_utility::{const_bigint, const_int, const_varchar},
+            AnalyzeError,
+        },
+    };
+    use alloc::{boxed::Box, collections::VecDeque, vec};
+    use bumpalo::Bump;
+
+    fn literal_multiply_expr() -> MultiplyExpr {
+        MultiplyExpr::try_new(Box::new(const_int(3)), Box::new(const_bigint(4))).unwrap()
+    }
+
+    #[test]
+    fn we_can_inspect_multiply_expr_inputs_and_references() {
+        let table_ref = TableRef::new("sxt", "orders");
+        let quantity_ref = ColumnRef::new(table_ref.clone(), "quantity".into(), ColumnType::Int);
+        let price_ref = ColumnRef::new(table_ref, "price".into(), ColumnType::BigInt);
+        let expr = MultiplyExpr::try_new(
+            Box::new(DynProofExpr::new_column(quantity_ref.clone())),
+            Box::new(DynProofExpr::new_column(price_ref.clone())),
+        )
+        .unwrap();
+
+        assert_eq!(expr.lhs().data_type(), ColumnType::Int);
+        assert_eq!(expr.rhs().data_type(), ColumnType::BigInt);
+        assert!(matches!(expr.data_type(), ColumnType::Decimal75(_, 0)));
+
+        let mut columns = IndexSet::default();
+        expr.get_column_references(&mut columns);
+        assert_eq!(columns.len(), 2);
+        assert!(columns.contains(&quantity_ref));
+        assert!(columns.contains(&price_ref));
+    }
+
+    #[test]
+    fn we_cannot_build_multiply_expr_for_non_numeric_inputs() {
+        let err = MultiplyExpr::try_new(Box::new(const_int(3)), Box::new(const_varchar("x")))
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            AnalyzeError::DataTypeMismatch {
+                left_type: _,
+                right_type: _
+            }
+        ));
+    }
+
+    #[test]
+    fn we_can_evaluate_literal_multiply_expr_rounds() {
+        let alloc = Bump::new();
+        let data = table([borrowed_int("rows", [0, 0], &alloc)]);
+        let expr = literal_multiply_expr();
+        let expected_values = [TestScalar::from(12_u64), TestScalar::from(12_u64)];
+        let expected = Column::Decimal75(expr.precision(), expr.scale(), &expected_values);
+
+        assert_eq!(
+            expr.first_round_evaluate(&alloc, &data, &[]).unwrap(),
+            expected
+        );
+
+        let mut builder = FinalRoundBuilder::<TestScalar>::new(1, VecDeque::new());
+        assert_eq!(
+            expr.final_round_evaluate(&mut builder, &alloc, &data, &[])
+                .unwrap(),
+            expected
+        );
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+        assert_eq!(
+            builder.evaluate_pcs_proof_mles(&[TestScalar::ONE, TestScalar::ZERO]),
+            [TestScalar::from(12_u64)]
+        );
+    }
+
+    #[test]
+    fn we_can_verify_literal_multiply_expr_evaluation() {
+        let expr = literal_multiply_expr();
+        let mut builder = MockVerificationBuilder::new(
+            vec![],
+            3,
+            vec![],
+            vec![vec![TestScalar::from(12_u64)]],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let accessor = IndexMap::default();
+
+        assert_eq!(
+            expr.verifier_evaluate(&mut builder, &accessor, TestScalar::ONE, &[])
+                .unwrap(),
+            TestScalar::from(12_u64)
+        );
+        assert_eq!(builder.get_identity_results(), vec![vec![true]]);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add no-default unit coverage for `MultiplyExpr` construction, accessors, and column refs
- cover first/final round literal multiplication and verifier evaluation
- add no-default unit coverage for `ColumnExpr` metadata, round evaluation, references, and verifier lookup errors
- keep production behavior unchanged

## Coverage
Local LCOV comparison against the no-default `test` baseline shows 80 existing production lines newly covered:

- `crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs`: 66 lines
  - 36-38, 53-68, 71-85, 88-99, 101-126, 131-137
- `crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs`: 14 lines
  - 43-45, 75-82, 115-117

Final payable-line accounting is left to the maintainer baseline.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test column_expr::tests -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test multiply_expr::tests -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/proof-of-sql-proof-exprs.lcov -- proof_exprs::`
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One`
- `git diff --check`
- `source scripts/check_commits.sh`
