### PR TITLE
test: cover rayon cfg macro

### DIFF
--- a/crates/proof-of-sql/src/base/rayon_cfg.rs
+++ b/crates/proof-of-sql/src/base/rayon_cfg.rs
@@ -11,3 +11,24 @@ macro_rules! if_rayon {
     }};
 }
 pub(crate) use if_rayon;
+
+#[cfg(test)]
+mod tests {
+    use super::if_rayon;
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn if_rayon_uses_rayon_branch_when_enabled() {
+        let value = if_rayon!(17, fallback_value());
+
+        assert_eq!(value, 17);
+    }
+
+    #[cfg(not(feature = "rayon"))]
+    #[test]
+    fn if_rayon_uses_fallback_branch_when_disabled() {
+        let value = if_rayon!(rayon_value(), 23);
+
+        assert_eq!(value, 23);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused tests for the `if_rayon!` compile-time branch selector
- cover the fallback branch when `rayon` is disabled
- cover the rayon branch when `rayon` is enabled without default/blitzar features
- keep production behavior unchanged

## Non-overlap check
- searched current issue comments and open PR bodies for `rayon_cfg`, `if_rayon`, and related rayon-cfg wording before submitting

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --no-default-features --features test base::rayon_cfg::tests -- --nocapture`
- `cargo test -p proof-of-sql --no-default-features --features test,rayon base::rayon_cfg::tests -- --nocapture`
- `git diff --check`