### PR TITLE
test: cache Dory evaluation proof setups

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,6 +1,7 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    test_rng,
+    test_setup_cache::{cached_prover_setup, cached_verifier_setup},
+    DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -8,45 +9,41 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(4);
+    let verifier_setup = cached_verifier_setup(4);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(prover_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(prover_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(6);
+    let verifier_setup = cached_verifier_setup(6);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(prover_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(4);
+    let verifier_setup = cached_verifier_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(prover_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(prover_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(6);
+    let verifier_setup = cached_verifier_setup(6);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(prover_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
@@ -55,15 +52,14 @@ fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
     let setup_setup = [(4, 4), (4, 3), (6, 2)];
     for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let prover_setup = cached_prover_setup(setup_p.0);
+        let verifier_setup = cached_verifier_setup(setup_p.0);
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
-                &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &DoryProverPublicSetup::new(prover_setup, setup_p.1),
+                &DoryVerifierPublicSetup::new(verifier_setup, setup_p.1),
             );
         }
     }
@@ -72,8 +68,7 @@ fn test_random_ipa_with_various_lengths() {
 #[test]
 fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
     let mut rng = test_rng();
-    let public_parameters = PublicParameters::test_rand(4, &mut rng);
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(4);
     let a = core::iter::repeat_with(|| DoryScalar::rand(&mut rng))
         .take(30)
         .collect::<Vec<_>>();
@@ -86,7 +81,7 @@ fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
         &a,
         &b_point,
         0,
-        &DoryProverPublicSetup::new(&prover_setup, 3),
+        &DoryProverPublicSetup::new(prover_setup, 3),
     );
     let encoded = postcard::to_allocvec(&proof).unwrap();
     let decoded: DoryEvaluationProof = postcard::from_bytes(&encoded).unwrap();

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -1,5 +1,7 @@
 use super::{
-    test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
+    test_rng,
+    test_setup_cache::{cached_prover_setup, cached_verifier_setup},
+    DoryScalar, DynamicDoryEvaluationProof,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -7,53 +9,48 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(4);
+    let verifier_setup = cached_verifier_setup(4);
     test_simple_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &prover_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(4);
+    let verifier_setup = cached_verifier_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &prover_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 #[should_panic = "verification improperly failed"]
 fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(6);
+    let verifier_setup = cached_verifier_setup(2);
     test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
         128,
         0,
-        &&prover_setup,
-        &&verifier_setup,
+        &prover_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(6);
+    let verifier_setup = cached_verifier_setup(6);
     for length in lengths {
         test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
             length,
             0,
-            &&prover_setup,
-            &&verifier_setup,
+            &prover_setup,
+            &verifier_setup,
         );
     }
 }
@@ -61,8 +58,7 @@ fn test_random_ipa_with_various_lengths() {
 #[test]
 fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
     let mut rng = test_rng();
-    let public_parameters = PublicParameters::test_rand(4, &mut rng);
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let prover_setup = cached_prover_setup(4);
     let a = core::iter::repeat_with(|| DoryScalar::rand(&mut rng))
         .take(30)
         .collect::<Vec<_>>();
@@ -70,7 +66,7 @@ fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
         .take(5)
         .collect::<Vec<_>>();
     let mut transcript = Transcript::new(b"evaluation_proof");
-    let proof = DynamicDoryEvaluationProof::new(&mut transcript, &a, &b_point, 0, &&prover_setup);
+    let proof = DynamicDoryEvaluationProof::new(&mut transcript, &a, &b_point, 0, &prover_setup);
     let encoded = postcard::to_allocvec(&proof).unwrap();
     let decoded: DynamicDoryEvaluationProof = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(decoded, proof);

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -39,6 +39,8 @@ mod setup;
 pub use setup::{ProverSetup, VerifierSetup};
 #[cfg(test)]
 mod setup_test;
+#[cfg(test)]
+mod test_setup_cache;
 
 mod state;
 pub(crate) use state::{ProverState, VerifierState};

--- a/crates/proof-of-sql/src/proof_primitive/dory/test_setup_cache.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/test_setup_cache.rs
@@ -1,0 +1,60 @@
+use super::{test_rng, ProverSetup, PublicParameters, VerifierSetup};
+use std::sync::OnceLock;
+
+pub(super) fn cached_public_parameters(max_nu: usize) -> &'static PublicParameters {
+    fn get_or_init(
+        cache: &'static OnceLock<PublicParameters>,
+        max_nu: usize,
+    ) -> &'static PublicParameters {
+        cache.get_or_init(|| PublicParameters::test_rand(max_nu, &mut test_rng()))
+    }
+
+    static NU_2: OnceLock<PublicParameters> = OnceLock::new();
+    static NU_4: OnceLock<PublicParameters> = OnceLock::new();
+    static NU_6: OnceLock<PublicParameters> = OnceLock::new();
+
+    match max_nu {
+        2 => get_or_init(&NU_2, 2),
+        4 => get_or_init(&NU_4, 4),
+        6 => get_or_init(&NU_6, 6),
+        _ => panic!("no cached Dory test setup for max_nu {max_nu}"),
+    }
+}
+
+pub(super) fn cached_prover_setup(max_nu: usize) -> &'static ProverSetup<'static> {
+    fn get_or_init(
+        cache: &'static OnceLock<ProverSetup<'static>>,
+        max_nu: usize,
+    ) -> &'static ProverSetup<'static> {
+        cache.get_or_init(|| ProverSetup::from(cached_public_parameters(max_nu)))
+    }
+
+    static NU_4: OnceLock<ProverSetup<'static>> = OnceLock::new();
+    static NU_6: OnceLock<ProverSetup<'static>> = OnceLock::new();
+
+    match max_nu {
+        4 => get_or_init(&NU_4, 4),
+        6 => get_or_init(&NU_6, 6),
+        _ => panic!("no cached Dory prover setup for max_nu {max_nu}"),
+    }
+}
+
+pub(super) fn cached_verifier_setup(max_nu: usize) -> &'static VerifierSetup {
+    fn get_or_init(
+        cache: &'static OnceLock<VerifierSetup>,
+        max_nu: usize,
+    ) -> &'static VerifierSetup {
+        cache.get_or_init(|| VerifierSetup::from(cached_public_parameters(max_nu)))
+    }
+
+    static NU_2: OnceLock<VerifierSetup> = OnceLock::new();
+    static NU_4: OnceLock<VerifierSetup> = OnceLock::new();
+    static NU_6: OnceLock<VerifierSetup> = OnceLock::new();
+
+    match max_nu {
+        2 => get_or_init(&NU_2, 2),
+        4 => get_or_init(&NU_4, 4),
+        6 => get_or_init(&NU_6, 6),
+        _ => panic!("no cached Dory verifier setup for max_nu {max_nu}"),
+    }
+}


### PR DESCRIPTION
/claim #557

## Summary
- Adds a test-only Dory setup cache for the expensive public parameter, prover setup, and verifier setup constructors used by the Dory evaluation proof tests.
- Reuses cached `max_nu` 2/4/6 setups across the static and dynamic Dory evaluation proof suites.
- Keeps production code unchanged; the cached helpers are compiled only for tests.

## Validation
- `C:\Users\Mio\.cargo\bin\cargo.exe fmt --all -- --check`
- `git diff --check`
- `wsl.exe bash -lc "source $HOME/.cargo/env && cd /mnt/c/Users/Mio/oss-bounty-work/sxt-proof-of-sql && cargo test -p proof-of-sql --lib dory_commitment_evaluation_proof_test -- --nocapture"`

## Notes
Windows default-feature validation is not viable because `blitzar-sys` is Linux-only, so I validated the default-feature test path under WSL Ubuntu.

AI-assisted implementation disclosure: I used Codex to prepare and validate this test-performance change.
