### PR TITLE
test: add timezone parsing edge-case coverage

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -119,4 +119,29 @@ mod timezone_parsing_tests {
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
         ));
     }
+    #[test]
+    fn we_can_parse_positive_time_zone() {
+        let timezone_as_str: Option<Arc<str>> = Some("+01:30".into());
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+        assert_eq!(timezone, PoSQLTimeZone::new(5400));
+    }
+
+    #[test]
+    fn we_can_parse_utc_aliases_case_insensitive() {
+        let utc_aliases = ["z", "utc", "00:00", "+00:00", "0:00", "+0:00"];
+        for alias in utc_aliases {
+            let timezone_as_str: Option<Arc<str>> = Some(alias.into());
+            let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+            assert_eq!(timezone, PoSQLTimeZone::utc());
+        }
+    }
+
+    #[test]
+    fn we_cannot_parse_invalid_time_zone_offset_components() {
+        for invalid_offset in ["+0A:00", "+01:0A"] {
+            let timezone_as_str: Option<Arc<str>> = Some(invalid_offset.into());
+            let timezone_err = PoSQLTimeZone::try_from(&timezone_as_str).unwrap_err();
+            assert_eq!(timezone_err, PoSQLTimestampError::InvalidTimezoneOffset);
+        }
+    }
 }


### PR DESCRIPTION
Bounty #560

## Summary
- add coverage for parsing positive timezone offsets (`+01:30`)
- add coverage for case-insensitive UTC aliases (`z`, `utc`, `00:00`, `+00:00`, `0:00`, `+0:00`)
- add coverage for invalid timezone-offset components that should raise `InvalidTimezoneOffset`

## Notes
- this PR is intentionally scoped to `posql_time/timezone.rs` so it can land independently alongside other coverage PRs on #560.