### PR TITLE
Add FixedSizeBinary support

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -7,9 +7,10 @@ use crate::base::{
 };
 use arrow::{
     array::{
-        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, FixedSizeBinaryArray,
+        Int16Array, Int32Array, Int64Array, Int8Array, LargeBinaryArray, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, TimeUnit as ArrowTimeUnit},
 };
@@ -305,6 +306,28 @@ impl ArrayRefExt for ArrayRef {
                     };
 
                     Ok(Column::VarBinary((vals, scals)))
+                } else {
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
+                }
+            }
+            DataType::FixedSizeBinary(byte_width) => {
+                if let Some(array) = self.as_any().downcast_ref::<FixedSizeBinaryArray>() {
+                    let vals = alloc
+                        .alloc_slice_fill_with(range.end - range.start, |i| -> &'a [u8] {
+                            array.value(range.start + i)
+                        });
+
+                    let scals = if let Some(scals) = precomputed_scals {
+                        &scals[range.start..range.end]
+                    } else {
+                        alloc.alloc_slice_fill_with(vals.len(), |i| {
+                            S::from_fixed_size_byte_slice(vals[i])
+                        })
+                    };
+
+                    Ok(Column::FixedSizeBinary(*byte_width, (vals, scals)))
                 } else {
                     Err(ArrowArrayToColumnConversionError::UnsupportedType {
                         datatype: self.data_type().clone(),
@@ -1032,6 +1055,59 @@ mod tests {
                 .to_column::<DoryScalar>(&alloc, &(0..2), None)
                 .unwrap(),
             Column::VarBinary((&data[..], &scals[..]))
+        );
+    }
+
+    #[test]
+    fn we_can_convert_valid_fixed_size_binary_array_refs_into_valid_columns() {
+        let alloc = Bump::new();
+        let data = [b"cd".as_slice(), b"ef".as_slice()];
+        let scals: Vec<_> = data
+            .iter()
+            .copied()
+            .map(DoryScalar::from_fixed_size_byte_slice)
+            .collect();
+        let array: ArrayRef =
+            Arc::new(FixedSizeBinaryArray::try_new(2, b"cdef".to_vec().into(), None).unwrap());
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(0..2), None)
+                .unwrap(),
+            Column::FixedSizeBinary(2, (&data[..], &scals[..]))
+        );
+    }
+
+    #[test]
+    fn fixed_size_binary_scalars_are_natural_for_31_byte_values_and_hashed_for_32_byte_values() {
+        let alloc = Bump::new();
+        let data_31 = [1_u8; 31];
+        let array: ArrayRef =
+            Arc::new(FixedSizeBinaryArray::try_new(31, data_31.to_vec().into(), None).unwrap());
+        let expected_scals = [DoryScalar::from_fixed_size_byte_slice(&data_31)];
+        assert_ne!(
+            expected_scals[0],
+            DoryScalar::from_byte_slice_via_hash(&data_31)
+        );
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(0..1), None)
+                .unwrap(),
+            Column::FixedSizeBinary(31, (&[data_31.as_slice()][..], &expected_scals[..]))
+        );
+
+        let data_32 = [1_u8; 32];
+        let array: ArrayRef =
+            Arc::new(FixedSizeBinaryArray::try_new(32, data_32.to_vec().into(), None).unwrap());
+        let expected_scals = [DoryScalar::from_byte_slice_via_hash(&data_32)];
+        assert_eq!(
+            DoryScalar::from_fixed_size_byte_slice(&data_32),
+            expected_scals[0]
+        );
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(0..1), None)
+                .unwrap(),
+            Column::FixedSizeBinary(32, (&[data_32.as_slice()][..], &expected_scals[..]))
         );
     }
 

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -22,6 +22,7 @@ impl From<&ColumnType> for DataType {
             }
             ColumnType::VarChar => DataType::Utf8,
             ColumnType::VarBinary => DataType::LargeBinary,
+            ColumnType::FixedSizeBinary(byte_width) => DataType::FixedSizeBinary(*byte_width),
             ColumnType::Scalar => unimplemented!("Cannot convert Scalar type to arrow type"),
             ColumnType::TimestampTZ(timeunit, timezone) => {
                 let arrow_timezone = Some(Arc::from(timezone.to_string()));
@@ -67,6 +68,7 @@ impl TryFrom<DataType> for ColumnType {
             }
             DataType::Utf8 => Ok(ColumnType::VarChar),
             DataType::LargeBinary => Ok(ColumnType::VarBinary),
+            DataType::FixedSizeBinary(byte_width) => Ok(ColumnType::FixedSizeBinary(byte_width)),
             _ => Err(format!("Unsupported arrow data type {data_type:?}")),
         }
     }
@@ -95,5 +97,14 @@ mod tests {
 
             prop_assert_eq!(actual, column_type);
         }
+    }
+
+    #[test]
+    fn we_can_roundtrip_fixed_size_binary_column_type() {
+        let column_type = ColumnType::FixedSizeBinary(32);
+        let arrow = DataType::from(&column_type);
+        let actual = ColumnType::try_from(arrow).unwrap();
+
+        assert_eq!(actual, column_type);
     }
 }

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -23,9 +23,10 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Int16Array,
+        Int32Array, Int64Array, Int8Array, LargeBinaryArray, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
     error::ArrowError,
@@ -99,6 +100,14 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
             OwnedColumn::VarBinary(col) => Arc::new(LargeBinaryArray::from_iter_values(
                 col.iter().map(Vec::as_slice),
             )),
+            OwnedColumn::FixedSizeBinary(byte_width, col) => {
+                assert!(
+                    col.iter().all(|value| value.len() == byte_width as usize),
+                    "FixedSizeBinary values must match the declared byte width"
+                );
+                let values: Vec<u8> = col.into_iter().flatten().collect();
+                Arc::new(FixedSizeBinaryArray::try_new(byte_width, values.into(), None).unwrap())
+            }
             OwnedColumn::TimestampTZ(time_unit, _, col) => match time_unit {
                 PoSQLTimeUnit::Second => Arc::new(TimestampSecondArray::from(col)),
                 PoSQLTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(col)),
@@ -239,6 +248,16 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .map(|s| s.map(<[u8]>::to_vec).unwrap())
                     .collect(),
             )),
+            DataType::FixedSizeBinary(byte_width) => Ok(Self::FixedSizeBinary(
+                *byte_width,
+                value
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap()
+                    .iter()
+                    .map(|s| s.map(<[u8]>::to_vec).unwrap())
+                    .collect(),
+            )),
             DataType::Timestamp(time_unit, timezone) => match time_unit {
                 ArrowTimeUnit::Second => {
                     let array = value
@@ -325,5 +344,21 @@ impl<S: Scalar> TryFrom<RecordBatch> for OwnedTable<S> {
         } else {
             Err(OwnedArrowConversionError::DuplicateIdents)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_roundtrip_fixed_size_binary_owned_column_through_arrow() {
+        let column =
+            OwnedColumn::<TestScalar>::FixedSizeBinary(32, vec![vec![1_u8; 32], vec![2_u8; 32]]);
+        let array_ref = ArrayRef::from(column.clone());
+
+        assert_eq!(*array_ref.data_type(), DataType::FixedSizeBinary(32));
+        assert_eq!(OwnedColumn::try_from(array_ref).unwrap(), column);
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -239,6 +239,7 @@ impl ColumnBounds {
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
             | CommittableColumn::VarBinary(_)
+            | CommittableColumn::FixedSizeBinary(_, _)
             | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
         }
     }

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -55,6 +55,7 @@ impl ColumnCommitmentMetadata {
                 ColumnType::Boolean
                 | ColumnType::VarChar
                 | ColumnType::VarBinary
+                | ColumnType::FixedSizeBinary(_)
                 | ColumnType::Scalar
                 | ColumnType::Decimal75(..),
                 ColumnBounds::NoOrder,
@@ -290,6 +291,18 @@ mod tests {
                 bounds: ColumnBounds::NoOrder
             }
         );
+
+        assert_eq!(
+            ColumnCommitmentMetadata::try_new(
+                ColumnType::FixedSizeBinary(16),
+                ColumnBounds::NoOrder
+            )
+            .unwrap(),
+            ColumnCommitmentMetadata {
+                column_type: ColumnType::FixedSizeBinary(16),
+                bounds: ColumnBounds::NoOrder
+            }
+        );
     }
 
     #[test]
@@ -429,6 +442,20 @@ mod tests {
         let varchar_metadata = ColumnCommitmentMetadata::from_column(&committable_varchar_column);
         assert_eq!(varchar_metadata.column_type(), &ColumnType::VarChar);
         assert_eq!(varchar_metadata.bounds(), &ColumnBounds::NoOrder);
+
+        let fixed_size_binary_column = OwnedColumn::<TestScalar>::FixedSizeBinary(
+            3,
+            [b"foo".to_vec(), b"bar".to_vec(), b"baz".to_vec()].to_vec(),
+        );
+        let committable_fixed_size_binary_column =
+            CommittableColumn::from(&fixed_size_binary_column);
+        let fixed_size_binary_metadata =
+            ColumnCommitmentMetadata::from_column(&committable_fixed_size_binary_column);
+        assert_eq!(
+            fixed_size_binary_metadata.column_type(),
+            &ColumnType::FixedSizeBinary(3)
+        );
+        assert_eq!(fixed_size_binary_metadata.bounds(), &ColumnBounds::NoOrder);
 
         let bigint_column = OwnedColumn::<TestScalar>::BigInt([1, 2, 3, 1, 0].to_vec());
         let committable_bigint_column = CommittableColumn::from(&bigint_column);

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -48,6 +48,8 @@ pub enum CommittableColumn<'a> {
     VarChar(Vec<[u64; 4]>),
     /// Column of limbs for committing to scalars, hashed from a `Binary` column.
     VarBinary(Vec<[u64; 4]>),
+    /// Column of limbs for committing to scalars, embedded from a `FixedSizeBinary` column.
+    FixedSizeBinary(i32, Vec<[u64; 4]>),
     /// Borrowed Timestamp column with Timezone, mapped to `i64`.
     TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, &'a [i64]),
 }
@@ -66,7 +68,8 @@ impl CommittableColumn<'_> {
             CommittableColumn::Decimal75(_, _, col)
             | CommittableColumn::Scalar(col)
             | CommittableColumn::VarChar(col)
-            | CommittableColumn::VarBinary(col) => col.len(),
+            | CommittableColumn::VarBinary(col)
+            | CommittableColumn::FixedSizeBinary(_, col) => col.len(),
             CommittableColumn::Boolean(col) => col.len(),
         }
     }
@@ -99,6 +102,9 @@ impl<'a> From<&CommittableColumn<'a>> for ColumnType {
             CommittableColumn::Scalar(_) => ColumnType::Scalar,
             CommittableColumn::VarChar(_) => ColumnType::VarChar,
             CommittableColumn::VarBinary(_) => ColumnType::VarBinary,
+            CommittableColumn::FixedSizeBinary(byte_width, _) => {
+                ColumnType::FixedSizeBinary(*byte_width)
+            }
             CommittableColumn::Boolean(_) => ColumnType::Boolean,
             CommittableColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
         }
@@ -127,6 +133,10 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::VarBinary((_, scalars)) => {
                 let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
                 CommittableColumn::VarBinary(as_limbs)
+            }
+            Column::FixedSizeBinary(byte_width, (_, scalars)) => {
+                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                CommittableColumn::FixedSizeBinary(*byte_width, as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
         }
@@ -170,6 +180,14 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 bytes
                     .iter()
                     .map(|b| S::from_byte_slice_via_hash(b))
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+            OwnedColumn::FixedSizeBinary(byte_width, bytes) => CommittableColumn::FixedSizeBinary(
+                *byte_width,
+                bytes
+                    .iter()
+                    .map(|b| S::from_fixed_size_byte_slice(b))
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),
@@ -240,7 +258,8 @@ impl<'a, 'b> From<&'a CommittableColumn<'b>> for Sequence<'a> {
             CommittableColumn::Decimal75(_, _, limbs)
             | CommittableColumn::Scalar(limbs)
             | CommittableColumn::VarChar(limbs)
-            | CommittableColumn::VarBinary(limbs) => Sequence::from(limbs),
+            | CommittableColumn::VarBinary(limbs)
+            | CommittableColumn::FixedSizeBinary(_, limbs) => Sequence::from(limbs),
             CommittableColumn::Boolean(bools) => Sequence::from(*bools),
             CommittableColumn::TimestampTZ(_, _, times) => Sequence::from(*times),
         }

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -148,7 +148,8 @@ impl Commitment for NaiveCommitment {
                         scalar_vec.iter().map(core::convert::Into::into).collect()
                     }
                     CommittableColumn::VarChar(varchar_vec)
-                    | CommittableColumn::VarBinary(varchar_vec) => {
+                    | CommittableColumn::VarBinary(varchar_vec)
+                    | CommittableColumn::FixedSizeBinary(_, varchar_vec) => {
                         varchar_vec.iter().map(core::convert::Into::into).collect()
                     }
                     CommittableColumn::TimestampTZ(_, _, i64_vec) => {

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -47,6 +47,8 @@ pub enum Column<'a, S: Scalar> {
     Scalar(&'a [S]),
     /// Variable length binary columns
     VarBinary((&'a [&'a [u8]], &'a [S])),
+    /// Fixed length binary columns
+    FixedSizeBinary(i32, (&'a [&'a [u8]], &'a [S])),
 }
 
 impl<'a, S: Scalar> Column<'a, S> {
@@ -68,6 +70,7 @@ impl<'a, S: Scalar> Column<'a, S> {
                 ColumnType::TimestampTZ(*time_unit, *timezone)
             }
             Self::VarBinary(..) => ColumnType::VarBinary,
+            Self::FixedSizeBinary(byte_width, _) => ColumnType::FixedSizeBinary(*byte_width),
         }
     }
     /// Returns the length of the column.
@@ -86,7 +89,7 @@ impl<'a, S: Scalar> Column<'a, S> {
                 assert_eq!(col.len(), scals.len());
                 col.len()
             }
-            Self::VarBinary((col, scals)) => {
+            Self::VarBinary((col, scals)) | Self::FixedSizeBinary(_, (col, scals)) => {
                 assert_eq!(col.len(), scals.len());
                 col.len()
             }
@@ -198,6 +201,20 @@ impl<'a, S: Scalar> Column<'a, S> {
                     alloc.alloc_slice_copy(scalars.as_slice()),
                 ))
             }
+            OwnedColumn::FixedSizeBinary(byte_width, col) => {
+                let scalars = col
+                    .iter()
+                    .map(|b| S::from_fixed_size_byte_slice(b))
+                    .collect::<Vec<_>>();
+                let bytes = col.iter().map(|s| s as &'a [u8]).collect::<Vec<_>>();
+                Column::FixedSizeBinary(
+                    *byte_width,
+                    (
+                        alloc.alloc_slice_clone(&bytes),
+                        alloc.alloc_slice_copy(scalars.as_slice()),
+                    ),
+                )
+            }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col.as_slice()),
         }
     }
@@ -290,6 +307,14 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
 
+    /// Returns the column as fixed-size binary data if it is a fixed-size binary column. Otherwise, returns None.
+    pub(crate) fn as_fixed_size_binary(&self) -> Option<(i32, &'a [&'a [u8]], &'a [S])> {
+        match self {
+            Self::FixedSizeBinary(byte_width, (col, scals)) => Some((*byte_width, col, scals)),
+            _ => None,
+        }
+    }
+
     /// Returns the column as a slice of i64 if it is a timestamp column. Otherwise, returns None.
     pub(crate) fn as_timestamptz(&self) -> Option<&'a [i64]> {
         match self {
@@ -311,7 +336,9 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::BigInt(col) | Self::TimestampTZ(_, _, col) => S::from(col[index]),
             Self::Int128(col) => S::from(col[index]),
             Self::Scalar(col) | Self::Decimal75(_, _, col) => col[index],
-            Self::VarChar((_, scals)) | Self::VarBinary((_, scals)) => scals[index],
+            Self::VarChar((_, scals))
+            | Self::VarBinary((_, scals))
+            | Self::FixedSizeBinary(_, (_, scals)) => scals[index],
         })
     }
 
@@ -322,7 +349,9 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::Boolean(col) => slice_cast_with(col, |b| S::from(b)),
             Self::Decimal75(_, _, col) => slice_cast_with(col, |s| *s),
             Self::VarChar((_, values)) => slice_cast_with(values, |s| *s),
-            Self::VarBinary((_, values)) => slice_cast_with(values, |s| *s),
+            Self::VarBinary((_, values)) | Self::FixedSizeBinary(_, (_, values)) => {
+                slice_cast_with(values, |s| *s)
+            }
             Self::Uint8(col) => slice_cast_with(col, |i| S::from(i)),
             Self::TinyInt(col) => slice_cast_with(col, |i| S::from(i)),
             Self::SmallInt(col) => slice_cast_with(col, |i| S::from(i)),

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -103,6 +103,20 @@ where
                 alloc.alloc_slice_copy(&scalars) as &[_],
             )))
         }
+        ColumnType::FixedSizeBinary(byte_width) => {
+            let (_, raw_values, raw_scalars) = column
+                .as_fixed_size_binary()
+                .expect("Column types should match");
+            let raw_values = apply_slice_to_indexes(raw_values, indexes)?;
+            let scalars = apply_slice_to_indexes(raw_scalars, indexes)?;
+            Ok(Column::FixedSizeBinary(
+                byte_width,
+                (
+                    alloc.alloc_slice_clone(&raw_values) as &[_],
+                    alloc.alloc_slice_copy(&scalars) as &[_],
+                ),
+            ))
+        }
         ColumnType::TimestampTZ(tu, tz) => {
             let raw_values = apply_slice_to_indexes(
                 column.as_timestamptz().expect("Column types should match"),

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -119,6 +119,31 @@ pub trait RepetitionOp {
                     }) as &[_],
                 ))
             }
+            ColumnType::FixedSizeBinary(byte_width) => {
+                let (_, raw_result, raw_scalars) = column
+                    .as_fixed_size_binary()
+                    .expect("Column types should match");
+
+                // Create iterators for both the result and scalars
+                let mut result_iter = Self::op(raw_result, n);
+                let mut scalar_iter = Self::op(raw_scalars, n);
+
+                Column::FixedSizeBinary(
+                    byte_width,
+                    (
+                        alloc.alloc_slice_fill_with(len, |_| {
+                            result_iter
+                                .next()
+                                .expect("Iterator should have enough elements")
+                        }) as &[_],
+                        alloc.alloc_slice_fill_with(len, |_| {
+                            scalar_iter
+                                .next()
+                                .expect("Iterator should have enough elements")
+                        }) as &[_],
+                    ),
+                )
+            }
             ColumnType::TimestampTZ(tu, tz) => {
                 let mut iter = Self::op(
                     column.as_timestamptz().expect("Column types should match"),

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -54,8 +54,12 @@ pub enum ColumnType {
     #[cfg_attr(test, proptest(skip))]
     Scalar,
     /// Mapped to [u8]
-    #[serde(alias = "BINARY", alias = "BINARY")]
+    #[serde(alias = "BINARY", alias = "binary")]
     VarBinary,
+    /// Mapped to fixed-width binary blobs of the specified byte width.
+    #[serde(alias = "FIXED_SIZE_BINARY", alias = "fixed_size_binary")]
+    #[cfg_attr(test, proptest(skip))]
+    FixedSizeBinary(i32),
 }
 
 impl ColumnType {
@@ -187,7 +191,7 @@ impl ColumnType {
             // Scalars are not in database & are only used for typeless comparisons for testing so we return 0
             // so that they do not cause errors when used in comparisons.
             Self::Scalar => Some(0_u8),
-            Self::Boolean | Self::VarChar | Self::VarBinary => None,
+            Self::Boolean | Self::VarChar | Self::VarBinary | Self::FixedSizeBinary(_) => None,
         }
     }
     /// Returns scale of a [`ColumnType`] if it is convertible to a decimal wrapped in `Some()`. Otherwise return None.
@@ -202,7 +206,7 @@ impl ColumnType {
             | Self::BigInt
             | Self::Int128
             | Self::Scalar => Some(0),
-            Self::Boolean | Self::VarBinary | Self::VarChar => None,
+            Self::Boolean | Self::VarBinary | Self::VarChar | Self::FixedSizeBinary(_) => None,
             Self::TimestampTZ(tu, _) => match tu {
                 PoSQLTimeUnit::Second => Some(0),
                 PoSQLTimeUnit::Millisecond => Some(3),
@@ -223,9 +227,11 @@ impl ColumnType {
             Self::Int => size_of::<i32>(),
             Self::BigInt | Self::TimestampTZ(_, _) => size_of::<i64>(),
             Self::Int128 => size_of::<i128>(),
-            Self::Scalar | Self::Decimal75(_, _) | Self::VarBinary | Self::VarChar => {
-                size_of::<[u64; 4]>()
-            }
+            Self::Scalar
+            | Self::Decimal75(_, _)
+            | Self::VarBinary
+            | Self::VarChar
+            | Self::FixedSizeBinary(_) => size_of::<[u64; 4]>(),
         }
     }
 
@@ -249,6 +255,7 @@ impl ColumnType {
             Self::Decimal75(_, _)
             | Self::Scalar
             | Self::VarBinary
+            | Self::FixedSizeBinary(_)
             | Self::VarChar
             | Self::Boolean
             | Self::Uint8 => false,
@@ -289,6 +296,9 @@ impl Display for ColumnType {
             }
             ColumnType::VarChar => write!(f, "VARCHAR"),
             ColumnType::VarBinary => write!(f, "BINARY"),
+            ColumnType::FixedSizeBinary(byte_width) => {
+                write!(f, "FIXED_SIZE_BINARY({byte_width})")
+            }
             ColumnType::Scalar => write!(f, "SCALAR"),
             ColumnType::TimestampTZ(timeunit, timezone) => {
                 write!(f, "TIMESTAMP(TIMEUNIT: {timeunit}, TIMEZONE: {timezone})")

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -278,6 +278,9 @@ pub fn try_equals_types(lhs: ColumnType, rhs: ColumnType) -> ColumnOperationResu
             | (ColumnType::Boolean, ColumnType::Boolean)
             | (_, ColumnType::Scalar)
             | (ColumnType::Scalar, _)
+    ) || matches!(
+        (lhs, rhs),
+        (ColumnType::FixedSizeBinary(left), ColumnType::FixedSizeBinary(right)) if left == right
     ) || (lhs.is_numeric() && rhs.is_numeric() && lhs.scale() == rhs.scale())
         || matches!(
             (lhs, rhs),
@@ -353,6 +356,9 @@ pub fn try_equals_types_with_scaling(
             | (ColumnType::Boolean, ColumnType::Boolean)
             | (_, ColumnType::Scalar)
             | (ColumnType::Scalar, _)
+    ) || matches!(
+        (lhs, rhs),
+        (ColumnType::FixedSizeBinary(left), ColumnType::FixedSizeBinary(right)) if left == right
     ) || (lhs.is_numeric() && rhs.is_numeric()))
     .then_some(())
     .ok_or(ColumnOperationError::BinaryOperationInvalidColumnType {

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -69,6 +69,13 @@ pub fn filter_column_by_index<'a, S: Scalar>(
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
         )),
+        Column::FixedSizeBinary(byte_width, (col, scals)) => Column::FixedSizeBinary(
+            *byte_width,
+            (
+                alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+                alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
+            ),
+        ),
         Column::Scalar(col) => {
             Column::Scalar(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -170,7 +170,8 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         Column::VarChar(_)
         | Column::TimestampTZ(_, _, _)
         | Column::Boolean(_)
-        | Column::VarBinary(_) => {
+        | Column::VarBinary(_)
+        | Column::FixedSizeBinary(_, _) => {
             unreachable!("SUM can not be applied to non-numeric types")
         }
     }
@@ -203,8 +204,8 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
             max_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarBinary(_) => {
-            unreachable!("MAX can not be applied to varbinary")
+        Column::VarBinary(_) | Column::FixedSizeBinary(_, _) => {
+            unreachable!("MAX can not be applied to binary data")
         }
         // The following should never be reached because the `MAX` function can't be applied to varchar.
         Column::VarChar(_) => {
@@ -240,7 +241,9 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
             min_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarBinary(_) => unreachable!("MIN can not be applied to varbinary"),
+        Column::VarBinary(_) | Column::FixedSizeBinary(_, _) => {
+            unreachable!("MIN can not be applied to binary data")
+        }
         // The following should never be reached because the `MIN` function can't be applied to varchar.
         Column::VarChar(_) => {
             unreachable!("MIN can not be applied to varchar")

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -25,7 +25,9 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
             Column::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
             Column::Scalar(col) => col[i].cmp(&col[j]),
             Column::VarChar((col, _)) => col[i].cmp(col[j]),
-            Column::VarBinary((col, _)) => col[i].cmp(col[j]),
+            Column::VarBinary((col, _)) | Column::FixedSizeBinary(_, (col, _)) => {
+                col[i].cmp(col[j])
+            }
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -10,7 +10,9 @@ use crate::base::{
     },
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::Scalar,
-    slice_ops::{inner_product_ref_cast, inner_product_with_bytes},
+    slice_ops::{
+        inner_product_ref_cast, inner_product_with_bytes, inner_product_with_fixed_size_bytes,
+    },
 };
 use alloc::{
     string::{String, ToString},
@@ -51,6 +53,9 @@ pub enum OwnedColumn<S: Scalar> {
     Scalar(Vec<S>),
     /// Variable length binary columns
     VarBinary(Vec<Vec<u8>>),
+    /// Fixed length binary columns
+    #[cfg_attr(test, proptest(skip))]
+    FixedSizeBinary(i32, Vec<Vec<u8>>),
 }
 
 impl<S: Scalar> OwnedColumn<S> {
@@ -67,6 +72,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             OwnedColumn::VarChar(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::VarBinary(col) => inner_product_with_bytes(col, vec),
+            OwnedColumn::FixedSizeBinary(_, col) => inner_product_with_fixed_size_bytes(col, vec),
             OwnedColumn::Int128(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => {
                 inner_product_ref_cast(col, vec)
@@ -85,7 +91,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Int(col) => col.len(),
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.len(),
             OwnedColumn::VarChar(col) => col.len(),
-            OwnedColumn::VarBinary(col) => col.len(),
+            OwnedColumn::VarBinary(col) | OwnedColumn::FixedSizeBinary(_, col) => col.len(),
             OwnedColumn::Int128(col) => col.len(),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col.len(),
         }
@@ -102,6 +108,9 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) => OwnedColumn::BigInt(permutation.try_apply(col)?),
             OwnedColumn::VarChar(col) => OwnedColumn::VarChar(permutation.try_apply(col)?),
             OwnedColumn::VarBinary(col) => OwnedColumn::VarBinary(permutation.try_apply(col)?),
+            OwnedColumn::FixedSizeBinary(byte_width, col) => {
+                OwnedColumn::FixedSizeBinary(*byte_width, permutation.try_apply(col)?)
+            }
             OwnedColumn::Int128(col) => OwnedColumn::Int128(permutation.try_apply(col)?),
             OwnedColumn::Decimal75(precision, scale, col) => {
                 OwnedColumn::Decimal75(*precision, *scale, permutation.try_apply(col)?)
@@ -125,6 +134,9 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) => OwnedColumn::BigInt(col[start..end].to_vec()),
             OwnedColumn::VarChar(col) => OwnedColumn::VarChar(col[start..end].to_vec()),
             OwnedColumn::VarBinary(col) => OwnedColumn::VarBinary(col[start..end].to_vec()),
+            OwnedColumn::FixedSizeBinary(byte_width, col) => {
+                OwnedColumn::FixedSizeBinary(*byte_width, col[start..end].to_vec())
+            }
             OwnedColumn::Int128(col) => OwnedColumn::Int128(col[start..end].to_vec()),
             OwnedColumn::Decimal75(precision, scale, col) => {
                 OwnedColumn::Decimal75(*precision, *scale, col[start..end].to_vec())
@@ -147,7 +159,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Int(col) => col.is_empty(),
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.is_empty(),
             OwnedColumn::VarChar(col) => col.is_empty(),
-            OwnedColumn::VarBinary(col) => col.is_empty(),
+            OwnedColumn::VarBinary(col) | OwnedColumn::FixedSizeBinary(_, col) => col.is_empty(),
             OwnedColumn::Int128(col) => col.is_empty(),
             OwnedColumn::Scalar(col) | OwnedColumn::Decimal75(_, _, col) => col.is_empty(),
         }
@@ -164,6 +176,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(_) => ColumnType::BigInt,
             OwnedColumn::VarChar(_) => ColumnType::VarChar,
             OwnedColumn::VarBinary(_) => ColumnType::VarBinary,
+            OwnedColumn::FixedSizeBinary(byte_width, _) => ColumnType::FixedSizeBinary(*byte_width),
             OwnedColumn::Int128(_) => ColumnType::Int128,
             OwnedColumn::Scalar(_) => ColumnType::Scalar,
             OwnedColumn::Decimal75(precision, scale, _) => {
@@ -254,10 +267,12 @@ impl<S: Scalar> OwnedColumn<S> {
                 Ok(OwnedColumn::TimestampTZ(tu, tz, raw_values))
             }
             // Can not convert scalars to VarChar
-            ColumnType::VarChar | ColumnType::VarBinary => Err(OwnedColumnError::TypeCastError {
-                from_type: ColumnType::Scalar,
-                to_type: ColumnType::VarChar,
-            }),
+            ColumnType::VarChar | ColumnType::VarBinary | ColumnType::FixedSizeBinary(_) => {
+                Err(OwnedColumnError::TypeCastError {
+                    from_type: ColumnType::Scalar,
+                    to_type: column_type,
+                })
+            }
         }
     }
 
@@ -373,6 +388,10 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for OwnedColumn<S> {
             Column::VarBinary((col, _)) => {
                 OwnedColumn::VarBinary(col.iter().map(|slice| slice.to_vec()).collect())
             }
+            Column::FixedSizeBinary(byte_width, (col, _)) => OwnedColumn::FixedSizeBinary(
+                *byte_width,
+                col.iter().map(|slice| slice.to_vec()).collect(),
+            ),
             Column::Int128(col) => OwnedColumn::Int128(col.to_vec()),
             Column::Decimal75(precision, scale, col) => {
                 OwnedColumn::Decimal75(*precision, *scale, col.to_vec())
@@ -904,6 +923,25 @@ mod test {
 
         let expected =
             lhs_hashes[0] * scalars[0] + lhs_hashes[1] * scalars[1] + lhs_hashes[2] * scalars[2];
+
+        assert_eq!(product, expected);
+    }
+
+    #[test]
+    fn we_can_compute_inner_product_with_fixed_size_binary_columns_using_fixed_embedding() {
+        let lhs =
+            OwnedColumn::<TestScalar>::FixedSizeBinary(2, vec![vec![1, 2], vec![3, 4], vec![5, 6]]);
+        let scalars = vec![
+            TestScalar::from(10),
+            TestScalar::from(20),
+            TestScalar::from(30),
+        ];
+
+        let product = lhs.inner_product(&scalars);
+
+        let expected = TestScalar::from_fixed_size_byte_slice(&[1, 2]) * scalars[0]
+            + TestScalar::from_fixed_size_byte_slice(&[3, 4]) * scalars[1]
+            + TestScalar::from_fixed_size_byte_slice(&[5, 6]) * scalars[2];
 
         assert_eq!(product, expected);
     }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -126,6 +126,16 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
 
                 Column::VarBinary((col_as_slices, scals))
             }
+            OwnedColumn::FixedSizeBinary(byte_width, col) => {
+                let col_as_slices: &mut [&[u8]] = self
+                    .alloc
+                    .alloc_slice_fill_iter(col.iter().map(Vec::as_slice));
+                let scals: &mut [CP::Scalar] = self.alloc.alloc_slice_fill_iter(
+                    col.iter()
+                        .map(|b| CP::Scalar::from_fixed_size_byte_slice(b.as_slice())),
+                );
+                Column::FixedSizeBinary(*byte_width, (col_as_slices, scals))
+            }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col),
         }
     }

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -183,6 +183,37 @@ pub fn column_union<'a, S: Scalar>(
                 }) as &[_],
             ))
         }
+        ColumnType::FixedSizeBinary(byte_width) => {
+            let (nested_results, nested_scalars): (Vec<_>, Vec<_>) = columns
+                .iter()
+                .map(|col| {
+                    let (_, values, scalars) = col
+                        .as_fixed_size_binary()
+                        .expect("Column types should match");
+                    (values, scalars)
+                })
+                .unzip();
+
+            // Create iterators for both results and scalars
+            let mut result_iter = nested_results.into_iter().flatten().copied();
+            let mut scalar_iter = nested_scalars.into_iter().flatten().copied();
+
+            Column::FixedSizeBinary(
+                byte_width,
+                (
+                    alloc.alloc_slice_fill_with(len, |_| {
+                        result_iter
+                            .next()
+                            .expect("Iterator should have enough elements")
+                    }) as &[_],
+                    alloc.alloc_slice_fill_with(len, |_| {
+                        scalar_iter
+                            .next()
+                            .expect("Iterator should have enough elements")
+                    }) as &[_],
+                ),
+            )
+        }
         ColumnType::TimestampTZ(tu, tz) => {
             let mut iter = columns
                 .iter()

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -102,6 +102,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
             Column::Uint8(c) => c.inner_product(evaluation_vec),
             Column::TinyInt(c) => c.inner_product(evaluation_vec),
@@ -118,6 +119,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => {
                 c.mul_add(res, multiplier);
             }
@@ -136,6 +138,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
             Column::Uint8(c) => c.to_sumcheck_term(num_vars),
             Column::TinyInt(c) => c.to_sumcheck_term(num_vars),
@@ -152,6 +155,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
             Column::Uint8(c) => MultilinearExtension::<S>::id(c),
             Column::TinyInt(c) => MultilinearExtension::<S>::id(c),

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -51,6 +51,21 @@ pub trait ScalarExt: Scalar {
         let masked_val = hashed_val & Self::CHALLENGE_MASK;
         Self::from_wrapping(masked_val)
     }
+
+    /// Converts a fixed-size byte slice to a Scalar.
+    ///
+    /// Values up to 31 bytes are embedded naturally as a little-endian unsigned integer.
+    /// Larger fixed-size values are hashed into the scalar field.
+    #[must_use]
+    fn from_fixed_size_byte_slice(bytes: &[u8]) -> Self {
+        if bytes.len() <= 31 {
+            let value =
+                U256::from_le_slice(bytes).expect("byte slices up to 31 bytes parse as U256");
+            Self::from_wrapping(value)
+        } else {
+            Self::from_byte_slice_via_hash(bytes)
+        }
+    }
 }
 
 impl<S: Scalar> ScalarExt for S {}
@@ -82,6 +97,23 @@ mod tests {
     #[test]
     fn we_can_get_zero_from_zero_bytes() {
         assert_eq!(TestScalar::from_byte_slice_via_hash(&[]), TestScalar::ZERO);
+    }
+
+    #[test]
+    fn fixed_size_bytes_up_to_31_bytes_use_natural_embedding() {
+        assert_eq!(
+            TestScalar::from_fixed_size_byte_slice(&[1, 2]),
+            TestScalar::from(513_u64)
+        );
+    }
+
+    #[test]
+    fn fixed_size_32_byte_values_are_hashed() {
+        let bytes = [7_u8; 32];
+        assert_eq!(
+            TestScalar::from_fixed_size_byte_slice(&bytes),
+            TestScalar::from_byte_slice_via_hash(&bytes)
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -40,3 +40,12 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
         .sum()
 }
+
+/// Cannot use [`inner_product_with_bytes`] for fixed-size binary columns because fixed-size
+/// bytes are embedded naturally when they fit in 31 bytes and hashed only for larger values.
+pub fn inner_product_with_fixed_size_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
+    if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
+        .zip(b)
+        .map(|(lhs_bytes, &rhs)| S::from_fixed_size_byte_slice(lhs_bytes) * rhs)
+        .sum()
+}

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -41,6 +41,7 @@ pub const fn min_as_f(column_type: ColumnType) -> F {
         | ColumnType::Scalar
         | ColumnType::VarChar
         | ColumnType::VarBinary
+        | ColumnType::FixedSizeBinary(_)
         | ColumnType::Boolean => MontFp!("0"),
     }
 }
@@ -133,7 +134,8 @@ fn copy_column_data_to_slice(
         CommittableColumn::Scalar(column)
         | CommittableColumn::Decimal75(_, _, column)
         | CommittableColumn::VarChar(column)
-        | CommittableColumn::VarBinary(column) => {
+        | CommittableColumn::VarBinary(column)
+        | CommittableColumn::FixedSizeBinary(_, column) => {
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -76,7 +76,9 @@ fn compute_dory_commitment(
             compute_dory_commitment_impl(column, offset, setup)
         }
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::VarBinary(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::VarBinary(column) | CommittableColumn::FixedSizeBinary(_, column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -83,6 +83,7 @@ fn compute_dory_commitment(
         CommittableColumn::Int128(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::VarChar(column)
         | CommittableColumn::VarBinary(column)
+        | CommittableColumn::FixedSizeBinary(_, column)
         | CommittableColumn::Decimal75(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -448,7 +448,8 @@ pub fn bit_table_and_scalars_for_packed_msm(
             CommittableColumn::Decimal75(_, _, column)
             | CommittableColumn::Scalar(column)
             | CommittableColumn::VarChar(column)
-            | CommittableColumn::VarBinary(column) => {
+            | CommittableColumn::VarBinary(column)
+            | CommittableColumn::FixedSizeBinary(_, column) => {
                 pack_bit(
                     column,
                     &mut packed_scalars,

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -156,7 +156,8 @@ fn compute_commitments_impl(
             CommittableColumn::Decimal75(_, _, vals)
             | CommittableColumn::Scalar(vals)
             | CommittableColumn::VarChar(vals)
-            | CommittableColumn::VarBinary(vals) => {
+            | CommittableColumn::VarBinary(vals)
+            | CommittableColumn::FixedSizeBinary(_, vals) => {
                 compute_commitment_generic_impl(setup, offset, vals)
             }
         })

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
@@ -94,7 +94,8 @@ mod tests {
                 CommittableColumn::Decimal75(_, _, vals)
                 | CommittableColumn::Scalar(vals)
                 | CommittableColumn::VarChar(vals)
-                | CommittableColumn::VarBinary(vals) => {
+                | CommittableColumn::VarBinary(vals)
+                | CommittableColumn::FixedSizeBinary(_, vals) => {
                     expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
                 }
             }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -124,6 +124,15 @@ impl ProvableQueryResult {
                         let x = S::from_byte_slice_via_hash(raw_bytes);
                         Ok((x, used))
                     }
+                    ColumnType::FixedSizeBinary(byte_width) => {
+                        let (raw_bytes, used) =
+                            decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;
+                        if raw_bytes.len() != byte_width as usize {
+                            return Err(QueryError::MiscellaneousDecodingError);
+                        }
+                        let x = S::from_fixed_size_byte_slice(raw_bytes);
+                        Ok((x, used))
+                    }
                     ColumnType::TimestampTZ(_, _) => {
                         decode_and_convert::<i64, S>(&self.data[offset..])
                     }
@@ -212,6 +221,27 @@ impl ProvableQueryResult {
                         let col_vec = decoded_slices.into_iter().map(<[u8]>::to_vec).collect();
 
                         Ok((field.name(), OwnedColumn::VarBinary(col_vec)))
+                    }
+                    ColumnType::FixedSizeBinary(byte_width) => {
+                        // Manually specify the item type: `&[u8]`
+                        let (decoded_slices, num_read) =
+                            decode_multiple_elements::<&[u8]>(&self.data[offset..], n)?;
+                        offset += num_read;
+
+                        if decoded_slices
+                            .iter()
+                            .any(|raw_bytes| raw_bytes.len() != byte_width as usize)
+                        {
+                            return Err(QueryError::MiscellaneousDecodingError);
+                        }
+
+                        // Convert those slices to owned `Vec<u8>`
+                        let col_vec = decoded_slices.into_iter().map(<[u8]>::to_vec).collect();
+
+                        Ok((
+                            field.name(),
+                            OwnedColumn::FixedSizeBinary(byte_width, col_vec),
+                        ))
                     }
                     ColumnType::Scalar => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -5,7 +5,7 @@ use crate::{
         database::{Column, ColumnField, ColumnType},
         math::decimal::Precision,
         polynomial::compute_evaluation_vector,
-        scalar::Scalar,
+        scalar::{Scalar, ScalarExt},
     },
     // proof_primitive::inner_product::TestScalar,
 };
@@ -192,6 +192,41 @@ fn evaluation_fails_if_integer_overflow_happens() {
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::Overflow)
+    ));
+}
+
+#[test]
+fn evaluation_fails_if_fixed_size_binary_width_does_not_match() {
+    let raw_bytes = [b"ab".as_ref(), b"cd".as_ref()];
+    let scalars: Vec<TestScalar> = raw_bytes
+        .iter()
+        .map(|&bytes| TestScalar::from_fixed_size_byte_slice(bytes))
+        .collect();
+    let cols: [Column<TestScalar>; 1] = [Column::FixedSizeBinary(2, (&raw_bytes, &scalars))];
+    let res = ProvableQueryResult::new(2, &cols);
+    let evaluation_point = [TestScalar::from(10u64), TestScalar::from(100u64)];
+    let column_fields = vec![ColumnField::new("a".into(), ColumnType::FixedSizeBinary(3))];
+
+    assert!(matches!(
+        res.evaluate(&evaluation_point, 2, &column_fields[..]),
+        Err(QueryError::MiscellaneousDecodingError)
+    ));
+}
+
+#[test]
+fn to_owned_table_fails_if_fixed_size_binary_width_does_not_match() {
+    let raw_bytes = [b"ab".as_ref(), b"cd".as_ref()];
+    let scalars: Vec<TestScalar> = raw_bytes
+        .iter()
+        .map(|&bytes| TestScalar::from_fixed_size_byte_slice(bytes))
+        .collect();
+    let cols: [Column<TestScalar>; 1] = [Column::FixedSizeBinary(2, (&raw_bytes, &scalars))];
+    let res = ProvableQueryResult::new(2, &cols);
+    let column_fields = vec![ColumnField::new("a".into(), ColumnType::FixedSizeBinary(3))];
+
+    assert!(matches!(
+        res.to_owned_table::<TestScalar>(&column_fields[..]),
+        Err(QueryError::MiscellaneousDecodingError)
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -41,6 +41,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) | Column::Scalar(col) => col.num_bytes(length),
             Column::VarChar((col, _)) => col.num_bytes(length),
             Column::VarBinary((col, _)) => col.num_bytes(length),
+            Column::FixedSizeBinary(_, (col, _)) => col.num_bytes(length),
         }
     }
 
@@ -56,6 +57,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) | Column::Scalar(col) => col.write(out, length),
             Column::VarChar((col, _)) => col.write(out, length),
             Column::VarBinary((col, _)) => col.write(out, length),
+            Column::FixedSizeBinary(_, (col, _)) => col.write(out, length),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
@@ -97,7 +97,8 @@ impl AggregateExec {
     }
 
     /// Checks if the group by expression can prove uniqueness
-    /// This is true if there is only one group by column and its type is not `VarChar` and not `VarBinary`
+    /// This is true if there is only one group by column and its type is not `VarChar`, `VarBinary`,
+    /// or `FixedSizeBinary`
     pub fn try_get_is_uniqueness_provable(&self) -> Option<bool> {
         match (
             self.group_by_exprs.len(),
@@ -107,7 +108,10 @@ impl AggregateExec {
         ) {
             (0, _) => Some(false),
             (1, Some(data_type))
-                if !matches!(data_type, ColumnType::VarChar | ColumnType::VarBinary) =>
+                if !matches!(
+                    data_type,
+                    ColumnType::VarChar | ColumnType::VarBinary | ColumnType::FixedSizeBinary(_)
+                ) =>
             {
                 Some(true)
             }

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -97,7 +97,8 @@ impl GroupByExec {
     }
 
     /// Checks if the group by expression can prove uniqueness
-    /// This is true if there is only one group by column and its type is not `VarChar` and not `VarBinary`
+    /// This is true if there is only one group by column and its type is not `VarChar`, `VarBinary`,
+    /// or `FixedSizeBinary`
     pub fn try_get_is_uniqueness_provable(&self) -> Option<bool> {
         match (
             self.group_by_exprs.len(),
@@ -105,7 +106,10 @@ impl GroupByExec {
         ) {
             (0, _) => Some(false),
             (1, Some(data_type))
-                if !matches!(data_type, ColumnType::VarChar | ColumnType::VarBinary) =>
+                if !matches!(
+                    data_type,
+                    ColumnType::VarChar | ColumnType::VarBinary | ColumnType::FixedSizeBinary(_)
+                ) =>
             {
                 Some(true)
             }


### PR DESCRIPTION
## Summary
- add `FixedSizeBinary` support across Arrow conversion, owned/borrowed columns, committable columns, query operations, and provable result handling
- make fixed-size binary commitment/inner-product paths use the fixed-size scalar embedding instead of varbinary hashing
- validate decoded fixed-size binary result lengths against the declared byte width

## Notes
- `ColumnType::FixedSizeBinary(_)::byte_size()` now reports the 32-byte scalar-limb representation used by commitments, matching `[u64; 4]` packing rather than the logical Arrow byte width
- `FixedSizeBinary` metadata/bounds are treated like other unordered binary/string-like columns

## Testing
- `cargo fmt --check`
- `cargo check -p proof-of-sql --lib --no-default-features`
- `cargo test -p proof-of-sql --lib --no-default-features --features arrow,test fixed_size_binary -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features arrow,test column_commitment_metadata -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features arrow,test base::arrow -- --nocapture`

Also attempted broader `cargo test -p proof-of-sql --lib --no-default-features --features arrow,test`; it progressed through the suite but timed out locally after 600s on macOS before a final summary.
