### PR TITLE
test: run sort merge join tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -59,7 +59,7 @@ mod union_exec_test;
 
 mod sort_merge_join_exec;
 pub use sort_merge_join_exec::SortMergeJoinExec;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod sort_merge_join_exec_test;
 
 mod dyn_proof_plan;

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -1,22 +1,23 @@
 use super::test_utility::*;
 use crate::{
-    base::database::{
-        owned_table_utility::*, table_utility::*, ColumnType, TableRef, TableTestAccessor,
-        TestAccessor,
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        database::{
+            owned_table_utility::*, table_utility::*, ColumnType, TableRef, TableTestAccessor,
+            TestAccessor,
+        },
     },
-    sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-    },
+    sql::{proof::VerifiableQueryResult, proof_exprs::test_utility::*},
 };
-use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use sqlparser::ast::Ident;
+
+type Proof = NaiveEvaluationProof;
 
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<Proof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar(
@@ -56,9 +57,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<Proof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -74,7 +74,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_merge_join() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<Proof>::new_empty_with_setup(());
     let cats = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 29, 20, 21], &alloc),
         borrowed_varchar(
@@ -134,9 +134,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
         2,
         Some(3),
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<Proof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -153,7 +152,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
 #[expect(clippy::too_many_lines)]
 fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_sort_merge_joins() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<Proof>::new_empty_with_setup(());
     let cats = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 10, 29, 20, 21], &alloc),
         borrowed_varchar(
@@ -267,9 +266,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
         ],
     );
 
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<Proof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -296,7 +294,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
 #[test]
 fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<Proof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar(
@@ -332,9 +330,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<Proof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -353,7 +350,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
 ) {
     // Left table has no rows but right table has rows
     let alloc = Bump::new();
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<Proof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [0_i64; 0], &alloc),
         borrowed_varchar("name", [""; 0], &alloc),
@@ -385,9 +382,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<Proof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_right);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -400,7 +396,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
     assert_eq!(res, expected_res);
 
     // Right table has no rows but left table has rows
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<Proof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar(
@@ -436,9 +432,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<Proof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -451,7 +446,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
     assert_eq!(res, expected_res);
 
     // Both tables have no rows
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<Proof>::new_empty_with_setup(());
     let left = table([
         borrowed_bigint("id", [0_i64; 0], &alloc),
         borrowed_varchar("name", [""; 0], &alloc),
@@ -483,7 +478,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![0],
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
-    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+    let verifiable_res: VerifiableQueryResult<Proof> =
         VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])


### PR DESCRIPTION
## Summary
- run the existing sort-merge-join proof-plan tests under the no-default test configuration
- switch the tests from `InnerProductProof` to `NaiveEvaluationProof` so they do not require the `blitzar` feature
- keep production behavior unchanged and keep the existing positive/empty result assertions

## Coverage
Local LCOV evidence from this branch:
- `crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs`: 404 / 435 executable lines covered in the focused run
- Compared against my saved `origin/main` baseline from `cargo llvm-cov -p proof-of-sql --no-default-features --features arrow --lib --lcov --output-path target/proof-of-sql-arrow-baseline.lcov`, 346 previously zero-hit lines in `sort_merge_join_exec.rs` are hit by this slice
- At the issue rate of $0.10 / newly covered line, that is approximately $34.60 if the maintainer baseline matches

This is separate from #1717, which targets constructor validation and the unsupported multi-column join path.

## Verification
- `cargo test -p proof-of-sql --lib --no-default-features --features test sort_merge_join_exec_test -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/proof-of-sql-sort-merge-join-naive.lcov -- sort_merge_join_exec_test`
- `cargo test -p proof-of-sql --lib --no-default-features --features test`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

/claim #560