### PR TITLE
test: cover standard binary deserialization edges

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,37 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn deserialization_reports_consumed_bytes_with_trailing_data() {
+        let obj = SerdeTestType {
+            a: "test".to_string(),
+            b: true,
+            c: -123,
+        };
+        let serialized = try_standard_binary_serialization(obj.clone()).unwrap();
+        let mut serialized_with_trailing_data = serialized.clone();
+        serialized_with_trailing_data.extend_from_slice(&[1, 2, 3]);
+
+        let (deserialized, bytes_consumed): (SerdeTestType, _) =
+            try_standard_binary_deserialization(&serialized_with_trailing_data).unwrap();
+
+        assert_eq!(obj, deserialized);
+        assert_eq!(bytes_consumed, serialized.len());
+    }
+
+    #[test]
+    fn deserialization_errors_when_payload_is_truncated() {
+        let obj = SerdeTestType {
+            a: "test".to_string(),
+            b: false,
+            c: 123,
+        };
+        let serialized = try_standard_binary_serialization(obj).unwrap();
+
+        let result: Result<(SerdeTestType, _), _> =
+            try_standard_binary_deserialization(&serialized[..serialized.len() - 1]);
+
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- add coverage that standard binary deserialization reports the consumed byte count when trailing data is present
- add coverage that truncated serialized payloads return a decode error

/claim #560

## Test plan
- cargo fmt --check
- cargo test -p proof-of-sql --no-default-features --features test standard_serializations::binary::tests --lib
- git diff --check

Note: running the focused test without `--features test` fails in this crate because the lib test target compiles no-std test modules that require the repository test feature.