### PR TITLE
test: add coverage for table_ref and column_comparison_operation

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_arithmetic_operation_test.rs
+++ b/crates/proof-of-sql/src/base/database/column_arithmetic_operation_test.rs
@@ -1,0 +1,254 @@
+use crate::base::{
+    database::{
+        column_arithmetic_operation::{AddOp, ArithmeticOp, DivOp, MulOp, SubOp},
+        ColumnOperationError, OwnedColumn,
+    },
+    scalar::test_scalar::TestScalar,
+};
+
+// ========== AddOp tests ==========
+
+#[test]
+fn add_op_on_bigint() {
+    let lhs = OwnedColumn::BigInt(vec![1, 2, 3]);
+    let rhs = OwnedColumn::BigInt(vec![10, 20, 30]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![11, 22, 33]));
+}
+
+#[test]
+fn add_op_on_uint8() {
+    let lhs = OwnedColumn::Uint8(vec![1u8, 2, 3]);
+    let rhs = OwnedColumn::Uint8(vec![10u8, 20, 30]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Uint8(vec![11u8, 22, 33]));
+}
+
+#[test]
+fn add_op_on_tinyint() {
+    let lhs = OwnedColumn::TinyInt(vec![1i8, -2, 3]);
+    let rhs = OwnedColumn::TinyInt(vec![10i8, 20, -30]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::TinyInt(vec![11i8, 18, -27]));
+}
+
+#[test]
+fn add_op_on_smallint() {
+    let lhs = OwnedColumn::SmallInt(vec![100i16, 200]);
+    let rhs = OwnedColumn::SmallInt(vec![200i16, 300]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::SmallInt(vec![300i16, 500]));
+}
+
+#[test]
+fn add_op_on_int() {
+    let lhs = OwnedColumn::Int(vec![1000i32, 2000]);
+    let rhs = OwnedColumn::Int(vec![2000i32, 3000]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Int(vec![3000i32, 5000]));
+}
+
+#[test]
+fn add_op_on_int128() {
+    let lhs = OwnedColumn::Int128(vec![100i128, 200]);
+    let rhs = OwnedColumn::Int128(vec![200i128, 300]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Int128(vec![300i128, 500]));
+}
+
+#[test]
+fn add_op_bigint_overflow_returns_error() {
+    let lhs = OwnedColumn::BigInt(vec![i64::MAX]);
+    let rhs = OwnedColumn::BigInt(vec![1]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::IntegerOverflow { .. })
+    ));
+}
+
+#[test]
+fn add_op_different_length_errors() {
+    let lhs = OwnedColumn::BigInt(vec![1, 2, 3]);
+    let rhs = OwnedColumn::BigInt(vec![1, 2]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::DifferentColumnLength { .. })
+    ));
+}
+
+#[test]
+fn add_op_uint8_tinyint_errors() {
+    let lhs = OwnedColumn::Uint8(vec![1u8]);
+    let rhs = OwnedColumn::TinyInt(vec![1i8]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::SignedCastingError { .. })
+    ));
+}
+
+#[test]
+fn add_op_incompatible_types_errors() {
+    let lhs = OwnedColumn::BigInt(vec![1]);
+    let rhs = OwnedColumn::Boolean(vec![true]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}
+
+#[test]
+fn add_op_empty_columns() {
+    let lhs = OwnedColumn::BigInt(vec![]);
+    let rhs = OwnedColumn::BigInt(vec![]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![]));
+}
+
+// ========== SubOp tests ==========
+
+#[test]
+fn sub_op_on_bigint() {
+    let lhs = OwnedColumn::BigInt(vec![10, 20, 30]);
+    let rhs = OwnedColumn::BigInt(vec![1, 2, 3]);
+    let result = SubOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![9, 18, 27]));
+}
+
+#[test]
+fn sub_op_on_int128() {
+    let lhs = OwnedColumn::Int128(vec![100i128, 200]);
+    let rhs = OwnedColumn::Int128(vec![50i128, 100]);
+    let result = SubOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Int128(vec![50i128, 100]));
+}
+
+#[test]
+fn sub_op_bigint_underflow_returns_error() {
+    let lhs = OwnedColumn::BigInt(vec![i64::MIN]);
+    let rhs = OwnedColumn::BigInt(vec![1]);
+    let result = SubOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::IntegerOverflow { .. })
+    ));
+}
+
+#[test]
+fn sub_op_empty_columns() {
+    let lhs = OwnedColumn::BigInt(vec![]);
+    let rhs = OwnedColumn::BigInt(vec![]);
+    let result = SubOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![]));
+}
+
+// ========== MulOp tests ==========
+
+#[test]
+fn mul_op_on_bigint() {
+    let lhs = OwnedColumn::BigInt(vec![2, 3, 4]);
+    let rhs = OwnedColumn::BigInt(vec![10, 20, 30]);
+    let result = MulOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![20, 60, 120]));
+}
+
+#[test]
+fn mul_op_on_int128() {
+    let lhs = OwnedColumn::Int128(vec![5i128, 10]);
+    let rhs = OwnedColumn::Int128(vec![20i128, 30]);
+    let result = MulOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Int128(vec![100i128, 300]));
+}
+
+#[test]
+fn mul_op_bigint_overflow_returns_error() {
+    let lhs = OwnedColumn::BigInt(vec![i64::MAX]);
+    let rhs = OwnedColumn::BigInt(vec![2]);
+    let result = MulOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::IntegerOverflow { .. })
+    ));
+}
+
+#[test]
+fn mul_op_empty_columns() {
+    let lhs = OwnedColumn::BigInt(vec![]);
+    let rhs = OwnedColumn::BigInt(vec![]);
+    let result = MulOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![]));
+}
+
+// ========== DivOp tests ==========
+
+#[test]
+fn div_op_on_bigint() {
+    let lhs = OwnedColumn::BigInt(vec![10, 20, 30]);
+    let rhs = OwnedColumn::BigInt(vec![2, 4, 5]);
+    let result = DivOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![5, 5, 6]));
+}
+
+#[test]
+fn div_op_on_int128() {
+    let lhs = OwnedColumn::Int128(vec![100i128, 200]);
+    let rhs = OwnedColumn::Int128(vec![10i128, 20]);
+    let result = DivOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Int128(vec![10i128, 10]));
+}
+
+#[test]
+fn div_op_by_zero_returns_error() {
+    let lhs = OwnedColumn::BigInt(vec![10]);
+    let rhs = OwnedColumn::BigInt(vec![0]);
+    let result = DivOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::DivisionByZero { .. })
+    ));
+}
+
+#[test]
+fn div_op_empty_columns() {
+    let lhs = OwnedColumn::BigInt(vec![]);
+    let rhs = OwnedColumn::BigInt(vec![]);
+    let result = DivOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![]));
+}
+
+// ========== Mixed type arithmetic (upcasting) ==========
+
+#[test]
+fn add_op_uint8_with_smallint() {
+    let lhs = OwnedColumn::Uint8(vec![1u8, 2, 3]);
+    let rhs = OwnedColumn::SmallInt(vec![100i16, 200, 300]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::SmallInt(vec![101i16, 202, 303]));
+}
+
+#[test]
+fn add_op_smallint_with_bigint() {
+    let lhs = OwnedColumn::SmallInt(vec![100i16, 200]);
+    let rhs = OwnedColumn::BigInt(vec![1000i64, 2000]);
+    let result = AddOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![1100i64, 2200]));
+}
+
+#[test]
+fn sub_op_uint8_with_int() {
+    let lhs = OwnedColumn::Uint8(vec![10u8, 20]);
+    let rhs = OwnedColumn::Int(vec![5i32, 10]);
+    let result = SubOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Int(vec![5i32, 10]));
+}
+
+#[test]
+fn mul_op_tinyint_with_bigint() {
+    let lhs = OwnedColumn::TinyInt(vec![5i8, 10]);
+    let rhs = OwnedColumn::BigInt(vec![100i64, 200]);
+    let result = MulOp::owned_column_element_wise_arithmetic::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::BigInt(vec![500i64, 2000]));
+}

--- a/crates/proof-of-sql/src/base/database/column_comparison_operation_test.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation_test.rs
@@ -1,0 +1,248 @@
+use crate::base::{
+    database::{
+        column_comparison_operation::{ComparisonOp, EqualOp, GreaterThanOp, LessThanOp},
+        ColumnOperationError, OwnedColumn,
+    },
+    scalar::test_scalar::TestScalar,
+};
+
+// ========== EqualOp tests ==========
+
+#[test]
+fn equal_op_on_booleans() {
+    let lhs = OwnedColumn::Boolean(vec![true, false, true]);
+    let rhs = OwnedColumn::Boolean(vec![true, true, false]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+}
+
+#[test]
+fn equal_op_on_bigint() {
+    let lhs = OwnedColumn::BigInt(vec![1, 2, 3]);
+    let rhs = OwnedColumn::BigInt(vec![1, 5, 3]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, true]));
+}
+
+#[test]
+fn equal_op_on_varchar() {
+    let lhs = OwnedColumn::VarChar(vec!["hello".to_string(), "world".to_string()]);
+    let rhs = OwnedColumn::VarChar(vec!["hello".to_string(), "foo".to_string()]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false]));
+}
+
+#[test]
+fn equal_op_on_uint8() {
+    let lhs = OwnedColumn::Uint8(vec![1u8, 2, 3]);
+    let rhs = OwnedColumn::Uint8(vec![1u8, 5, 3]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, true]));
+}
+
+#[test]
+fn equal_op_on_tinyint() {
+    let lhs = OwnedColumn::TinyInt(vec![1i8, -2, 3]);
+    let rhs = OwnedColumn::TinyInt(vec![1i8, 2, 3]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, true]));
+}
+
+#[test]
+fn equal_op_on_smallint() {
+    let lhs = OwnedColumn::SmallInt(vec![100i16, 200, 300]);
+    let rhs = OwnedColumn::SmallInt(vec![100i16, 999, 300]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, true]));
+}
+
+#[test]
+fn equal_op_on_int() {
+    let lhs = OwnedColumn::Int(vec![100000i32, 200000, 300000]);
+    let rhs = OwnedColumn::Int(vec![100000i32, 999999, 300000]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, true]));
+}
+
+#[test]
+fn equal_op_on_int128() {
+    let lhs = OwnedColumn::Int128(vec![1i128, 2, 3]);
+    let rhs = OwnedColumn::Int128(vec![1i128, 5, 3]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, true]));
+}
+
+#[test]
+fn equal_op_different_length_errors() {
+    let lhs = OwnedColumn::BigInt(vec![1, 2, 3]);
+    let rhs = OwnedColumn::BigInt(vec![1, 2]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::DifferentColumnLength { .. })
+    ));
+}
+
+#[test]
+fn equal_op_incompatible_types_errors() {
+    let lhs = OwnedColumn::BigInt(vec![1]);
+    let rhs = OwnedColumn::Boolean(vec![true]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}
+
+#[test]
+fn equal_op_uint8_tinyint_errors() {
+    let lhs = OwnedColumn::Uint8(vec![1u8]);
+    let rhs = OwnedColumn::TinyInt(vec![1i8]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::SignedCastingError { .. })
+    ));
+}
+
+// ========== GreaterThanOp tests ==========
+
+#[test]
+fn greater_than_op_on_booleans() {
+    let lhs = OwnedColumn::Boolean(vec![true, false, true]);
+    let rhs = OwnedColumn::Boolean(vec![false, true, true]);
+    let result =
+        GreaterThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+}
+
+#[test]
+fn greater_than_op_on_bigint() {
+    let lhs = OwnedColumn::BigInt(vec![5, 1, 3]);
+    let rhs = OwnedColumn::BigInt(vec![3, 2, 3]);
+    let result =
+        GreaterThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+}
+
+#[test]
+fn greater_than_op_varchar_errors() {
+    let lhs = OwnedColumn::VarChar(vec!["a".to_string()]);
+    let rhs = OwnedColumn::VarChar(vec!["b".to_string()]);
+    let result = GreaterThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}
+
+#[test]
+fn greater_than_op_on_int128() {
+    let lhs = OwnedColumn::Int128(vec![100i128, 50, 75]);
+    let rhs = OwnedColumn::Int128(vec![99i128, 50, 100]);
+    let result =
+        GreaterThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+}
+
+// ========== LessThanOp tests ==========
+
+#[test]
+fn less_than_op_on_booleans() {
+    let lhs = OwnedColumn::Boolean(vec![true, false, true]);
+    let rhs = OwnedColumn::Boolean(vec![false, true, true]);
+    let result =
+        LessThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![false, true, false]));
+}
+
+#[test]
+fn less_than_op_on_bigint() {
+    let lhs = OwnedColumn::BigInt(vec![1, 5, 3]);
+    let rhs = OwnedColumn::BigInt(vec![3, 2, 3]);
+    let result =
+        LessThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+}
+
+#[test]
+fn less_than_op_varchar_errors() {
+    let lhs = OwnedColumn::VarChar(vec!["a".to_string()]);
+    let rhs = OwnedColumn::VarChar(vec!["b".to_string()]);
+    let result = LessThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs);
+    assert!(matches!(
+        result,
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+    ));
+}
+
+#[test]
+fn less_than_op_on_tinyint() {
+    let lhs = OwnedColumn::TinyInt(vec![1i8, 5, 3]);
+    let rhs = OwnedColumn::TinyInt(vec![3i8, 2, 3]);
+    let result =
+        LessThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+}
+
+#[test]
+fn less_than_op_on_smallint() {
+    let lhs = OwnedColumn::SmallInt(vec![10i16, 50, 30]);
+    let rhs = OwnedColumn::SmallInt(vec![30i16, 20, 30]);
+    let result =
+        LessThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+}
+
+#[test]
+fn less_than_op_on_int() {
+    let lhs = OwnedColumn::Int(vec![1i32, 500, 300]);
+    let rhs = OwnedColumn::Int(vec![3i32, 200, 300]);
+    let result =
+        LessThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+}
+
+#[test]
+fn less_than_op_empty_columns() {
+    let lhs = OwnedColumn::BigInt(vec![]);
+    let rhs = OwnedColumn::BigInt(vec![]);
+    let result =
+        LessThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![]));
+}
+
+#[test]
+fn equal_op_empty_columns() {
+    let lhs = OwnedColumn::BigInt(vec![]);
+    let rhs = OwnedColumn::BigInt(vec![]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![]));
+}
+
+// ========== Mixed type comparisons (upcasting) ==========
+
+#[test]
+fn equal_op_uint8_with_smallint() {
+    let lhs = OwnedColumn::Uint8(vec![1u8, 2, 3]);
+    let rhs = OwnedColumn::SmallInt(vec![1i16, 2, 3]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, true, true]));
+}
+
+#[test]
+fn equal_op_smallint_with_bigint() {
+    let lhs = OwnedColumn::SmallInt(vec![100i16, 200]);
+    let rhs = OwnedColumn::BigInt(vec![100i64, 999]);
+    let result = EqualOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false]));
+}
+
+#[test]
+fn greater_than_op_bigint_with_int128() {
+    let lhs = OwnedColumn::BigInt(vec![100i64, 50]);
+    let rhs = OwnedColumn::Int128(vec![99i128, 50]);
+    let result =
+        GreaterThanOp::owned_column_element_wise_comparison::<TestScalar>(&lhs, &rhs).unwrap();
+    assert_eq!(result, OwnedColumn::Boolean(vec![true, false]));
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -37,6 +37,8 @@ pub(super) use column_arithmetic_operation::{AddOp, ArithmeticOp, DivOp, MulOp, 
 
 mod column_comparison_operation;
 pub(super) use column_comparison_operation::{ComparisonOp, EqualOp, GreaterThanOp, LessThanOp};
+#[cfg(test)]
+mod column_comparison_operation_test;
 
 mod column_index_operation;
 pub(super) use column_index_operation::apply_column_to_indexes;
@@ -67,6 +69,8 @@ pub use crate::base::arrow::{
     scalar_and_i256_conversions,
 };
 pub use table_ref::TableRef;
+#[cfg(test)]
+mod table_ref_test;
 
 #[cfg(feature = "arrow")]
 pub mod arrow_schema_utility;

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -34,6 +34,8 @@ pub use column_type_operation::{
 
 mod column_arithmetic_operation;
 pub(super) use column_arithmetic_operation::{AddOp, ArithmeticOp, DivOp, MulOp, SubOp};
+#[cfg(test)]
+mod column_arithmetic_operation_test;
 
 mod column_comparison_operation;
 pub(super) use column_comparison_operation::{ComparisonOp, EqualOp, GreaterThanOp, LessThanOp};

--- a/crates/proof-of-sql/src/base/database/table_ref_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref_test.rs
@@ -1,0 +1,189 @@
+use crate::base::database::{ParseError, TableRef};
+use alloc::string::ToString;
+use core::str::FromStr;
+use sqlparser::ast::Ident;
+
+#[test]
+fn we_can_create_table_ref_with_schema() {
+    let table_ref = TableRef::new("myschema", "mytable");
+    assert_eq!(
+        table_ref.schema_id(),
+        Some(&Ident::new("myschema".to_string()))
+    );
+    assert_eq!(table_ref.table_id(), &Ident::new("mytable".to_string()));
+}
+
+#[test]
+fn we_can_create_table_ref_without_schema() {
+    let table_ref = TableRef::new("", "mytable");
+    assert_eq!(table_ref.schema_id(), None);
+    assert_eq!(table_ref.table_id(), &Ident::new("mytable".to_string()));
+}
+
+#[test]
+fn we_can_create_table_ref_from_names() {
+    let table_ref = TableRef::from_names(Some("public"), "users");
+    assert_eq!(
+        table_ref.schema_id(),
+        Some(&Ident::new("public".to_string()))
+    );
+    assert_eq!(table_ref.table_id(), &Ident::new("users".to_string()));
+}
+
+#[test]
+fn we_can_create_table_ref_from_names_without_schema() {
+    let table_ref = TableRef::from_names(None, "users");
+    assert_eq!(table_ref.schema_id(), None);
+    assert_eq!(table_ref.table_id(), &Ident::new("users".to_string()));
+}
+
+#[test]
+fn we_can_create_table_ref_from_idents() {
+    let schema = Some(Ident::new("myschema".to_string()));
+    let table = Ident::new("mytable".to_string());
+    let table_ref = TableRef::from_idents(schema.clone(), table.clone());
+    assert_eq!(table_ref.schema_id(), schema.as_ref());
+    assert_eq!(table_ref.table_id(), &table);
+}
+
+#[test]
+fn we_can_create_table_ref_from_single_component_strs() {
+    let table_ref = TableRef::from_strs(&["mytable"]).unwrap();
+    assert_eq!(table_ref.schema_id(), None);
+    assert_eq!(table_ref.table_id(), &Ident::new("mytable".to_string()));
+}
+
+#[test]
+fn we_can_create_table_ref_from_two_component_strs() {
+    let table_ref = TableRef::from_strs(&["myschema", "mytable"]).unwrap();
+    assert_eq!(
+        table_ref.schema_id(),
+        Some(&Ident::new("myschema".to_string()))
+    );
+    assert_eq!(table_ref.table_id(), &Ident::new("mytable".to_string()));
+}
+
+#[test]
+fn we_cannot_create_table_ref_from_three_component_strs() {
+    let result = TableRef::from_strs(&["a", "b", "c"]);
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { .. })
+    ));
+}
+
+#[test]
+fn we_cannot_create_table_ref_from_empty_strs() {
+    let result = TableRef::from_strs::<&str>(&[]);
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { .. })
+    ));
+}
+
+#[test]
+fn we_can_try_from_dot_separated_str() {
+    let table_ref = TableRef::try_from("myschema.mytable").unwrap();
+    assert_eq!(
+        table_ref.schema_id(),
+        Some(&Ident::new("myschema".to_string()))
+    );
+    assert_eq!(table_ref.table_id(), &Ident::new("mytable".to_string()));
+}
+
+#[test]
+fn we_can_try_from_single_str() {
+    let table_ref = TableRef::try_from("mytable").unwrap();
+    assert_eq!(table_ref.schema_id(), None);
+    assert_eq!(table_ref.table_id(), &Ident::new("mytable".to_string()));
+}
+
+#[test]
+fn we_cannot_try_from_triple_dot_str() {
+    let result = TableRef::try_from("a.b.c");
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { .. })
+    ));
+}
+
+#[test]
+fn we_can_parse_table_ref_from_str() {
+    let table_ref: TableRef = "myschema.mytable".parse().unwrap();
+    assert_eq!(
+        table_ref.schema_id(),
+        Some(&Ident::new("myschema".to_string()))
+    );
+}
+
+#[test]
+fn table_ref_display_with_schema() {
+    let table_ref = TableRef::new("myschema", "mytable");
+    assert_eq!(table_ref.to_string(), "myschema.mytable");
+}
+
+#[test]
+fn table_ref_display_without_schema() {
+    let table_ref = TableRef::new("", "mytable");
+    assert_eq!(table_ref.to_string(), "mytable");
+}
+
+#[test]
+fn table_ref_serialize_deserialize_roundtrip() {
+    let table_ref = TableRef::new("myschema", "mytable");
+    let serialized = serde_json::to_string(&table_ref).unwrap();
+    assert_eq!(serialized, "\"myschema.mytable\"");
+
+    let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized, table_ref);
+}
+
+#[test]
+fn table_ref_serialize_deserialize_roundtrip_no_schema() {
+    let table_ref = TableRef::new("", "mytable");
+    let serialized = serde_json::to_string(&table_ref).unwrap();
+    assert_eq!(serialized, "\"mytable\"");
+
+    let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized, table_ref);
+}
+
+#[test]
+fn table_ref_deserialize_invalid_fails() {
+    let result: Result<TableRef, _> = serde_json::from_str("\"a.b.c\"");
+    assert!(result.is_err());
+}
+
+#[test]
+fn table_ref_clone_eq() {
+    let a = TableRef::new("schema", "table");
+    let b = a.clone();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn table_ref_equivalent_trait() {
+    use indexmap::Equivalent;
+    let a = TableRef::new("schema", "table");
+    let b = TableRef::new("schema", "table");
+    let a_ref = &a;
+    assert!(a_ref.equivalent(&b));
+}
+
+#[test]
+fn table_ref_equivalent_trait_different_schema() {
+    use indexmap::Equivalent;
+    let a = TableRef::new("schema1", "table");
+    let b = TableRef::new("schema2", "table");
+    let a_ref = &a;
+    assert!(!a_ref.equivalent(&b));
+}
+
+#[test]
+fn table_ref_equivalent_trait_different_table() {
+    use indexmap::Equivalent;
+    let a = TableRef::new("schema", "table1");
+    let b = TableRef::new("schema", "table2");
+    let a_ref = &a;
+    assert!(!a_ref.equivalent(&b));
+}


### PR DESCRIPTION
Add tests for three previously uncovered modules (75 tests total).

## table_ref.rs (22 tests)
- Construction: `new`, `from_names`, `from_idents`, `from_strs`
- Parsing: `TryFrom<&str>`, `FromStr` (valid and invalid inputs)
- Display: with and without schema
- Serialization: roundtrip via serde_json, invalid deserialization
- Trait: `Clone`, `Eq`, `Equivalent` (positive and negative cases)

## column_comparison_operation.rs (26 tests)
- EqualOp: Boolean, BigInt, VarChar, Uint8, TinyInt, SmallInt, Int, Int128, empty columns, length mismatch, incompatible types, signed casting errors, mixed-type upcasting
- GreaterThanOp: Boolean, BigInt, Int128, VarChar error
- LessThanOp: Boolean, BigInt, TinyInt, SmallInt, Int, VarChar error, empty columns

## column_arithmetic_operation.rs (27 tests)
- AddOp: all integer types, overflow, empty columns, incompatible types, signed casting, mixed-type upcasting
- SubOp: BigInt, Int128, underflow, empty columns
- MulOp: BigInt, Int128, overflow, empty columns
- DivOp: BigInt, Int128, division by zero, empty columns