### PR TITLE
refactor: explicit Scalar limb conversions for #228 slice

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -155,7 +155,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 decimals
                     .iter()
                     .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|s| s.to_limbs())
                     .collect(),
             ),
             OwnedColumn::Scalar(scalars) => (scalars as &[_]).into(),
@@ -163,14 +163,14 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 strings
                     .iter()
                     .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|s| s.to_limbs())
                     .collect(),
             ),
             OwnedColumn::VarBinary(bytes) => CommittableColumn::VarBinary(
                 bytes
                     .iter()
                     .map(|b| S::from_byte_slice_via_hash(b))
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|s| s.to_limbs())
                     .collect(),
             ),
             OwnedColumn::TimestampTZ(tu, tz, times) => {

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -3,7 +3,6 @@ use crate::base::{
     if_rayon,
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    ref_into::RefInto,
     scalar::{Scalar, ScalarExt},
 };
 use alloc::vec::Vec;
@@ -116,16 +115,16 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::BigInt(ints) => CommittableColumn::BigInt(ints),
             Column::Int128(ints) => CommittableColumn::Int128(ints),
             Column::Decimal75(precision, scale, decimals) => {
-                let as_limbs: Vec<_> = decimals.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = decimals.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::Decimal75(*precision, *scale, as_limbs)
             }
             Column::Scalar(scalars) => (scalars as &[_]).into(),
             Column::VarChar((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarChar(as_limbs)
             }
             Column::VarBinary((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarBinary(as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
@@ -216,7 +215,7 @@ impl<'a, S: Scalar> From<&'a [S]> for CommittableColumn<'a> {
     fn from(value: &'a [S]) -> Self {
         CommittableColumn::Scalar(
             if_rayon!(value.par_iter(), value.iter())
-                .map(RefInto::<[u64; 4]>::ref_into)
+                .map(Scalar::to_limbs)
                 .collect(),
         )
     }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -127,7 +127,7 @@ impl<'a, S: Scalar> Column<'a, S> {
                 Column::Int128(alloc.alloc_slice_fill_copy(length, *value))
             }
             LiteralValue::Scalar(value) => {
-                Column::Scalar(alloc.alloc_slice_fill_copy(length, (*value).into()))
+                Column::Scalar(alloc.alloc_slice_fill_copy(length, S::from_limbs(*value)))
             }
             LiteralValue::Decimal75(precision, scale, value) => Column::Decimal75(
                 *precision,

--- a/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
@@ -254,7 +254,7 @@ pub trait ComparisonOp {
             (
                 OwnedColumn::Decimal75(_, _, lhs_values),
                 OwnedColumn::Decimal75(_, _, rhs_values),
-            ) => Ok(Self::decimal_op_left_upcast(
+            ) => Ok(Self::decimal_op_left_upcast::<S, S>(
                 lhs_values,
                 rhs_values,
                 lhs.column_type(),

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -85,7 +85,7 @@ impl LiteralValue {
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),
-            Self::Scalar(limbs) => (*limbs).into(),
+            Self::Scalar(limbs) => S::from_limbs(*limbs),
             Self::TimeStampTZ(_, _, time) => time.into(),
         }
     }

--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -49,9 +49,9 @@ impl I256 {
     /// NOTE: this is not a particularly efficient method. Please either refactor or avoid when performance matters.
     pub fn into_scalar<S: Scalar>(self) -> S {
         if self.0[3] & 0x8000_0000_0000_0000 == 0 {
-            self.0.into()
+            S::from_limbs(self.0)
         } else {
-            (Into::<S>::into(self.neg().0)).neg()
+            S::from_limbs(self.neg().0).neg()
         }
     }
 

--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -1,8 +1,5 @@
 use super::Transcript;
-use crate::base::{
-    ref_into::RefInto,
-    scalar::{Scalar, ScalarExt},
-};
+use crate::base::scalar::{Scalar, ScalarExt};
 use bnum::types::U256;
 use zerocopy::{AsBytes, FromBytes};
 
@@ -57,7 +54,7 @@ impl<T: TranscriptCore> Transcript for T {
         &mut self,
         messages: impl IntoIterator<Item = &'a S>,
     ) {
-        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(RefInto::ref_into));
+        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(Scalar::to_limbs));
     }
     fn scalar_challenge_as_be<S: Scalar>(&mut self) -> S {
         ScalarExt::from_wrapping(

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -230,7 +230,7 @@ where
         assert!(digits.len() <= 4); // This should not happen if the above check is correct
         let mut limbs = [0u64; 4];
         limbs[..digits.len()].copy_from_slice(&digits);
-        let result = Self::from(limbs);
+        let result = Self::from_limbs(limbs);
         Ok(match sign {
             num_bigint::Sign::Minus => -result,
             num_bigint::Sign::Plus | num_bigint::Sign::NoSign => result,
@@ -275,7 +275,7 @@ impl<T: MontConfig<4>> num_traits::Inv for MontScalar<T> {
 }
 impl<T: MontConfig<4>> Serialize for MontScalar<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut limbs: [u64; 4] = self.into();
+        let mut limbs = self.to_limbs();
         limbs.reverse();
         limbs.serialize(serializer)
     }
@@ -284,7 +284,7 @@ impl<'de, T: MontConfig<4>> Deserialize<'de> for MontScalar<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let mut limbs: [u64; 4] = Deserialize::deserialize(deserializer)?;
         limbs.reverse();
-        Ok(limbs.into())
+        Ok(Self::from_limbs(limbs))
     }
 }
 
@@ -403,6 +403,14 @@ where
         255 - T::MODULUS.0[3].leading_zeros() as u8
     };
     const MAX_SIGNED_U256: U256 = U256::from_digits(T::MODULUS.divide_by_2_round_down().0);
+
+    fn from_limbs(val: [u64; 4]) -> Self {
+        Self(Fp::new(ark_ff::BigInt(val)))
+    }
+
+    fn to_limbs(&self) -> [u64; 4] {
+        self.0.into_bigint().0
+    }
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool
@@ -413,9 +421,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -447,7 +455,7 @@ where
             });
         }
 
-        let abs: [u64; 4] = value.into();
+        let abs = value.to_limbs();
 
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -471,9 +479,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -495,9 +503,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -519,9 +527,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -543,9 +551,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -569,9 +577,9 @@ where
     #[expect(clippy::cast_possible_wrap)]
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -603,7 +611,7 @@ where
         } else {
             num_bigint::Sign::Plus
         };
-        let value_abs: [u64; 4] = (if is_negative { -value } else { value }).into();
+        let value_abs = (if is_negative { -value } else { value }).to_limbs();
         let bits: &[u8] = bytemuck::cast_slice(&value_abs);
         BigInt::from_bytes_le(sign, bits)
     }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
+use crate::base::{encode::VarInt, scalar::ScalarConversionError};
 use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
@@ -49,7 +49,6 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + RefInto<[u64; 4]>
     + for<'a> core::convert::From<&'a String>
     + VarInt
     + core::convert::From<String>

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -40,8 +40,6 @@ pub trait Scalar:
     + core::convert::TryInto <i32>
     + core::convert::TryInto <i64>
     + core::convert::TryInto <i128>
-    + core::convert::Into<[u64; 4]>
-    + core::convert::From<[u64; 4]>
     + core::convert::From<u8>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
@@ -65,6 +63,11 @@ pub trait Scalar:
     + core::convert::Into<BigInt>
     + TryFrom<BigInt, Error = ScalarConversionError>
 {
+    /// Convert limb representation into a scalar field element.
+    fn from_limbs(val: [u64; 4]) -> Self;
+    /// Convert a scalar field element into limb representation.
+    fn to_limbs(&self) -> [u64; 4];
+
     /// The value (p - 1) / 2. This is "mid-point" of the field - the "six" on the clock.
     /// It is the largest signed value that can be represented in the field with the natural embedding.
     const MAX_SIGNED: Self;

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -24,12 +24,12 @@ pub trait ScalarExt: Scalar {
     /// Converts a U256 to Scalar, wrapping as needed
     fn from_wrapping(value: U256) -> Self {
         let value_as_limbs: [u64; 4] = value.into();
-        Self::from(value_as_limbs)
+        Self::from_limbs(value_as_limbs)
     }
 
     /// Converts a Scalar to U256. Note that any values above `MAX_SIGNED` shall remain positive, even if they are representative of negative values.
     fn into_u256_wrapping(self) -> U256 {
-        U256::from(Into::<[u64; 4]>::into(self))
+        U256::from(self.to_limbs())
     }
 
     /// Converts a byte slice to a Scalar using a hash function, preventing collisions.
@@ -102,7 +102,7 @@ mod tests {
             u64::from_le_bytes(limbs_native[2].to_le_bytes()),
             u64::from_le_bytes(limbs_native[3].to_le_bytes()),
         ];
-        let scalar_from_ref = TestScalar::from(limbs_le);
+        let scalar_from_ref = TestScalar::from_limbs(limbs_le);
 
         assert_eq!(
             scalar_from_bytes, scalar_from_ref,

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
@@ -103,7 +103,7 @@ impl ProofExpr for ScalingCastExpr {
     ) -> Result<S, ProofError> {
         self.from_expr
             .verifier_evaluate(builder, accessor, chi_eval, params)
-            .map(|unscaled_eval| S::from(self.scaling_factor) * unscaled_eval)
+            .map(|unscaled_eval| S::from_limbs(self.scaling_factor) * unscaled_eval)
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -137,7 +137,7 @@ pub fn const_varbinary(val: &[u8]) -> DynProofExpr {
 
 /// Create a constant scalar value. Used if we don't want to specify column types.
 pub fn const_scalar<S: Scalar, T: Into<S>>(val: T) -> DynProofExpr {
-    DynProofExpr::new_literal(LiteralValue::Scalar(val.into().into()))
+    DynProofExpr::new_literal(LiteralValue::Scalar(val.into().to_limbs()))
 }
 
 /// # Panics

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -191,7 +191,7 @@ where
             .take(31)
             .collect();
     for (i, scalar) in column_data.iter().enumerate() {
-        let scalar_array: [u64; 4] = (*scalar).into().into();
+        let scalar_array = Into::<S>::into(*scalar).to_limbs();
         // Convert the [u64; 4] into a slice of bytes
         let scalar_bytes = &cast_slice::<u64, u8>(&scalar_array)[..31];
 


### PR DESCRIPTION
## Summary
This PR takes a focused first-slice pass on #228 by introducing explicit limb conversion methods on `Scalar` and migrating internal call sites in this slice away from implicit `From`/`Into<[u64; 4]>` bounds.

### Changes
- Add `Scalar::from_limbs([u64; 4])` and `Scalar::to_limbs(&self)`.
- Remove `Into<[u64; 4]>` and `From<[u64; 4]>` requirements from the `Scalar` trait bounds.
- Implement `from_limbs` / `to_limbs` for `MontScalar<T>`.
- Update affected scalar/column/proof-expression paths to use explicit methods.
- Keep existing concrete `From` impls on `MontScalar` and `[u64;4]` for compatibility, but stop depending on them via `Scalar` bounds.

### Validation
- `cargo test -p proof-of-sql --no-default-features --features test scalar_ext -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features test literal_value -- --nocapture`

/claim #228