### PR TITLE
test: cover small helper branches

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -171,6 +171,19 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
     }
 }
 
+#[cfg(test)]
+mod no_blitzar_tests {
+    use super::*;
+    use crate::base::commitment::naive_commitment::NaiveCommitment;
+
+    #[test]
+    fn we_can_count_commitments() {
+        let commitments = vec![NaiveCommitment::default(), NaiveCommitment::default()];
+
+        assert_eq!(commitments.num_commitments(), 2);
+    }
+}
+
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -578,4 +578,198 @@ mod tests {
         let round_trip_owned: OwnedColumn<TestScalar> = (&column).into();
         assert_eq!(owned_varbinary, round_trip_owned);
     }
+
+    #[test]
+    fn we_can_create_constant_columns_from_literals() {
+        let alloc = Bump::new();
+        let precision = Precision::new(10).unwrap();
+        let timezone = PoSQLTimeZone::utc();
+
+        let cases = [
+            (
+                LiteralValue::Boolean(true),
+                ColumnType::Boolean,
+                TestScalar::from(true),
+            ),
+            (
+                LiteralValue::Uint8(2),
+                ColumnType::Uint8,
+                TestScalar::from(2_u8),
+            ),
+            (
+                LiteralValue::TinyInt(-3),
+                ColumnType::TinyInt,
+                TestScalar::from(-3_i8),
+            ),
+            (
+                LiteralValue::SmallInt(4),
+                ColumnType::SmallInt,
+                TestScalar::from(4_i16),
+            ),
+            (
+                LiteralValue::Int(-5),
+                ColumnType::Int,
+                TestScalar::from(-5_i32),
+            ),
+            (
+                LiteralValue::BigInt(6),
+                ColumnType::BigInt,
+                TestScalar::from(6_i64),
+            ),
+            (
+                LiteralValue::Int128(-7),
+                ColumnType::Int128,
+                TestScalar::from(-7_i128),
+            ),
+            (
+                LiteralValue::Scalar([8, 0, 0, 0]),
+                ColumnType::Scalar,
+                TestScalar::from([8, 0, 0, 0]),
+            ),
+            (
+                LiteralValue::Decimal75(precision, 2, 9.into()),
+                ColumnType::Decimal75(precision, 2),
+                TestScalar::from(9_i32),
+            ),
+            (
+                LiteralValue::TimeStampTZ(PoSQLTimeUnit::Second, timezone, 10),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, timezone),
+                TestScalar::from(10_i64),
+            ),
+            (
+                LiteralValue::VarChar("abc".into()),
+                ColumnType::VarChar,
+                TestScalar::from("abc"),
+            ),
+            (
+                LiteralValue::VarBinary(vec![1, 2, 3]),
+                ColumnType::VarBinary,
+                TestScalar::from_byte_slice_via_hash(&[1, 2, 3]),
+            ),
+        ];
+
+        for (literal, column_type, expected_scalar) in cases {
+            let column: Column<'_, TestScalar> =
+                Column::from_literal_with_length(&literal, 3, &alloc);
+            assert_eq!(column.len(), 3);
+            assert_eq!(column.column_type(), column_type);
+            assert_eq!(column.to_scalar(), vec![expected_scalar; 3]);
+        }
+    }
+
+    #[test]
+    fn we_can_create_rho_columns() {
+        let alloc = Bump::new();
+        let column = Column::<TestScalar>::rho(4, &alloc);
+
+        assert_eq!(column, Column::Int128(&[0, 1, 2, 3]));
+    }
+
+    #[test]
+    fn we_can_get_typed_column_accessors() {
+        let scalars = [TestScalar::from(1), TestScalar::from(2)];
+        let strings = ["a", "b"];
+        let bytes: &[&[u8]] = &[b"a", b"b"];
+        let precision = Precision::new(10).unwrap();
+        let timezone = PoSQLTimeZone::utc();
+
+        let boolean = Column::<TestScalar>::Boolean(&[true, false]);
+        assert_eq!(boolean.as_boolean(), Some(&[true, false][..]));
+        assert_eq!(boolean.as_uint8(), None);
+
+        let uint8 = Column::<TestScalar>::Uint8(&[1, 2]);
+        assert_eq!(uint8.as_uint8(), Some(&[1, 2][..]));
+        assert_eq!(uint8.as_boolean(), None);
+
+        let tinyint = Column::<TestScalar>::TinyInt(&[-1, 2]);
+        assert_eq!(tinyint.as_tinyint(), Some(&[-1, 2][..]));
+
+        let smallint = Column::<TestScalar>::SmallInt(&[-3, 4]);
+        assert_eq!(smallint.as_smallint(), Some(&[-3, 4][..]));
+
+        let int = Column::<TestScalar>::Int(&[-5, 6]);
+        assert_eq!(int.as_int(), Some(&[-5, 6][..]));
+
+        let bigint = Column::<TestScalar>::BigInt(&[-7, 8]);
+        assert_eq!(bigint.as_bigint(), Some(&[-7, 8][..]));
+
+        let int128 = Column::<TestScalar>::Int128(&[-9, 10]);
+        assert_eq!(int128.as_int128(), Some(&[-9, 10][..]));
+
+        let scalar = Column::Scalar(&scalars);
+        assert_eq!(scalar.as_scalar(), Some(&scalars[..]));
+
+        let decimal = Column::Decimal75(precision, 2, &scalars);
+        assert_eq!(decimal.as_decimal75(), Some(&scalars[..]));
+
+        let varchar = Column::VarChar((&strings, &scalars));
+        assert_eq!(varchar.as_varchar(), Some((&strings[..], &scalars[..])));
+
+        let varbinary = Column::VarBinary((bytes, &scalars));
+        assert_eq!(varbinary.as_varbinary(), Some((bytes, &scalars[..])));
+
+        let timestamptz =
+            Column::<TestScalar>::TimestampTZ(PoSQLTimeUnit::Millisecond, timezone, &[11, 12]);
+        assert_eq!(timestamptz.as_timestamptz(), Some(&[11, 12][..]));
+    }
+
+    #[test]
+    fn we_can_get_column_values_as_scalars() {
+        let scalars = [TestScalar::from(1), TestScalar::from(2)];
+        let strings = ["a", "b"];
+        let bytes: &[&[u8]] = &[b"a", b"b"];
+        let binary_scalars = [
+            TestScalar::from_byte_slice_via_hash(b"a"),
+            TestScalar::from_byte_slice_via_hash(b"b"),
+        ];
+        let precision = Precision::new(10).unwrap();
+        let timezone = PoSQLTimeZone::utc();
+
+        let cases = [
+            (
+                Column::<TestScalar>::Boolean(&[true, false]),
+                vec![TestScalar::from(true), TestScalar::from(false)],
+            ),
+            (
+                Column::<TestScalar>::Uint8(&[1, 2]),
+                vec![TestScalar::from(1_u8), TestScalar::from(2_u8)],
+            ),
+            (
+                Column::<TestScalar>::TinyInt(&[-1, 2]),
+                vec![TestScalar::from(-1_i8), TestScalar::from(2_i8)],
+            ),
+            (
+                Column::<TestScalar>::SmallInt(&[-3, 4]),
+                vec![TestScalar::from(-3_i16), TestScalar::from(4_i16)],
+            ),
+            (
+                Column::<TestScalar>::Int(&[-5, 6]),
+                vec![TestScalar::from(-5_i32), TestScalar::from(6_i32)],
+            ),
+            (
+                Column::<TestScalar>::BigInt(&[-7, 8]),
+                vec![TestScalar::from(-7_i64), TestScalar::from(8_i64)],
+            ),
+            (
+                Column::<TestScalar>::Int128(&[-9, 10]),
+                vec![TestScalar::from(-9_i128), TestScalar::from(10_i128)],
+            ),
+            (Column::Scalar(&scalars), scalars.to_vec()),
+            (Column::Decimal75(precision, 2, &scalars), scalars.to_vec()),
+            (Column::VarChar((&strings, &scalars)), scalars.to_vec()),
+            (
+                Column::VarBinary((bytes, &binary_scalars)),
+                binary_scalars.to_vec(),
+            ),
+            (
+                Column::<TestScalar>::TimestampTZ(PoSQLTimeUnit::Millisecond, timezone, &[11, 12]),
+                vec![TestScalar::from(11_i64), TestScalar::from(12_i64)],
+            ),
+        ];
+
+        for (column, expected_scalars) in cases {
+            assert_eq!(column.scalar_at(0), Some(expected_scalars[0]));
+            assert_eq!(column.to_scalar(), expected_scalars);
+        }
+    }
 }

--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -780,6 +780,17 @@ mod tests {
         assert_eq!(result, &[1, 0, 3, 1], "Expected multiplicities");
     }
 
+    #[test]
+    fn we_can_get_multiplicities_when_data_has_smaller_rows() {
+        let alloc = Bump::new();
+        let data = vec![Column::<TestScalar>::Int(&[1, 3])];
+        let unique = vec![Column::<TestScalar>::Int(&[3])];
+
+        let result = get_multiplicities(&data, &unique, &alloc);
+
+        assert_eq!(result, &[1]);
+    }
+
     // Get Columns of Table
     #[test]
     fn we_can_get_columns_of_table() {
@@ -904,6 +915,16 @@ mod tests {
         let left_on = vec![Column::<TestScalar>::Int(&[3_i32, 15, 9, 14, 15, 7])];
         let right_on = vec![Column::<TestScalar>::Int(&[10_i32, 11, 6, 5, 5, 4, 8])];
         let row_indexes = get_sort_merge_join_indexes(&left_on, &right_on, 6, 7);
+        assert!(row_indexes.is_empty());
+    }
+
+    #[test]
+    fn we_get_no_sort_merge_join_indexes_for_incompatible_column_types() {
+        let left_on = vec![Column::<TestScalar>::Int(&[1])];
+        let right_on = vec![Column::<TestScalar>::BigInt(&[1_i64])];
+
+        let row_indexes = get_sort_merge_join_indexes(&left_on, &right_on, 1, 1);
+
         assert!(row_indexes.is_empty());
     }
 

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
@@ -141,3 +141,38 @@ impl<'a, S: Scalar + 'a> IntoIterator for &'a OptimizedSumcheckTerms<'a, S> {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_merge_constant_only_terms_into_one_optimized_term() {
+        let constant_term = SumcheckTerm::<TestScalar>::new();
+        let optimizer = SumcheckTermOptimizer::new(
+            [
+                (
+                    SumcheckSubpolynomialType::ZeroSum,
+                    TestScalar::from(2),
+                    &constant_term,
+                ),
+                (
+                    SumcheckSubpolynomialType::ZeroSum,
+                    TestScalar::from(3),
+                    &constant_term,
+                ),
+            ]
+            .into_iter(),
+            4,
+        );
+        let terms = optimizer.terms();
+        let optimized_terms = (&terms).into_iter().collect::<Vec<_>>();
+
+        assert_eq!(optimized_terms.len(), 1);
+        let (ty, coeff, multiplicands) = optimized_terms[0];
+        assert_eq!(ty, SumcheckSubpolynomialType::ZeroSum);
+        assert_eq!(coeff, TestScalar::from(5));
+        assert!(multiplicands.is_empty());
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for constant-only `SumcheckTermOptimizer` merges
- cover `VecCommitmentExt::num_commitments` in the no-Blitzar test lane
- cover join helper branches for skipped smaller data rows and incompatible sort-merge join columns
- add no-default column helper coverage for literal-backed constant columns, `rho`, typed accessors, `scalar_at`, and `to_scalar` variants

## Coverage
Local LCOV for the no-default `test` lane now hits the previously uncovered production lines:
- `crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs`: 31-33
- `crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs`: 169-171
- `crates/proof-of-sql/src/base/database/join_util.rs`: 144-146, 330
- `crates/proof-of-sql/src/base/database/column.rs`: 58 baseline-zero lines moved to hits in local comparison (`113-114, 119-120, 122-124, 126-127, 129-130, 132-138, 140-142, 144, 146-147, 150-151, 153, 209, 217, 222-224, 227, 270-272, 275, 294-296, 299, 306, 314, 320-333, 335`)

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test sumcheck_term_optimizer -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test vec_commitment_ext -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test join_util -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test column::tests -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test -- we_`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --no-clean --lcov --output-path target/sxt-small-helper-coverage.lcov -- we_`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --no-clean --lcov --output-path target/proof-of-sql-column-current.lcov -- column::tests`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed and validated the diff locally.