### PR TITLE
test: cover ColumnField accessors, equality, and serde round-trip

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field_test.rs
+++ b/crates/proof-of-sql/src/base/database/column_field_test.rs
@@ -1,0 +1,35 @@
+use super::{ColumnField, ColumnType};
+use sqlparser::ast::Ident;
+
+#[test]
+fn we_can_create_a_column_field_and_read_back_its_name_and_type() {
+    let field = ColumnField::new(Ident::new("amount"), ColumnType::BigInt);
+    assert_eq!(field.name(), Ident::new("amount"));
+    assert_eq!(field.data_type(), ColumnType::BigInt);
+}
+
+#[test]
+fn column_fields_are_equal_only_when_both_name_and_type_match() {
+    let base = ColumnField::new(Ident::new("a"), ColumnType::BigInt);
+    let same = ColumnField::new(Ident::new("a"), ColumnType::BigInt);
+    let other_name = ColumnField::new(Ident::new("b"), ColumnType::BigInt);
+    let other_type = ColumnField::new(Ident::new("a"), ColumnType::Boolean);
+
+    assert_eq!(base, same);
+    assert_ne!(base, other_name);
+    assert_ne!(base, other_type);
+}
+
+#[test]
+fn a_cloned_column_field_is_equal_to_the_original() {
+    let field = ColumnField::new(Ident::new("flag"), ColumnType::Boolean);
+    assert_eq!(field.clone(), field);
+}
+
+#[test]
+fn a_column_field_round_trips_through_serde_json() {
+    let field = ColumnField::new(Ident::new("label"), ColumnType::Boolean);
+    let json = serde_json::to_string(&field).expect("ColumnField should serialize");
+    let decoded: ColumnField = serde_json::from_str(&json).expect("ColumnField should deserialize");
+    assert_eq!(field, decoded);
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -18,6 +18,9 @@ pub use column_ref::ColumnRef;
 mod column_field;
 pub use column_field::ColumnField;
 
+#[cfg(test)]
+mod column_field_test;
+
 #[cfg_attr(not(test), expect(dead_code))]
 pub(crate) mod slice_operation;
 


### PR DESCRIPTION
## Summary

Adds dedicated unit-test coverage for `base::database::column_field` (`ColumnField`), which previously had none. New `column_field_test.rs` covers:

- `ColumnField::new` plus the `name()` and `data_type()` accessors
- `PartialEq` semantics (equal only when both name and type match; differing name or differing type are unequal)
- `Clone` correctness
- `serde` round-trip via `serde_json`

## Context

Non-overlapping coverage slice for #560. Scope is limited to `column_field` and does not touch modules addressed by other open coverage PRs.

## Verification

- `cargo test -p proof-of-sql --lib base::database::column_field_test` → 4 passed
- `cargo fmt -- --check` clean on the changed files