### PR TITLE
test: cover commitment evaluation proof forwarding

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof.rs
@@ -71,3 +71,75 @@ pub trait CommitmentEvaluationProof {
         setup: &Self::VerifierPublicSetup<'_>,
     ) -> Result<(), Self::Error>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CommitmentEvaluationProof;
+    use crate::base::{
+        commitment::naive_commitment::NaiveCommitment,
+        proof::{Keccak256Transcript, Transcript},
+        scalar::{test_scalar::TestScalar, Scalar},
+    };
+
+    struct ForwardingProof;
+
+    impl CommitmentEvaluationProof for ForwardingProof {
+        type Scalar = TestScalar;
+        type Commitment = NaiveCommitment;
+        type Error = &'static str;
+        type ProverPublicSetup<'a> = ();
+        type VerifierPublicSetup<'a> = ();
+
+        fn new(
+            _transcript: &mut impl Transcript,
+            _a: &[Self::Scalar],
+            _b_point: &[Self::Scalar],
+            _generators_offset: u64,
+            _setup: &Self::ProverPublicSetup<'_>,
+        ) -> Self {
+            Self
+        }
+
+        fn verify_batched_proof(
+            &self,
+            _transcript: &mut impl Transcript,
+            commit_batch: &[Self::Commitment],
+            batching_factors: &[Self::Scalar],
+            evaluations: &[Self::Scalar],
+            b_point: &[Self::Scalar],
+            generators_offset: u64,
+            table_length: usize,
+            _setup: &Self::VerifierPublicSetup<'_>,
+        ) -> Result<(), Self::Error> {
+            assert_eq!(
+                commit_batch,
+                &[NaiveCommitment(vec![TestScalar::from(9u8)])]
+            );
+            assert_eq!(batching_factors, &[TestScalar::ONE]);
+            assert_eq!(evaluations, &[TestScalar::from(7u8)]);
+            assert_eq!(b_point, &[TestScalar::from(3u8), TestScalar::from(4u8)]);
+            assert_eq!(generators_offset, 11);
+            assert_eq!(table_length, 5);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn verify_proof_forwards_single_inputs_to_verify_batched_proof() {
+        let proof = ForwardingProof;
+        let mut transcript: Keccak256Transcript = Transcript::new();
+        let b_point = [TestScalar::from(3u8), TestScalar::from(4u8)];
+
+        let result = proof.verify_proof(
+            &mut transcript,
+            &NaiveCommitment(vec![TestScalar::from(9u8)]),
+            &TestScalar::from(7u8),
+            &b_point,
+            11,
+            5,
+            &(),
+        );
+
+        assert_eq!(result, Ok(()));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add a focused unit test for the default `CommitmentEvaluationProof::verify_proof()` helper
- verify the helper forwards a single commitment, product, and batching factor into `verify_batched_proof()` exactly as documented
- keep the change fully test-only

## Testing
- `cargo test -p proof-of-sql --lib --no-default-features --features test base::commitment::commitment_evaluation_proof::tests::verify_proof_forwards_single_inputs_to_verify_batched_proof -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
