### PR TITLE
test: cover public parameter size accounting

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -267,6 +267,24 @@ mod tests {
             .expect("Deserialized parameters are not valid");
     }
 
+    #[test]
+    fn serialized_size_matches_serialized_byte_length() {
+        let mut rng = thread_rng();
+        let public_parameters = PublicParameters::rand(2, &mut rng);
+
+        for compress in [Compress::No, Compress::Yes] {
+            let mut serialized_data = Vec::new();
+            public_parameters
+                .serialize_with_mode(&mut serialized_data, compress)
+                .expect("Failed to serialize PublicParameters");
+
+            assert_eq!(
+                public_parameters.serialized_size(compress),
+                serialized_data.len()
+            );
+        }
+    }
+
     // 13th Gen Intel® Core™ i9-13900H × 20
     // nu vs proof size & time:
     // nu = 4  |  0.005 MB  | 287.972567ms

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
@@ -135,11 +135,12 @@ mod tests {
         base::{
             database::table_utility::borrowed_bigint,
             polynomial::MultilinearExtension,
+            proof::ProofError,
             scalar::{test_scalar::TestScalar, Scalar},
         },
         sql::proof::{
-            mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
-            FirstRoundBuilder,
+            mock_verification_builder::{run_verify_for_each_row, MockVerificationBuilder},
+            FinalRoundBuilder, FirstRoundBuilder,
         },
     };
     use bumpalo::Bump;
@@ -188,5 +189,35 @@ mod tests {
             .get_zero_sum_results()
             .iter()
             .all(|v| *v));
+    }
+
+    #[test]
+    fn verifier_rejects_mismatched_column_counts() {
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            0,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let err = verify_permutation_check(
+            &mut builder,
+            TestScalar::TWO,
+            TestScalar::TEN,
+            TestScalar::ONE,
+            &[TestScalar::ONE],
+            &[],
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ProofError::VerificationError {
+                error: "The number of source and candidate columns should be equal"
+            }
+        ));
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- Add a focused Dory `PublicParameters::serialized_size` test for compressed and uncompressed serialization.
- Add verifier coverage for mismatched source/candidate column counts in the permutation-check gadget.

## Coverage
Full no-default `test` LCOV comparison against the pre-change local baseline:
- `crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs`: `LH 154 / LF 175` to `LH 185 / LF 187` (missing 21 to 2).
- `crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs`: `LH 110 / LF 118` to `LH 130 / LF 135` (missing 8 to 5).

## Validation
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS='' cargo test -p proof-of-sql --lib --no-default-features --features test serialized_size_matches_serialized_byte_length`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS='' cargo test -p proof-of-sql --lib --no-default-features --features test verifier_rejects_mismatched_column_counts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS='' cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path /tmp/sxt-after.lcov`
