### PR TITLE
test: cover inner product ref casting

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -162,3 +162,31 @@ fn test_inner_product_testscalar_uneven() {
     ];
     assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
+
+#[test]
+fn test_inner_product_ref_cast() {
+    let a = vec![1_u64, 2, 3];
+    let b = vec![
+        TestScalar::from(4_u64),
+        TestScalar::from(5_u64),
+        TestScalar::from(6_u64),
+    ];
+
+    assert_eq!(TestScalar::from(32_u64), inner_product_ref_cast(&a, &b));
+}
+
+#[test]
+fn test_inner_product_ref_cast_uses_shorter_length() {
+    let a = vec![1_u64, 2, 3, 100];
+    let b = vec![TestScalar::from(4_u64), TestScalar::from(5_u64)];
+
+    assert_eq!(TestScalar::from(14_u64), inner_product_ref_cast(&a, &b));
+}
+
+#[test]
+fn test_inner_product_ref_cast_empty_inputs() {
+    let a: Vec<u64> = vec![];
+    let b: Vec<TestScalar> = vec![];
+
+    assert_eq!(TestScalar::from(0_u64), inner_product_ref_cast(&a, &b));
+}


### PR DESCRIPTION
/claim #560

## Scope
Adds a small, test-only coverage slice for `base::slice_ops::inner_product`.

Covered behavior:
- `inner_product_ref_cast` casts left-hand references before multiplying
- uneven inputs stop at the shorter slice
- empty inputs return the additive identity

No production behavior changes.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test inner_product -- --nocapture` -> 80 passed
- `cargo fmt --check`
- `git diff --check`