### PR TITLE
test: cover naive commitment column variants

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -223,6 +223,63 @@ fn we_can_compute_commitments_from_committable_varbinary_column_with_offset() {
     assert_eq!(commitments[0].0, expected);
 }
 
+#[test]
+fn we_can_compute_commitments_from_remaining_committable_column_variants() {
+    use crate::base::{
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    };
+    use core::iter::once;
+
+    fn with_offset(values: impl IntoIterator<Item = TestScalar>) -> Vec<TestScalar> {
+        once(TestScalar::ZERO).chain(values).collect()
+    }
+
+    let boolean_column = [true, false, true];
+    let uint8_column = [1_u8, 2, 3];
+    let tinyint_column = [-1_i8, 0, 2];
+    let smallint_column = [-3_i16, 5, 8];
+    let int_column = [-13_i32, 21, 34];
+    let int128_column = [-55_i128, 89, 144];
+    let decimal_limbs = vec![[1_u64, 2, 3, 4], [5, 6, 7, 8]];
+    let timestamp_column = [1_700_000_000_i64, -1_700_000_001];
+
+    let expected = vec![
+        with_offset(boolean_column.iter().map(Into::into)),
+        with_offset(uint8_column.iter().map(Into::into)),
+        with_offset(tinyint_column.iter().map(Into::into)),
+        with_offset(smallint_column.iter().map(Into::into)),
+        with_offset(int_column.iter().map(Into::into)),
+        with_offset(int128_column.iter().map(Into::into)),
+        with_offset(decimal_limbs.iter().map(Into::into)),
+        with_offset(timestamp_column.iter().map(Into::into)),
+    ];
+
+    let committable_columns = [
+        CommittableColumn::Boolean(&boolean_column),
+        CommittableColumn::Uint8(&uint8_column),
+        CommittableColumn::TinyInt(&tinyint_column),
+        CommittableColumn::SmallInt(&smallint_column),
+        CommittableColumn::Int(&int_column),
+        CommittableColumn::Int128(&int128_column),
+        CommittableColumn::Decimal75(Precision::new(10).unwrap(), 2, decimal_limbs),
+        CommittableColumn::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            &timestamp_column,
+        ),
+    ];
+
+    let commitments = NaiveCommitment::compute_commitments(&committable_columns, 1, &());
+    assert_eq!(
+        commitments
+            .into_iter()
+            .map(|commitment| commitment.0)
+            .collect::<Vec<_>>(),
+        expected
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -242,6 +242,7 @@ fn we_can_compute_commitments_from_remaining_committable_column_variants() {
     let int_column = [-13_i32, 21, 34];
     let int128_column = [-55_i128, 89, 144];
     let decimal_limbs = vec![[1_u64, 2, 3, 4], [5, 6, 7, 8]];
+    let scalar_limbs = vec![[13_u64, 21, 34, 55], [89, 144, 233, 377]];
     let timestamp_column = [1_700_000_000_i64, -1_700_000_001];
 
     let expected = vec![
@@ -252,6 +253,7 @@ fn we_can_compute_commitments_from_remaining_committable_column_variants() {
         with_offset(int_column.iter().map(Into::into)),
         with_offset(int128_column.iter().map(Into::into)),
         with_offset(decimal_limbs.iter().map(Into::into)),
+        with_offset(scalar_limbs.iter().map(Into::into)),
         with_offset(timestamp_column.iter().map(Into::into)),
     ];
 
@@ -263,6 +265,7 @@ fn we_can_compute_commitments_from_remaining_committable_column_variants() {
         CommittableColumn::Int(&int_column),
         CommittableColumn::Int128(&int128_column),
         CommittableColumn::Decimal75(Precision::new(10).unwrap(), 2, decimal_limbs),
+        CommittableColumn::Scalar(scalar_limbs),
         CommittableColumn::TimestampTZ(
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::utc(),


### PR DESCRIPTION
/claim #560

## Summary
- Add focused test coverage for the remaining `NaiveCommitment::compute_commitments` committable-column variants.
- Covers Boolean, Uint8, TinyInt, SmallInt, Int, Int128, Decimal75, and TimestampTZ conversion arms with an offset.
- No production behavior changes.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_compute_commitments_from_remaining_committable_column_variants -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test naive_commitment -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test`
- `cargo fmt --all -- --check`
- `git diff --check`

## Coverage Evidence
Focused LCOV command:
`cargo llvm-cov -p proof-of-sql --no-default-features --features test --lib --lcov --output-path target\sxt-naive-commitment-after.lcov -- we_can_compute_commitments_from_remaining_committable_column_variants --nocapture`

Targeted production lines now covered in `crates/proof-of-sql/src/base/commitment/naive_commitment.rs`:
`122,123,125,126,128,129,131,132,133,134,135,136,141,142,144,145,154,155`