### PR TITLE
test: cover empty dory CPU helper path

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -107,3 +107,22 @@ pub(super) fn compute_dynamic_dory_commitments(
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_dory_commitment_impl;
+    use crate::proof_primitive::dory::{
+        test_rng, DoryScalar, DynamicDoryCommitment, ProverSetup, PublicParameters,
+    };
+
+    #[test]
+    fn we_can_compute_default_commitment_for_empty_cpu_impl_column() {
+        let public_parameters = PublicParameters::test_rand(1, &mut test_rng());
+        let setup = ProverSetup::from(&public_parameters);
+        let column: &[DoryScalar] = &[];
+
+        let commitment = compute_dory_commitment_impl(column, 0, &setup);
+
+        assert_eq!(commitment, DynamicDoryCommitment::default());
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add an in-module CPU Dory helper test for the private empty-column guard.
- Verify `compute_dory_commitment_impl` returns the default dynamic commitment before touching setup data.

## Coverage
The focused LCOV run hits the previously unexercised empty-column guard in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs`:

```text
SF:crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
DA:32,1
DA:33,1
```

## Validation
- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib --no-default-features --features test dynamic_dory_commitment_helper_cpu -- --nocapture`
- `BLITZAR_BACKEND=cpu cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/dory-empty-impl-coverage.lcov -- dynamic_dory_commitment_helper_cpu`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

I did not run the full `source scripts/run_ci_checks.sh`; this is a narrow test-only coverage slice and the focused checks above passed locally.