### PR TITLE
test: cover table evaluation accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,56 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableEvaluation;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::vec;
+
+    #[test]
+    fn stores_column_evaluations_and_chi_metadata() {
+        let table_evaluation = TableEvaluation::new(
+            vec![
+                TestScalar::from(7u64),
+                TestScalar::from(11u64),
+                TestScalar::from(13u64),
+            ],
+            (TestScalar::from(5u64), 8),
+        );
+
+        assert_eq!(
+            table_evaluation.column_evals(),
+            &[
+                TestScalar::from(7u64),
+                TestScalar::from(11u64),
+                TestScalar::from(13u64),
+            ],
+        );
+        assert_eq!(table_evaluation.chi_eval(), TestScalar::from(5u64));
+        assert_eq!(table_evaluation.chi(), (TestScalar::from(5u64), 8));
+    }
+
+    #[test]
+    fn supports_empty_column_evaluation_results() {
+        let table_evaluation = TableEvaluation::new(vec![], (TestScalar::from(3u64), 0));
+
+        assert!(table_evaluation.column_evals().is_empty());
+        assert_eq!(table_evaluation.chi_eval(), TestScalar::from(3u64));
+        assert_eq!(table_evaluation.chi(), (TestScalar::from(3u64), 0));
+    }
+
+    #[test]
+    fn clone_and_equality_preserve_all_fields() {
+        let table_evaluation = TableEvaluation::new(
+            vec![TestScalar::from(17u64), TestScalar::from(19u64)],
+            (TestScalar::from(23u64), 2),
+        );
+
+        let cloned = table_evaluation.clone();
+
+        assert_eq!(cloned, table_evaluation);
+        assert_eq!(cloned.column_evals(), table_evaluation.column_evals());
+        assert_eq!(cloned.chi(), table_evaluation.chi());
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope
Adds a small, test-only coverage slice for `base::database::table_evaluation`.

Covered behavior:
- constructor stores column evaluations and chi metadata
- `column_evals`, `chi_eval`, and `chi` accessors
- empty column evaluation results
- clone/equality semantics

No production behavior changes.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test table_evaluation::tests -- --nocapture` -> 3 passed
- `cargo fmt --check`
- `git diff --check`