### PR TITLE
Add nullable column support proof of concept

### DIFF
--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -137,9 +137,12 @@ pub fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
         column_fields
             .into_iter()
             .map(|column_field| {
-                //TODO: Make columns nullable
                 let data_type = (&column_field.data_type()).into();
-                Field::new(column_field.name().value.as_str(), data_type, false)
+                Field::new(
+                    column_field.name().value.as_str(),
+                    data_type,
+                    column_field.is_nullable(),
+                )
             })
             .collect::<Vec<_>>(),
     )
@@ -516,6 +519,7 @@ mod tests {
         let column_fields = vec![
             ColumnField::new("a".into(), ColumnType::SmallInt),
             ColumnField::new("b".into(), ColumnType::VarChar),
+            ColumnField::new_nullable("c".into(), ColumnType::BigInt),
         ];
         let schema = column_fields_to_schema(column_fields);
         assert_eq!(
@@ -523,6 +527,7 @@ mod tests {
             vec![
                 &Field::new("a", DataType::Int16, false),
                 &Field::new("b", DataType::Utf8, false),
+                &Field::new("c", DataType::Int64, true),
             ]
         );
     }

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -77,7 +77,7 @@ impl From<&ColumnField> for Field {
         Field::new(
             column_field.name().value.as_str(),
             (&column_field.data_type()).into(),
-            false,
+            column_field.is_nullable(),
         )
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -10,13 +10,29 @@ use sqlparser::ast::Ident;
 pub struct ColumnField {
     name: Ident,
     data_type: ColumnType,
+    #[serde(default, skip_serializing_if = "is_false")]
+    nullable: bool,
 }
 
 impl ColumnField {
     /// Create a new `ColumnField` from a name and a type
     #[must_use]
     pub fn new(name: Ident, data_type: ColumnType) -> ColumnField {
-        ColumnField { name, data_type }
+        ColumnField {
+            name,
+            data_type,
+            nullable: false,
+        }
+    }
+
+    /// Create a new nullable `ColumnField` from a name and a type
+    #[must_use]
+    pub fn new_nullable(name: Ident, data_type: ColumnType) -> ColumnField {
+        ColumnField {
+            name,
+            data_type,
+            nullable: true,
+        }
     }
 
     /// Returns the name of the column
@@ -30,4 +46,21 @@ impl ColumnField {
     pub fn data_type(&self) -> ColumnType {
         self.data_type
     }
+
+    /// Returns whether the column can contain null values
+    #[must_use]
+    pub fn is_nullable(&self) -> bool {
+        self.nullable
+    }
+
+    /// Returns this field with the requested nullability
+    #[must_use]
+    pub fn with_nullable(mut self, nullable: bool) -> Self {
+        self.nullable = nullable;
+        self
+    }
+}
+
+const fn is_false(value: &bool) -> bool {
+    !*value
 }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -18,6 +18,20 @@ pub use column_ref::ColumnRef;
 mod column_field;
 pub use column_field::ColumnField;
 
+mod validity;
+pub use validity::{
+    all_rows_valid, and_validity_masks, canonicalize_nulls, ensure_canonical_column_nulls,
+    ensure_canonical_nulls, filter_valid_owned_values, validate_mask_length, validity_column,
+    ValidityError, ValidityResult,
+};
+
+mod nullable_column;
+pub use nullable_column::{
+    NullableColumn, NullableColumnError, NullableColumnResult, NullableOwnedColumn,
+};
+#[cfg(test)]
+mod nullable_column_test;
+
 #[cfg_attr(not(test), expect(dead_code))]
 pub(crate) mod slice_operation;
 

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -1,0 +1,199 @@
+use super::{
+    and_validity_masks, canonicalize_nulls, ensure_canonical_column_nulls, ensure_canonical_nulls,
+    filter_valid_owned_values, validate_mask_length, validity_column, Column, ColumnOperationError,
+    ColumnType, OwnedColumn, ValidityError,
+};
+use crate::base::{math::permutation::Permutation, scalar::Scalar};
+use alloc::vec::Vec;
+use snafu::Snafu;
+
+/// Errors for nullable column construction and operations.
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum NullableColumnError {
+    /// Validity mask or canonical-null invariant failed.
+    #[snafu(transparent)]
+    Validity {
+        /// The underlying validity error.
+        source: ValidityError,
+    },
+    /// Backing column operation failed.
+    #[snafu(transparent)]
+    ColumnOperation {
+        /// The underlying column operation error.
+        source: ColumnOperationError,
+    },
+}
+
+/// Result type for nullable column operations.
+pub type NullableColumnResult<T> = core::result::Result<T, NullableColumnError>;
+
+/// An owned nullable column represented as values plus a validity mask.
+///
+/// Invalid rows must contain the canonical null sentinel for their physical
+/// column type. This makes nullable columns deterministic for commitments while
+/// the validity mask carries SQL null semantics.
+#[derive(Debug, PartialEq, Clone, Eq)]
+pub struct NullableOwnedColumn<S: Scalar> {
+    values: OwnedColumn<S>,
+    validity: Vec<bool>,
+}
+
+impl<S: Scalar> NullableOwnedColumn<S> {
+    /// Creates a nullable column from already-canonicalized values.
+    pub fn try_new(values: OwnedColumn<S>, validity: Vec<bool>) -> NullableColumnResult<Self> {
+        ensure_canonical_nulls(&values, &validity)?;
+        Ok(Self { values, validity })
+    }
+
+    /// Creates a nullable column and canonicalizes invalid rows in-place.
+    pub fn try_new_canonicalized(
+        mut values: OwnedColumn<S>,
+        validity: Vec<bool>,
+    ) -> NullableColumnResult<Self> {
+        canonicalize_nulls(&mut values, &validity)?;
+        Ok(Self { values, validity })
+    }
+
+    /// Returns the backing values column.
+    #[must_use]
+    pub fn values(&self) -> &OwnedColumn<S> {
+        &self.values
+    }
+
+    /// Returns the validity mask.
+    #[must_use]
+    pub fn validity(&self) -> &[bool] {
+        &self.validity
+    }
+
+    /// Consumes the nullable column into its values and validity mask.
+    #[must_use]
+    pub fn into_parts(self) -> (OwnedColumn<S>, Vec<bool>) {
+        (self.values, self.validity)
+    }
+
+    /// Returns the number of rows in the nullable column.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Returns `true` if the nullable column has no rows.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Returns the physical type of the nullable column values.
+    #[must_use]
+    pub fn column_type(&self) -> ColumnType {
+        self.values.column_type()
+    }
+
+    /// Returns the number of non-null rows.
+    #[must_use]
+    pub fn valid_len(&self) -> usize {
+        self.validity.iter().filter(|is_valid| **is_valid).count()
+    }
+
+    /// Returns the validity mask as a boolean `OwnedColumn`.
+    #[must_use]
+    pub fn validity_column(&self) -> OwnedColumn<S> {
+        validity_column(&self.validity)
+    }
+
+    /// Returns only the values whose rows are non-null.
+    pub fn valid_values(&self) -> NullableColumnResult<OwnedColumn<S>> {
+        Ok(filter_valid_owned_values(&self.values, &self.validity)?)
+    }
+
+    /// Returns the nullable column with its rows permuted.
+    pub fn try_permute(
+        &self,
+        permutation: &Permutation,
+    ) -> Result<Self, crate::base::math::permutation::PermutationError> {
+        let values = self.values.try_permute(permutation)?;
+        let validity = permutation.try_apply(&self.validity)?;
+        Ok(Self { values, validity })
+    }
+
+    /// Returns the sliced nullable column.
+    #[must_use]
+    pub fn slice(&self, start: usize, end: usize) -> Self {
+        Self {
+            values: self.values.slice(start, end),
+            validity: self.validity[start..end].to_vec(),
+        }
+    }
+
+    /// Adds a nullable column to a non-nullable column.
+    ///
+    /// The output is null exactly where `self` is null.
+    pub fn try_element_wise_add_nonnullable(
+        &self,
+        rhs: &OwnedColumn<S>,
+    ) -> NullableColumnResult<Self> {
+        validate_mask_length(rhs.len(), &self.validity)?;
+        let mut values = self.values.element_wise_add(rhs)?;
+        canonicalize_nulls(&mut values, &self.validity)?;
+        Ok(Self {
+            values,
+            validity: self.validity.clone(),
+        })
+    }
+
+    /// Adds two nullable columns.
+    ///
+    /// The output is null unless both input rows are non-null.
+    pub fn try_element_wise_add_nullable(&self, rhs: &Self) -> NullableColumnResult<Self> {
+        let validity = and_validity_masks(&self.validity, &rhs.validity)?;
+        let mut values = self.values.element_wise_add(&rhs.values)?;
+        canonicalize_nulls(&mut values, &validity)?;
+        Ok(Self { values, validity })
+    }
+}
+
+/// A borrowed nullable column represented as values plus a validity mask.
+#[derive(Debug, PartialEq, Clone, Eq)]
+pub struct NullableColumn<'a, S: Scalar> {
+    values: Column<'a, S>,
+    validity: &'a [bool],
+}
+
+impl<'a, S: Scalar> NullableColumn<'a, S> {
+    /// Creates a borrowed nullable column from canonicalized values.
+    pub fn try_new(values: Column<'a, S>, validity: &'a [bool]) -> NullableColumnResult<Self> {
+        ensure_canonical_column_nulls(&values, validity)?;
+        Ok(Self { values, validity })
+    }
+
+    /// Returns the backing values column.
+    #[must_use]
+    pub fn values(&self) -> Column<'a, S> {
+        self.values
+    }
+
+    /// Returns the validity mask.
+    #[must_use]
+    pub fn validity(&self) -> &'a [bool] {
+        self.validity
+    }
+
+    /// Returns the number of rows in the nullable column.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Returns `true` if the nullable column has no rows.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Returns the physical type of the nullable column values.
+    #[must_use]
+    pub fn column_type(&self) -> ColumnType {
+        self.values.column_type()
+    }
+}

--- a/crates/proof-of-sql/src/base/database/nullable_column_test.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column_test.rs
@@ -1,0 +1,155 @@
+use super::{
+    owned_table_utility::*, ColumnField, ColumnType, NullableOwnedColumn, OwnedColumn,
+    OwnedTableTestAccessor, TableRef, ValidityError,
+};
+use crate::{
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof, scalar::test_scalar::TestScalar,
+    },
+    sql::{
+        proof::VerifiableQueryResult,
+        proof_exprs::test_utility::{add, aliased_plan, column},
+        proof_plans::test_utility::{filter, table_exec},
+    },
+};
+use alloc::vec;
+
+#[test]
+fn we_can_construct_nullable_bigint_with_canonical_nulls() {
+    let nullable = NullableOwnedColumn::<TestScalar>::try_new_canonicalized(
+        OwnedColumn::BigInt(vec![10, 999, 20, 777]),
+        vec![true, false, true, false],
+    )
+    .unwrap();
+
+    assert_eq!(nullable.values(), &OwnedColumn::BigInt(vec![10, 0, 20, 0]));
+    assert_eq!(nullable.validity(), &[true, false, true, false]);
+    assert_eq!(nullable.valid_len(), 2);
+}
+
+#[test]
+fn we_reject_nullable_columns_with_noncanonical_nulls() {
+    let result = NullableOwnedColumn::<TestScalar>::try_new(
+        OwnedColumn::BigInt(vec![10, 999, 20]),
+        vec![true, false, true],
+    );
+
+    assert!(matches!(
+        result,
+        Err(super::NullableColumnError::Validity {
+            source: ValidityError::NonCanonicalNull { index: 1 }
+        })
+    ));
+}
+
+#[test]
+fn we_can_add_nullable_bigint_to_nonnullable_bigint() {
+    let nullable = NullableOwnedColumn::<TestScalar>::try_new_canonicalized(
+        OwnedColumn::BigInt(vec![10, 999, 20, 777]),
+        vec![true, false, true, false],
+    )
+    .unwrap();
+    let rhs = OwnedColumn::BigInt(vec![1, 2, 3, 4]);
+
+    let sum = nullable.try_element_wise_add_nonnullable(&rhs).unwrap();
+
+    assert_eq!(sum.validity(), &[true, false, true, false]);
+    assert_eq!(sum.values(), &OwnedColumn::BigInt(vec![11, 0, 23, 0]));
+}
+
+#[test]
+fn we_can_add_two_nullable_bigints() {
+    let left = NullableOwnedColumn::<TestScalar>::try_new_canonicalized(
+        OwnedColumn::BigInt(vec![10, 999, 20, 777]),
+        vec![true, false, true, false],
+    )
+    .unwrap();
+    let right = NullableOwnedColumn::<TestScalar>::try_new_canonicalized(
+        OwnedColumn::BigInt(vec![1, 2, 333, 4]),
+        vec![true, true, false, false],
+    )
+    .unwrap();
+
+    let sum = left.try_element_wise_add_nullable(&right).unwrap();
+
+    assert_eq!(sum.validity(), &[true, false, false, false]);
+    assert_eq!(sum.values(), &OwnedColumn::BigInt(vec![11, 0, 0, 0]));
+}
+
+#[test]
+fn we_can_prove_a_query_over_nullable_bigint_with_validity_filter() {
+    let nullable_score = NullableOwnedColumn::<TestScalar>::try_new_canonicalized(
+        OwnedColumn::BigInt(vec![10, 999, 16, 777, 22]),
+        vec![true, false, true, false, true],
+    )
+    .unwrap();
+    let score_plus_bonus = nullable_score
+        .try_element_wise_add_nonnullable(&OwnedColumn::BigInt(vec![1, 2, 3, 4, 5]))
+        .unwrap();
+    assert_eq!(
+        score_plus_bonus.valid_values().unwrap(),
+        OwnedColumn::BigInt(vec![11, 19, 27])
+    );
+
+    let table = owned_table([
+        ("score".into(), nullable_score.values().clone()),
+        ("score_valid".into(), nullable_score.validity_column()),
+        ("bonus".into(), OwnedColumn::BigInt(vec![1, 2, 3, 4, 5])),
+    ]);
+    let table_ref = TableRef::new("sxt", "nullable_scores");
+    let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        table_ref.clone(),
+        table,
+        0,
+        (),
+    );
+    let plan = filter(
+        vec![aliased_plan(
+            add(
+                column(&table_ref, "score", &accessor),
+                column(&table_ref, "bonus", &accessor),
+            ),
+            "score_plus_bonus",
+        )],
+        table_exec(
+            table_ref.clone(),
+            vec![
+                ColumnField::new_nullable("score".into(), ColumnType::BigInt),
+                ColumnField::new("score_valid".into(), ColumnType::Boolean),
+                ColumnField::new("bonus".into(), ColumnType::BigInt),
+            ],
+        ),
+        column(&table_ref, "score_valid", &accessor),
+    );
+
+    let verifiable_result =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+    let result = verifiable_result
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    assert_eq!(
+        result,
+        owned_table([decimal75("score_plus_bonus", 20, 0, [11_i64, 19, 27])])
+    );
+}
+
+#[test]
+fn nullable_schema_fields_preserve_nullability() {
+    let field = ColumnField::new_nullable("score".into(), ColumnType::BigInt);
+
+    assert_eq!(field.name().value, "score");
+    assert_eq!(field.data_type(), ColumnType::BigInt);
+    assert!(field.is_nullable());
+
+    let field = field.with_nullable(false);
+    assert!(!field.is_nullable());
+}
+
+#[test]
+fn nonnullable_schema_fields_remain_the_default() {
+    let field = ColumnField::new("score".into(), ColumnType::BigInt);
+
+    assert!(!field.is_nullable());
+}

--- a/crates/proof-of-sql/src/base/database/validity.rs
+++ b/crates/proof-of-sql/src/base/database/validity.rs
@@ -1,0 +1,250 @@
+use super::{Column, OwnedColumn};
+use crate::base::scalar::Scalar;
+use alloc::{string::String, vec::Vec};
+use snafu::Snafu;
+
+/// Errors for validity-mask based nullable column handling.
+#[derive(Snafu, Debug, PartialEq, Eq, Clone)]
+pub enum ValidityError {
+    /// The value column and validity mask have different lengths.
+    #[snafu(display(
+        "validity mask length mismatch: value length {value_len}, validity length {validity_len}"
+    ))]
+    LengthMismatch {
+        /// Number of values in the backing column.
+        value_len: usize,
+        /// Number of entries in the validity mask.
+        validity_len: usize,
+    },
+    /// A null row contains a non-canonical value.
+    #[snafu(display("non-canonical null value at row {index}"))]
+    NonCanonicalNull {
+        /// Row index containing a non-canonical null sentinel.
+        index: usize,
+    },
+}
+
+/// Result type for validity-mask operations.
+pub type ValidityResult<T> = core::result::Result<T, ValidityError>;
+
+/// Checks that a values column and validity mask have equal row counts.
+pub fn validate_mask_length(value_len: usize, validity: &[bool]) -> ValidityResult<()> {
+    if value_len == validity.len() {
+        Ok(())
+    } else {
+        Err(ValidityError::LengthMismatch {
+            value_len,
+            validity_len: validity.len(),
+        })
+    }
+}
+
+/// Computes the SQL validity mask for a binary operation.
+///
+/// A binary expression is non-null exactly when both inputs are non-null.
+pub fn and_validity_masks(lhs: &[bool], rhs: &[bool]) -> ValidityResult<Vec<bool>> {
+    validate_mask_length(lhs.len(), rhs)?;
+    Ok(lhs
+        .iter()
+        .zip(rhs)
+        .map(|(left, right)| *left && *right)
+        .collect())
+}
+
+/// Returns `true` when all rows in the validity mask are non-null.
+#[must_use]
+pub fn all_rows_valid(validity: &[bool]) -> bool {
+    validity.iter().all(|is_valid| *is_valid)
+}
+
+/// Replaces every invalid row with the canonical null sentinel for the column type.
+pub fn canonicalize_nulls<S: Scalar>(
+    values: &mut OwnedColumn<S>,
+    validity: &[bool],
+) -> ValidityResult<()> {
+    validate_mask_length(values.len(), validity)?;
+    match values {
+        OwnedColumn::Boolean(values) => canonicalize_slice(values, validity, false),
+        OwnedColumn::Uint8(values) => canonicalize_slice(values, validity, 0),
+        OwnedColumn::TinyInt(values) => canonicalize_slice(values, validity, 0),
+        OwnedColumn::SmallInt(values) => canonicalize_slice(values, validity, 0),
+        OwnedColumn::Int(values) => canonicalize_slice(values, validity, 0),
+        OwnedColumn::BigInt(values) | OwnedColumn::TimestampTZ(_, _, values) => {
+            canonicalize_slice(values, validity, 0);
+        }
+        OwnedColumn::Int128(values) => canonicalize_slice(values, validity, 0),
+        OwnedColumn::VarChar(values) => {
+            canonicalize_slice(values, validity, String::new());
+        }
+        OwnedColumn::VarBinary(values) => canonicalize_slice(values, validity, Vec::new()),
+        OwnedColumn::Decimal75(_, _, values) | OwnedColumn::Scalar(values) => {
+            canonicalize_slice(values, validity, S::ZERO);
+        }
+    }
+    Ok(())
+}
+
+/// Checks that every invalid row already contains the canonical null sentinel.
+pub fn ensure_canonical_nulls<S: Scalar>(
+    values: &OwnedColumn<S>,
+    validity: &[bool],
+) -> ValidityResult<()> {
+    validate_mask_length(values.len(), validity)?;
+    match values {
+        OwnedColumn::Boolean(values) => ensure_canonical_slice(values, validity, &false),
+        OwnedColumn::Uint8(values) => ensure_canonical_slice(values, validity, &0),
+        OwnedColumn::TinyInt(values) => ensure_canonical_slice(values, validity, &0),
+        OwnedColumn::SmallInt(values) => ensure_canonical_slice(values, validity, &0),
+        OwnedColumn::Int(values) => ensure_canonical_slice(values, validity, &0),
+        OwnedColumn::BigInt(values) | OwnedColumn::TimestampTZ(_, _, values) => {
+            ensure_canonical_slice(values, validity, &0)
+        }
+        OwnedColumn::Int128(values) => ensure_canonical_slice(values, validity, &0),
+        OwnedColumn::VarChar(values) => ensure_canonical_slice(values, validity, &String::new()),
+        OwnedColumn::VarBinary(values) => ensure_canonical_slice(values, validity, &Vec::new()),
+        OwnedColumn::Decimal75(_, _, values) | OwnedColumn::Scalar(values) => {
+            ensure_canonical_slice(values, validity, &S::ZERO)
+        }
+    }
+}
+
+/// Checks that a borrowed column uses canonical null sentinels for invalid rows.
+pub fn ensure_canonical_column_nulls<S: Scalar>(
+    values: &Column<'_, S>,
+    validity: &[bool],
+) -> ValidityResult<()> {
+    validate_mask_length(values.len(), validity)?;
+    match values {
+        Column::Boolean(values) => ensure_canonical_slice(values, validity, &false),
+        Column::Uint8(values) => ensure_canonical_slice(values, validity, &0),
+        Column::TinyInt(values) => ensure_canonical_slice(values, validity, &0),
+        Column::SmallInt(values) => ensure_canonical_slice(values, validity, &0),
+        Column::Int(values) => ensure_canonical_slice(values, validity, &0),
+        Column::BigInt(values) | Column::TimestampTZ(_, _, values) => {
+            ensure_canonical_slice(values, validity, &0)
+        }
+        Column::Int128(values) => ensure_canonical_slice(values, validity, &0),
+        Column::VarChar((values, _)) => ensure_canonical_slice(values, validity, &""),
+        Column::VarBinary((values, _)) => ensure_canonical_slice(values, validity, &&[][..]),
+        Column::Decimal75(_, _, values) | Column::Scalar(values) => {
+            ensure_canonical_slice(values, validity, &S::ZERO)
+        }
+    }
+}
+
+/// Filters an owned column down to rows that are marked valid.
+pub fn filter_valid_owned_values<S: Scalar>(
+    values: &OwnedColumn<S>,
+    validity: &[bool],
+) -> ValidityResult<OwnedColumn<S>> {
+    validate_mask_length(values.len(), validity)?;
+    Ok(match values {
+        OwnedColumn::Boolean(values) => OwnedColumn::Boolean(filter_valid_slice(values, validity)),
+        OwnedColumn::Uint8(values) => OwnedColumn::Uint8(filter_valid_slice(values, validity)),
+        OwnedColumn::TinyInt(values) => OwnedColumn::TinyInt(filter_valid_slice(values, validity)),
+        OwnedColumn::SmallInt(values) => {
+            OwnedColumn::SmallInt(filter_valid_slice(values, validity))
+        }
+        OwnedColumn::Int(values) => OwnedColumn::Int(filter_valid_slice(values, validity)),
+        OwnedColumn::BigInt(values) => OwnedColumn::BigInt(filter_valid_slice(values, validity)),
+        OwnedColumn::Int128(values) => OwnedColumn::Int128(filter_valid_slice(values, validity)),
+        OwnedColumn::VarChar(values) => OwnedColumn::VarChar(filter_valid_slice(values, validity)),
+        OwnedColumn::VarBinary(values) => {
+            OwnedColumn::VarBinary(filter_valid_slice(values, validity))
+        }
+        OwnedColumn::Decimal75(precision, scale, values) => {
+            OwnedColumn::Decimal75(*precision, *scale, filter_valid_slice(values, validity))
+        }
+        OwnedColumn::TimestampTZ(time_unit, timezone, values) => {
+            OwnedColumn::TimestampTZ(*time_unit, *timezone, filter_valid_slice(values, validity))
+        }
+        OwnedColumn::Scalar(values) => OwnedColumn::Scalar(filter_valid_slice(values, validity)),
+    })
+}
+
+/// Builds a boolean column from a validity mask.
+#[must_use]
+pub fn validity_column<S: Scalar>(validity: &[bool]) -> OwnedColumn<S> {
+    OwnedColumn::Boolean(validity.to_vec())
+}
+
+fn canonicalize_slice<T: Clone>(values: &mut [T], validity: &[bool], canonical_null: T) {
+    for (value, is_valid) in values.iter_mut().zip(validity) {
+        if !*is_valid {
+            *value = canonical_null.clone();
+        }
+    }
+}
+
+fn ensure_canonical_slice<T: PartialEq>(
+    values: &[T],
+    validity: &[bool],
+    canonical_null: &T,
+) -> ValidityResult<()> {
+    values
+        .iter()
+        .zip(validity)
+        .enumerate()
+        .find(|(_, (value, is_valid))| !**is_valid && *value != canonical_null)
+        .map_or(Ok(()), |(index, _)| {
+            Err(ValidityError::NonCanonicalNull { index })
+        })
+}
+
+fn filter_valid_slice<T: Clone>(values: &[T], validity: &[bool]) -> Vec<T> {
+    values
+        .iter()
+        .zip(validity)
+        .filter_map(|(value, is_valid)| is_valid.then(|| value.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::vec;
+
+    #[test]
+    fn we_can_canonicalize_invalid_rows() {
+        let mut column = OwnedColumn::<TestScalar>::BigInt(vec![10, 999, 20]);
+
+        canonicalize_nulls(&mut column, &[true, false, true]).unwrap();
+
+        assert_eq!(column, OwnedColumn::BigInt(vec![10, 0, 20]));
+    }
+
+    #[test]
+    fn we_reject_noncanonical_null_rows() {
+        let column = OwnedColumn::<TestScalar>::VarChar(vec![
+            "valid".to_string(),
+            "not-null-sentinel".to_string(),
+        ]);
+
+        assert_eq!(
+            ensure_canonical_nulls(&column, &[true, false]),
+            Err(ValidityError::NonCanonicalNull { index: 1 })
+        );
+    }
+
+    #[test]
+    fn we_can_filter_valid_rows() {
+        let column = OwnedColumn::<TestScalar>::Int(vec![4, 8, 15, 16, 23]);
+
+        let filtered =
+            filter_valid_owned_values(&column, &[true, false, true, false, true]).unwrap();
+
+        assert_eq!(filtered, OwnedColumn::Int(vec![4, 15, 23]));
+    }
+
+    #[test]
+    fn we_reject_validity_length_mismatches() {
+        assert_eq!(
+            validate_mask_length(3, &[true, false]),
+            Err(ValidityError::LengthMismatch {
+                value_len: 3,
+                validity_len: 2
+            })
+        );
+    }
+}


### PR DESCRIPTION
Addresses #183.

## Summary

This PR adds a proof-of-concept nullable column layer for Proof of SQL that is intentionally broader than metadata-only schema plumbing:

- Adds nullable schema metadata to `ColumnField` while preserving backwards-compatible serialization for existing non-nullable schemas.
- Propagates nullable metadata through Arrow `Field` conversion and planner schema construction.
- Introduces validity-mask utilities that validate mask length, canonicalize null payload values, reject non-canonical nulls, combine masks, and extract only valid values.
- Adds `NullableOwnedColumn` and borrowed `NullableColumn` wrappers around existing `OwnedColumn` values plus canonical validity masks.
- Implements nullable-aware `BigInt` addition for nullable + non-nullable and nullable + nullable operands, preserving canonical null representation.
- Adds an end-to-end proof test that proves a query over nullable `BigInt` data by pairing the nullable value column with its validity column and filtering out null rows before projection.

## Why

Issue #183 asks for nullable column support and calls out the need for a proof of concept that demonstrates how nullable values can participate in the proof system. This PR establishes the core representation and validation invariants, then shows the path through schema conversion, column operations, and proof execution.

## Validation

Run locally with a short target directory because the Windows workspace path was too long for dependency build scripts:

```powershell
$env:CARGO_TARGET_DIR='C:\sxt-target'; $env:CARGO_BUILD_JOBS='1'; cargo test -p proof-of-sql nullable --no-default-features --features "arrow cpu-perf test"
$env:CARGO_TARGET_DIR='C:\sxt-target'; $env:CARGO_BUILD_JOBS='1'; cargo test -p proof-of-sql validity --no-default-features --features "arrow cpu-perf test"
$env:CARGO_TARGET_DIR='C:\sxt-target'; $env:CARGO_BUILD_JOBS='1'; cargo test -p proof-of-sql-planner we_can_convert_column_fields_to_schema --features cpu-perf
```

All three targeted test runs passed.