### PR TITLE
test: cover ZigZag decoding paths

### DIFF
--- a/crates/proof-of-sql/src/base/encode/zigzag_test.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag_test.rs
@@ -99,3 +99,59 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
             == U256::from_words(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128, 0x1_u128)
     );
 }
+
+#[test]
+fn positive_zigzag_values_are_decoded_as_positive_scalars() {
+    assert_eq!(
+        <U256 as ZigZag<TestScalar>>::zigzag(&U256::from_words(0, 0)),
+        TestScalar::from(0_u64)
+    );
+    assert_eq!(
+        <U256 as ZigZag<TestScalar>>::zigzag(&U256::from_words(2, 0)),
+        TestScalar::from(1_u64)
+    );
+    assert_eq!(
+        <U256 as ZigZag<TestScalar>>::zigzag(&U256::from_words(4, 0)),
+        TestScalar::from(2_u64)
+    );
+
+    let encoded = U256::from_words(0, 1);
+    let expected: TestScalar =
+        (&U256::from_words(0x8000_0000_0000_0000_0000_0000_0000_0000, 0)).into();
+    assert_eq!(<U256 as ZigZag<TestScalar>>::zigzag(&encoded), expected);
+}
+
+#[test]
+fn negative_zigzag_values_are_decoded_as_negative_scalars() {
+    assert_eq!(
+        <U256 as ZigZag<TestScalar>>::zigzag(&U256::from_words(1, 0)),
+        -TestScalar::from(1_u64)
+    );
+    assert_eq!(
+        <U256 as ZigZag<TestScalar>>::zigzag(&U256::from_words(3, 0)),
+        -TestScalar::from(2_u64)
+    );
+    assert_eq!(
+        <U256 as ZigZag<TestScalar>>::zigzag(&U256::from_words(1_999, 0)),
+        -TestScalar::from(1_000_u64)
+    );
+}
+
+#[test]
+fn zigzag_round_trips_signed_scalars() {
+    let scalars = [
+        TestScalar::from(0_u64),
+        TestScalar::from(1_u64),
+        TestScalar::from(999_u64),
+        TestScalar::from(u128::MAX),
+        -TestScalar::from(1_u64),
+        -TestScalar::from(2_u64),
+        -TestScalar::from(999_u64),
+    ];
+
+    for scalar in scalars {
+        let encoded = scalar.zigzag();
+        let decoded = <U256 as ZigZag<TestScalar>>::zigzag(&encoded);
+        assert_eq!(decoded, scalar);
+    }
+}


### PR DESCRIPTION
## Summary
- add focused tests for decoding `U256` ZigZag values back into `TestScalar`
- cover positive/even encodings, negative/odd encodings, high-limb shift behavior, and signed scalar round trips
- keep the change test-only with no production behavior changes

Part of #560.

/claim #560

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test zigzag -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes
This PR was prepared with AI assistance using Codex and reviewed/tested locally before submission.
