### PR TITLE
test: cover Dory public setup wrappers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup_test.rs
@@ -1,0 +1,27 @@
+use super::{
+    test_rng, DoryProverPublicSetup, DoryVerifierPublicSetup, ProverSetup, PublicParameters,
+    VerifierSetup,
+};
+
+#[test]
+fn prover_public_setup_returns_its_sigma_and_setup() {
+    let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let public_setup = DoryProverPublicSetup::new(&prover_setup, 2);
+
+    assert_eq!(public_setup.sigma(), 2);
+    assert!(core::ptr::eq(public_setup.prover_setup(), &prover_setup));
+}
+
+#[test]
+fn verifier_public_setup_returns_its_sigma_and_setup() {
+    let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let public_setup = DoryVerifierPublicSetup::new(&verifier_setup, 1);
+
+    assert_eq!(public_setup.sigma(), 1);
+    assert!(core::ptr::eq(
+        public_setup.verifier_setup(),
+        &verifier_setup
+    ));
+}

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -104,6 +104,8 @@ mod vmv_state_test;
 
 mod dory_public_setup;
 pub use dory_public_setup::{DoryProverPublicSetup, DoryVerifierPublicSetup};
+#[cfg(test)]
+mod dory_public_setup_test;
 
 mod dory_commitment;
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Adds focused test coverage for `DoryProverPublicSetup` constructor/accessor behavior.
- Adds focused test coverage for `DoryVerifierPublicSetup` constructor/accessor behavior.
- Keeps the change test-only and scoped to `proof_primitive::dory::dory_public_setup`.

/claim #560

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test dory_public_setup_test` -> 2 passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Environment note
- `cargo test -p proof-of-sql --no-default-features dory_public_setup_test` is blocked by existing no-std test compilation issues in unrelated modules (`std`/`vec` unavailable before this test slice can run).
- `cargo test -p proof-of-sql dory_public_setup_test` is blocked on this macOS arm64 environment by upstream `halo2curves` enabling the x86_64-only `asm` feature through default features.