### PR TITLE
test: cover limb serialization order

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,53 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use crate::base::standard_serializations::binary::{
+        try_standard_binary_deserialization, try_standard_binary_serialization,
+    };
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    struct StandardOrder {
+        limbs: [u64; 4],
+    }
+
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    struct CanonicalLimbOrder {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn we_can_serialize_limbs_in_reverse_canonical_order() {
+        let serialized = try_standard_binary_serialization(CanonicalLimbOrder {
+            limbs: [1, 2, 3, 4],
+        })
+        .unwrap();
+        let expected = try_standard_binary_serialization(StandardOrder {
+            limbs: [4, 3, 2, 1],
+        })
+        .unwrap();
+
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn we_can_deserialize_reversed_limbs_back_to_native_order() {
+        let serialized = try_standard_binary_serialization(StandardOrder {
+            limbs: [4, 3, 2, 1],
+        })
+        .unwrap();
+        let (decoded, bytes_read): (CanonicalLimbOrder, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(decoded.limbs, [1, 2, 3, 4]);
+        assert_eq!(bytes_read, serialized.len());
+    }
+}


### PR DESCRIPTION
## Summary
- Add focused tests for the standard limb serde helpers.
- Assert serialization writes `[u64; 4]` limbs in reversed canonical wire order.
- Assert deserialization maps reversed wire-order limbs back to native order and consumes the full payload.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features arrow,test standard_serializations::limbs`
- `rustfmt --check crates/proof-of-sql/src/base/standard_serializations/limbs.rs`
- `git diff --check`

/claim #560