### PR TITLE
test: add TableRef parser/serde coverage slice

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -60,6 +60,8 @@ mod error;
 pub use error::ParseError;
 
 mod table_ref;
+#[cfg(test)]
+mod table_ref_test;
 #[cfg(feature = "arrow")]
 pub use crate::base::arrow::{
     arrow_array_to_column_conversion::{ArrayRefExt, ArrowArrayToColumnConversionError},

--- a/crates/proof-of-sql/src/base/database/table_ref_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref_test.rs
@@ -1,0 +1,59 @@
+use super::{ParseError, TableRef};
+use alloc::string::ToString;
+use sqlparser::ast::Ident;
+
+#[test]
+fn table_ref_new_handles_schema_and_no_schema() {
+    let with_schema = TableRef::new("analytics", "events");
+    assert_eq!(with_schema.schema_id(), Some(&Ident::new("analytics")));
+    assert_eq!(with_schema.table_id(), &Ident::new("events"));
+    assert_eq!(with_schema.to_string(), "analytics.events");
+
+    let without_schema = TableRef::new("", "events");
+    assert_eq!(without_schema.schema_id(), None);
+    assert_eq!(without_schema.table_id(), &Ident::new("events"));
+    assert_eq!(without_schema.to_string(), "events");
+}
+
+#[test]
+fn table_ref_parse_helpers_cover_success_and_errors() {
+    let one = TableRef::from_strs(&["events"]).unwrap();
+    assert_eq!(one.schema_id(), None);
+    assert_eq!(one.table_id(), &Ident::new("events"));
+
+    let two = TableRef::from_strs(&["analytics", "events"]).unwrap();
+    assert_eq!(two.schema_id(), Some(&Ident::new("analytics")));
+    assert_eq!(two.table_id(), &Ident::new("events"));
+
+    let err = TableRef::from_strs(&["a", "b", "c"]).unwrap_err();
+    assert_eq!(
+        err,
+        ParseError::InvalidTableReference {
+            table_reference: "a,b,c".to_string(),
+        }
+    );
+
+    let parsed = TableRef::try_from("analytics.events").unwrap();
+    assert_eq!(parsed, two);
+
+    let bad = TableRef::try_from("a.b.c").unwrap_err();
+    assert_eq!(
+        bad,
+        ParseError::InvalidTableReference {
+            table_reference: "a.b.c".to_string(),
+        }
+    );
+}
+
+#[test]
+fn table_ref_serde_roundtrip_and_invalid_input() {
+    let table = TableRef::from_names(Some("analytics"), "events");
+    let json = serde_json::to_string(&table).unwrap();
+    assert_eq!(json, "\"analytics.events\"");
+
+    let decoded: TableRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded, table);
+
+    let decode_err = serde_json::from_str::<TableRef>("\"a.b.c\"").unwrap_err();
+    assert!(decode_err.to_string().contains("Invalid table reference"));
+}


### PR DESCRIPTION
/claim #560

## Summary
- add dedicated tests for `TableRef::new` with and without schema
- add parser helper coverage for `from_strs` and `TryFrom<&str>` success/error paths
- add serde round-trip and invalid input coverage for `TableRef`
- wire `table_ref_test` into `base/database/mod.rs`

## Validation
- attempted: `cargo test -p proof-of-sql table_ref_ -- --nocapture`
- blocked in this macOS environment by upstream build constraints: `blitzar-sys` requires Linux and `halo2curves` asm gate requires x86_64
- attempted fallback: `cargo test -p proof-of-sql --no-default-features table_ref_ -- --nocapture`
- fallback build also fails due unrelated upstream no-std test compile errors across many files

This PR is intentionally a small non-overlapping test-only coverage slice for bounty issue #560.