### PR TITLE
test: add record batch conversion coverage

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -177,3 +177,119 @@ mod tests {
         assert_eq!(commitment, expected_commitment);
     }
 }
+
+#[cfg(test)]
+mod batch_to_columns_tests {
+    use super::*;
+    use crate::base::{
+        arrow::arrow_array_to_column_conversion::ArrowArrayToColumnConversionError,
+        scalar::{test_scalar::TestScalar, ScalarExt},
+    };
+    use arrow::{
+        array::{
+            ArrayRef, BooleanArray, Float32Array, Int64Array, LargeBinaryArray, StringArray,
+            UInt8Array,
+        },
+        datatypes::{DataType, Field, Schema},
+        record_batch::RecordBatch,
+    };
+    use std::sync::Arc;
+
+    #[test]
+    fn we_can_convert_record_batch_columns_with_field_names() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("flag", DataType::Boolean, false),
+            Field::new("byte", DataType::UInt8, false),
+            Field::new("amount", DataType::Int64, false),
+            Field::new("label", DataType::Utf8, false),
+            Field::new("payload", DataType::LargeBinary, false),
+        ]));
+        let payloads: Vec<&[u8]> = vec![b"left".as_slice(), b"right".as_slice()];
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(BooleanArray::from(vec![true, false])) as ArrayRef,
+                Arc::new(UInt8Array::from(vec![7, 9])),
+                Arc::new(Int64Array::from(vec![11, 22])),
+                Arc::new(StringArray::from(vec!["alpha", "beta"])),
+                Arc::new(LargeBinaryArray::from(payloads.clone())),
+            ],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+
+        let columns = batch_to_columns::<TestScalar>(&batch, &alloc).unwrap();
+
+        let labels = ["alpha", "beta"];
+        let label_scalars: Vec<TestScalar> = labels.iter().map(|label| (*label).into()).collect();
+        let payload_scalars: Vec<TestScalar> = payloads
+            .iter()
+            .copied()
+            .map(TestScalar::from_byte_slice_via_hash)
+            .collect();
+        let expected = vec![
+            (Ident::new("flag"), Column::Boolean(&[true, false])),
+            (Ident::new("byte"), Column::Uint8(&[7, 9])),
+            (Ident::new("amount"), Column::BigInt(&[11, 22])),
+            (
+                Ident::new("label"),
+                Column::VarChar((&labels, label_scalars.as_slice())),
+            ),
+            (
+                Ident::new("payload"),
+                Column::VarBinary((payloads.as_slice(), payload_scalars.as_slice())),
+            ),
+        ];
+        assert_eq!(columns, expected);
+    }
+
+    #[test]
+    fn we_error_when_record_batch_column_type_is_unsupported() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "unsupported",
+            DataType::Float32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Float32Array::from(vec![1.0_f32, 2.0]))],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+
+        let result = batch_to_columns::<TestScalar>(&batch, &alloc);
+
+        assert!(matches!(
+            result,
+            Err(RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                source: ArrowArrayToColumnConversionError::UnsupportedType { datatype }
+            }) if datatype == DataType::Float32
+        ));
+    }
+
+    #[test]
+    fn we_error_when_record_batch_contains_nulls() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "nullable",
+            DataType::Int64,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int64Array::from(vec![Some(1), None]))],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+
+        let result = batch_to_columns::<TestScalar>(&batch, &alloc);
+
+        assert!(matches!(
+            result,
+            Err(
+                RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                    source: ArrowArrayToColumnConversionError::ArrayContainsNulls
+                }
+            )
+        ));
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here:
https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here:
https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md.
In particular `!` is used if and only if at least one breaking change
has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow
clean commit guidelines as described here:
https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR
by simple rebase if possible, if not, then conflicts are resolved
appropriately.

# Rationale for this change

Adds focused coverage for `batch_to_columns`, which currently only gets exercised indirectly by a `blitzar`-gated RecordBatch commitment test.

# What changes are included in this PR?

- Adds a direct success-path test for converting a RecordBatch into named Proof of SQL columns across boolean, uint8, int64, utf8, and large binary Arrow arrays.
- Adds error-path tests for unsupported Arrow column types and null-containing arrays.

# Are these changes tested?

- `cargo fmt --check` passes locally.
- `git diff --check` passes locally.
- `cargo test -p proof-of-sql batch_to_columns` was attempted locally, but this Windows environment is missing MSVC/Windows SDK linker libraries (`link.exe`, `kernel32.lib`, etc.), so compilation cannot complete here. CI should provide the authoritative test result.

Related bounty: #560