### PR TITLE
test: add coverage for EVM proof plan error variants

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,46 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evm_proof_plan_error_display_messages_are_stable() {
+        assert_eq!(EVMProofPlanError::NotSupported.to_string(), "plan not yet supported");
+        assert_eq!(EVMProofPlanError::ColumnNotFound.to_string(), "column not found");
+        assert_eq!(EVMProofPlanError::TableNotFound.to_string(), "table not found");
+        assert_eq!(
+            EVMProofPlanError::InvalidTableName.to_string(),
+            "table name can not be parsed into TableRef"
+        );
+        assert_eq!(
+            EVMProofPlanError::InvalidOutputColumnName.to_string(),
+            "invalid or missing output column name"
+        );
+        assert_eq!(
+            EVMProofPlanError::InconsistentGroupByColumnCounts.to_string(),
+            "column counts in group by plans are inconsistent"
+        );
+        assert_eq!(
+            EVMProofPlanError::IncorrectScalingFactor.to_string(),
+            "incorrect scaling factor"
+        );
+    }
+
+    #[test]
+    fn analyze_error_variant_preserves_source_and_display() {
+        let err = EVMProofPlanError::AnalyzeError {
+            source: AnalyzeError::NotEnoughInputPlans,
+        };
+
+        assert_eq!(err.to_string(), "Not enough input plans");
+        assert_eq!(
+            err,
+            EVMProofPlanError::AnalyzeError {
+                source: AnalyzeError::NotEnoughInputPlans
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add focused tests for `EVMProofPlanError` display variants
- add wrapper-path test validating `AnalyzeError` source/display propagation
- keep runtime behavior unchanged (tests only)

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test sql::evm_proof_plan::error::tests:: -- --nocapture`

/claim #560