### PR TITLE
test: cover Dory offset byte encoding

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -60,3 +60,64 @@ impl OffsetToBytes<32> for [u64; 4] {
         bytemuck::cast(*self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OffsetToBytes;
+
+    #[test]
+    fn unsigned_values_are_encoded_as_little_endian_bytes() {
+        assert_eq!(0_u8.offset_to_bytes(), [0]);
+        assert_eq!(255_u8.offset_to_bytes(), [255]);
+
+        let value = 0x0123_4567_89ab_cdef_u64;
+        assert_eq!(value.offset_to_bytes(), value.to_le_bytes());
+    }
+
+    #[test]
+    fn signed_values_are_offset_before_little_endian_encoding() {
+        assert_eq!(i8::MIN.offset_to_bytes(), [0]);
+        assert_eq!(0_i8.offset_to_bytes(), [128]);
+        assert_eq!(i8::MAX.offset_to_bytes(), [255]);
+
+        assert_eq!(i16::MIN.offset_to_bytes(), 0_u16.to_le_bytes());
+        assert_eq!(0_i16.offset_to_bytes(), 0x8000_u16.to_le_bytes());
+        assert_eq!(i16::MAX.offset_to_bytes(), u16::MAX.to_le_bytes());
+
+        assert_eq!(i32::MIN.offset_to_bytes(), 0_u32.to_le_bytes());
+        assert_eq!(0_i32.offset_to_bytes(), 0x8000_0000_u32.to_le_bytes());
+        assert_eq!(i32::MAX.offset_to_bytes(), u32::MAX.to_le_bytes());
+
+        assert_eq!(i64::MIN.offset_to_bytes(), 0_u64.to_le_bytes());
+        assert_eq!(
+            0_i64.offset_to_bytes(),
+            0x8000_0000_0000_0000_u64.to_le_bytes()
+        );
+        assert_eq!(i64::MAX.offset_to_bytes(), u64::MAX.to_le_bytes());
+
+        assert_eq!(i128::MIN.offset_to_bytes(), 0_u128.to_le_bytes());
+        assert_eq!(
+            0_i128.offset_to_bytes(),
+            0x8000_0000_0000_0000_0000_0000_0000_0000_u128.to_le_bytes()
+        );
+        assert_eq!(i128::MAX.offset_to_bytes(), u128::MAX.to_le_bytes());
+    }
+
+    #[test]
+    fn booleans_are_encoded_as_zero_or_one() {
+        assert_eq!(false.offset_to_bytes(), [0]);
+        assert_eq!(true.offset_to_bytes(), [1]);
+    }
+
+    #[test]
+    fn u64_arrays_are_encoded_as_contiguous_native_endian_words() {
+        let values = [0_u64, 1_u64, 0x0123_4567_89ab_cdef_u64, u64::MAX];
+        let mut expected = [0; 32];
+        for (index, value) in values.iter().enumerate() {
+            let start = index * 8;
+            expected[start..start + 8].copy_from_slice(&value.to_ne_bytes());
+        }
+
+        assert_eq!(values.offset_to_bytes(), expected);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

Adds focused unit tests for Dory offset byte encoding across unsigned integers, signed integer boundary values, booleans, and fixed-size u64 arrays. This improves coverage for the OffsetToBytes implementations without changing runtime behavior.



<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
