### PR TITLE
test: run aggregate exec tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
@@ -1,18 +1,14 @@
 use super::test_utility::*;
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnType,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
+        scalar::test_scalar::TestScalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
-    sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-        proof_plans::AggregateExec,
-    },
+    sql::{proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::AggregateExec},
 };
 use bumpalo::Bump;
 
@@ -25,7 +21,7 @@ fn we_can_prove_aggregation_without_group_by() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = aggregate(
         vec![],
@@ -41,8 +37,8 @@ fn we_can_prove_aggregation_without_group_by() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_c", [101 + 104 + 102 + 103]),
@@ -60,7 +56,7 @@ fn we_can_prove_a_simple_aggregate_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = aggregate(
         cols_expr_plan(&t, &["a"], &accessor),
@@ -76,8 +72,8 @@ fn we_can_prove_a_simple_aggregate_with_bigint_columns() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
@@ -96,7 +92,7 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = aggregate(
         cols_expr_plan(&t, &["a"], &accessor),
@@ -118,8 +114,8 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
         ),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
@@ -134,19 +130,19 @@ fn we_can_prove_an_aggregate_with_bigint_columns() {
 #[expect(clippy::too_many_lines)]
 #[test]
 fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
-    let scalar_filter_data: Vec<Curve25519Scalar> = [
+    let scalar_filter_data: Vec<TestScalar> = [
         333, 222, 222, 333, 222, 333, 333, 333, 222, 222, 222, 333, 222, 222, 222, 222, 222, 222,
         333, 333,
     ]
     .iter()
     .map(core::convert::Into::into)
     .collect();
-    let scalar_group_data: Vec<Curve25519Scalar> =
+    let scalar_group_data: Vec<TestScalar> =
         [5, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 4, 5]
             .iter()
             .map(core::convert::Into::into)
             .collect();
-    let scalar_sum_data: Vec<Curve25519Scalar> = [
+    let scalar_sum_data: Vec<TestScalar> = [
         119, 522, 100, 325, 501, 447, 759, 375, 212, 532, 459, 616, 579, 179, 695, 963, 532, 868,
         331, 830,
     ]
@@ -209,7 +205,7 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
     ]);
 
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // SELECT scalar_group, int128_group, bigint_group, sum(bigint_sum + 1) as sum_int, sum(bigint_sum - int128_sum) as sum_bigint, sum(scalar_filter) as sum_scal, count(*) as __count__
@@ -306,8 +302,8 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_int", [1406 + 927 + 637]),
@@ -328,7 +324,7 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         borrowed_bigint("b", [10, 20, 30, 40, 50], &alloc),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // Intermediate data after FilterExec: rows where b > 15
@@ -337,7 +333,7 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         borrowed_bigint("b", [20, 30, 40, 50], &alloc),
     ]);
     let mut intermediate_accessor =
-        TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+        TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     intermediate_accessor.add_table(t.clone(), intermediate_data, 0);
 
     // Create a TableExec as input
@@ -377,8 +373,8 @@ fn we_can_aggregate_with_decimal75_variable_on_filter() {
         const_bool(true),
     );
 
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         decimal75("one_plus_double_a", 40, 0, [3, 5, 7]),

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -44,7 +44,7 @@ mod filter_exec_test;
 mod aggregate_exec;
 pub(crate) use aggregate_exec::AggregateExec;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod aggregate_exec_test;
 
 mod slice_exec;


### PR DESCRIPTION
/claim #560

## Summary

This moves the existing `aggregate_exec_test` module out from behind the `blitzar` feature gate and runs it with `NaiveEvaluationProof`, so the aggregate proof plan tests execute in the no-default-features test configuration.

## Coverage evidence

Using the existing no-default-features baseline LCOV report and a focused `aggregate_exec_test` LCOV run, this conservatively newly covers 274 previously zero-hit executable lines in:

- `crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs`

At `$0.10` per newly covered line, that focused claim is approximately `$27.40`. I am not counting shared/transitive proof plumbing coverage or newly executed test-file lines in that estimate.

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test aggregate_exec_test -- --nocapture` (5 passed)
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/proof-of-sql-aggregate-exec-naive.lcov -- aggregate_exec_test`
- `cargo test -p proof-of-sql --lib --no-default-features --features test` (965 passed)
- `rustfmt --edition 2021 --check crates/proof-of-sql/src/sql/proof_plans/mod.rs crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: `cargo fmt --all -- --check` still reports an unrelated pre-existing import-order diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`.
