### PR TITLE
test: cover decimal proof expression metadata

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -78,3 +78,46 @@ pub(crate) trait DecimalProofExpr: ProofExpr {
         self.data_type().scale().expect("Scale should be valid")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DecimalProofExpr;
+    use crate::{
+        base::{
+            database::LiteralValue,
+            math::{decimal::Precision, i256::I256},
+        },
+        sql::proof_exprs::{AddExpr, DynProofExpr, MultiplyExpr, SubtractExpr},
+    };
+
+    fn decimal_literal(precision: u8, scale: i8, value: impl Into<I256>) -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Decimal75(
+            Precision::new(precision).unwrap(),
+            scale,
+            value.into(),
+        ))
+    }
+
+    fn assert_decimal_metadata(expr: &impl DecimalProofExpr) {
+        let data_type = expr.data_type();
+        assert_eq!(
+            expr.precision(),
+            Precision::new(data_type.precision_value().unwrap()).unwrap()
+        );
+        assert_eq!(expr.scale(), data_type.scale().unwrap());
+    }
+
+    #[test]
+    fn decimal_proof_expr_metadata_matches_add_subtract_and_multiply_result_types() {
+        let lhs = decimal_literal(12, 3, 1234);
+        let rhs = decimal_literal(12, 3, 567);
+
+        assert_decimal_metadata(
+            &AddExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap(),
+        );
+        assert_decimal_metadata(
+            &SubtractExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap(),
+        );
+        assert_decimal_metadata(&MultiplyExpr::try_new(Box::new(lhs), Box::new(rhs)).unwrap());
+    }
+}


### PR DESCRIPTION
/claim #560

# Rationale for this change

The `DecimalProofExpr` default metadata helpers were not exercised in the std-only coverage baseline. This adds a narrow unit test that constructs decimal add, subtract, and multiply proof expressions and asserts that their `precision()` and `scale()` helpers agree with the expression result type metadata.

# What changes are included in this PR?

- Adds an in-file unit test for `DecimalProofExpr` metadata helpers.
- Covers the helper implementations through `AddExpr`, `SubtractExpr`, and `MultiplyExpr`.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql --no-default-features --features std decimal_proof_expr_metadata -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features std --lib --lcov --output-path target/proof-expr-decimal-metadata.lcov -- decimal_proof_expr_metadata`
- `cargo fmt --all -- --check`
- `git diff --check`

Focused LCOV for `crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs` moved the production helper lines from 0 hits in the baseline to covered in this focused run.