### PR TITLE
test: optimize test profile for faster CI runtimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,5 @@ allow_attributes = "warn"
 # patch for sqlparser no_std compatibility with the serde feature enabled.
 # required until proof-of-sql upgrades to at least sqlparser 0.56.0.
 sqlparser = { git = "https://github.com/tlovell-sxt/datafusion-sqlparser-rs.git", rev = "a828cbea22cf19bb6b4596f902bdd6f4d14a00b8" }
+[profile.test]
+opt-level = 3


### PR DESCRIPTION
/claim #557

## Summary
- add `[profile.test]` with `opt-level = 3` at the workspace root
- keep all test logic and assertions unchanged

## Why
Issue #557 explicitly allows CI/runtime improvements without weakening tests. This change targets compute-heavy cryptographic tests by compiling tests with optimization while preserving debuginfo and test behavior.

## Validation
- `cargo test -p proof-of-sql --no-run --no-default-features --features std`

## Notes
- This is intentionally small and low-risk so maintainers can quickly compare CI timing deltas against baseline.
