### PR TITLE
test: cover BigDecimalExt scaled conversions

### DIFF
--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -89,4 +89,24 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, IntermediateDecimalError::ConversionFailure));
     }
+
+    #[test]
+    fn we_can_convert_decimal_to_bigint_with_extra_scale() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+        let bigint = big_decimal
+            .try_into_bigint_with_precision_and_scale(7, 4)
+            .unwrap();
+
+        assert_eq!(bigint.to_string(), "1234500");
+    }
+
+    #[test]
+    fn we_can_catch_lossy_cast_when_scaled_digits_exceed_precision() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+        let err = big_decimal
+            .try_into_bigint_with_precision_and_scale(4, 2)
+            .unwrap_err();
+
+        assert!(matches!(err, IntermediateDecimalError::LossyCast));
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for `BigDecimalExt::try_into_bigint_with_precision_and_scale`
- cover successful scaling to a larger target scale
- cover the `LossyCast` branch when scaled digits exceed precision

## Coverage accounting
Compared against `upstream/main` with the same filtered llvm-cov command, the following production lines in `crates/proof-of-sql/src/base/math/big_decimal_ext.rs` moved from uncovered to covered:

- 41: `0 -> 2`
- 42: `0 -> 2`
- 43: `0 -> 2`
- 44: `0 -> 1`
- 45: `0 -> 1`
- 46: `0 -> 1`
- 47: `0 -> 1`

Final covered-line accounting is left to the maintainer baseline.

## Verification
- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features std big_decimal_ext`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features std --lib --lcov --output-path target/proof-of-sql-std-big-decimal-current.lcov -- big_decimal_ext`