### PR TITLE
test: improve timezone parsing coverage

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -104,6 +104,30 @@ mod timezone_parsing_tests {
     }
 
     #[test]
+    fn we_can_parse_positive_time_zone() {
+        let timezone_as_str: Option<Arc<str>> = Some("+05:45".into());
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+        let expected_time_zone = PoSQLTimeZone::new(20_700);
+        assert_eq!(timezone, expected_time_zone);
+    }
+
+    #[test]
+    fn we_can_parse_utc_alias_time_zones() {
+        let aliases: [Option<Arc<str>>; 6] = [
+            Some("Z".into()),
+            Some("UTC".into()),
+            Some("utc".into()),
+            Some("00:00".into()),
+            Some("+00:00".into()),
+            Some("+0:00".into()),
+        ];
+
+        for alias in aliases {
+            assert_eq!(PoSQLTimeZone::try_from(&alias), Ok(PoSQLTimeZone::utc()));
+        }
+    }
+
+    #[test]
     fn we_can_parse_none_time_zone() {
         let timezone = PoSQLTimeZone::try_from(&None).unwrap();
         let expected_time_zone = PoSQLTimeZone::utc();
@@ -118,5 +142,18 @@ mod timezone_parsing_tests {
             timezone_err,
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
         ));
+    }
+
+    #[test]
+    fn we_cannot_parse_invalid_time_zone_offsets() {
+        let invalid_offsets: [Option<Arc<str>>; 2] =
+            [Some("+0A:00".into()), Some("+01:BB".into())];
+
+        for offset in invalid_offsets {
+            assert_eq!(
+                PoSQLTimeZone::try_from(&offset),
+                Err(PoSQLTimestampError::InvalidTimezoneOffset)
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add coverage for parsing positive fixed timezone offsets
- add coverage for UTC aliases accepted by `PoSQLTimeZone::try_from`
- add coverage for invalid fixed-offset parse errors

## Related
- Contributes to #560

## Validation
- Not run locally: this machine does not currently have `cargo`/`rustc` installed on PATH.

Worked on by GPT-5.5 with Codex, with Tom's human review before delivery.