### PR TITLE
Reject nullable Arrow ArrayRefs before OwnedColumn conversion

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -23,7 +23,7 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
+        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
         Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
         TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
     },
@@ -148,6 +148,9 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
     /// - `Decimal256Array` when converting from `DataType::Decimal256` if precision is less than or equal to 75.
     /// - `StringArray` when converting from `DataType::Utf8`.
     fn try_from(value: &ArrayRef) -> Result<Self, Self::Error> {
+        if value.null_count() != 0 {
+            return Err(OwnedArrowConversionError::NullNotSupportedYet);
+        }
         match &value.data_type() {
             // Arrow uses a bit-packed representation for booleans.
             // Hence we need to unpack the bits to get the actual boolean values.

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -101,6 +101,16 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
     ));
 }
 
+#[test]
+fn we_reject_nullable_bigint_array_ref_instead_of_silently_reading_values() {
+    let array_ref: ArrayRef = Arc::new(Int64Array::from(vec![Some(7), None, Some(9)]));
+
+    assert!(matches!(
+        OwnedColumn::<TestScalar>::try_from(array_ref),
+        Err(OwnedArrowConversionError::NullNotSupportedYet)
+    ));
+}
+
 fn we_can_convert_between_owned_table_and_record_batch_impl(
     owned_table: &OwnedTable<TestScalar>,
     record_batch: &RecordBatch,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Related to #183.

/claim #183

`ArrayRefExt::to_column` already rejects arrays containing nulls, but `OwnedColumn::<S>::try_from(&ArrayRef)` did not check `null_count()` before reading the physical values buffer. For arrays such as `Int64Array::from(vec![Some(7), None, Some(9)])`, Arrow still exposes a values buffer, so this conversion path could silently read a placeholder value for a null slot.

This PR keeps the current no-null boundary explicit by returning `OwnedArrowConversionError::NullNotSupportedYet` before converting nullable `ArrayRef` values into `OwnedColumn`.

# What changes are included in this PR?

- Import the Arrow `Array` trait so `null_count()` is available on `ArrayRef`.
- Return `OwnedArrowConversionError::NullNotSupportedYet` when the input `ArrayRef` contains nulls.
- Add a regression test for nullable `Int64Array` input.

# Are these changes tested?

Yes, focused local tests passed:

```bash
cargo test -p proof-of-sql --no-default-features --features "arrow test" base::arrow::owned_and_arrow_conversions_test::we_reject_nullable_bigint_array_ref_instead_of_silently_reading_values --lib
cargo test -p proof-of-sql --no-default-features --features "arrow test" base::arrow::owned_and_arrow_conversions_test --lib
cargo test -p proof-of-sql --no-default-features --features "arrow test" base::arrow --lib
```

The broader focused `base::arrow` run reported 78 passed, 0 failed. I have not run the full repository CI script locally.
