### PR TITLE
test: cover column index and repetition variants

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -120,7 +120,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::ColumnOperationError, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        database::ColumnOperationError,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn test_apply_index_op() {
@@ -150,6 +155,61 @@ mod tests {
         assert_eq!(
             result,
             Column::VarChar((&expected_strings, &expected_scalars))
+        );
+    }
+
+    #[test]
+    fn test_apply_index_op_for_remaining_scalar_backed_types() {
+        let bump = Bump::new();
+        let indexes = [2, 0, 2];
+
+        let column = Column::<TestScalar>::Boolean(&[true, false, true]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::Boolean(&[true, true, true]));
+
+        let column = Column::<TestScalar>::Uint8(&[4, 5, 6]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::Uint8(&[6, 4, 6]));
+
+        let column = Column::<TestScalar>::TinyInt(&[-4, 5, -6]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::TinyInt(&[-6, -4, -6]));
+
+        let column = Column::<TestScalar>::SmallInt(&[-300, 200, 100]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::SmallInt(&[100, -300, 100]));
+
+        let column = Column::<TestScalar>::BigInt(&[-9_000, 8_000, 7_000]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::BigInt(&[7_000, -9_000, 7_000]));
+
+        let column = Column::<TestScalar>::Int128(&[-12_000, 11_000, 10_000]);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::Int128(&[10_000, -12_000, 10_000]));
+    }
+
+    #[test]
+    fn test_apply_index_op_for_decimal_and_timestamp() {
+        let bump = Bump::new();
+        let indexes = [1, 2, 0, 1];
+        let precision = Precision::new(12).unwrap();
+
+        let decimal_values = [10, 20, 30].map(TestScalar::from);
+        let column = Column::Decimal75(precision, -2, &decimal_values);
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        let expected_values = [20, 30, 10, 20].map(TestScalar::from);
+        assert_eq!(result, Column::Decimal75(precision, -2, &expected_values));
+
+        let timezone = PoSQLTimeZone::new(3600);
+        let column = Column::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            timezone,
+            &[100, 200, 300],
+        );
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(
+            result,
+            Column::TimestampTZ(PoSQLTimeUnit::Millisecond, timezone, &[200, 300, 100, 200])
         );
     }
 

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -153,7 +153,11 @@ impl RepetitionOp for ElementwiseRepeatOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::{
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn test_column_repetition_op() {
@@ -212,6 +216,95 @@ mod tests {
         let column: Column<TestScalar> = Column::Uint8(&[3u8, 5u8, 2u8]);
         let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
         assert_eq!(result.as_uint8().unwrap(), &[3u8, 3u8, 5u8, 5u8, 2u8, 2u8]);
+    }
+
+    #[test]
+    fn test_column_repetition_op_for_remaining_scalar_backed_types() {
+        let bump = Bump::new();
+        let precision = Precision::new(12).unwrap();
+
+        let column = Column::<TestScalar>::TinyInt(&[-2, 0, 2]);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result, Column::TinyInt(&[-2, 0, 2, -2, 0, 2]));
+
+        let column = Column::<TestScalar>::SmallInt(&[-300, 200, 100]);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result, Column::SmallInt(&[-300, 200, 100, -300, 200, 100]));
+
+        let column = Column::<TestScalar>::BigInt(&[-9_000, 8_000]);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 3);
+        assert_eq!(
+            result,
+            Column::BigInt(&[-9_000, 8_000, -9_000, 8_000, -9_000, 8_000])
+        );
+
+        let column = Column::<TestScalar>::Int128(&[-12_000, 11_000]);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result, Column::Int128(&[-12_000, 11_000, -12_000, 11_000]));
+
+        let scalars = [10, 20].map(TestScalar::from);
+        let column = Column::<TestScalar>::Scalar(&scalars);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        let expected = [10, 20, 10, 20].map(TestScalar::from);
+        assert_eq!(result, Column::Scalar(&expected));
+
+        let decimals = [30, 40].map(TestScalar::from);
+        let column = Column::Decimal75(precision, -2, &decimals);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        let expected = [30, 40, 30, 40].map(TestScalar::from);
+        assert_eq!(result, Column::Decimal75(precision, -2, &expected));
+
+        let timezone = PoSQLTimeZone::new(-1800);
+        let column =
+            Column::<TestScalar>::TimestampTZ(PoSQLTimeUnit::Microsecond, timezone, &[100, 200]);
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(
+            result,
+            Column::TimestampTZ(PoSQLTimeUnit::Microsecond, timezone, &[100, 200, 100, 200])
+        );
+    }
+
+    #[test]
+    fn test_elementwise_repetition_op_for_remaining_scalar_backed_types() {
+        let bump = Bump::new();
+        let precision = Precision::new(15).unwrap();
+
+        let column = Column::<TestScalar>::TinyInt(&[-2, 0, 2]);
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result, Column::TinyInt(&[-2, -2, 0, 0, 2, 2]));
+
+        let column = Column::<TestScalar>::SmallInt(&[-300, 200]);
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 3);
+        assert_eq!(result, Column::SmallInt(&[-300, -300, -300, 200, 200, 200]));
+
+        let column = Column::<TestScalar>::BigInt(&[-9_000, 8_000]);
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result, Column::BigInt(&[-9_000, -9_000, 8_000, 8_000]));
+
+        let column = Column::<TestScalar>::Int128(&[-12_000, 11_000]);
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result, Column::Int128(&[-12_000, -12_000, 11_000, 11_000]));
+
+        let scalars = [10, 20].map(TestScalar::from);
+        let column = Column::<TestScalar>::Scalar(&scalars);
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        let expected = [10, 10, 20, 20].map(TestScalar::from);
+        assert_eq!(result, Column::Scalar(&expected));
+
+        let decimals = [30, 40].map(TestScalar::from);
+        let column = Column::Decimal75(precision, 2, &decimals);
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        let expected = [30, 30, 40, 40].map(TestScalar::from);
+        assert_eq!(result, Column::Decimal75(precision, 2, &expected));
+
+        let timezone = PoSQLTimeZone::new(7200);
+        let column =
+            Column::<TestScalar>::TimestampTZ(PoSQLTimeUnit::Nanosecond, timezone, &[100, 200]);
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(
+            result,
+            Column::TimestampTZ(PoSQLTimeUnit::Nanosecond, timezone, &[100, 100, 200, 200])
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add focused tests for unexercised `apply_column_to_indexes` typed branches.
- Add focused tests for `ColumnRepeatOp` and `ElementwiseRepeatOp` typed branches.
- Keep the patch test-only; no production behavior changes.

/claim #560

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test test_apply_index_op -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features test repetition_op -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
