### PR TITLE
test(bit): add boundary coverage for make_bit_mask sign transition

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils_test.rs
@@ -1,7 +1,7 @@
 use super::bit_mask_utils::make_bit_mask;
 use crate::base::{
     bit::bit_mask_utils::is_bit_mask_negative_representation,
-    scalar::{test_scalar::TestScalar, Scalar},
+    scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
 };
 use bnum::types::U256;
 use core::ops::Shl;
@@ -54,4 +54,37 @@ fn we_can_verify_negative_bit_mask_is_negative_representation() {
 
     // ASSERT
     assert!(is_negative);
+}
+
+#[test]
+fn zero_maps_to_msb_only_and_is_not_negative_representation() {
+    // ACT
+    let bit_mask = make_bit_mask(TestScalar::ZERO);
+
+    // ASSERT
+    assert_eq!(bit_mask, U256::ONE.shl(255));
+    assert!(!is_bit_mask_negative_representation(bit_mask));
+}
+
+#[test]
+fn max_signed_stays_in_positive_representation_branch() {
+    // ACT
+    let bit_mask = make_bit_mask(TestScalar::MAX_SIGNED);
+
+    // ASSERT
+    assert_eq!(bit_mask, U256::ONE.shl(255) + TestScalar::MAX_SIGNED_U256);
+    assert!(!is_bit_mask_negative_representation(bit_mask));
+}
+
+#[test]
+fn first_value_above_max_signed_switches_to_negative_representation() {
+    // ARRANGE
+    let first_negative_like_value = TestScalar::from_wrapping(TestScalar::MAX_SIGNED_U256 + U256::ONE);
+
+    // ACT
+    let bit_mask = make_bit_mask(first_negative_like_value);
+
+    // ASSERT
+    assert_eq!(bit_mask, (U256::ONE.shl(255)) - TestScalar::MAX_SIGNED_U256);
+    assert!(is_bit_mask_negative_representation(bit_mask));
 }


### PR DESCRIPTION
## Summary
- add boundary test for zero in `make_bit_mask`
- add boundary test that `MAX_SIGNED` stays on positive representation branch
- add boundary test that first wrapped value above `MAX_SIGNED` flips to negative representation

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test bit_mask_utils_test -- --nocapture`

## Notes
- This is a small non-overlapping coverage slice for bounty issue #560 and does not change production behavior.