### PR TITLE
test: cover evaluation vector bounds

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
@@ -66,6 +66,20 @@ fn we_compute_the_evaluation_vector_for_an_empty_point() {
 }
 
 #[test]
+fn we_can_compute_an_empty_evaluation_vector() {
+    let mut v: Vec<TestScalar> = vec![];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64), TestScalar::from(4u64)]);
+    assert!(v.is_empty());
+}
+
+#[test]
+#[should_panic]
+fn compute_evaluation_vector_panics_when_output_exceeds_hypercube_size() {
+    let mut v = [TestScalar::zero(); 3];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64)]);
+}
+
+#[test]
 fn we_get_the_same_result_using_evaluation_vector_as_direct_evaluation() {
     let xs = [
         TestScalar::from(3u64),


### PR DESCRIPTION
/claim #560

## Summary
- add coverage for the empty-output fast path in compute_evaluation_vector
- assert the helper panics when the output length exceeds the hypercube size

## Testing
- cargo test -p proof-of-sql --lib --no-default-features --features test evaluation_vector_test -- --nocapture
- cargo fmt --all -- --check
- git diff --check