### PR TITLE
test: run sign expr tests without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use sign_expr::{
 mod range_check;
 #[cfg(all(test, feature = "blitzar"))]
 mod range_check_test;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod sign_expr_test;
 pub(crate) use monotonic::{
     final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic,


### PR DESCRIPTION
/claim #560

## Summary
- enable `sign_expr_test` when running no-default-feature tests
- keep the existing `TestScalar` sign gadget tests unchanged; they do not require blitzar
- cover sign first-round, final-round, and verifier paths under the normal `test` feature

## Coverage
- Baseline: `target/proof-of-sql-baseline.lcov` from `main` with `--no-default-features --features test`
- Candidate: `target/proof-of-sql-sign-expr-test.lcov` from this branch with `sign_expr_test`
- Newly covered production lines in `crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs`: 28
- Conservative bounty estimate: ~$2.80 at $0.10/line

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test sign_expr_test -- --nocapture` (7 passed)
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/proof-of-sql-sign-expr-test.lcov -- sign_expr_test`
- `cargo test -p proof-of-sql --lib --no-default-features --features test` (967 passed)
- `rustfmt --check crates/proof-of-sql/src/sql/proof_gadgets/mod.rs`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: `cargo fmt --all -- --check` still reports the pre-existing import ordering difference in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`, which this PR does not touch.

AI-assisted with OpenAI Codex; I reviewed and validated the diff locally.
