### PR TITLE
ci: skip benches in test jobs

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -116,7 +116,7 @@ jobs:
           key: ${{ matrix.rust }}
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
-      - run: cargo test --all-features
+      - run: cargo test --workspace --exclude proof-of-sql-benches --all-features
 
   testnorayon:
     name: Test Suite without rayon (${{ matrix.rust }})
@@ -144,7 +144,7 @@ jobs:
           key: ${{ matrix.rust }}
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
-      - run: cargo test --no-default-features --features="arrow blitzar"
+      - run: cargo test --workspace --exclude proof-of-sql-benches --no-default-features --features="arrow blitzar"
 
   testother:
     name: Test Suite other (${{ matrix.rust }})


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

/claim #557

# Rationale for this change

Issue #557 was clarified to include broad CI runtime improvements. The `test` and `testnorayon` workflow jobs currently run root-level `cargo test` commands from the virtual workspace, which selects every workspace member including `proof-of-sql-benches`.

`proof-of-sql-benches` is a benchmark-only crate with no `#[test]` tests, and the existing `check` job still compiles the workspace. The coverage workflow already excludes this crate as well. Excluding it from the test-only jobs should avoid compiling benchmark-only dependencies in the Rust test matrix without dropping actual test coverage.

# What changes are included in this PR?

- Change the all-features test job command to `cargo test --workspace --exclude proof-of-sql-benches --all-features`.
- Change the no-rayon test job command to `cargo test --workspace --exclude proof-of-sql-benches --no-default-features --features="arrow blitzar"`.
- Leave the check job and all Rust source code unchanged.

# Are these changes tested?

Static validation:

- `git diff --check HEAD~1..HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lint-and-test.yml"); puts "yaml ok"'`
- `bash scripts/check_commits.sh`
- `rg "#\\[test\\]" crates/proof-of-sql-benches` returned no matches

Limitations:

- I could not run `source scripts/run_ci_checks.sh` or the Cargo commands locally because this environment does not have Cargo installed. CI is the meaningful validation path for this workflow-only change.
