### PR TITLE
test: cover PoSQL-compatible Arrow schema conversion

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -7,7 +7,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 /// Converts an Arrow schema to a PoSQL-compatible schema.
 ///
 /// This function takes an Arrow `SchemaRef` and returns a new `SchemaRef` where
-/// floating-point data types (Float16, Float32, Float64) are converted to Decimal256(75, 30).
+/// floating-point data types (Float16, Float32, Float64) are converted to Decimal256(20, 10).
 /// Other data types remain unchanged.
 ///
 /// # Arguments
@@ -34,4 +34,49 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
         .collect();
 
     Arc::new(Schema::new(new_fields))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_convert_floating_point_fields_to_posql_decimal_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("float16", DataType::Float16, false),
+            Field::new("float32", DataType::Float32, true),
+            Field::new("float64", DataType::Float64, false),
+        ]));
+
+        let compatible_schema = get_posql_compatible_schema(&schema);
+
+        assert_eq!(
+            compatible_schema.field(0).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert_eq!(
+            compatible_schema.field(1).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert_eq!(
+            compatible_schema.field(2).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert!(!compatible_schema.field(0).is_nullable());
+        assert!(compatible_schema.field(1).is_nullable());
+        assert!(!compatible_schema.field(2).is_nullable());
+    }
+
+    #[test]
+    fn we_can_preserve_non_floating_point_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("int", DataType::Int64, false),
+            Field::new("decimal", DataType::Decimal256(38, 6), true),
+            Field::new("string", DataType::Utf8, true),
+        ]));
+
+        let compatible_schema = get_posql_compatible_schema(&schema);
+
+        assert_eq!(compatible_schema.fields(), schema.fields());
+    }
 }


### PR DESCRIPTION
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines.
- [x] I have run the focused test command below.
- [ ] I have run `source scripts/run_ci_checks.sh`.
- [ ] I have run `source scripts/check_commits.sh`.
- [x] The latest changes from `main` were incorporated through the fork compare branch.

# Rationale for this change

Refs #560.

This PR adds focused test coverage for `get_posql_compatible_schema`, which is used by the planner examples to normalize Arrow schemas into PoSQL-compatible schemas.

# What changes are included in this PR?

- Add coverage for Float16, Float32, and Float64 conversion to `Decimal256(20, 10)`.
- Add coverage that non-floating Arrow fields are preserved unchanged.
- Verify field nullability is preserved during schema conversion.
- Correct the doc comment to match the actual implementation, which converts floats to `Decimal256(20, 10)`.

# Are these changes tested?

Yes.

```powershell
cargo test -p proof-of-sql --no-default-features --features="arrow" arrow_schema_utility