### PR TITLE
Add coverage for TableRef parsing and ZigZag decoding

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -60,6 +60,8 @@ mod error;
 pub use error::ParseError;
 
 mod table_ref;
+#[cfg(test)]
+mod table_ref_test;
 #[cfg(feature = "arrow")]
 pub use crate::base::arrow::{
     arrow_array_to_column_conversion::{ArrayRefExt, ArrowArrayToColumnConversionError},

--- a/crates/proof-of-sql/src/base/database/table_ref_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref_test.rs
@@ -1,0 +1,74 @@
+use crate::base::database::{ParseError, TableRef};
+use indexmap::Equivalent;
+use sqlparser::ast::Ident;
+
+#[test]
+fn new_omits_empty_schema_name() {
+    let table = TableRef::new("", "people");
+
+    assert_eq!(table.schema_id(), None);
+    assert_eq!(table.table_id().value, "people");
+    assert_eq!(table.to_string(), "people");
+}
+
+#[test]
+fn from_strs_supports_one_or_two_components() {
+    let without_schema = TableRef::from_strs(&["people"]).unwrap();
+    let with_schema = TableRef::from_strs(&["public", "people"]).unwrap();
+
+    assert_eq!(without_schema.schema_id(), None);
+    assert_eq!(without_schema.table_id().value, "people");
+    assert_eq!(
+        with_schema.schema_id().map(|ident| ident.value.as_str()),
+        Some("public")
+    );
+    assert_eq!(with_schema.table_id().value, "people");
+}
+
+#[test]
+fn from_strs_rejects_invalid_component_counts() {
+    let err = TableRef::from_strs(&["db", "public", "people"]).unwrap_err();
+
+    assert_eq!(
+        err,
+        ParseError::InvalidTableReference {
+            table_reference: "db,public,people".to_string(),
+        }
+    );
+}
+
+#[test]
+fn try_from_str_round_trips_through_display_and_serde() {
+    let table = TableRef::try_from("public.people").unwrap();
+
+    assert_eq!(table.to_string(), "public.people");
+    let serialized = serde_json::to_string(&table).unwrap();
+    assert_eq!(serialized, "\"public.people\"");
+
+    let decoded: TableRef = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(decoded, table);
+}
+
+#[test]
+fn try_from_str_rejects_too_many_components() {
+    let err = TableRef::try_from("db.public.people").unwrap_err();
+
+    assert_eq!(
+        err,
+        ParseError::InvalidTableReference {
+            table_reference: "db.public.people".to_string(),
+        }
+    );
+}
+
+#[test]
+fn from_idents_and_equivalent_consider_schema_and_table_name() {
+    let left = TableRef::from_idents(Some(Ident::new("public")), Ident::new("people"));
+    let same = TableRef::from_names(Some("public"), "people");
+    let different_schema = TableRef::from_names(Some("private"), "people");
+    let different_table = TableRef::from_names(Some("public"), "orders");
+
+    assert!((&left).equivalent(&same));
+    assert!(!(&left).equivalent(&different_schema));
+    assert!(!(&left).equivalent(&different_table));
+}

--- a/crates/proof-of-sql/src/base/encode/zigzag_test.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag_test.rs
@@ -99,3 +99,41 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
             == U256::from_words(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128, 0x1_u128)
     );
 }
+
+#[test]
+fn even_zigzag_values_decode_to_positive_scalars() {
+    assert_eq!(U256::from_words(0, 0).zigzag(), TestScalar::from(0_u64));
+    assert_eq!(U256::from_words(2, 0).zigzag(), TestScalar::from(1_u8));
+    assert_eq!(U256::from_words(4, 0).zigzag(), TestScalar::from(2_u32));
+    assert_eq!(
+        U256::from_words(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_fffe, 0x1).zigzag(),
+        TestScalar::from(u128::MAX)
+    );
+
+    for x in 0..1000_u128 {
+        assert_eq!(U256::from_words(2 * x, 0).zigzag(), TestScalar::from(x));
+    }
+}
+
+#[test]
+fn odd_zigzag_values_decode_to_negative_scalars() {
+    assert_eq!(U256::from_words(1, 0).zigzag(), -TestScalar::from(1_u32));
+    assert_eq!(U256::from_words(3, 0).zigzag(), -TestScalar::from(2_u32));
+
+    for y in 1..1000_u128 {
+        assert_eq!(
+            U256::from_words(2 * y - 1, 0).zigzag(),
+            -TestScalar::from(y)
+        );
+    }
+}
+
+#[test]
+fn odd_zigzag_values_with_low_word_carry_round_trip() {
+    let encoded = U256::from_words(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128, 0x1_u128);
+    let magnitude: TestScalar = (&U256::from_words(0, 1)).into();
+    let decoded: TestScalar = encoded.zigzag();
+
+    assert_eq!(decoded, -magnitude);
+    assert!(decoded.zigzag() == encoded);
+}


### PR DESCRIPTION
/claim #560

Adds focused coverage for two uncovered areas:
- `TableRef` parsing, display, serde round-trips, and invalid component counts
- `ZigZag` decoding paths, including positive/negative decoding and a low-word carry round-trip case

Validation:
- `cargo test -p proof-of-sql zigzag --no-default-features --features="test" --no-run`
- `cargo test -p proof-of-sql table_ref --no-default-features --features="test" --no-run`
- targeted exact tests for the newly added `table_ref` and `zigzag` cases