### PR TITLE
test: cover error display paths

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,85 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_column_operation_errors() {
+        let cases = [
+            (
+                ColumnOperationError::DifferentColumnLength { len_a: 3, len_b: 4 },
+                "Columns have different lengths: 3 != 4",
+            ),
+            (
+                ColumnOperationError::BinaryOperationInvalidColumnType {
+                    operator: "add".to_string(),
+                    left_type: ColumnType::BigInt,
+                    right_type: ColumnType::VarChar,
+                },
+                "\"add\"(lhs: BigInt, rhs: VarChar) is not supported",
+            ),
+            (
+                ColumnOperationError::UnaryOperationInvalidColumnType {
+                    operator: "negation".to_string(),
+                    operand_type: ColumnType::Boolean,
+                },
+                "\"negation\"(operand: Boolean) is not supported",
+            ),
+            (
+                ColumnOperationError::IntegerOverflow {
+                    error: "i64 overflow".to_string(),
+                },
+                "Overflow in integer operation: i64 overflow",
+            ),
+            (ColumnOperationError::DivisionByZero, "Division by zero"),
+            (
+                ColumnOperationError::DecimalConversionError {
+                    source: DecimalError::InvalidDecimal {
+                        error: "not a decimal".to_string(),
+                    },
+                },
+                "Invalid decimal format or value: not a decimal",
+            ),
+            (
+                ColumnOperationError::UnionDifferentTypes {
+                    correct_type: ColumnType::BigInt,
+                    actual_type: ColumnType::Int,
+                },
+                "Cannot union columns of different types: BigInt and Int",
+            ),
+            (
+                ColumnOperationError::IndexOutOfBounds { index: 9, len: 7 },
+                "Index out of bounds: 9 >= 7",
+            ),
+            (
+                ColumnOperationError::SignedCastingError {
+                    left_type: ColumnType::TinyInt,
+                    right_type: ColumnType::Uint8,
+                },
+                "Cannot fit TINYINT into UINT8 without losing data",
+            ),
+            (
+                ColumnOperationError::CastingError {
+                    left_type: ColumnType::BigInt,
+                    right_type: ColumnType::Int,
+                },
+                "Cannot fit BIGINT into INT without losing data",
+            ),
+            (
+                ColumnOperationError::ScaleCastingError {
+                    left_type: ColumnType::Int128,
+                    right_type: ColumnType::SmallInt,
+                },
+                "Cannot fit DECIMAL into SMALLINT without losing data",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+}

--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,18 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_parse_errors() {
+        let error = ParseError::InvalidTableReference {
+            table_reference: "too.many.parts".to_string(),
+        };
+
+        assert_eq!(error.to_string(), "Invalid table reference: too.many.parts");
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,56 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_owned_column_errors() {
+        let cases = [
+            (
+                OwnedColumnError::TypeCastError {
+                    from_type: ColumnType::VarChar,
+                    to_type: ColumnType::BigInt,
+                },
+                "Can not perform type casting from VarChar to BigInt",
+            ),
+            (
+                OwnedColumnError::ScalarConversionError {
+                    error: "overflow".to_string(),
+                },
+                "Error in converting scalars to a given column type: overflow",
+            ),
+            (
+                OwnedColumnError::Unsupported {
+                    error: "varchar subtraction".to_string(),
+                },
+                "Unsupported operation: varchar subtraction",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn we_can_display_column_coercion_errors() {
+        let cases = [
+            (
+                ColumnCoercionError::Overflow,
+                "Overflow when coercing a column",
+            ),
+            (
+                ColumnCoercionError::InvalidTypeCoercion,
+                "Invalid type coercion",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,69 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{string::ToString, vec::Vec};
+
+    #[test]
+    fn we_can_display_table_operation_errors() {
+        let cases = [
+            (
+                TableOperationError::UnionIncompatibleSchemas {
+                    correct_schema: Vec::new(),
+                    actual_schema: Vec::new(),
+                },
+                "Cannot union tables with incompatible schemas: [] and []",
+            ),
+            (
+                TableOperationError::UnionNotEnoughTables,
+                "Cannot union fewer than 2 tables",
+            ),
+            (
+                TableOperationError::JoinWithDifferentNumberOfColumns {
+                    left_num_columns: 1,
+                    right_num_columns: 2,
+                },
+                "Cannot join tables with different numbers of columns: 1 and 2",
+            ),
+            (
+                TableOperationError::JoinIncompatibleTypes {
+                    left_type: ColumnType::BigInt,
+                    right_type: ColumnType::VarChar,
+                },
+                "Cannot join tables on columns with incompatible types: BigInt and VarChar",
+            ),
+            (
+                TableOperationError::DuplicateColumn,
+                "Some column is duplicated in table",
+            ),
+            (
+                TableOperationError::ColumnOperationError {
+                    source: ColumnOperationError::DivisionByZero,
+                },
+                "Division by zero",
+            ),
+            (
+                TableOperationError::ColumnIndexOutOfBounds { column_index: 5 },
+                "Column index out of bounds: 5",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn we_can_display_missing_column_errors() {
+        let error = TableOperationError::ColumnDoesNotExist {
+            column_ident: Ident::new("missing_column"),
+        };
+        let message = error.to_string();
+
+        assert!(message.starts_with("Column Ident { value: \"missing_column\""));
+        assert!(message.ends_with(" does not exist in table"));
+    }
+}

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,130 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_proof_errors() {
+        let cases = [
+            (
+                ProofError::VerificationError { error: "bad proof" },
+                "Verification error: bad proof",
+            ),
+            (
+                ProofError::UnsupportedQueryPlan { error: "aggregate" },
+                "Unsupported query plan: aggregate",
+            ),
+            (
+                ProofError::InvalidTypeCoercion,
+                "Result does not match query: type mismatch",
+            ),
+            (
+                ProofError::FieldNamesMismatch,
+                "Result does not match query: field names mismatch",
+            ),
+            (
+                ProofError::FieldCountMismatch,
+                "Result does not match query: field count mismatch",
+            ),
+            (
+                ProofError::ProofSizeMismatch {
+                    source: ProofSizeMismatch::TooFewMLEEvaluations,
+                },
+                "Proof has too few MLE evaluations",
+            ),
+            (
+                ProofError::PlaceholderError {
+                    source: PlaceholderError::ZeroPlaceholderId,
+                },
+                "Placeholder id must be greater than 0",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn we_can_display_proof_size_mismatch_errors() {
+        let cases = [
+            (
+                ProofSizeMismatch::SumcheckProofTooSmall,
+                "Sumcheck proof is too small",
+            ),
+            (
+                ProofSizeMismatch::TooFewMLEEvaluations,
+                "Proof has too few MLE evaluations",
+            ),
+            (
+                ProofSizeMismatch::PostResultCountMismatch,
+                "Post result challenge count mismatch",
+            ),
+            (
+                ProofSizeMismatch::ConstraintCountMismatch,
+                "Constraint count mismatch",
+            ),
+            (
+                ProofSizeMismatch::TooFewBitDistributions,
+                "Proof has too few bit distributions",
+            ),
+            (
+                ProofSizeMismatch::TooFewChiLengths,
+                "Proof has too few one lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewRhoLengths,
+                "Proof has too few rho lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewSumcheckVariables,
+                "Proof has too few sumcheck variables",
+            ),
+            (
+                ProofSizeMismatch::ChiLengthNotFound,
+                "Proof doesn't have requested one length",
+            ),
+            (
+                ProofSizeMismatch::RhoLengthNotFound,
+                "Proof doesn't have requested rho length",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn we_can_display_placeholder_errors() {
+        let cases = [
+            (
+                PlaceholderError::InvalidPlaceholderIndex {
+                    index: 3,
+                    num_params: 2,
+                },
+                "Invalid placeholder index: 3, number of params: 2",
+            ),
+            (
+                PlaceholderError::InvalidPlaceholderType {
+                    index: 1,
+                    expected: ColumnType::BigInt,
+                    actual: ColumnType::VarChar,
+                },
+                "Invalid placeholder type: 1, expected: BIGINT, actual: VARCHAR",
+            ),
+            (
+                PlaceholderError::ZeroPlaceholderId,
+                "Placeholder id must be greater than 0",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+}

--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,18 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_scalar_conversion_errors() {
+        let error = ScalarConversionError::Overflow {
+            error: "too many bits".to_string(),
+        };
+
+        assert_eq!(error.to_string(), "Overflow error: too many bits");
+    }
+}

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,71 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_analyze_errors() {
+        let cases = [
+            (
+                AnalyzeError::InvalidDataType {
+                    expr_type: ColumnType::VarChar,
+                },
+                "Expression has datatype VARCHAR, which was not valid",
+            ),
+            (
+                AnalyzeError::DataTypeMismatch {
+                    left_type: "BIGINT".to_string(),
+                    right_type: "BOOLEAN".to_string(),
+                },
+                "Left side has 'BIGINT' type but right side has 'BOOLEAN' type",
+            ),
+            (
+                AnalyzeError::DifferentColumnLength { len_a: 2, len_b: 5 },
+                "Columns have different lengths: 2 != 5",
+            ),
+            (
+                AnalyzeError::DecimalConversionError {
+                    source: DecimalError::InvalidScale {
+                        scale: "129".to_string(),
+                    },
+                },
+                "Decimal scale is not valid: 129",
+            ),
+            (
+                AnalyzeError::PlaceholderError {
+                    source: PlaceholderError::ZeroPlaceholderId,
+                },
+                "Placeholder id must be greater than 0",
+            ),
+            (AnalyzeError::NotEnoughInputPlans, "Not enough input plans"),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn we_can_convert_analyze_errors_into_strings() {
+        let message = String::from(AnalyzeError::DataTypeMismatch {
+            left_type: "INT".to_string(),
+            right_type: "VARCHAR".to_string(),
+        });
+
+        assert_eq!(
+            message,
+            "Left side has 'INT' type but right side has 'VARCHAR' type"
+        );
+    }
+
+    #[test]
+    fn we_can_convert_intermediate_decimal_errors_into_analyze_errors() {
+        let error = AnalyzeError::from(IntermediateDecimalError::OutOfRange);
+
+        assert_eq!(error.to_string(), "Value out of range for target type");
+    }
+}


### PR DESCRIPTION
## Summary
- add direct display coverage for proof, database, scalar, and analyze error variants
- cover transparent error forwarding and `AnalyzeError` string conversions

## Tests
- `cargo test -p proof-of-sql --no-default-features --features arrow,test we_can_display`
- `cargo test -p proof-of-sql --no-default-features --features arrow,test we_can_convert`

/claim #560
