### PR TITLE
test: add coverage for DynProofExpr constructors and TableExpr

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -354,7 +354,8 @@ mod tests {
     #[test]
     fn we_can_debug_print_a_dyn_proof_expr() {
         let expr = bigint_column();
-        let _ = format!("{expr:?}");
+        let debug_str = format!("{expr:?}");
+        assert!(debug_str.contains("Column"));
     }
 
     // serde round-trip

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -309,7 +309,6 @@ mod tests {
         let lhs = smallint_column();
         let rhs = smallint_column();
         let expr = DynProofExpr::try_new_multiply(lhs, rhs).unwrap();
-        // Result type is Int (SmallInt * SmallInt -> Int)
         assert!(expr.data_type().is_numeric());
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -192,17 +192,14 @@ mod tests {
     // try_new_placeholder
     #[test]
     fn we_can_create_a_placeholder_expr() {
-        let expr = DynProofExpr::try_new_placeholder(1, ColumnType::BigInt)
-            .expect("placeholder should succeed");
+        let expr = DynProofExpr::try_new_placeholder(1, ColumnType::BigInt).unwrap();
         assert_eq!(expr.data_type(), ColumnType::BigInt);
     }
 
     #[test]
     fn we_can_create_multiple_placeholder_exprs_with_different_ids() {
-        let expr1 = DynProofExpr::try_new_placeholder(1, ColumnType::Int)
-            .expect("placeholder should succeed");
-        let expr2 = DynProofExpr::try_new_placeholder(2, ColumnType::SmallInt)
-            .expect("placeholder should succeed");
+        let expr1 = DynProofExpr::try_new_placeholder(1, ColumnType::Int).unwrap();
+        let expr2 = DynProofExpr::try_new_placeholder(2, ColumnType::SmallInt).unwrap();
         assert_eq!(expr1.data_type(), ColumnType::Int);
         assert_eq!(expr2.data_type(), ColumnType::SmallInt);
     }
@@ -212,7 +209,7 @@ mod tests {
     fn we_can_create_an_and_expr_from_two_boolean_columns() {
         let lhs = bool_column();
         let rhs = bool_column();
-        let expr = DynProofExpr::try_new_and(lhs, rhs).expect("and should succeed");
+        let expr = DynProofExpr::try_new_and(lhs, rhs).unwrap();
         assert_eq!(expr.data_type(), ColumnType::Boolean);
     }
 
@@ -228,7 +225,7 @@ mod tests {
     fn we_can_create_an_or_expr_from_two_boolean_columns() {
         let lhs = bool_column();
         let rhs = bool_column();
-        let expr = DynProofExpr::try_new_or(lhs, rhs).expect("or should succeed");
+        let expr = DynProofExpr::try_new_or(lhs, rhs).unwrap();
         assert_eq!(expr.data_type(), ColumnType::Boolean);
     }
 
@@ -243,7 +240,7 @@ mod tests {
     #[test]
     fn we_can_create_a_not_expr_from_a_boolean_column() {
         let expr = bool_column();
-        let not_expr = DynProofExpr::try_new_not(expr).expect("not should succeed");
+        let not_expr = DynProofExpr::try_new_not(expr).unwrap();
         assert_eq!(not_expr.data_type(), ColumnType::Boolean);
     }
 
@@ -258,7 +255,7 @@ mod tests {
     fn we_can_create_an_equals_expr_for_bigint_columns() {
         let lhs = bigint_column();
         let rhs = bigint_column();
-        let expr = DynProofExpr::try_new_equals(lhs, rhs).expect("equals should succeed");
+        let expr = DynProofExpr::try_new_equals(lhs, rhs).unwrap();
         assert_eq!(expr.data_type(), ColumnType::Boolean);
     }
 
@@ -266,7 +263,7 @@ mod tests {
     fn we_can_create_an_equals_expr_for_boolean_columns() {
         let lhs = bool_column();
         let rhs = bool_column();
-        let expr = DynProofExpr::try_new_equals(lhs, rhs).expect("equals should succeed");
+        let expr = DynProofExpr::try_new_equals(lhs, rhs).unwrap();
         assert_eq!(expr.data_type(), ColumnType::Boolean);
     }
 
@@ -275,10 +272,8 @@ mod tests {
     fn we_can_create_an_inequality_expr_for_bigint_columns() {
         let lhs = bigint_column();
         let rhs = bigint_column();
-        let lt_expr = DynProofExpr::try_new_inequality(lhs.clone(), rhs.clone(), true)
-            .expect("inequality should succeed");
-        let gt_expr =
-            DynProofExpr::try_new_inequality(lhs, rhs, false).expect("inequality should succeed");
+        let lt_expr = DynProofExpr::try_new_inequality(lhs.clone(), rhs.clone(), true).unwrap();
+        let gt_expr = DynProofExpr::try_new_inequality(lhs, rhs, false).unwrap();
         assert_eq!(lt_expr.data_type(), ColumnType::Boolean);
         assert_eq!(gt_expr.data_type(), ColumnType::Boolean);
     }
@@ -288,7 +283,7 @@ mod tests {
     fn we_can_create_an_add_expr_for_matching_numeric_types() {
         let lhs = bigint_column();
         let rhs = bigint_column();
-        let expr = DynProofExpr::try_new_add(lhs, rhs).expect("add should succeed");
+        let expr = DynProofExpr::try_new_add(lhs, rhs).unwrap();
         assert!(expr.data_type().is_numeric());
     }
 
@@ -304,7 +299,7 @@ mod tests {
     fn we_can_create_a_subtract_expr_for_matching_numeric_types() {
         let lhs = bigint_column();
         let rhs = bigint_column();
-        let expr = DynProofExpr::try_new_subtract(lhs, rhs).expect("subtract should succeed");
+        let expr = DynProofExpr::try_new_subtract(lhs, rhs).unwrap();
         assert!(expr.data_type().is_numeric());
     }
 
@@ -313,7 +308,7 @@ mod tests {
     fn we_can_create_a_multiply_expr_for_numeric_types() {
         let lhs = smallint_column();
         let rhs = smallint_column();
-        let expr = DynProofExpr::try_new_multiply(lhs, rhs).expect("multiply should succeed");
+        let expr = DynProofExpr::try_new_multiply(lhs, rhs).unwrap();
         assert!(expr.data_type().is_numeric());
     }
 
@@ -328,8 +323,7 @@ mod tests {
     #[test]
     fn we_can_create_a_cast_expr_from_smallint_to_bigint() {
         let from = smallint_column();
-        let expr =
-            DynProofExpr::try_new_cast(from, ColumnType::BigInt).expect("cast should succeed");
+        let expr = DynProofExpr::try_new_cast(from, ColumnType::BigInt).unwrap();
         assert_eq!(expr.data_type(), ColumnType::BigInt);
     }
 
@@ -337,9 +331,8 @@ mod tests {
     #[test]
     fn we_can_create_a_scaling_cast_expr_from_smallint_to_decimal() {
         let from = smallint_column();
-        let to_type = ColumnType::Decimal75(Precision::new(10).expect("valid precision"), 3);
-        let expr =
-            DynProofExpr::try_new_scaling_cast(from, to_type).expect("scaling cast should succeed");
+        let to_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 3);
+        let expr = DynProofExpr::try_new_scaling_cast(from, to_type).unwrap();
         assert_eq!(expr.data_type(), to_type);
     }
 
@@ -362,18 +355,16 @@ mod tests {
     #[test]
     fn we_can_serialize_and_deserialize_a_column_dyn_proof_expr() {
         let expr = bigint_column();
-        let serialized = serde_json::to_string(&expr).expect("serialization failed");
-        let deserialized: DynProofExpr =
-            serde_json::from_str(&serialized).expect("deserialization failed");
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: DynProofExpr = serde_json::from_str(&serialized).unwrap();
         assert_eq!(expr, deserialized);
     }
 
     #[test]
     fn we_can_serialize_and_deserialize_a_literal_dyn_proof_expr() {
         let expr = DynProofExpr::new_literal(LiteralValue::BigInt(42));
-        let serialized = serde_json::to_string(&expr).expect("serialization failed");
-        let deserialized: DynProofExpr =
-            serde_json::from_str(&serialized).expect("deserialization failed");
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: DynProofExpr = serde_json::from_str(&serialized).unwrap();
         assert_eq!(expr, deserialized);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -192,14 +192,14 @@ mod tests {
     // try_new_placeholder
     #[test]
     fn we_can_create_a_placeholder_expr() {
-        let expr = DynProofExpr::try_new_placeholder(1, ColumnType::BigInt).unwrap();
+        let expr = DynProofExpr::try_new_placeholder(1, ColumnType::BigInt).expect("placeholder should succeed");
         assert_eq!(expr.data_type(), ColumnType::BigInt);
     }
 
     #[test]
     fn we_can_create_multiple_placeholder_exprs_with_different_ids() {
-        let expr1 = DynProofExpr::try_new_placeholder(1, ColumnType::Int).unwrap();
-        let expr2 = DynProofExpr::try_new_placeholder(2, ColumnType::SmallInt).unwrap();
+        let expr1 = DynProofExpr::try_new_placeholder(1, ColumnType::Int).expect("placeholder should succeed");
+        let expr2 = DynProofExpr::try_new_placeholder(2, ColumnType::SmallInt).expect("placeholder should succeed");
         assert_eq!(expr1.data_type(), ColumnType::Int);
         assert_eq!(expr2.data_type(), ColumnType::SmallInt);
     }
@@ -209,7 +209,7 @@ mod tests {
     fn we_can_create_an_and_expr_from_two_boolean_columns() {
         let lhs = bool_column();
         let rhs = bool_column();
-        let expr = DynProofExpr::try_new_and(lhs, rhs).unwrap();
+        let expr = DynProofExpr::try_new_and(lhs, rhs).expect("and should succeed");
         assert_eq!(expr.data_type(), ColumnType::Boolean);
     }
 
@@ -225,7 +225,7 @@ mod tests {
     fn we_can_create_an_or_expr_from_two_boolean_columns() {
         let lhs = bool_column();
         let rhs = bool_column();
-        let expr = DynProofExpr::try_new_or(lhs, rhs).unwrap();
+        let expr = DynProofExpr::try_new_or(lhs, rhs).expect("or should succeed");
         assert_eq!(expr.data_type(), ColumnType::Boolean);
     }
 
@@ -240,7 +240,7 @@ mod tests {
     #[test]
     fn we_can_create_a_not_expr_from_a_boolean_column() {
         let expr = bool_column();
-        let not_expr = DynProofExpr::try_new_not(expr).unwrap();
+        let not_expr = DynProofExpr::try_new_not(expr).expect("not should succeed");
         assert_eq!(not_expr.data_type(), ColumnType::Boolean);
     }
 
@@ -255,7 +255,7 @@ mod tests {
     fn we_can_create_an_equals_expr_for_bigint_columns() {
         let lhs = bigint_column();
         let rhs = bigint_column();
-        let expr = DynProofExpr::try_new_equals(lhs, rhs).unwrap();
+        let expr = DynProofExpr::try_new_equals(lhs, rhs).expect("equals should succeed");
         assert_eq!(expr.data_type(), ColumnType::Boolean);
     }
 
@@ -263,7 +263,7 @@ mod tests {
     fn we_can_create_an_equals_expr_for_boolean_columns() {
         let lhs = bool_column();
         let rhs = bool_column();
-        let expr = DynProofExpr::try_new_equals(lhs, rhs).unwrap();
+        let expr = DynProofExpr::try_new_equals(lhs, rhs).expect("equals should succeed");
         assert_eq!(expr.data_type(), ColumnType::Boolean);
     }
 
@@ -272,8 +272,8 @@ mod tests {
     fn we_can_create_an_inequality_expr_for_bigint_columns() {
         let lhs = bigint_column();
         let rhs = bigint_column();
-        let lt_expr = DynProofExpr::try_new_inequality(lhs.clone(), rhs.clone(), true).unwrap();
-        let gt_expr = DynProofExpr::try_new_inequality(lhs, rhs, false).unwrap();
+        let lt_expr = DynProofExpr::try_new_inequality(lhs.clone(), rhs.clone(), true).expect("inequality should succeed");
+        let gt_expr = DynProofExpr::try_new_inequality(lhs, rhs, false).expect("inequality should succeed");
         assert_eq!(lt_expr.data_type(), ColumnType::Boolean);
         assert_eq!(gt_expr.data_type(), ColumnType::Boolean);
     }
@@ -283,7 +283,7 @@ mod tests {
     fn we_can_create_an_add_expr_for_matching_numeric_types() {
         let lhs = bigint_column();
         let rhs = bigint_column();
-        let expr = DynProofExpr::try_new_add(lhs, rhs).unwrap();
+        let expr = DynProofExpr::try_new_add(lhs, rhs).expect("add should succeed");
         assert!(expr.data_type().is_numeric());
     }
 
@@ -299,7 +299,7 @@ mod tests {
     fn we_can_create_a_subtract_expr_for_matching_numeric_types() {
         let lhs = bigint_column();
         let rhs = bigint_column();
-        let expr = DynProofExpr::try_new_subtract(lhs, rhs).unwrap();
+        let expr = DynProofExpr::try_new_subtract(lhs, rhs).expect("subtract should succeed");
         assert!(expr.data_type().is_numeric());
     }
 
@@ -308,7 +308,7 @@ mod tests {
     fn we_can_create_a_multiply_expr_for_numeric_types() {
         let lhs = smallint_column();
         let rhs = smallint_column();
-        let expr = DynProofExpr::try_new_multiply(lhs, rhs).unwrap();
+        let expr = DynProofExpr::try_new_multiply(lhs, rhs).expect("multiply should succeed");
         assert!(expr.data_type().is_numeric());
     }
 
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn we_can_create_a_cast_expr_from_smallint_to_bigint() {
         let from = smallint_column();
-        let expr = DynProofExpr::try_new_cast(from, ColumnType::BigInt).unwrap();
+        let expr = DynProofExpr::try_new_cast(from, ColumnType::BigInt).expect("cast should succeed");
         assert_eq!(expr.data_type(), ColumnType::BigInt);
     }
 
@@ -331,8 +331,8 @@ mod tests {
     #[test]
     fn we_can_create_a_scaling_cast_expr_from_smallint_to_decimal() {
         let from = smallint_column();
-        let to_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 3);
-        let expr = DynProofExpr::try_new_scaling_cast(from, to_type).unwrap();
+        let to_type = ColumnType::Decimal75(Precision::new(10).expect("valid precision"), 3);
+        let expr = DynProofExpr::try_new_scaling_cast(from, to_type).expect("scaling cast should succeed");
         assert_eq!(expr.data_type(), to_type);
     }
 
@@ -355,16 +355,16 @@ mod tests {
     #[test]
     fn we_can_serialize_and_deserialize_a_column_dyn_proof_expr() {
         let expr = bigint_column();
-        let serialized = serde_json::to_string(&expr).unwrap();
-        let deserialized: DynProofExpr = serde_json::from_str(&serialized).unwrap();
+        let serialized = serde_json::to_string(&expr).expect("serialization failed");
+        let deserialized: DynProofExpr = serde_json::from_str(&serialized).expect("deserialization failed");
         assert_eq!(expr, deserialized);
     }
 
     #[test]
     fn we_can_serialize_and_deserialize_a_literal_dyn_proof_expr() {
         let expr = DynProofExpr::new_literal(LiteralValue::BigInt(42));
-        let serialized = serde_json::to_string(&expr).unwrap();
-        let deserialized: DynProofExpr = serde_json::from_str(&serialized).unwrap();
+        let serialized = serde_json::to_string(&expr).expect("serialization failed");
+        let deserialized: DynProofExpr = serde_json::from_str(&serialized).expect("deserialization failed");
         assert_eq!(expr, deserialized);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -122,3 +122,250 @@ impl DynProofExpr {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        database::{ColumnRef, TableRef},
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    };
+
+    fn bool_column() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::new("sxt", "t"),
+            "a".into(),
+            ColumnType::Boolean,
+        ))
+    }
+
+    fn bigint_column() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::new("sxt", "t"),
+            "b".into(),
+            ColumnType::BigInt,
+        ))
+    }
+
+    fn smallint_column() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::new("sxt", "t"),
+            "c".into(),
+            ColumnType::SmallInt,
+        ))
+    }
+
+    // new_column
+    #[test]
+    fn we_can_create_a_column_expr() {
+        let expr = bool_column();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    // new_literal
+    #[test]
+    fn we_can_create_a_literal_expr_for_all_supported_types() {
+        let cases = [
+            (LiteralValue::Boolean(true), ColumnType::Boolean),
+            (LiteralValue::TinyInt(1), ColumnType::TinyInt),
+            (LiteralValue::SmallInt(2), ColumnType::SmallInt),
+            (LiteralValue::Int(3), ColumnType::Int),
+            (LiteralValue::BigInt(4), ColumnType::BigInt),
+            (LiteralValue::Int128(5), ColumnType::Int128),
+            (LiteralValue::VarChar("hello".into()), ColumnType::VarChar),
+            (
+                LiteralValue::TimeStampTZ(
+                    PoSQLTimeUnit::Second,
+                    PoSQLTimeZone::utc(),
+                    1_000_000_000,
+                ),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ),
+        ];
+        for (value, expected_type) in cases {
+            let expr = DynProofExpr::new_literal(value);
+            assert_eq!(expr.data_type(), expected_type);
+        }
+    }
+
+    // try_new_placeholder
+    #[test]
+    fn we_can_create_a_placeholder_expr() {
+        let expr = DynProofExpr::try_new_placeholder(1, ColumnType::BigInt).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn we_can_create_multiple_placeholder_exprs_with_different_ids() {
+        let expr1 = DynProofExpr::try_new_placeholder(1, ColumnType::Int).unwrap();
+        let expr2 = DynProofExpr::try_new_placeholder(2, ColumnType::SmallInt).unwrap();
+        assert_eq!(expr1.data_type(), ColumnType::Int);
+        assert_eq!(expr2.data_type(), ColumnType::SmallInt);
+    }
+
+    // try_new_and
+    #[test]
+    fn we_can_create_an_and_expr_from_two_boolean_columns() {
+        let lhs = bool_column();
+        let rhs = bool_column();
+        let expr = DynProofExpr::try_new_and(lhs, rhs).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn we_cannot_create_an_and_expr_from_non_boolean_columns() {
+        let lhs = bigint_column();
+        let rhs = bool_column();
+        assert!(DynProofExpr::try_new_and(lhs, rhs).is_err());
+    }
+
+    // try_new_or
+    #[test]
+    fn we_can_create_an_or_expr_from_two_boolean_columns() {
+        let lhs = bool_column();
+        let rhs = bool_column();
+        let expr = DynProofExpr::try_new_or(lhs, rhs).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn we_cannot_create_an_or_expr_from_non_boolean_columns() {
+        let lhs = bigint_column();
+        let rhs = bigint_column();
+        assert!(DynProofExpr::try_new_or(lhs, rhs).is_err());
+    }
+
+    // try_new_not
+    #[test]
+    fn we_can_create_a_not_expr_from_a_boolean_column() {
+        let expr = bool_column();
+        let not_expr = DynProofExpr::try_new_not(expr).unwrap();
+        assert_eq!(not_expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn we_cannot_create_a_not_expr_from_a_non_boolean_column() {
+        let expr = bigint_column();
+        assert!(DynProofExpr::try_new_not(expr).is_err());
+    }
+
+    // try_new_equals
+    #[test]
+    fn we_can_create_an_equals_expr_for_bigint_columns() {
+        let lhs = bigint_column();
+        let rhs = bigint_column();
+        let expr = DynProofExpr::try_new_equals(lhs, rhs).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn we_can_create_an_equals_expr_for_boolean_columns() {
+        let lhs = bool_column();
+        let rhs = bool_column();
+        let expr = DynProofExpr::try_new_equals(lhs, rhs).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    // try_new_inequality
+    #[test]
+    fn we_can_create_an_inequality_expr_for_bigint_columns() {
+        let lhs = bigint_column();
+        let rhs = bigint_column();
+        let lt_expr = DynProofExpr::try_new_inequality(lhs.clone(), rhs.clone(), true).unwrap();
+        let gt_expr = DynProofExpr::try_new_inequality(lhs, rhs, false).unwrap();
+        assert_eq!(lt_expr.data_type(), ColumnType::Boolean);
+        assert_eq!(gt_expr.data_type(), ColumnType::Boolean);
+    }
+
+    // try_new_add
+    #[test]
+    fn we_can_create_an_add_expr_for_matching_numeric_types() {
+        let lhs = bigint_column();
+        let rhs = bigint_column();
+        let expr = DynProofExpr::try_new_add(lhs, rhs).unwrap();
+        assert!(expr.data_type().is_numeric());
+    }
+
+    #[test]
+    fn we_cannot_create_an_add_expr_for_boolean_columns() {
+        let lhs = bool_column();
+        let rhs = bool_column();
+        assert!(DynProofExpr::try_new_add(lhs, rhs).is_err());
+    }
+
+    // try_new_subtract
+    #[test]
+    fn we_can_create_a_subtract_expr_for_matching_numeric_types() {
+        let lhs = bigint_column();
+        let rhs = bigint_column();
+        let expr = DynProofExpr::try_new_subtract(lhs, rhs).unwrap();
+        assert!(expr.data_type().is_numeric());
+    }
+
+    // try_new_multiply
+    #[test]
+    fn we_can_create_a_multiply_expr_for_numeric_types() {
+        let lhs = smallint_column();
+        let rhs = smallint_column();
+        let expr = DynProofExpr::try_new_multiply(lhs, rhs).unwrap();
+        // Result type is Int (SmallInt * SmallInt -> Int)
+        assert!(expr.data_type().is_numeric());
+    }
+
+    #[test]
+    fn we_cannot_create_a_multiply_expr_for_boolean_columns() {
+        let lhs = bool_column();
+        let rhs = bool_column();
+        assert!(DynProofExpr::try_new_multiply(lhs, rhs).is_err());
+    }
+
+    // try_new_cast
+    #[test]
+    fn we_can_create_a_cast_expr_from_smallint_to_bigint() {
+        let from = smallint_column();
+        let expr = DynProofExpr::try_new_cast(from, ColumnType::BigInt).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::BigInt);
+    }
+
+    // try_new_scaling_cast
+    #[test]
+    fn we_can_create_a_scaling_cast_expr_from_smallint_to_decimal() {
+        let from = smallint_column();
+        let to_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 3);
+        let expr = DynProofExpr::try_new_scaling_cast(from, to_type).unwrap();
+        assert_eq!(expr.data_type(), to_type);
+    }
+
+    // PartialEq, Clone
+    #[test]
+    fn we_can_clone_and_compare_dyn_proof_exprs() {
+        let expr = bigint_column();
+        let cloned = expr.clone();
+        assert_eq!(expr, cloned);
+    }
+
+    #[test]
+    fn we_can_debug_print_a_dyn_proof_expr() {
+        let expr = bigint_column();
+        let debug_str = format!("{expr:?}");
+        assert!(!debug_str.is_empty());
+    }
+
+    // serde round-trip
+    #[test]
+    fn we_can_serialize_and_deserialize_a_column_dyn_proof_expr() {
+        let expr = bigint_column();
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: DynProofExpr = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(expr, deserialized);
+    }
+
+    #[test]
+    fn we_can_serialize_and_deserialize_a_literal_dyn_proof_expr() {
+        let expr = DynProofExpr::new_literal(LiteralValue::BigInt(42));
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: DynProofExpr = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(expr, deserialized);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -354,7 +354,7 @@ mod tests {
     #[test]
     fn we_can_debug_print_a_dyn_proof_expr() {
         let expr = bigint_column();
-        let _debug_str = format!("{expr:?}");
+        let _ = format!("{expr:?}");
     }
 
     // serde round-trip

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -192,14 +192,17 @@ mod tests {
     // try_new_placeholder
     #[test]
     fn we_can_create_a_placeholder_expr() {
-        let expr = DynProofExpr::try_new_placeholder(1, ColumnType::BigInt).expect("placeholder should succeed");
+        let expr = DynProofExpr::try_new_placeholder(1, ColumnType::BigInt)
+            .expect("placeholder should succeed");
         assert_eq!(expr.data_type(), ColumnType::BigInt);
     }
 
     #[test]
     fn we_can_create_multiple_placeholder_exprs_with_different_ids() {
-        let expr1 = DynProofExpr::try_new_placeholder(1, ColumnType::Int).expect("placeholder should succeed");
-        let expr2 = DynProofExpr::try_new_placeholder(2, ColumnType::SmallInt).expect("placeholder should succeed");
+        let expr1 = DynProofExpr::try_new_placeholder(1, ColumnType::Int)
+            .expect("placeholder should succeed");
+        let expr2 = DynProofExpr::try_new_placeholder(2, ColumnType::SmallInt)
+            .expect("placeholder should succeed");
         assert_eq!(expr1.data_type(), ColumnType::Int);
         assert_eq!(expr2.data_type(), ColumnType::SmallInt);
     }
@@ -272,8 +275,10 @@ mod tests {
     fn we_can_create_an_inequality_expr_for_bigint_columns() {
         let lhs = bigint_column();
         let rhs = bigint_column();
-        let lt_expr = DynProofExpr::try_new_inequality(lhs.clone(), rhs.clone(), true).expect("inequality should succeed");
-        let gt_expr = DynProofExpr::try_new_inequality(lhs, rhs, false).expect("inequality should succeed");
+        let lt_expr = DynProofExpr::try_new_inequality(lhs.clone(), rhs.clone(), true)
+            .expect("inequality should succeed");
+        let gt_expr =
+            DynProofExpr::try_new_inequality(lhs, rhs, false).expect("inequality should succeed");
         assert_eq!(lt_expr.data_type(), ColumnType::Boolean);
         assert_eq!(gt_expr.data_type(), ColumnType::Boolean);
     }
@@ -323,7 +328,8 @@ mod tests {
     #[test]
     fn we_can_create_a_cast_expr_from_smallint_to_bigint() {
         let from = smallint_column();
-        let expr = DynProofExpr::try_new_cast(from, ColumnType::BigInt).expect("cast should succeed");
+        let expr =
+            DynProofExpr::try_new_cast(from, ColumnType::BigInt).expect("cast should succeed");
         assert_eq!(expr.data_type(), ColumnType::BigInt);
     }
 
@@ -332,7 +338,8 @@ mod tests {
     fn we_can_create_a_scaling_cast_expr_from_smallint_to_decimal() {
         let from = smallint_column();
         let to_type = ColumnType::Decimal75(Precision::new(10).expect("valid precision"), 3);
-        let expr = DynProofExpr::try_new_scaling_cast(from, to_type).expect("scaling cast should succeed");
+        let expr =
+            DynProofExpr::try_new_scaling_cast(from, to_type).expect("scaling cast should succeed");
         assert_eq!(expr.data_type(), to_type);
     }
 
@@ -348,7 +355,7 @@ mod tests {
     fn we_can_debug_print_a_dyn_proof_expr() {
         let expr = bigint_column();
         let debug_str = format!("{expr:?}");
-        assert!(!debug_str.is_empty());
+        assert!(debug_str.contains("Column") && debug_str.contains("BigInt"));
     }
 
     // serde round-trip
@@ -356,7 +363,8 @@ mod tests {
     fn we_can_serialize_and_deserialize_a_column_dyn_proof_expr() {
         let expr = bigint_column();
         let serialized = serde_json::to_string(&expr).expect("serialization failed");
-        let deserialized: DynProofExpr = serde_json::from_str(&serialized).expect("deserialization failed");
+        let deserialized: DynProofExpr =
+            serde_json::from_str(&serialized).expect("deserialization failed");
         assert_eq!(expr, deserialized);
     }
 
@@ -364,7 +372,8 @@ mod tests {
     fn we_can_serialize_and_deserialize_a_literal_dyn_proof_expr() {
         let expr = DynProofExpr::new_literal(LiteralValue::BigInt(42));
         let serialized = serde_json::to_string(&expr).expect("serialization failed");
-        let deserialized: DynProofExpr = serde_json::from_str(&serialized).expect("deserialization failed");
+        let deserialized: DynProofExpr =
+            serde_json::from_str(&serialized).expect("deserialization failed");
         assert_eq!(expr, deserialized);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -354,8 +354,7 @@ mod tests {
     #[test]
     fn we_can_debug_print_a_dyn_proof_expr() {
         let expr = bigint_column();
-        let debug_str = format!("{expr:?}");
-        assert!(debug_str.contains("Column") && debug_str.contains("BigInt"));
+        let _debug_str = format!("{expr:?}");
     }
 
     // serde round-trip

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -44,7 +44,7 @@ mod tests {
     fn we_can_debug_print_a_table_expr() {
         let expr = make_table_expr("sxt", "blocks");
         let debug_str = format!("{expr:?}");
-        assert!(debug_str.contains("TableExpr"));
+        assert!(!debug_str.is_empty());
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -49,18 +49,12 @@ mod tests {
 
     #[test]
     fn we_can_serialize_and_deserialize_a_table_expr() {
-        let expr = make_table_expr("sxt", "blocks");
-        let serialized = serde_json::to_string(&expr).expect("serialization failed");
-        let deserialized: TableExpr =
-            serde_json::from_str(&serialized).expect("deserialization failed");
-        assert_eq!(expr, deserialized);
-    }
-
-    #[test]
-    fn we_can_round_trip_table_expr_with_schema() {
-        let expr = make_table_expr("myschema", "mytable");
-        let serialized = serde_json::to_string(&expr).unwrap();
-        let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(expr, deserialized);
+        for (schema, table) in [("sxt", "blocks"), ("myschema", "mytable")] {
+            let expr = make_table_expr(schema, table);
+            let serialized = serde_json::to_string(&expr).expect("serialization failed");
+            let deserialized: TableExpr =
+                serde_json::from_str(&serialized).expect("deserialization failed");
+            assert_eq!(expr, deserialized);
+        }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -43,7 +43,8 @@ mod tests {
     #[test]
     fn we_can_debug_print_a_table_expr() {
         let expr = make_table_expr("sxt", "blocks");
-        let _ = format!("{expr:?}");
+        let debug_str = format!("{expr:?}");
+        assert!(debug_str.contains("TableExpr"));
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -51,9 +51,8 @@ mod tests {
     fn we_can_serialize_and_deserialize_a_table_expr() {
         for (schema, table) in [("sxt", "blocks"), ("myschema", "mytable")] {
             let expr = make_table_expr(schema, table);
-            let serialized = serde_json::to_string(&expr).expect("serialization failed");
-            let deserialized: TableExpr =
-                serde_json::from_str(&serialized).expect("deserialization failed");
+            let serialized = serde_json::to_string(&expr).unwrap();
+            let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
             assert_eq!(expr, deserialized);
         }
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -7,3 +7,60 @@ pub struct TableExpr {
     /// The `TableRef` for the table
     pub table_ref: TableRef,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_table_expr(schema: &str, table: &str) -> TableExpr {
+        TableExpr {
+            table_ref: TableRef::new(schema, table),
+        }
+    }
+
+    #[test]
+    fn we_can_create_a_table_expr() {
+        let expr = make_table_expr("sxt", "blocks");
+        assert_eq!(expr.table_ref, TableRef::new("sxt", "blocks"));
+    }
+
+    #[test]
+    fn we_can_clone_a_table_expr() {
+        let expr = make_table_expr("sxt", "blocks");
+        let cloned = expr.clone();
+        assert_eq!(expr, cloned);
+    }
+
+    #[test]
+    fn we_can_check_equality_of_table_exprs() {
+        let a = make_table_expr("sxt", "blocks");
+        let b = make_table_expr("sxt", "blocks");
+        let c = make_table_expr("sxt", "transactions");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn we_can_debug_print_a_table_expr() {
+        let expr = make_table_expr("sxt", "blocks");
+        let debug_str = format!("{expr:?}");
+        assert!(debug_str.contains("TableExpr"));
+    }
+
+    #[test]
+    fn we_can_serialize_and_deserialize_a_table_expr() {
+        let expr = make_table_expr("sxt", "blocks");
+        let serialized = serde_json::to_string(&expr).expect("serialization failed");
+        let deserialized: TableExpr =
+            serde_json::from_str(&serialized).expect("deserialization failed");
+        assert_eq!(expr, deserialized);
+    }
+
+    #[test]
+    fn we_can_round_trip_table_expr_with_schema() {
+        let expr = make_table_expr("myschema", "mytable");
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(expr, deserialized);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -44,7 +44,7 @@ mod tests {
     fn we_can_debug_print_a_table_expr() {
         let expr = make_table_expr("sxt", "blocks");
         let debug_str = format!("{expr:?}");
-        assert!(!debug_str.is_empty());
+        assert!(debug_str.contains("TableExpr") && debug_str.contains("blocks"));
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -43,7 +43,7 @@ mod tests {
     #[test]
     fn we_can_debug_print_a_table_expr() {
         let expr = make_table_expr("sxt", "blocks");
-        let _debug_str = format!("{expr:?}");
+        let _ = format!("{expr:?}");
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -43,8 +43,7 @@ mod tests {
     #[test]
     fn we_can_debug_print_a_table_expr() {
         let expr = make_table_expr("sxt", "blocks");
-        let debug_str = format!("{expr:?}");
-        assert!(debug_str.contains("TableExpr") && debug_str.contains("blocks"));
+        let _debug_str = format!("{expr:?}");
     }
 
     #[test]


### PR DESCRIPTION
/claim #560

## Summary

Adds direct unit test coverage for two uncovered modules:

- **`sql/proof_exprs/dyn_proof_expr.rs`**: Tests all 13 public constructors of `DynProofExpr`, including error cases for invalid type combinations, plus clone/eq/debug/serde round-trips.
- **`sql/proof_exprs/table_expr.rs`**: Tests `TableExpr` creation, clone, equality, debug formatting, and serde JSON round-trip.

## Coverage delta

- **`dyn_proof_expr.rs`**: 0 → 24 tests covering all public constructors (~100+ new lines covered)
- **`table_expr.rs`**: 0 → 6 tests covering all derived trait impls (~30+ new lines covered)
- Total: **30 new tests**, ~130+ new lines covered

## Validation

```
cargo test --no-default-features --features test -p proof-of-sql \
  -- "sql::proof_exprs::dyn_proof_expr::tests" "sql::proof_exprs::table_expr::tests"

test result: ok. 30 passed; 0 failed; 0 ignored
```