### PR TITLE
test: cover owned column OR length mismatch

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -112,6 +112,12 @@ mod test {
             Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
+        let result = lhs.element_wise_or(&rhs);
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::DifferentColumnLength { .. })
+        ));
+
         let result = lhs.element_wise_eq(&rhs);
         assert!(matches!(
             result,


### PR DESCRIPTION
## Summary
- add `element_wise_or` to the existing different-length owned-column operation test
- covers the early `DifferentColumnLength` branch before OR type dispatch

## Coverage
- baseline LCOV had `owned_column_operation.rs` lines 47-50 uncovered
- targeted LCOV now covers lines 47-50 through `we_cannot_do_binary_operation_on_columns_with_different_lengths`

## Validation
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib --no-default-features --features arrow we_cannot_do_binary_operation_on_columns_with_different_lengths -- --nocapture`
- `BLITZAR_BACKEND=cpu cargo llvm-cov -p proof-of-sql --lib --no-default-features --features arrow --lcov --output-path target/owned-column-operation-or-mismatch.lcov -- we_cannot_do_binary_operation_on_columns_with_different_lengths`
- `cargo fmt --all -- --check`
- `git diff --check`

/claim #560