### PR TITLE
test: cover OwnedColumnError and ColumnCoercionError display + equality

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -78,6 +78,9 @@ mod owned_column_error;
 pub(crate) use owned_column_error::ColumnCoercionError;
 pub use owned_column_error::{OwnedColumnError, OwnedColumnResult};
 
+#[cfg(test)]
+mod owned_column_error_test;
+
 /// Module providing element-wise operations on [`OwnedColumn`] types.
 ///
 /// This module implements arithmetic, comparison, and logical operations

--- a/crates/proof-of-sql/src/base/database/owned_column_error_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error_test.rs
@@ -1,0 +1,67 @@
+use super::{ColumnCoercionError, ColumnType, OwnedColumnError};
+use alloc::string::{String, ToString};
+
+#[test]
+fn owned_column_error_messages_are_formatted_as_expected() {
+    let cast = OwnedColumnError::TypeCastError {
+        from_type: ColumnType::Boolean,
+        to_type: ColumnType::BigInt,
+    };
+    assert_eq!(
+        cast.to_string(),
+        "Can not perform type casting from Boolean to BigInt"
+    );
+
+    let scalar = OwnedColumnError::ScalarConversionError {
+        error: String::from("overflow"),
+    };
+    assert_eq!(
+        scalar.to_string(),
+        "Error in converting scalars to a given column type: overflow"
+    );
+
+    let unsupported = OwnedColumnError::Unsupported {
+        error: String::from("nope"),
+    };
+    assert_eq!(unsupported.to_string(), "Unsupported operation: nope");
+}
+
+#[test]
+fn owned_column_error_equality_depends_on_fields() {
+    let a = OwnedColumnError::TypeCastError {
+        from_type: ColumnType::Boolean,
+        to_type: ColumnType::BigInt,
+    };
+    let same = OwnedColumnError::TypeCastError {
+        from_type: ColumnType::Boolean,
+        to_type: ColumnType::BigInt,
+    };
+    let different = OwnedColumnError::TypeCastError {
+        from_type: ColumnType::Boolean,
+        to_type: ColumnType::Int,
+    };
+    assert_eq!(a, same);
+    assert_ne!(a, different);
+    assert_ne!(
+        a,
+        OwnedColumnError::Unsupported {
+            error: String::from("x")
+        }
+    );
+}
+
+#[test]
+fn column_coercion_error_messages_are_formatted_as_expected() {
+    assert_eq!(
+        ColumnCoercionError::Overflow.to_string(),
+        "Overflow when coercing a column"
+    );
+    assert_eq!(
+        ColumnCoercionError::InvalidTypeCoercion.to_string(),
+        "Invalid type coercion"
+    );
+    assert_ne!(
+        ColumnCoercionError::Overflow,
+        ColumnCoercionError::InvalidTypeCoercion
+    );
+}


### PR DESCRIPTION
## Summary

Adds unit-test coverage for `base::database::owned_column_error`, which previously had no tests. New `owned_column_error_test.rs` covers:

- `OwnedColumnError` `Display` output for all three variants (`TypeCastError`, `ScalarConversionError`, `Unsupported`)
- `OwnedColumnError` `PartialEq` (equality depends on fields/variant)
- `ColumnCoercionError` `Display` output (`Overflow`, `InvalidTypeCoercion`) and inequality

## Context

Non-overlapping coverage slice for #560 — limited to `owned_column_error`, no overlap with other open coverage PRs.

## Verification

- `cargo test -p proof-of-sql --lib base::database::owned_column_error_test` → 3 passed
- `cargo fmt -- --check` clean on changed files