### PR TITLE
test: add ColumnRef coverage

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,36 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_ref_accessors_return_the_values_used_to_construct_it() {
+        let table_ref = TableRef::new("analytics", "events");
+        let column_id = Ident::new("event_count");
+        let column_ref = ColumnRef::new(table_ref.clone(), column_id.clone(), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), column_id);
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_ref_serialization_round_trips_schema_and_type_information() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("public", "accounts"),
+            Ident::new("display_name"),
+            ColumnType::VarChar,
+        );
+        let serialized = serde_json::to_string(&column_ref).unwrap();
+
+        let deserialized: ColumnRef = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, column_ref);
+        assert_eq!(deserialized.table_ref().to_string(), "public.accounts");
+        assert_eq!(deserialized.column_id(), Ident::new("display_name"));
+        assert_eq!(deserialized.column_type(), &ColumnType::VarChar);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Adds a small, non-overlapping test-only coverage slice for `ColumnRef` as part of #560.

# What changes are included in this PR?
- Add coverage for `ColumnRef::new` and the accessor methods.
- Add serde round-trip coverage to confirm table schema, column id, and column type information are preserved.

# Are these changes tested?
Tests are included in `crates/proof-of-sql/src/base/database/column_ref.rs`.

Local validation:
- `git diff --check`

Not run locally:
- `cargo fmt`, `cargo test`, `source scripts/run_ci_checks.sh`, and `source scripts/check_commits.sh` because this Windows environment does not have `cargo` or `rustc` installed.