### PR TITLE
test: cover offset-to-bytes conversions

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -60,3 +60,63 @@ impl OffsetToBytes<32> for [u64; 4] {
         bytemuck::cast(*self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OffsetToBytes;
+
+    #[test]
+    fn unsigned_and_bool_values_use_direct_little_endian_bytes() {
+        assert_eq!(5_u8.offset_to_bytes(), [5]);
+        assert_eq!(false.offset_to_bytes(), [0]);
+        assert_eq!(true.offset_to_bytes(), [1]);
+
+        let value = 0x0123_4567_89ab_cdef_u64;
+        assert_eq!(value.offset_to_bytes(), value.to_le_bytes());
+    }
+
+    #[test]
+    fn signed_values_are_shifted_by_their_minimum_before_encoding() {
+        assert_eq!(i8::MIN.offset_to_bytes(), [0]);
+        assert_eq!(0_i8.offset_to_bytes(), [128]);
+        assert_eq!(i8::MAX.offset_to_bytes(), [255]);
+
+        assert_eq!(i16::MIN.offset_to_bytes(), 0_u16.to_le_bytes());
+        assert_eq!(0_i16.offset_to_bytes(), 0x8000_u16.to_le_bytes());
+        assert_eq!(i16::MAX.offset_to_bytes(), u16::MAX.to_le_bytes());
+
+        assert_eq!(i32::MIN.offset_to_bytes(), 0_u32.to_le_bytes());
+        assert_eq!(0_i32.offset_to_bytes(), 0x8000_0000_u32.to_le_bytes());
+        assert_eq!(i32::MAX.offset_to_bytes(), u32::MAX.to_le_bytes());
+    }
+
+    #[test]
+    fn wide_signed_values_preserve_order_through_shifted_bytes() {
+        assert_eq!(i64::MIN.offset_to_bytes(), 0_u64.to_le_bytes());
+        assert_eq!(
+            0_i64.offset_to_bytes(),
+            0x8000_0000_0000_0000_u64.to_le_bytes()
+        );
+        assert_eq!(i64::MAX.offset_to_bytes(), u64::MAX.to_le_bytes());
+
+        assert_eq!(i128::MIN.offset_to_bytes(), 0_u128.to_le_bytes());
+        assert_eq!(0_i128.offset_to_bytes(), (1_u128 << 127).to_le_bytes());
+        assert_eq!(i128::MAX.offset_to_bytes(), u128::MAX.to_le_bytes());
+    }
+
+    #[test]
+    fn limb_arrays_are_encoded_in_native_limb_order() {
+        let limbs = [
+            0x0123_4567_89ab_cdef_u64,
+            0xfedc_ba98_7654_3210_u64,
+            0x0f0e_0d0c_0b0a_0908_u64,
+            0x8070_6050_4030_2010_u64,
+        ];
+        let mut expected = [0_u8; 32];
+        for (index, limb) in limbs.iter().enumerate() {
+            expected[index * 8..(index + 1) * 8].copy_from_slice(&limb.to_le_bytes());
+        }
+
+        assert_eq!(limbs.offset_to_bytes(), expected);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused unit coverage for OffsetToBytes conversions.
- Cover unsigned values, bools, signed min/zero/max offset encoding, i128 offset encoding, and [u64; 4] limb byte order.
- Keep the change test-only with no production behavior changes.

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo test -p proof-of-sql offset_to_bytes --no-default-features --features test
