### PR TITLE
test: cover timestamp timezone parsing

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -111,6 +111,30 @@ mod timezone_parsing_tests {
     }
 
     #[test]
+    fn we_can_parse_utc_alias_time_zones() {
+        for alias in ["Z", "z", "UTC", "utc", "00:00", "+00:00", "0:00", "+0:00"] {
+            let timezone_as_str: Option<Arc<str>> = Some(alias.into());
+            let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+
+            assert_eq!(timezone, PoSQLTimeZone::utc());
+            assert_eq!(timezone.offset(), 0);
+        }
+    }
+
+    #[test]
+    fn malformed_offset_components_report_invalid_timezone_offset() {
+        for invalid_offset in ["+AA:00", "+01:BB"] {
+            let timezone_as_str: Option<Arc<str>> = Some(invalid_offset.into());
+            let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();
+
+            assert!(matches!(
+                timezone_err,
+                PoSQLTimestampError::InvalidTimezoneOffset
+            ));
+        }
+    }
+
+    #[test]
     fn we_cannot_parse_invalid_time_zone() {
         let timezone_as_str: Option<Arc<str>> = Some("111111111".into());
         let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Adds a small, non-overlapping test-only coverage slice for timestamp timezone parsing as part of #560.

# What changes are included in this PR?
- Add coverage for accepted UTC timezone aliases including case-normalized `Z` and `UTC` values.
- Add coverage for malformed hour/minute offset components returning `InvalidTimezoneOffset`.

# Are these changes tested?
Tests are included in `crates/proof-of-sql/src/base/posql_time/timezone.rs`.

Local validation:
- `git diff --check`

Not run locally:
- `cargo fmt`, `cargo test`, `source scripts/run_ci_checks.sh`, and `source scripts/check_commits.sh` because this Windows environment does not have `cargo` or `rustc` installed.