### PR TITLE
test: cover aliased proof expression wrapper

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -10,3 +10,32 @@ pub struct AliasedDynProofExpr {
     /// The alias for the expression.
     pub alias: Ident,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::LiteralValue;
+
+    fn aliased_literal() -> AliasedDynProofExpr {
+        AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::VarChar("value".into())),
+            alias: "result_alias".into(),
+        }
+    }
+
+    #[test]
+    fn aliased_dyn_proof_expr_clones_with_alias_and_expr() {
+        let aliased = aliased_literal();
+
+        assert_eq!(aliased.clone(), aliased);
+    }
+
+    #[test]
+    fn aliased_dyn_proof_expr_round_trips_through_json() {
+        let aliased = aliased_literal();
+        let serialized = serde_json::to_string(&aliased).unwrap();
+        let deserialized: AliasedDynProofExpr = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, aliased);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds direct coverage for `AliasedDynProofExpr` clone/equality behavior.
- Adds a serde JSON round-trip test for the alias and wrapped expression fields.
- Keeps the change test-only and scoped to `sql::proof_exprs::aliased_dyn_proof_expr`.

/claim #560

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test aliased_dyn_proof_expr -- --nocapture` -> 2 passed
- `cargo fmt --all -- --check`
- `git diff --check`