### PR TITLE
test: cover byte matrix constant inputs

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -39,6 +39,32 @@ mod tests {
     use bumpalo::Bump;
 
     #[test]
+    fn we_can_compute_varying_byte_matrix_for_empty_columns() {
+        let alloc = Bump::new();
+        let scalars = Vec::<TestScalar>::new();
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert_eq!(byte_distribution.varying_byte_count(), 0);
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_constant_columns() {
+        let alloc = Bump::new();
+        let scalars: Vec<TestScalar> = [42, 42, 42].iter().map(TestScalar::from).collect();
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert_eq!(byte_distribution.varying_byte_count(), 0);
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
     fn we_can_compute_varying_byte_matrix_for_small_scalars() {
         let alloc = Bump::new();
         let scalars: Vec<TestScalar> = [1, 2, 3, 255, 256, 257]


### PR DESCRIPTION
## Summary
- add direct coverage for empty input to compute_varying_byte_matrix
- add direct coverage for constant columns with no varying byte matrix entries
- keep the slice scoped to byte_matrix_utils tests only

## Validation
- cargo test -p proof-of-sql --no-default-features --features arrow,test byte_matrix
- rustfmt --check crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
- git diff --check

/claim #560