### PR TITLE
test: cover memory logging helper

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -67,7 +67,7 @@ merlin = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["std"] }
 rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -30,3 +30,69 @@ pub fn log_memory_usage(name: &str) {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tracing::{
+        span::{Attributes, Id, Record},
+        Event, Metadata, Subscriber,
+    };
+
+    struct TraceCountingSubscriber {
+        events: AtomicUsize,
+    }
+
+    impl TraceCountingSubscriber {
+        const fn new() -> Self {
+            Self {
+                events: AtomicUsize::new(0),
+            }
+        }
+
+        fn event_count(&self) -> usize {
+            self.events.load(Ordering::Relaxed)
+        }
+    }
+
+    impl Subscriber for TraceCountingSubscriber {
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            *metadata.level() == Level::TRACE
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, _event: &Event<'_>) {
+            self.events.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
+
+    #[test]
+    fn we_skip_memory_logging_when_trace_is_disabled() {
+        log_memory_usage("trace-disabled");
+    }
+
+    #[test]
+    fn we_emit_memory_logging_when_trace_is_enabled() {
+        let subscriber = Arc::new(TraceCountingSubscriber::new());
+        let observed_subscriber = Arc::clone(&subscriber);
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_memory_usage("trace-enabled");
+        });
+
+        assert_eq!(observed_subscriber.event_count(), 1);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused unit coverage for `utils::log::log_memory_usage` with TRACE disabled and TRACE enabled.
- Use a small test subscriber to verify the TRACE-enabled path emits exactly one event.
- Enable `tracing`'s `std` feature for dev builds only so tests can use scoped subscriber dispatch.

No production behavior changes.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test utils::log::tests -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/log-memory-coverage.lcov -- utils::log::tests --nocapture`
  - `utils/log.rs`: `LH:37/44` in the focused LCOV run, including production lines `14`, `16-25`, `31-32`.
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
