### PR TITLE
test: cover table expression basics

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -65,6 +65,8 @@ mod equals_expr_test;
 
 mod table_expr;
 pub use table_expr::TableExpr;
+#[cfg(test)]
+mod table_expr_test;
 
 #[cfg(test)]
 pub(crate) mod test_utility;

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr_test.rs
@@ -1,0 +1,27 @@
+use super::TableExpr;
+use crate::base::database::TableRef;
+
+#[test]
+fn table_expr_preserves_table_ref_when_cloned() {
+    let table_expr = TableExpr {
+        table_ref: TableRef::new("public", "orders"),
+    };
+
+    let cloned = table_expr.clone();
+
+    assert_eq!(cloned, table_expr);
+    assert_eq!(cloned.table_ref.to_string(), "public.orders");
+}
+
+#[test]
+fn table_expr_serializes_through_table_ref() {
+    let table_expr = TableExpr {
+        table_ref: TableRef::new("", "orders"),
+    };
+
+    let serialized = serde_json::to_string(&table_expr).unwrap();
+    let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(serialized, r#"{"table_ref":"orders"}"#);
+    assert_eq!(deserialized, table_expr);
+}


### PR DESCRIPTION
## Summary
- Adds focused test coverage for `TableExpr` clone/equality behavior.
- Adds a serde round-trip test that verifies `TableExpr` serializes through its `TableRef` field.
- Keeps the change test-only and scoped to `sql::proof_exprs::table_expr`.

/claim #560

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test table_expr_test` -> 2 passed
- `cargo fmt --all -- --check`
- `git diff --check`