### PR TITLE
test: cover test accessors without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -108,12 +108,12 @@ pub use test_accessor::TestAccessor;
 
 mod owned_table_test_accessor;
 pub use owned_table_test_accessor::OwnedTableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod owned_table_test_accessor_test;
 
 mod table_test_accessor;
 pub use table_test_accessor::TableTestAccessor;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod table_test_accessor_test;
 
 /// Module providing utilities for filtering columns based on selection vectors.

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -45,9 +45,14 @@ fn we_can_access_the_columns_of_a_table() {
     }
 
     let data2 = owned_table([
+        uint8("u8", [1_u8, 2, 3, 4]),
+        tinyint("tiny", [-1_i8, 2, -3, 4]),
+        smallint("small", [-10_i16, 20, -30, 40]),
+        int("int", [-100_i32, 200, -300, 400]),
         bigint("a", [1, 2, 3, 4]),
         bigint("b", [4, 5, 6, 5]),
         int128("c128", [1, 2, 3, 4]),
+        decimal75("decimal", 12, 2, [10, 20, 30, 40]),
         varchar("varchar", ["a", "bc", "d", "e"]),
         scalar("scalar", [1, 2, 3, 4]),
         boolean("boolean", [true, false, true, false]),
@@ -65,6 +70,26 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     }
 
+    match accessor.get_column(&table_ref_2, &"u8".into()) {
+        Column::Uint8(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"tiny".into()) {
+        Column::TinyInt(col) => assert_eq!(col.to_vec(), vec![-1, 2, -3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"small".into()) {
+        Column::SmallInt(col) => assert_eq!(col.to_vec(), vec![-10, 20, -30, 40]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"int".into()) {
+        Column::Int(col) => assert_eq!(col.to_vec(), vec![-100, 200, -300, 400]),
+        _ => panic!("Invalid column type"),
+    }
+
     match accessor.get_column(&table_ref_2, &"b".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
@@ -72,6 +97,23 @@ fn we_can_access_the_columns_of_a_table() {
 
     match accessor.get_column(&table_ref_2, &"c128".into()) {
         Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"decimal".into()) {
+        Column::Decimal75(precision, scale, col) => {
+            assert_eq!(precision.value(), 12);
+            assert_eq!(scale, 2);
+            assert_eq!(
+                col.to_vec(),
+                vec![
+                    TestScalar::from(10),
+                    TestScalar::from(20),
+                    TestScalar::from(30),
+                    TestScalar::from(40)
+                ]
+            );
+        }
         _ => panic!("Invalid column type"),
     }
 

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -241,3 +241,52 @@ fn we_can_correctly_update_offsets() {
     assert_eq!(accessor1.get_offset(&table_ref), offset);
     assert_eq!(accessor2.get_offset(&table_ref), offset);
 }
+
+#[test]
+fn new_from_table_sets_up_metadata_and_commitments() {
+    let table_ref = TableRef::new("sxt", "owned_from_table");
+    let offset = 7;
+    let data = owned_table([
+        bigint("id", [11, 12, 13]),
+        varchar("label", ["a", "b", "c"]),
+    ]);
+
+    let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        table_ref.clone(),
+        data,
+        offset,
+        (),
+    );
+
+    assert_eq!(accessor.get_length(&table_ref), 3);
+    assert_eq!(accessor.get_offset(&table_ref), offset);
+    assert_eq!(accessor.get_column_names(&table_ref), vec!["id", "label"]);
+    assert_eq!(
+        accessor.lookup_column(&table_ref, &"id".into()),
+        Some(ColumnType::BigInt)
+    );
+    assert_eq!(
+        accessor.get_commitment(&table_ref, &"id".into()),
+        NaiveCommitment::compute_commitments(
+            &[CommittableColumn::from(&[11i64, 12, 13][..])],
+            offset,
+            &()
+        )[0]
+    );
+}
+
+#[test]
+fn owned_accessor_returns_varbinary_columns() {
+    let table_ref = TableRef::new("sxt", "binary_payloads");
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    let data = owned_table([varbinary("payload", [vec![1_u8, 2], vec![3, 4, 5]])]);
+    accessor.add_table(table_ref.clone(), data, 0_usize);
+
+    match accessor.get_column(&table_ref, &"payload".into()) {
+        Column::VarBinary((bytes, scalars)) => {
+            assert_eq!(bytes, [&[1_u8, 2][..], &[3_u8, 4, 5][..]]);
+            assert_eq!(scalars.len(), 2);
+        }
+        _ => panic!("Invalid column type"),
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -274,3 +274,37 @@ fn we_can_correctly_update_offsets() {
     assert_eq!(accessor1.get_offset(&table_ref), offset);
     assert_eq!(accessor2.get_offset(&table_ref), offset);
 }
+
+#[test]
+fn new_from_table_sets_up_metadata_and_commitments() {
+    let alloc = Bump::new();
+    let table_ref = TableRef::new("sxt", "from_table");
+    let offset = 7;
+    let data = table([
+        borrowed_bigint("id", [11, 12, 13], &alloc),
+        borrowed_varchar("label", ["a", "b", "c"], &alloc),
+    ]);
+
+    let accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        table_ref.clone(),
+        data,
+        offset,
+        (),
+    );
+
+    assert_eq!(accessor.get_length(&table_ref), 3);
+    assert_eq!(accessor.get_offset(&table_ref), offset);
+    assert_eq!(accessor.get_column_names(&table_ref), vec!["id", "label"]);
+    assert_eq!(
+        accessor.lookup_column(&table_ref, &"id".into()),
+        Some(ColumnType::BigInt)
+    );
+    assert_eq!(
+        accessor.get_commitment(&table_ref, &"id".into()),
+        NaiveCommitment::compute_commitments(
+            &[CommittableColumn::from(&[11i64, 12, 13][..])],
+            offset,
+            &()
+        )[0]
+    );
+}

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -57,9 +57,14 @@ fn we_can_access_the_columns_of_a_table() {
     }
 
     let data2 = table([
+        borrowed_uint8("u8", [1_u8, 2, 3, 4], &alloc),
+        borrowed_tinyint("tiny", [-1_i8, 2, -3, 4], &alloc),
+        borrowed_smallint("small", [-10_i16, 20, -30, 40], &alloc),
+        borrowed_int("int", [-100_i32, 200, -300, 400], &alloc),
         borrowed_bigint("a", [1, 2, 3, 4], &alloc),
         borrowed_bigint("b", [4, 5, 6, 5], &alloc),
         borrowed_int128("c128", [1, 2, 3, 4], &alloc),
+        borrowed_decimal75("decimal", 12, 2, [10, 20, 30, 40], &alloc),
         borrowed_varchar("varchar", ["a", "bc", "d", "e"], &alloc),
         borrowed_scalar("scalar", [1, 2, 3, 4], &alloc),
         borrowed_boolean("boolean", [true, false, true, false], &alloc),
@@ -78,6 +83,26 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     }
 
+    match accessor.get_column(&table_ref_2, &"u8".into()) {
+        Column::Uint8(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"tiny".into()) {
+        Column::TinyInt(col) => assert_eq!(col.to_vec(), vec![-1, 2, -3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"small".into()) {
+        Column::SmallInt(col) => assert_eq!(col.to_vec(), vec![-10, 20, -30, 40]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"int".into()) {
+        Column::Int(col) => assert_eq!(col.to_vec(), vec![-100, 200, -300, 400]),
+        _ => panic!("Invalid column type"),
+    }
+
     match accessor.get_column(&table_ref_2, &"b".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
@@ -85,6 +110,23 @@ fn we_can_access_the_columns_of_a_table() {
 
     match accessor.get_column(&table_ref_2, &"c128".into()) {
         Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"decimal".into()) {
+        Column::Decimal75(precision, scale, col) => {
+            assert_eq!(precision.value(), 12);
+            assert_eq!(scale, 2);
+            assert_eq!(
+                col.to_vec(),
+                vec![
+                    TestScalar::from(10),
+                    TestScalar::from(20),
+                    TestScalar::from(30),
+                    TestScalar::from(40)
+                ]
+            );
+        }
         _ => panic!("Invalid column type"),
     }
 


### PR DESCRIPTION
/claim #560

Summary:
- Enables the existing TableTestAccessor and OwnedTableTestAccessor tests under plain `#[cfg(test)]`.
- Adds extra test coverage for `new_from_table` metadata/offset/commitment setup on both borrowed and owned accessors.
- Adds a new `OwnedTableTestAccessor` VarBinary conversion test so this PR now covers more than only flipping the two cfg gates.
- Adds no production behavior changes.

Coverage:
- Baseline no-default test lcov before the original change: `owned_table_test_accessor.rs` 0/117, `table_test_accessor.rs` 0/88.
- Original focused lcov after enabling both modules: `owned_table_test_accessor.rs` 86/117, `table_test_accessor.rs` 72/88, approx. +158 covered production lines for no-default `test` coverage.
- Follow-up commit adds targeted no-default coverage for `new_from_table` constructors and the owned VarBinary accessor path.

Competitor/overlap note:
- A REST fallback scan found older split PRs #1897 and #1899 that each enable one of the two accessor test modules. This PR is now intentionally a combined slice with additional unique assertions beyond those one-line cfg flips. If maintainers prefer split patches, those earlier PRs are the direct split alternatives; if they prefer one consolidated no-blitzar accessor coverage patch, this PR carries both modules plus extra coverage.
- Fresh post-refresh #560 PRs #2011 and #2012 do not touch the accessor files in this PR. #2011 covers sign gadget test gating in `sql/proof_gadgets/mod.rs`; #2012 adds constructor/TableExpr coverage in `sql/proof_exprs/*`.
- Fresh #2013 is also in `base/database`, but it covers value/reference/evaluation helpers (`column_field.rs`, `column_ref.rs`, `table_evaluation.rs`, `table_ref.rs`). This PR stays on `TableTestAccessor` / `OwnedTableTestAccessor` behavior in `table_test_accessor_test.rs`, `owned_table_test_accessor_test.rs`, and the module wiring.

Validation:
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test test_accessor -- --nocapture` -> 16 passed, 0 failed
- `git diff --check`
- `git diff --cached --check`
