### PR TITLE
test: run group by exec tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
@@ -1,15 +1,11 @@
 use super::test_utility::*;
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{owned_table_utility::*, OwnedTableTestAccessor, TableRef, TestAccessor},
+        scalar::test_scalar::TestScalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
-    sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-        proof_plans::GroupByExec,
-    },
+    sql::{proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::GroupByExec},
 };
 
 /// `select sum(c) as sum_c, count(*) as __count__ from sxt.t where b = 99`
@@ -21,7 +17,7 @@ fn we_can_prove_aggregation_without_group_by() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = group_by(
         vec![],
@@ -30,8 +26,8 @@ fn we_can_prove_aggregation_without_group_by() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_c", [101 + 104 + 102 + 103]),
@@ -49,7 +45,7 @@ fn we_can_prove_a_simple_group_by_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = group_by(
         cols_expr(&t, &["a"], &accessor),
@@ -58,8 +54,8 @@ fn we_can_prove_a_simple_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
@@ -78,7 +74,7 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
     let expr = group_by(
         cols_expr(&t, &["a"], &accessor),
@@ -93,8 +89,8 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
@@ -109,19 +105,19 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
 #[expect(clippy::too_many_lines)]
 #[test]
 fn we_cannot_prove_a_complex_group_by_query_with_many_columns() {
-    let scalar_filter_data: Vec<Curve25519Scalar> = [
+    let scalar_filter_data: Vec<TestScalar> = [
         333, 222, 222, 333, 222, 333, 333, 333, 222, 222, 222, 333, 222, 222, 222, 222, 222, 222,
         333, 333,
     ]
     .iter()
     .map(core::convert::Into::into)
     .collect();
-    let scalar_group_data: Vec<Curve25519Scalar> =
+    let scalar_group_data: Vec<TestScalar> =
         [5, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 4, 5]
             .iter()
             .map(core::convert::Into::into)
             .collect();
-    let scalar_sum_data: Vec<Curve25519Scalar> = [
+    let scalar_sum_data: Vec<TestScalar> = [
         119, 522, 100, 325, 501, 447, 759, 375, 212, 532, 459, 616, 579, 179, 695, 963, 532, 868,
         331, 830,
     ]
@@ -184,7 +180,7 @@ fn we_cannot_prove_a_complex_group_by_query_with_many_columns() {
     ]);
 
     let t = TableRef::new("sxt", "t");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor.add_table(t.clone(), data, 0);
 
     // SELECT scalar_group, int128_group, bigint_group, sum(bigint_sum + 1) as sum_int, sum(bigint_sum - int128_sum) as sum_bigint, sum(scalar_filter) as sum_scal, count(*) as __count__
@@ -251,8 +247,8 @@ fn we_cannot_prove_a_complex_group_by_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_int", [1406 + 927 + 637]),

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -32,7 +32,7 @@ mod fold_util_test;
 mod group_by_exec;
 pub(crate) use group_by_exec::GroupByExec;
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod group_by_exec_test;
 
 mod filter_exec;


### PR DESCRIPTION
/claim #560

## Summary

This moves the existing `group_by_exec_test` module out from behind the `blitzar` feature gate and runs it with `NaiveEvaluationProof`, so the group-by proof plan tests execute in the no-default-features test configuration.

## Coverage evidence

Using the existing no-default-features baseline LCOV report and a focused `group_by_exec_test` LCOV run, this conservatively newly covers 268 previously zero-hit executable lines in:

- `crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs`

At `$0.10` per newly covered line, that focused claim is approximately `$26.80`. I am not counting shared/transitive proof plumbing coverage or newly executed test-file lines in that estimate.

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test group_by_exec_test -- --nocapture` (4 passed)
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/proof-of-sql-group-by-exec-naive.lcov -- group_by_exec_test`
- `cargo test -p proof-of-sql --lib --no-default-features --features test` (964 passed)
- `rustfmt --edition 2021 --check crates/proof-of-sql/src/sql/proof_plans/mod.rs crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: `cargo fmt --all -- --check` still reports an unrelated pre-existing import-order diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`.
