### PR TITLE
test: run query proof tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/naive_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_evaluation_proof.rs
@@ -7,6 +7,7 @@ use crate::base::{
 use core::ops::Add;
 
 /// This should only be used for the purpose of unit testing.
+#[derive(Clone)]
 pub struct NaiveEvaluationProof {
     a: NaiveCommitment,
     b_point: Vec<TestScalar>,

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use proof_plan::{HonestProver, ProverEvaluate, ProverHonestyMarker};
 
 mod query_proof;
 pub use query_proof::QueryProof;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod query_proof_test;
 
 mod query_result;

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -2,7 +2,7 @@ use super::{FinalRoundBuilder, ProofPlan, ProverEvaluate, QueryProof, Verificati
 use crate::{
     base::{
         bit::BitDistribution,
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof as InnerProductProof,
         database::{
             owned_table_utility::{bigint, owned_table},
             table_utility::*,
@@ -11,9 +11,8 @@ use crate::{
         },
         map::{indexset, IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
-        scalar::Scalar,
+        scalar::{test_scalar::TestScalar as Curve25519Scalar, Scalar},
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::{FirstRoundBuilder, QueryData, SumcheckSubpolynomialType},
 };
 use bumpalo::Bump;
@@ -605,7 +604,7 @@ fn verify_fails_if_an_intermediate_commitment_doesnt_match() {
     let (mut proof, result) =
         QueryProof::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     proof.final_round_message.round_commitments[0] =
-        proof.final_round_message.round_commitments[0] * Curve25519Scalar::from(2u64);
+        proof.final_round_message.round_commitments[0].clone() * Curve25519Scalar::from(2u64);
     assert!(proof.verify(&expr, &accessor, result, &(), &[]).is_err());
 }
 


### PR DESCRIPTION
/claim #560

## Summary
- Run the existing `query_proof_test` suite under the no-default `test` feature by using `NaiveEvaluationProof` instead of the blitzar-only `InnerProductProof`.
- Add `Clone` to the test-only `NaiveEvaluationProof` so the existing `QueryProof` clone assertions continue to exercise the same paths.
- Keep production behavior unchanged.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test query_proof_test -- --nocapture` -> 22 passed
- `cargo test -p proof-of-sql --lib --no-default-features --features test` -> 982 passed
- `cargo llvm-cov -p proof-of-sql --no-default-features --features test --lib --lcov --output-path target\query-proof.lcov -- query_proof_test` -> 22 passed; `sql/proof/query_proof.rs` 223/225 lines covered in focused LCOV
- `cargo fmt --all -- --check`
- `git diff --check`
