### PR TITLE
test: cache Dory setups in evaluation proof tests

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    test_dory_setup, test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar,
+    DoryVerifierPublicSetup, ProverSetup, PublicParameters,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -8,45 +8,45 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(4);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(prover_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(prover_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(6);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(prover_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(4);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(prover_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(prover_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(6);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(prover_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
@@ -55,15 +55,15 @@ fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
     let setup_setup = [(4, 4), (4, 3), (6, 2)];
     for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let cached_setup = test_dory_setup(setup_p.0);
+        let prover_setup = &cached_setup.prover_setup;
+        let verifier_setup = &cached_setup.verifier_setup;
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
-                &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &DoryProverPublicSetup::new(prover_setup, setup_p.1),
+                &DoryVerifierPublicSetup::new(verifier_setup, setup_p.1),
             );
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
+    test_dory_setup, test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup,
+    PublicParameters,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -7,53 +8,51 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(4);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_simple_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &prover_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(4);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_commitment_evaluation_proof_with_length_1::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &prover_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 #[should_panic = "verification improperly failed"]
 fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = &test_dory_setup(6).prover_setup;
+    let verifier_setup = &test_dory_setup(2).verifier_setup;
     test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
         128,
         0,
-        &&prover_setup,
-        &&verifier_setup,
+        &prover_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(6);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     for length in lengths {
         test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
             length,
             0,
-            &&prover_setup,
-            &&verifier_setup,
+            &prover_setup,
+            &verifier_setup,
         );
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -38,6 +38,10 @@ mod dory_messages_test;
 mod setup;
 pub use setup::{ProverSetup, VerifierSetup};
 #[cfg(test)]
+mod test_setup;
+#[cfg(test)]
+use test_setup::test_dory_setup;
+#[cfg(test)]
 mod setup_test;
 
 mod state;

--- a/crates/proof-of-sql/src/proof_primitive/dory/test_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/test_setup.rs
@@ -1,0 +1,45 @@
+use super::{rand_util::test_seed_rng, ProverSetup, PublicParameters, VerifierSetup};
+use std::sync::OnceLock;
+
+pub(crate) struct TestDorySetup {
+    pub(crate) prover_setup: ProverSetup<'static>,
+    pub(crate) verifier_setup: VerifierSetup,
+}
+
+pub(crate) fn test_dory_setup(max_nu: usize) -> &'static TestDorySetup {
+    match max_nu {
+        2 => setup_for::<2>(),
+        4 => setup_for::<4>(),
+        5 => setup_for::<5>(),
+        6 => setup_for::<6>(),
+        _ => panic!("missing cached Dory test setup for nu {max_nu}"),
+    }
+}
+
+fn setup_for<const MAX_NU: usize>() -> &'static TestDorySetup {
+    static SETUP_2: OnceLock<TestDorySetup> = OnceLock::new();
+    static SETUP_4: OnceLock<TestDorySetup> = OnceLock::new();
+    static SETUP_5: OnceLock<TestDorySetup> = OnceLock::new();
+    static SETUP_6: OnceLock<TestDorySetup> = OnceLock::new();
+
+    match MAX_NU {
+        2 => SETUP_2.get_or_init(|| setup_with_max_nu(MAX_NU)),
+        4 => SETUP_4.get_or_init(|| setup_with_max_nu(MAX_NU)),
+        5 => SETUP_5.get_or_init(|| setup_with_max_nu(MAX_NU)),
+        6 => SETUP_6.get_or_init(|| setup_with_max_nu(MAX_NU)),
+        _ => unreachable!("unsupported cached Dory test setup"),
+    }
+}
+
+fn setup_with_max_nu(max_nu: usize) -> TestDorySetup {
+    let mut rng = test_seed_rng([max_nu as u8; 32]);
+    let public_parameters =
+        Box::leak(Box::new(PublicParameters::test_rand(max_nu, &mut rng)));
+    let prover_setup = ProverSetup::from(&*public_parameters);
+    let verifier_setup = VerifierSetup::from(&*public_parameters);
+
+    TestDorySetup {
+        prover_setup,
+        verifier_setup,
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #557

# Please go through the following checklist

- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Addresses #557.

The Dory commitment evaluation proof tests repeatedly construct equivalent public parameters, prover setups, and verifier setups for the same `nu` values. `VerifierSetup::from` performs expensive pairing work, and `ProverSetup::from` may also prepare setup-specific state, so rebuilding these values in each test adds avoidable runtime.

# What changes are included in this PR?

- Add a test-only `test_setup.rs` helper with `OnceLock`-backed cached Dory setups for the `nu` values used by these tests.
- Wire the helper into the Dory test module.
- Update the static and dynamic Dory commitment evaluation proof tests to reuse cached prover/verifier setup values.

# Are these changes tested?

Partially. `git diff --check` passes locally.

I could not run `cargo test`, `source scripts/run_ci_checks.sh`, or `source scripts/check_commits.sh` in this Codex runtime because `cargo`/`rustfmt`/Rust toolchain managers are not installed on PATH here.