### PR TITLE
test: run add subtract expr tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -1,16 +1,16 @@
 use super::AddExpr;
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, ColumnType, OwnedTableTestAccessor, TableRef,
             TableTestAccessor,
         },
         math::decimal::Precision,
+        scalar::test_scalar::TestScalar,
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::VerifiableQueryResult,
         proof_exprs::{test_utility::*, DynProofExpr, ProofExpr},
         proof_plans::test_utility::*,
         AnalyzeError,
@@ -35,7 +35,7 @@ fn we_can_prove_a_typical_add_subtract_query() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             col_expr_plan(&t, "a", &accessor),
@@ -57,8 +57,8 @@ fn we_can_prove_a_typical_add_subtract_query() {
             const_bigint(3),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -83,7 +83,7 @@ fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             col_expr_plan(&t, "a", &accessor),
@@ -128,8 +128,8 @@ fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
             const_decimal75(12, 2, 35),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -167,7 +167,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -196,16 +196,16 @@ fn test_random_tables_with_given_offset(offset: usize) {
             and(
                 equal(
                     column(&t, "b", &accessor),
-                    const_scalar::<Curve25519Scalar, _>(filter_val1.as_str()),
+                    const_scalar::<TestScalar, _>(filter_val1.as_str()),
                 ),
                 equal(
                     column(&t, "c", &accessor),
-                    const_scalar::<Curve25519Scalar, _>(filter_val2),
+                    const_scalar::<TestScalar, _>(filter_val2),
                 ),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
+        let verifiable_res: VerifiableQueryResult<NaiveEvaluationProof> =
+            VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
             .unwrap()
@@ -220,7 +220,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
         ))
         .filter_map(|(a, b, c, d)| {
             if b == &filter_val1 && c == &filter_val2 {
-                Some((Curve25519Scalar::from(*a + *c - 4), d.clone()))
+                Some((TestScalar::from(*a + *c - 4), d.clone()))
             } else {
                 None
             }
@@ -255,7 +255,7 @@ fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_first_round_e
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let add_subtract_expr: DynProofExpr = add(
         column(&t, "b", &accessor),
         subtract(column(&t, "a", &accessor), const_bigint(1)),
@@ -276,7 +276,7 @@ fn we_cannot_add_subtract_mismatching_types() {
     ]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let lhs = Box::new(column(&t, "a", &accessor));
     let rhs = Box::new(column(&t, "b", &accessor));
     let add_err = AddExpr::try_new(lhs.clone(), rhs.clone()).unwrap_err();

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -12,7 +12,7 @@ mod add_expr;
 pub(crate) use add_expr::AddExpr;
 mod subtract_expr;
 pub(crate) use subtract_expr::SubtractExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod add_subtract_expr_test;
 
 mod multiply_expr;


### PR DESCRIPTION
/claim #560

## Summary
- enable `add_subtract_expr_test` when running no-default-feature tests
- switch the add/subtract expression tests from blitzar proof/scalar types to `NaiveEvaluationProof` and `TestScalar`
- keep the direct `verify` assertions so the tests exercise add/subtract expression proving without requiring blitzar

## Coverage
- Baseline: `target/proof-of-sql-baseline.lcov` from `main` with `--no-default-features --features test`
- Candidate: `target/proof-of-sql-add-subtract-expr-naive.lcov` from this branch with `add_subtract_expr_test`
- Newly covered production lines in `crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs`: 47
- Newly covered production lines in `crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs`: 48
- Conservative bounty estimate: ~$9.50 at $0.10/line

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test add_subtract_expr_test -- --nocapture` (6 passed)
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/proof-of-sql-add-subtract-expr-naive.lcov -- add_subtract_expr_test`
- `cargo test -p proof-of-sql --lib --no-default-features --features test` (966 passed)
- `rustfmt --check crates/proof-of-sql/src/sql/proof_exprs/mod.rs crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: `cargo fmt --all -- --check` still reports the pre-existing import ordering difference in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`, which this PR does not touch.