### PR TITLE
test: cover time unit formatting

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -59,6 +59,7 @@ impl fmt::Display for PoSQLTimeUnit {
 mod time_unit_tests {
     use super::*;
     use crate::base::posql_time::PoSQLTimestampError;
+    use alloc::format;
 
     #[test]
     fn test_valid_precisions() {
@@ -66,6 +67,34 @@ mod time_unit_tests {
         assert_eq!(PoSQLTimeUnit::try_from("3"), Ok(PoSQLTimeUnit::Millisecond));
         assert_eq!(PoSQLTimeUnit::try_from("6"), Ok(PoSQLTimeUnit::Microsecond));
         assert_eq!(PoSQLTimeUnit::try_from("9"), Ok(PoSQLTimeUnit::Nanosecond));
+    }
+
+    #[test]
+    fn test_time_unit_precision_values() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn test_time_unit_display_includes_unit_and_precision() {
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Second),
+            "seconds (precision: 0)"
+        );
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Millisecond),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Microsecond),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            format!("{}", PoSQLTimeUnit::Nanosecond),
+            "nanoseconds (precision: 9)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for `PoSQLTimeUnit` precision values from `From<PoSQLTimeUnit> for u64`.
- Add display-string coverage for the timestamp unit labels and precision values used in diagnostics/type descriptions.
- Keep the change test-only; no runtime behavior changes.

## Testing
- `CARGO_TARGET_DIR=C:\tmp\sxt-proof-target cargo test -p proof-of-sql time_unit_tests --no-default-features --features test` (4 passed, 958 filtered; existing warnings only)
- `rustfmt --check crates/proof-of-sql/src/base/posql_time/unit.rs`
- `git diff --cached --check`
- `bash scripts/check_commits.sh`

## Checklist
- [x] The PR title and commit message follow the conventional commit guidelines.
- [x] The focused test suite for this coverage slice passes locally.
- [x] The clean commit check passes locally.
- [ ] Full `source scripts/run_ci_checks.sh` was not run locally; this is a narrow test-only coverage slice and the PR CI should provide the full repository gate.