### PR TITLE
test: reduce Dory state setup size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_state_test.rs
@@ -9,10 +9,10 @@ use ark_ff::Fp;
 #[test]
 pub fn we_can_create_an_extended_verifier_state_from_an_extended_prover_state() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
-    for nu in 0..max_nu {
+    for nu in 0..=max_nu {
         let (v1, v2) = rand_G_vecs(nu, &mut rng);
         let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
         let mut s1 = vec![Fp::default(); 1 << nu];

--- a/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
@@ -4,10 +4,10 @@ use ark_ec::pairing::Pairing;
 #[test]
 pub fn we_can_create_a_verifier_state_from_a_prover_state() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
-    for nu in 0..max_nu {
+    for nu in 0..=max_nu {
         let (v1, v2) = rand_G_vecs(nu, &mut rng);
         let prover_state = ProverState::new(v1.clone(), v2.clone(), nu);
         let verifier_state = prover_state.calculate_verifier_state(&prover_setup);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

/claim #557

The Dory state tests only exercise `nu` values 0 through 4, but they generate public parameters for `max_nu = 5`. This creates a larger setup surface than the assertions use.

This keeps the same tested `nu` cases by switching the loops to `0..=max_nu`, while reducing the generated setup to `max_nu = 4`.

# What changes are included in this PR?

- Reduce the Dory prover-state test setup from `max_nu = 5` to `max_nu = 4`.
- Reduce the extended Dory prover-state test setup from `max_nu = 5` to `max_nu = 4`.
- Preserve coverage of `nu = 0, 1, 2, 3, 4` in both tests.

# Are these changes tested?

Yes.

Before/after focused test timings on the same local checkout with `BLITZAR_BACKEND=cpu`:

| Test | Baseline | This PR |
| --- | ---: | ---: |
| `proof_primitive::dory::state_test` | 10.54s | 7.16s |
| `proof_primitive::dory::extended_state_test` | 11.86s | 6.98s |

Validation commands:

- `CARGO_INCREMENTAL=0 BLITZAR_BACKEND=cpu /usr/bin/time -p /Users/dylanmiller/.cargo/bin/cargo test -p proof-of-sql --lib --no-default-features --features="test" proof_primitive::dory::state_test -- --nocapture`
- `CARGO_INCREMENTAL=0 BLITZAR_BACKEND=cpu /usr/bin/time -p /Users/dylanmiller/.cargo/bin/cargo test -p proof-of-sql --lib --no-default-features --features="test" proof_primitive::dory::extended_state_test -- --nocapture`
- `cargo f --check`
- `cargo check -p proof-of-sql --lib --no-default-features --features="test"`
- `git diff --check`
- `source scripts/check_commits.sh`

I also attempted `source scripts/run_ci_checks.sh`, but in this checkout it extracts workflow commands as literal `run: cargo ...` lines and fails before running the checks, e.g. `run:: command not found`.