### PR TITLE
test: cover decimal precision edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/math/decimal_tests.rs
+++ b/crates/proof-of-sql/src/base/math/decimal_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod precision_tests {
-    use crate::base::math::decimal::Precision;
+    use crate::base::math::decimal::{DecimalError, Precision};
     use serde_json;
 
     #[test]
@@ -32,5 +32,35 @@ mod precision_tests {
         let json = "\"not a number\"";
         let precision: Result<Precision, _> = serde_json::from_str(json);
         assert!(precision.is_err());
+    }
+
+    #[test]
+    fn we_can_convert_decimal_errors_to_strings() {
+        let error = DecimalError::InvalidScale {
+            scale: "76".to_string(),
+        };
+
+        let message: String = error.into();
+
+        assert_eq!(message, "Decimal scale is not valid: 76");
+    }
+
+    #[test]
+    fn we_can_create_precision_from_u64() {
+        let precision = Precision::try_from(75_u64).unwrap();
+
+        assert_eq!(precision.value(), 75);
+    }
+
+    #[test]
+    fn we_cannot_create_precision_from_large_u64() {
+        let precision = Precision::try_from(u64::MAX);
+
+        assert_eq!(
+            precision,
+            Err(DecimalError::InvalidPrecision {
+                error: u64::MAX.to_string(),
+            })
+        );
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for converting `DecimalError` into `String`.
- Cover `Precision::try_from(u64)` for valid `u64` input and large-value overflow.

## Coverage
Focused no-default decimal LCOV comparison against the local pre-change baseline:
- `crates/proof-of-sql/src/base/math/decimal.rs`: `LH 148 / LF 162` to `LH 160 / LF 162`.

## Validation
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS='' cargo test -p proof-of-sql --lib --no-default-features --features test precision_tests`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS='' cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path /tmp/sxt-decimal-precision.lcov -- decimal`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`