### PR TITLE
test: cover bit matrix ordering

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
@@ -74,6 +74,45 @@ fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_and_constant_bits() 
 }
 
 #[test]
+fn we_preserve_varying_bit_order_across_multiple_rows() {
+    let data: Vec<TestScalar> = vec![
+        TestScalar::zero(),
+        TestScalar::one(),
+        TestScalar::from(2),
+        TestScalar::from(4),
+    ];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
+    let alloc = Bump::new();
+    let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
+    assert_eq!(matrix.len(), 3);
+    let slice1 = vec![false, true, false, false];
+    let slice2 = vec![false, false, true, false];
+    let slice3 = vec![false, false, false, true];
+    assert_eq!(matrix[0], slice1);
+    assert_eq!(matrix[1], slice2);
+    assert_eq!(matrix[2], slice3);
+}
+
+#[test]
+fn we_preserve_cross_limb_varying_bit_order() {
+    let mut val = [0; 4];
+    val[2] = 1 << 2;
+    let data: Vec<TestScalar> = vec![
+        TestScalar::zero(),
+        TestScalar::one(),
+        TestScalar::from_bigint(val),
+    ];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
+    let alloc = Bump::new();
+    let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
+    assert_eq!(matrix.len(), 2);
+    let slice1 = vec![false, true, false];
+    let slice2 = vec![false, false, true];
+    assert_eq!(matrix[0], slice1);
+    assert_eq!(matrix[1], slice2);
+}
+
+#[test]
 fn we_can_compute_the_bit_matrix_for_data_entries_bigger_than_64_bit_integers() {
     let mut val = [0; 4];
     val[3] = 1 << 2;


### PR DESCRIPTION
/claim #560

## Summary
- add coverage for the ordering of multiple varying bits across more than two rows
- add coverage for cross-limb varying bits so the output columns stay in bit-position order

## Testing
- cargo test -p proof-of-sql --lib --no-default-features --features test bit_matrix_test -- --nocapture
- cargo fmt --all -- --check
- git diff --check