### PR TITLE
test: run proof expr test without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -2,7 +2,7 @@
 mod proof_expr;
 pub(crate) use proof_expr::DecimalProofExpr;
 pub use proof_expr::ProofExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod proof_expr_test;
 
 mod aliased_dyn_proof_expr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -1,6 +1,6 @@
 use super::{test_utility::*, DynProofExpr, ProofExpr};
 use crate::base::{
-    commitment::InnerProductProof,
+    commitment::naive_evaluation_proof::NaiveEvaluationProof,
     database::{table_utility::*, Column, TableRef, TableTestAccessor, TestAccessor},
 };
 use bumpalo::Bump;
@@ -30,7 +30,7 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_first_round_ev
             &alloc,
         ),
     ]);
-    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     let t = TableRef::new("sxt", "t");
     accessor.add_table(t.clone(), data.clone(), 0);
     // (a <= 5 || b == "g") && c != 3


### PR DESCRIPTION
/claim #560

## Summary
- enable the existing `proof_expr_test` module for plain `#[cfg(test)]`
- switch that test from `InnerProductProof` to the test-only `NaiveEvaluationProof`
- keep the coverage slice independent of the `blitzar` feature so it can run under the no-default `test` feature path

## Validation
- `git diff --check` passed
- Not run: `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_compute_the_correct_result_of_a_complex_bool_expr_using_first_round_evaluate` because `cargo` is not installed in this local environment

