### PR TITLE
test: cover sumcheck prover round behavior

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
@@ -124,3 +124,89 @@ fn in_place_fix_variable<S: Scalar>(multiplicand: &mut [S], r_as_field: S, num_v
 fn vec_elementwise_add<S: Scalar>(a: Vec<S>, b: Vec<S>) -> Vec<S> {
     a.into_iter().zip(b).map(|(x, y)| x + y).collect::<Vec<S>>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::vec;
+
+    #[test]
+    fn prove_round_evaluates_first_round_without_verifier_message() {
+        let mut state = ProverState::new(
+            vec![(TestScalar::from(3u64), vec![0])],
+            vec![vec![TestScalar::from(2u64), TestScalar::from(5u64)]],
+            1,
+            1,
+        );
+
+        let evaluations = prove_round(&mut state, &None);
+
+        assert_eq!(
+            evaluations,
+            vec![TestScalar::from(6u64), TestScalar::from(15u64)]
+        );
+        assert_eq!(state.round, 1);
+    }
+
+    #[test]
+    fn prove_round_fixes_previous_variable_with_verifier_challenge() {
+        let mut state = ProverState::new(
+            vec![(TestScalar::from(2u64), vec![0])],
+            vec![vec![
+                TestScalar::from(1u64),
+                TestScalar::from(3u64),
+                TestScalar::from(5u64),
+                TestScalar::from(7u64),
+            ]],
+            2,
+            1,
+        );
+
+        assert_eq!(
+            prove_round(&mut state, &None),
+            vec![TestScalar::from(12u64), TestScalar::from(20u64)]
+        );
+        assert_eq!(
+            prove_round(&mut state, &Some(TestScalar::from(4u64))),
+            vec![TestScalar::from(18u64), TestScalar::from(26u64)]
+        );
+        assert_eq!(
+            state.flattened_ml_extensions[0][..2],
+            [TestScalar::from(9u64), TestScalar::from(13u64)]
+        );
+        assert_eq!(state.round, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "first round should be prover first.")]
+    fn prove_round_rejects_verifier_message_on_first_round() {
+        let mut state = ProverState::new(
+            vec![(TestScalar::from(3u64), vec![0])],
+            vec![vec![TestScalar::from(2u64), TestScalar::from(5u64)]],
+            1,
+            1,
+        );
+
+        let _ = prove_round(&mut state, &Some(TestScalar::from(7u64)));
+    }
+
+    #[test]
+    #[should_panic(expected = "verifier message is empty")]
+    fn prove_round_requires_verifier_message_after_first_round() {
+        let mut state = ProverState::new(
+            vec![(TestScalar::from(2u64), vec![0])],
+            vec![vec![
+                TestScalar::from(1u64),
+                TestScalar::from(3u64),
+                TestScalar::from(5u64),
+                TestScalar::from(7u64),
+            ]],
+            2,
+            1,
+        );
+
+        let _ = prove_round(&mut state, &None);
+        let _ = prove_round(&mut state, &None);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add deterministic coverage for first-round `prove_round` evaluations.
- Add coverage for verifier-challenge folding of the previous variable between rounds.
- Add panic-path coverage for verifier messages arriving too early and missing after the first round.

This is a test-only coverage slice for `crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs`. I searched the #560 issue thread and open PR titles for `prover_round` / `prove_round` before submitting and did not find an active overlapping claim.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test prover_round -- --nocapture`
- `rustfmt --check crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs`
- `git diff --check`
- `bash scripts/check_commits.sh`

Notes:
- `cargo llvm-cov` is not installed in my local environment, so I could not generate local LCOV output.
- Full `cargo fmt --all -- --check` reports an unrelated import-order diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`; this PR does not touch that file.
