### PR TITLE
test: cover dynamic VMV state builders

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_build_vmv_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_build_vmv_state.rs
@@ -47,3 +47,55 @@ pub(super) fn build_dynamic_vmv_verifier_state(
         nu,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute_dynamic_vecs_as_fields(b_point: &[F]) -> (Vec<F>, Vec<F>) {
+        let (lo_vec, hi_vec) = compute_dynamic_vecs(bytemuck::TransparentWrapper::wrap_slice(
+            b_point,
+        ) as &[DoryScalar]);
+        (
+            bytemuck::TransparentWrapper::peel_slice(&lo_vec).to_vec(),
+            bytemuck::TransparentWrapper::peel_slice(&hi_vec).to_vec(),
+        )
+    }
+
+    #[test]
+    fn we_can_build_dynamic_vmv_prover_state() {
+        let a: Vec<F> = (100..109).map(Into::into).collect();
+        let b_point: Vec<F> = [2, 3, 5, 7, 11].into_iter().map(Into::into).collect();
+        let nu = 3;
+        let t_vec_prime = vec![G1Affine::identity(); 1 << nu];
+
+        let state = build_dynamic_vmv_prover_state(&a, &b_point, t_vec_prime.clone(), nu);
+
+        let (expected_r_vec, expected_l_vec) = compute_dynamic_vecs_as_fields(&b_point);
+        let expected_v_vec = compute_dynamic_v_vec(&a, &expected_l_vec, nu);
+
+        assert_eq!(state.v_vec, expected_v_vec);
+        assert_eq!(state.T_vec_prime, t_vec_prime);
+        assert_eq!(state.L_vec, expected_l_vec);
+        assert_eq!(state.R_vec, expected_r_vec);
+        assert!(state.l_tensor.is_empty());
+        assert_eq!(state.r_tensor, b_point);
+        assert_eq!(state.nu, nu);
+    }
+
+    #[test]
+    fn we_can_build_dynamic_vmv_verifier_state() {
+        let y = F::from(42);
+        let b_point: Vec<F> = [2, 3, 5, 7, 11].into_iter().map(Into::into).collect();
+        let t = DeferredGT::new([], []);
+        let nu = 3;
+
+        let state = build_dynamic_vmv_verifier_state(y, &b_point, t.clone(), nu);
+
+        assert_eq!(state.y, y);
+        assert_eq!(state.T, t);
+        assert!(state.l_tensor.is_empty());
+        assert_eq!(state.r_tensor, b_point);
+        assert_eq!(state.nu, nu);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Adds direct unit coverage for the dynamic VMV prover and verifier state builders.

# What changes are included in this PR?
- Test that `build_dynamic_vmv_prover_state` forwards row commitments, computes and stores the expected dynamic `L`/`R` vectors and `v_vec`, preserves the right tensor, and records `nu`.
- Test that `build_dynamic_vmv_verifier_state` preserves `y`, `T`, right tensor, empty left tensor, and `nu`.

# Are these changes tested?
Yes.

- `cargo test -p proof-of-sql dynamic_build_vmv_state --lib --no-default-features --features="rayon test"`
- `cargo fmt --check`
- `git diff --check`
- `bash -lc "tr -d '\r' < scripts/check_commits.sh | bash"`

CI note: on this Windows checkout, invoking the helper script directly hit CRLF line-ending artifacts, so I validated the Cargo commands extracted by the script directly and documented the exact commands/result in a PR comment.