### PR TITLE
test: cover if_rayon macro no-default branch behavior

### DIFF
--- a/crates/proof-of-sql/src/base/rayon_cfg.rs
+++ b/crates/proof-of-sql/src/base/rayon_cfg.rs
@@ -11,3 +11,29 @@ macro_rules! if_rayon {
     }};
 }
 pub(crate) use if_rayon;
+
+#[cfg(test)]
+mod tests {
+    use super::if_rayon;
+
+    #[test]
+    fn if_rayon_selects_else_value_when_rayon_is_disabled() {
+        let selected = if_rayon!(1usize, 2usize);
+        assert_eq!(selected, 2);
+    }
+
+    #[test]
+    fn if_rayon_keeps_selected_branch_side_effects_local() {
+        let (selected, from_else_branch) = if_rayon!(
+            {
+                (10usize, false)
+            },
+            {
+                (20usize, true)
+            }
+        );
+
+        assert_eq!(selected, 20);
+        assert!(from_else_branch);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused unit tests for `base::rayon_cfg::if_rayon!`
- verify no-default-feature path selects the else branch value
- verify branch-local behavior in the selected branch path

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test base::rayon_cfg::tests -- --nocapture`