### PR TITLE
test: cover permutation comparator constructor

### DIFF
--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -29,7 +29,7 @@ pub struct Permutation {
 
 impl Permutation {
     /// Create a new permutation from a comparison function with the given length
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn unchecked_new_from_cmp<F>(length: usize, cmp: F) -> Self
     where
         F: Fn(&usize, &usize) -> Ordering + Sync,
@@ -99,6 +99,20 @@ mod test {
         assert_eq!(
             permutation.try_apply(&["and", "Space", "Time"]).unwrap(),
             vec!["Space", "and", "Time"]
+        );
+    }
+
+    #[test]
+    fn test_unchecked_new_from_cmp_sorts_indexes_by_comparator() {
+        let values = [40, 10, 30, 20];
+        let permutation = Permutation::unchecked_new_from_cmp(values.len(), |left, right| {
+            values[*left].cmp(&values[*right])
+        });
+
+        assert_eq!(permutation.size(), 4);
+        assert_eq!(
+            permutation.try_apply(&values).unwrap(),
+            vec![10, 20, 30, 40]
         );
     }
 


### PR DESCRIPTION
/claim #560

# Rationale for this change

`Permutation::unchecked_new_from_cmp` is used to build a permutation by sorting indexes with a caller-provided comparator, but its constructor path was not covered in the no-default `test` lane.

# What changes are included in this PR?

- Add a focused unit test for `Permutation::unchecked_new_from_cmp` that sorts indexes by external values.
- Verify the resulting permutation by applying it to the original values.
- Scope the change to `crates/proof-of-sql/src/base/math/permutation.rs`.

# Are these changes tested?

Yes.

- [x] `cargo test -p proof-of-sql --lib --no-default-features --features test base::math::permutation::test`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `source scripts/check_commits.sh`
- [x] `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path /tmp/proof-of-sql-permutation.lcov -- base::math::permutation::test`

Targeted coverage reported `crates/proof-of-sql/src/base/math/permutation.rs` at 65/65 covered lines in the focused run. The baseline full no-default report had the comparator-constructor lines uncovered.

AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.