### PR TITLE
test: cover limb serialization helpers

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,61 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn we_can_serialize_limbs_in_reverse_word_order() {
+        let wrapper = LimbWrapper {
+            limbs: [1, 2, 3, 4],
+        };
+
+        assert_eq!(
+            serde_json::to_string(&wrapper).unwrap(),
+            r#"{"limbs":[4,3,2,1]}"#
+        );
+    }
+
+    #[test]
+    fn we_can_deserialize_limbs_back_to_internal_order() {
+        let wrapper: LimbWrapper = serde_json::from_str(r#"{"limbs":[40,30,20,10]}"#).unwrap();
+
+        assert_eq!(
+            wrapper,
+            LimbWrapper {
+                limbs: [10, 20, 30, 40],
+            }
+        );
+    }
+
+    #[test]
+    fn we_can_round_trip_internal_limb_order() {
+        let wrapper = LimbWrapper {
+            limbs: [u64::MAX, 17, 0, 1 << 63],
+        };
+
+        let serialized = serde_json::to_string(&wrapper).unwrap();
+        let deserialized: LimbWrapper = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, wrapper);
+    }
+
+    #[test]
+    fn we_cannot_deserialize_wrong_limb_count() {
+        let result = serde_json::from_str::<LimbWrapper>(r#"{"limbs":[3,2,1]}"#);
+
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- add focused tests for the limb serialization helpers used by scalar, bit, and database values
- cover reverse word-order serialization, deserialization back to internal order, round trips, and invalid limb counts
- keep the change test-only with no production behavior changes

Part of #560.

/claim #560

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test standard_serializations::limbs -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes
This PR was prepared with AI assistance using Codex and reviewed/tested locally before submission.
