### PR TITLE
test: cover bool VarInt implementation

### DIFF
--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -154,6 +154,13 @@ fn test_regression_22() {
     assert!(i8::decode_var(&encoded).is_none());
 }
 
+#[test]
+fn we_can_encode_and_decode_bool_values() {
+    test_encode_decode(false, [0]);
+    test_encode_decode(true, [1]);
+    assert!(bool::decode_var(&2_u8.encode_var_vec()).is_none());
+}
+
 // ------------------------------------------------------------------------------
 // End of tests taken directly from integer-encoding-rs with minimal modification
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add direct bool `VarInt` coverage for false, true, and invalid boolean values
- keeps production code unchanged

## Coverage
- baseline LCOV had `varint_trait.rs` bool implementation lines 136-138, 140-146, and 148-152 uncovered
- targeted LCOV now covers those bool `VarInt` production lines via `we_can_encode_and_decode_bool_values`

## Validation
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib --no-default-features --features arrow we_can_encode_and_decode_bool_values -- --nocapture`
- `BLITZAR_BACKEND=cpu cargo llvm-cov -p proof-of-sql --lib --no-default-features --features arrow --lcov --output-path target/bool-varint.lcov -- we_can_encode_and_decode_bool_values`
- `cargo fmt --all -- --check`
- `git diff --check`

/claim #560