### PR TITLE
test: cover mul_add_assign edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
@@ -12,6 +12,24 @@ fn test_mul_add_assign() {
     assert_eq!(a, c);
 }
 
+#[test]
+fn test_mul_add_assign_empty_input_keeps_result_unchanged() {
+    let mut a = [1, 2, 3].map(TestScalar::from).to_vec();
+    let b: Vec<i32> = Vec::new();
+    let expected = a.clone();
+    mul_add_assign(&mut a, TestScalar::from(10i32), &b);
+    assert_eq!(a, expected);
+}
+
+#[test]
+fn test_mul_add_assign_zero_multiplier_keeps_result_unchanged() {
+    let mut a = [1, 2, 3].map(TestScalar::from).to_vec();
+    let b = vec![10, 20, 30];
+    let expected = a.clone();
+    mul_add_assign(&mut a, TestScalar::from(0i32), &b);
+    assert_eq!(a, expected);
+}
+
 /// test [`mul_add_assign`] with uneven vectors
 #[test]
 fn test_mul_add_assign_uneven() {


### PR DESCRIPTION
## Summary

- Adds edge-case coverage for `mul_add_assign` when the input multiplier slice is empty.
- Adds coverage for a zero multiplier to confirm the destination slice remains unchanged.
- Keeps the change limited to the existing `mul_add_assign_test.rs` test module.

## Context

This contributes a small, non-overlapping test coverage slice for spaceandtimefdn/sxt-proof-of-sql#560.

/claim #560

## Verification

- `cargo test -p proof-of-sql mul_add_assign --no-default-features --features=std,test`
- `rustfmt --check crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs`
- `git diff --check origin/main...HEAD`
