### PR TITLE
test: cover table utility and union helper paths

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -363,3 +363,49 @@ pub fn borrowed_timestamptz<S: Scalar>(
         Column::TimestampTZ(time_unit, timezone, alloc_data),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{math::decimal::Precision, scalar::test_scalar::TestScalar};
+
+    #[test]
+    fn borrowed_integer_helpers_preserve_types_and_values() {
+        let alloc = Bump::new();
+
+        assert_eq!(
+            borrowed_uint8::<TestScalar>("u8", [1_u8, 2, 3], &alloc),
+            ("u8".into(), Column::Uint8(&[1, 2, 3]))
+        );
+        assert_eq!(
+            borrowed_tinyint::<TestScalar>("i8", [-1_i8, 0, 1], &alloc),
+            ("i8".into(), Column::TinyInt(&[-1, 0, 1]))
+        );
+        assert_eq!(
+            borrowed_smallint::<TestScalar>("i16", [-10_i16, 0, 10], &alloc),
+            ("i16".into(), Column::SmallInt(&[-10, 0, 10]))
+        );
+        assert_eq!(
+            borrowed_int::<TestScalar>("i32", [-100_i32, 0, 100], &alloc),
+            ("i32".into(), Column::Int(&[-100, 0, 100]))
+        );
+    }
+
+    #[test]
+    fn borrowed_decimal_helper_preserves_precision_scale_and_values() {
+        let alloc = Bump::new();
+        let expected = [
+            TestScalar::from(-123),
+            TestScalar::from(0),
+            TestScalar::from(456),
+        ];
+
+        assert_eq!(
+            borrowed_decimal75::<TestScalar>("amount", 12, 2, [-123, 0, 456], &alloc),
+            (
+                "amount".into(),
+                Column::Decimal75(Precision::new(12).unwrap(), 2, &expected)
+            )
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -287,7 +287,7 @@ mod tests {
     }
 
     #[test]
-    fn we_can_union_integer_columns_across_supported_widths() {
+    fn we_can_union_each_integer_column_type() {
         let alloc = Bump::new();
 
         let uint8_a: Column<TestScalar> = Column::Uint8(&[1, 2]);
@@ -369,12 +369,12 @@ mod tests {
         let timestamp_a: Column<TestScalar> = Column::TimestampTZ(
             PoSQLTimeUnit::Millisecond,
             PoSQLTimeZone::utc(),
-            &[1_700_000_000, 1_700_000_001],
+            &[1_700_000_000_000, 1_700_000_000_001],
         );
         let timestamp_b: Column<TestScalar> = Column::TimestampTZ(
             PoSQLTimeUnit::Millisecond,
             PoSQLTimeZone::utc(),
-            &[1_700_000_002, 1_700_000_003],
+            &[1_700_000_000_002, 1_700_000_000_003],
         );
         assert_eq!(
             column_union(
@@ -386,7 +386,12 @@ mod tests {
             Column::TimestampTZ(
                 PoSQLTimeUnit::Millisecond,
                 PoSQLTimeZone::utc(),
-                &[1_700_000_000, 1_700_000_001, 1_700_000_002, 1_700_000_003],
+                &[
+                    1_700_000_000_000,
+                    1_700_000_000_001,
+                    1_700_000_000_002,
+                    1_700_000_000_003,
+                ],
             )
         );
     }

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -245,7 +245,12 @@ pub fn table_union<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{map::IndexMap, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        map::IndexMap,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn we_can_union_no_columns() {
@@ -278,6 +283,111 @@ mod tests {
         assert_eq!(
             result,
             Column::VarChar((&doubled_strings, &doubled_scalars))
+        );
+    }
+
+    #[test]
+    fn we_can_union_integer_columns_across_supported_widths() {
+        let alloc = Bump::new();
+
+        let uint8_a: Column<TestScalar> = Column::Uint8(&[1, 2]);
+        let uint8_b: Column<TestScalar> = Column::Uint8(&[3, 4]);
+        assert_eq!(
+            column_union(&[&uint8_a, &uint8_b], &alloc, ColumnType::Uint8).unwrap(),
+            Column::Uint8(&[1, 2, 3, 4])
+        );
+
+        let tinyint_a: Column<TestScalar> = Column::TinyInt(&[-2, -1]);
+        let tinyint_b: Column<TestScalar> = Column::TinyInt(&[0, 1]);
+        assert_eq!(
+            column_union(&[&tinyint_a, &tinyint_b], &alloc, ColumnType::TinyInt).unwrap(),
+            Column::TinyInt(&[-2, -1, 0, 1])
+        );
+
+        let smallint_a: Column<TestScalar> = Column::SmallInt(&[-200, -100]);
+        let smallint_b: Column<TestScalar> = Column::SmallInt(&[0, 100]);
+        assert_eq!(
+            column_union(&[&smallint_a, &smallint_b], &alloc, ColumnType::SmallInt).unwrap(),
+            Column::SmallInt(&[-200, -100, 0, 100])
+        );
+
+        let int_a: Column<TestScalar> = Column::Int(&[-20_000, -10_000]);
+        let int_b: Column<TestScalar> = Column::Int(&[0, 10_000]);
+        assert_eq!(
+            column_union(&[&int_a, &int_b], &alloc, ColumnType::Int).unwrap(),
+            Column::Int(&[-20_000, -10_000, 0, 10_000])
+        );
+
+        let int128_a: Column<TestScalar> = Column::Int128(&[-200_000, -100_000]);
+        let int128_b: Column<TestScalar> = Column::Int128(&[0, 100_000]);
+        assert_eq!(
+            column_union(&[&int128_a, &int128_b], &alloc, ColumnType::Int128).unwrap(),
+            Column::Int128(&[-200_000, -100_000, 0, 100_000])
+        );
+    }
+
+    #[test]
+    fn we_can_union_scalar_decimal_and_timestamp_columns() {
+        let alloc = Bump::new();
+
+        let scalar_a_data = [TestScalar::from(1), TestScalar::from(2)];
+        let scalar_b_data = [TestScalar::from(3), TestScalar::from(4)];
+        let scalar_a = Column::Scalar(&scalar_a_data);
+        let scalar_b = Column::Scalar(&scalar_b_data);
+        let expected_scalars = [
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+            TestScalar::from(4),
+        ];
+        assert_eq!(
+            column_union(&[&scalar_a, &scalar_b], &alloc, ColumnType::Scalar).unwrap(),
+            Column::Scalar(&expected_scalars)
+        );
+
+        let precision = Precision::new(12).unwrap();
+        let decimal_a_data = [TestScalar::from(-100), TestScalar::from(0)];
+        let decimal_b_data = [TestScalar::from(100), TestScalar::from(200)];
+        let decimal_a = Column::Decimal75(precision, 2, &decimal_a_data);
+        let decimal_b = Column::Decimal75(precision, 2, &decimal_b_data);
+        let expected_decimals = [
+            TestScalar::from(-100),
+            TestScalar::from(0),
+            TestScalar::from(100),
+            TestScalar::from(200),
+        ];
+        assert_eq!(
+            column_union(
+                &[&decimal_a, &decimal_b],
+                &alloc,
+                ColumnType::Decimal75(precision, 2),
+            )
+            .unwrap(),
+            Column::Decimal75(precision, 2, &expected_decimals)
+        );
+
+        let timestamp_a: Column<TestScalar> = Column::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            &[1_700_000_000, 1_700_000_001],
+        );
+        let timestamp_b: Column<TestScalar> = Column::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            &[1_700_000_002, 1_700_000_003],
+        );
+        assert_eq!(
+            column_union(
+                &[&timestamp_a, &timestamp_b],
+                &alloc,
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+            )
+            .unwrap(),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::utc(),
+                &[1_700_000_000, 1_700_000_001, 1_700_000_002, 1_700_000_003],
+            )
         );
     }
 


### PR DESCRIPTION
/claim #560

## Summary
- add direct coverage for borrowed table utility helpers across Uint8, TinyInt, SmallInt, Int, and Decimal75 values
- add `column_union` coverage for integer widths that were not directly asserted before
- add union coverage for Scalar, Decimal75, and TimestampTZ columns while preserving precision/scale/time metadata

## Validation
- `/Users/lotfi/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin/rustfmt --check crates/proof-of-sql/src/base/database/table_utility.rs crates/proof-of-sql/src/base/database/union_util.rs --edition 2021`
- `git diff --check -- crates/proof-of-sql/src/base/database/table_utility.rs crates/proof-of-sql/src/base/database/union_util.rs`
- `/Users/lotfi/.cargo/bin/cargo test -p proof-of-sql --no-default-features --features='arrow test' table_utility::tests --lib` -> 2 passed
- `/Users/lotfi/.cargo/bin/cargo test -p proof-of-sql --no-default-features --features='arrow test' union_util::tests --lib` -> 11 passed

Note: local Apple Silicon validation used `--no-default-features --features='arrow test'` because the default `perf -> cpu-perf -> halo2curves/asm` feature path enables x86_64-only assembly.
