### PR TITLE
test: cover add const edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
@@ -7,3 +7,21 @@ fn test_add_const() {
     let b = vec![1 + 10, 2 + 10, 3 + 10, 4 + 10];
     assert_eq!(a, b);
 }
+
+#[test]
+fn we_can_add_const_to_an_empty_slice() {
+    let mut values: Vec<i32> = Vec::new();
+
+    add_const(&mut values, 7);
+
+    assert!(values.is_empty());
+}
+
+#[test]
+fn we_can_add_const_from_a_convertible_type() {
+    let mut values = vec![1_i64, -2, 3];
+
+    add_const(&mut values, 4_i32);
+
+    assert_eq!(values, vec![5, 2, 7]);
+}


### PR DESCRIPTION
## Summary
- Adds coverage for `add_const` on an empty slice.
- Adds coverage for using a convertible input type with a wider result type.
- Keeps the change test-only and scoped to `base::slice_ops::add_const`.

/claim #560

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test add_const` -> 3 passed
- `cargo fmt --all -- --check`
- `git diff --check`