### PR TITLE
test: add database value type coverage

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,27 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_preserves_name_and_data_type() {
+        let field = ColumnField::new(Ident::new("customer_id"), ColumnType::Int128);
+
+        assert_eq!(field.name().value, "customer_id");
+        assert_eq!(field.data_type(), ColumnType::Int128);
+    }
+
+    #[test]
+    fn name_returns_an_owned_identifier() {
+        let field = ColumnField::new(Ident::with_quote('"', "CustomerID"), ColumnType::BigInt);
+
+        let mut name = field.name();
+        name.value = "changed".into();
+
+        assert_eq!(field.name().value, "CustomerID");
+        assert_eq!(field.name().quote_style, Some('"'));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,34 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_preserves_table_column_and_type() {
+        let table_ref = TableRef::new("sales", "orders");
+        let column_ref =
+            ColumnRef::new(table_ref.clone(), Ident::new("amount"), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id().value, "amount");
+        assert_eq!(*column_ref.column_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn accessors_return_owned_identifiers() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("", "orders"),
+            Ident::with_quote('"', "total"),
+            ColumnType::Int,
+        );
+
+        let mut column_id = column_ref.column_id();
+        column_id.value = "changed".into();
+
+        assert_eq!(column_ref.column_id().value, "total");
+        assert_eq!(column_ref.column_id().quote_style, Some('"'));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,21 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn new_preserves_column_and_chi_evaluations() {
+        let column_evals = vec![TestScalar::from(3_u8), TestScalar::from(5_u8)];
+        let chi = (TestScalar::from(8_u8), 4);
+
+        let evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+        assert_eq!(evaluation.column_evals(), column_evals.as_slice());
+        assert_eq!(evaluation.chi_eval(), chi.0);
+        assert_eq!(evaluation.chi(), chi);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,58 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_omits_empty_schema() {
+        let table_ref = TableRef::new("", "orders");
+
+        assert_eq!(table_ref.schema_id(), None);
+        assert_eq!(table_ref.table_id().value, "orders");
+        assert_eq!(table_ref.to_string(), "orders");
+    }
+
+    #[test]
+    fn parses_schema_qualified_table_refs() {
+        let table_ref = TableRef::try_from("sales.orders").unwrap();
+
+        assert_eq!(table_ref.schema_id().unwrap().value, "sales");
+        assert_eq!(table_ref.table_id().value, "orders");
+        assert_eq!(table_ref.to_string(), "sales.orders");
+    }
+
+    #[test]
+    fn rejects_more_than_two_table_ref_components() {
+        let err = TableRef::try_from("catalog.sales.orders").unwrap_err();
+
+        assert!(matches!(
+            err,
+            ParseError::InvalidTableReference {
+                table_reference
+            } if table_reference == "catalog.sales.orders"
+        ));
+
+        let err = TableRef::from_strs(&["catalog", "sales", "orders"]).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ParseError::InvalidTableReference {
+                table_reference
+            } if table_reference == "catalog,sales,orders"
+        ));
+    }
+
+    #[test]
+    fn serde_round_trips_display_form() {
+        let table_ref = TableRef::new("analytics", "events");
+
+        let encoded = serde_json::to_string(&table_ref).unwrap();
+        assert_eq!(encoded, "\"analytics.events\"");
+
+        let decoded: TableRef = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, table_ref);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit coverage for TableRef parsing, display, invalid refs, and serde
- add accessor preservation tests for ColumnRef and ColumnField
- add TableEvaluation constructor/accessor coverage

/claim #560

## Validation
- cargo fmt
- cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --no-default-features --features test base::database

Related to #560