### PR TITLE
test: cover sumcheck rho256 evaluation

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
@@ -47,4 +47,33 @@ fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
         *evals.chi_evaluations.values().next().unwrap(),
         expected_eval
     );
+    assert_eq!(evals.rho_256_evaluation, None);
+}
+
+#[test]
+fn we_can_compute_rho_256_evaluation_for_eight_variable_points() {
+    let evaluation_point = [
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+    ];
+    let random_scalars = [Curve25519Scalar::from(2u64); 8];
+    let sumcheck_random_scalars = SumcheckRandomScalars::new(&random_scalars, 2, 8);
+
+    let evals = SumcheckMleEvaluations::new(
+        2,
+        [],
+        [],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &[],
+        &[],
+    );
+
+    assert_eq!(evals.rho_256_evaluation, Some(Curve25519Scalar::from(5u64)));
 }


### PR DESCRIPTION
## Summary
- add focused coverage for `SumcheckMleEvaluations::new` when the evaluation point has eight variables
- verify `rho_256_evaluation` computes the expected low-byte value and remains `None` for shorter points
- keep the change test-only and scoped to `sumcheck_mle_evaluations_test.rs`

/claim #560

## Coverage evidence
Baseline full std LCOV on upstream/main showed these production lines in `crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations.rs` uncovered:
- 65-69
- 71-74

Focused LCOV after this patch shows those lines covered: line 65-68 = 1 hit, line 69 = 8 hits, lines 71-74 = 1 hit.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features std sumcheck_mle_evaluations -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features std --lib --lcov --output-path target/sumcheck-mle-evaluations-rho256.lcov -- sumcheck_mle_evaluations`
- `cargo fmt --all -- --check`
- `git diff --check`

AI-assisted with OpenAI Codex; I reviewed and verified the diff before submitting.