### PR TITLE
test: cover RefInto blanket impl with focused unit tests

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,37 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Counter(u32);
+
+    impl From<&Counter> for u32 {
+        fn from(value: &Counter) -> Self {
+            value.0
+        }
+    }
+
+    impl From<&Counter> for String {
+        fn from(value: &Counter) -> Self {
+            value.0.to_string()
+        }
+    }
+
+    #[test]
+    fn it_uses_reference_based_into_for_custom_type() {
+        let counter = Counter(42);
+        let as_u32: u32 = counter.ref_into();
+        assert_eq!(as_u32, 42u32);
+    }
+
+    #[test]
+    fn it_can_target_multiple_output_types() {
+        let counter = Counter(11);
+        let as_string: String = counter.ref_into();
+        assert_eq!(as_string, "11");
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused unit tests in `base/ref_into.rs` for the blanket `RefInto` implementation
- verify a custom source type can convert into multiple target types via `ref_into`
- keep scope test-only with no production behavior changes

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test base::ref_into::tests -- --nocapture`
