### PR TITLE
test: reuse dory message fixture

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
@@ -1,291 +1,286 @@
 use super::{test_rng, DoryMessages, G1Affine, G2Affine, F, GT};
 use ark_std::UniformRand;
 use merlin::Transcript;
+use std::sync::OnceLock;
+
+#[derive(Clone)]
+struct ProverMessages {
+    f1: F,
+    g1_1: G1Affine,
+    g2_1: G2Affine,
+    gt: GT,
+    f2: F,
+    g1_2: G1Affine,
+    g2_2: G2Affine,
+    g1_3: G1Affine,
+    f3: F,
+}
+
+#[derive(Clone)]
+struct MessageFixture {
+    messages: DoryMessages,
+    prover: ProverMessages,
+    v1: (F, F),
+    v2: (F, F),
+    v3: (F, F),
+}
+
+fn prover_messages() -> ProverMessages {
+    static MESSAGES: OnceLock<ProverMessages> = OnceLock::new();
+    MESSAGES
+        .get_or_init(|| {
+            // test_rng is deterministic; cache these immutable randomized inputs because
+            // G1/G2/GT generation dominates this small message-order test module.
+            let mut rng = test_rng();
+            ProverMessages {
+                f1: F::rand(&mut rng),
+                g1_1: G1Affine::rand(&mut rng),
+                g2_1: G2Affine::rand(&mut rng),
+                gt: GT::rand(&mut rng),
+                f2: F::rand(&mut rng),
+                g1_2: G1Affine::rand(&mut rng),
+                g2_2: G2Affine::rand(&mut rng),
+                g1_3: G1Affine::rand(&mut rng),
+                f3: F::rand(&mut rng),
+            }
+        })
+        .clone()
+}
+
+fn message_fixture() -> MessageFixture {
+    let prover = prover_messages();
+    let mut messages = DoryMessages::default();
+    let mut transcript = Transcript::new(b"test");
+    messages.prover_send_F_message(&mut transcript, prover.f1.clone());
+    let v1 = messages.verifier_F_message(&mut transcript);
+    messages.prover_send_G1_message(&mut transcript, prover.g1_1.clone());
+    messages.prover_send_G2_message(&mut transcript, prover.g2_1.clone());
+    messages.prover_send_GT_message(&mut transcript, prover.gt.clone());
+    let v2 = messages.verifier_F_message(&mut transcript);
+    messages.prover_send_F_message(&mut transcript, prover.f2.clone());
+    messages.prover_send_G1_message(&mut transcript, prover.g1_2.clone());
+    messages.prover_send_G2_message(&mut transcript, prover.g2_2.clone());
+    messages.prover_send_G1_message(&mut transcript, prover.g1_3.clone());
+    let v3 = messages.verifier_F_message(&mut transcript);
+    messages.prover_send_F_message(&mut transcript, prover.f3.clone());
+
+    MessageFixture {
+        messages,
+        prover,
+        v1,
+        v2,
+        v3,
+    }
+}
 
 #[test]
 fn we_can_send_and_receive_the_correct_messages_in_the_same_order() {
-    let mut rng = test_rng();
-    let mut messages = DoryMessages::default();
-
-    // Prover side
-    let mut transcript = Transcript::new(b"test");
-    let Pmessage1 = F::rand(&mut rng);
-    let Pmessage2 = G1Affine::rand(&mut rng);
-    let Pmessage3 = G2Affine::rand(&mut rng);
-    let Pmessage4 = GT::rand(&mut rng);
-    let Pmessage5 = F::rand(&mut rng);
-    let Pmessage6 = G1Affine::rand(&mut rng);
-    let Pmessage7 = G2Affine::rand(&mut rng);
-    let Pmessage8 = G1Affine::rand(&mut rng);
-    let Pmessage9 = F::rand(&mut rng);
-    messages.prover_send_F_message(&mut transcript, Pmessage1);
-    let Vmessage1 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_G1_message(&mut transcript, Pmessage2);
-    messages.prover_send_G2_message(&mut transcript, Pmessage3);
-    messages.prover_send_GT_message(&mut transcript, Pmessage4);
-    let Vmessage2 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_F_message(&mut transcript, Pmessage5);
-    messages.prover_send_G1_message(&mut transcript, Pmessage6);
-    messages.prover_send_G2_message(&mut transcript, Pmessage7);
-    messages.prover_send_G1_message(&mut transcript, Pmessage8);
-    let Vmessage3 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_F_message(&mut transcript, Pmessage9);
+    let MessageFixture {
+        mut messages,
+        prover,
+        v1,
+        v2,
+        v3,
+    } = message_fixture();
 
     // Verifier side
     let mut transcript = Transcript::new(b"test");
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage1
+        prover.f1
     );
-    assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage1);
+    assert_eq!(messages.verifier_F_message(&mut transcript), v1);
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage2
+        prover.g1_1
     );
     assert_eq!(
         messages.prover_receive_G2_message(&mut transcript),
-        Pmessage3
+        prover.g2_1
     );
     assert_eq!(
         messages.prover_receive_GT_message(&mut transcript),
-        Pmessage4
+        prover.gt
     );
-    assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage2);
+    assert_eq!(messages.verifier_F_message(&mut transcript), v2);
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage5
+        prover.f2
     );
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage6
+        prover.g1_2
     );
     assert_eq!(
         messages.prover_receive_G2_message(&mut transcript),
-        Pmessage7
+        prover.g2_2
     );
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage8
+        prover.g1_3
     );
-    assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage3);
+    assert_eq!(messages.verifier_F_message(&mut transcript), v3);
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage9
+        prover.f3
     );
 }
 
 #[test]
 fn verifier_messages_fail_when_the_transcript_is_wrong() {
-    let mut rng = test_rng();
-    let mut messages = DoryMessages::default();
-
-    // Prover side
-    let mut transcript = Transcript::new(b"test");
-    let Pmessage1 = F::rand(&mut rng);
-    let Pmessage2 = G1Affine::rand(&mut rng);
-    let Pmessage3 = G2Affine::rand(&mut rng);
-    let Pmessage4 = GT::rand(&mut rng);
-    let Pmessage5 = F::rand(&mut rng);
-    let Pmessage6 = G1Affine::rand(&mut rng);
-    let Pmessage7 = G2Affine::rand(&mut rng);
-    let Pmessage8 = G1Affine::rand(&mut rng);
-    let Pmessage9 = F::rand(&mut rng);
-    messages.prover_send_F_message(&mut transcript, Pmessage1);
-    let Vmessage1 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_G1_message(&mut transcript, Pmessage2);
-    messages.prover_send_G2_message(&mut transcript, Pmessage3);
-    messages.prover_send_GT_message(&mut transcript, Pmessage4);
-    let Vmessage2 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_F_message(&mut transcript, Pmessage5);
-    messages.prover_send_G1_message(&mut transcript, Pmessage6);
-    messages.prover_send_G2_message(&mut transcript, Pmessage7);
-    messages.prover_send_G1_message(&mut transcript, Pmessage8);
-    let Vmessage3 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_F_message(&mut transcript, Pmessage9);
+    let MessageFixture {
+        mut messages,
+        prover,
+        v1,
+        v2,
+        v3,
+    } = message_fixture();
 
     // Verifier side
     let mut transcript = Transcript::new(b"test_wrong");
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage1
+        prover.f1
     );
-    assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage1);
+    assert_ne!(messages.verifier_F_message(&mut transcript), v1);
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage2
+        prover.g1_1
     );
     assert_eq!(
         messages.prover_receive_G2_message(&mut transcript),
-        Pmessage3
+        prover.g2_1
     );
     assert_eq!(
         messages.prover_receive_GT_message(&mut transcript),
-        Pmessage4
+        prover.gt
     );
-    assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage2);
+    assert_ne!(messages.verifier_F_message(&mut transcript), v2);
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage5
+        prover.f2
     );
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage6
+        prover.g1_2
     );
     assert_eq!(
         messages.prover_receive_G2_message(&mut transcript),
-        Pmessage7
+        prover.g2_2
     );
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage8
+        prover.g1_3
     );
-    assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage3);
+    assert_ne!(messages.verifier_F_message(&mut transcript), v3);
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage9
+        prover.f3
     );
 }
 
 #[test]
 fn verifier_messages_fail_when_a_verifier_message_is_in_the_wrong_order() {
-    let mut rng = test_rng();
-    let mut messages = DoryMessages::default();
-
-    // Prover side
-    let mut transcript = Transcript::new(b"test");
-    let Pmessage1 = F::rand(&mut rng);
-    let Pmessage2 = G1Affine::rand(&mut rng);
-    let Pmessage3 = G2Affine::rand(&mut rng);
-    let Pmessage4 = GT::rand(&mut rng);
-    let Pmessage5 = F::rand(&mut rng);
-    let Pmessage6 = G1Affine::rand(&mut rng);
-    let Pmessage7 = G2Affine::rand(&mut rng);
-    let Pmessage8 = G1Affine::rand(&mut rng);
-    let Pmessage9 = F::rand(&mut rng);
-    messages.prover_send_F_message(&mut transcript, Pmessage1);
-    let Vmessage1 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_G1_message(&mut transcript, Pmessage2);
-    messages.prover_send_G2_message(&mut transcript, Pmessage3);
-    messages.prover_send_GT_message(&mut transcript, Pmessage4);
-    let Vmessage2 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_F_message(&mut transcript, Pmessage5);
-    messages.prover_send_G1_message(&mut transcript, Pmessage6);
-    messages.prover_send_G2_message(&mut transcript, Pmessage7);
-    messages.prover_send_G1_message(&mut transcript, Pmessage8);
-    let Vmessage3 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_F_message(&mut transcript, Pmessage9);
+    let MessageFixture {
+        mut messages,
+        prover,
+        v1,
+        v2,
+        v3,
+    } = message_fixture();
 
     // Verifier side
     let mut transcript = Transcript::new(b"test");
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage1
+        prover.f1
     );
-    assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage1);
+    assert_eq!(messages.verifier_F_message(&mut transcript), v1);
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage2
+        prover.g1_1
     );
     assert_eq!(
         messages.prover_receive_G2_message(&mut transcript),
-        Pmessage3
+        prover.g2_1
     );
     assert_eq!(
         messages.prover_receive_GT_message(&mut transcript),
-        Pmessage4
+        prover.gt
     );
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage5
+        prover.f2
     );
-    assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage2);
+    assert_ne!(messages.verifier_F_message(&mut transcript), v2);
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage6
+        prover.g1_2
     );
     assert_eq!(
         messages.prover_receive_G2_message(&mut transcript),
-        Pmessage7
+        prover.g2_2
     );
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage8
+        prover.g1_3
     );
-    assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage3);
+    assert_ne!(messages.verifier_F_message(&mut transcript), v3);
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage9
+        prover.f3
     );
 }
 
 #[test]
 fn verifier_messages_fail_when_prover_messages_are_out_of_order() {
-    let mut rng = test_rng();
-    let mut messages = DoryMessages::default();
-
-    // Prover side
-    let mut transcript = Transcript::new(b"test");
-    let Pmessage1 = F::rand(&mut rng);
-    let Pmessage2 = G1Affine::rand(&mut rng);
-    let Pmessage3 = G2Affine::rand(&mut rng);
-    let Pmessage4 = GT::rand(&mut rng);
-    let Pmessage5 = F::rand(&mut rng);
-    let Pmessage6 = G1Affine::rand(&mut rng);
-    let Pmessage7 = G2Affine::rand(&mut rng);
-    let Pmessage8 = G1Affine::rand(&mut rng);
-    let Pmessage9 = F::rand(&mut rng);
-    messages.prover_send_F_message(&mut transcript, Pmessage1);
-    let Vmessage1 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_G1_message(&mut transcript, Pmessage2);
-    messages.prover_send_G2_message(&mut transcript, Pmessage3);
-    messages.prover_send_GT_message(&mut transcript, Pmessage4);
-    let Vmessage2 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_F_message(&mut transcript, Pmessage5);
-    messages.prover_send_G1_message(&mut transcript, Pmessage6);
-    messages.prover_send_G2_message(&mut transcript, Pmessage7);
-    messages.prover_send_G1_message(&mut transcript, Pmessage8);
-    let Vmessage3 = messages.verifier_F_message(&mut transcript);
-    messages.prover_send_F_message(&mut transcript, Pmessage9);
+    let MessageFixture {
+        mut messages,
+        prover,
+        v1,
+        v2,
+        v3,
+    } = message_fixture();
 
     // Verifier side
     let mut transcript = Transcript::new(b"test");
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage1
+        prover.f1
     );
-    assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage1);
+    assert_eq!(messages.verifier_F_message(&mut transcript), v1);
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage2
+        prover.g1_1
     );
     assert_eq!(
         messages.prover_receive_GT_message(&mut transcript),
-        Pmessage4
+        prover.gt
     );
     assert_eq!(
         messages.prover_receive_G2_message(&mut transcript),
-        Pmessage3
+        prover.g2_1
     );
-    assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage2);
+    assert_ne!(messages.verifier_F_message(&mut transcript), v2);
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage5
+        prover.f2
     );
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage6
+        prover.g1_2
     );
     assert_eq!(
         messages.prover_receive_G2_message(&mut transcript),
-        Pmessage7
+        prover.g2_2
     );
     assert_eq!(
         messages.prover_receive_G1_message(&mut transcript),
-        Pmessage8
+        prover.g1_3
     );
-    assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage3);
+    assert_ne!(messages.verifier_F_message(&mut transcript), v3);
     assert_eq!(
         messages.prover_receive_F_message(&mut transcript),
-        Pmessage9
+        prover.f3
     );
 }


### PR DESCRIPTION
/claim #557

## Summary
- Cache the randomized prover-message fixture used by `dory_messages_test` with `OnceLock`.
- Rebuild fresh `DoryMessages` queues per test so ordering, transcript, and mismatch assertions stay unchanged.
- Avoid regenerating the same BLS12-381 `F`, `G1`, `G2`, and `GT` random values separately in every message-order test.

## Timing
Focused warm runs on this machine with `BLITZAR_BACKEND=cpu`:

| Command | main | this PR |
| --- | ---: | ---: |
| `cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::dory::dory_messages_test -- --quiet` | 0.18s test / 0.75s real | 0.07s test / 0.43s real |

## Validation
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 BLITZAR_BACKEND=cpu /usr/bin/time -p cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::dory::dory_messages_test -- --quiet`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo check -p proof-of-sql --lib --no-default-features --features test`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
