### PR TITLE
test: cover Ristretto no-blitzar fallback

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs
@@ -62,4 +62,11 @@ mod tests {
             commitment2.to_transcript_bytes()
         );
     }
+
+    #[cfg(not(feature = "blitzar"))]
+    #[test]
+    #[should_panic(expected = "not implemented")]
+    fn compute_commitments_panics_without_blitzar() {
+        <RistrettoPoint as Commitment>::compute_commitments(&[], 0, &());
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add a focused no-default unit test for the `RistrettoPoint` `Commitment::compute_commitments` fallback
- assert the fallback keeps the current `not implemented` panic behavior when `blitzar` is disabled
- keep the change test-only with no production behavior changes

## Validation
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test ristretto_point -- --nocapture` (2 passed; existing warnings only)
- `cargo fmt --all -- --check`
- `git diff --check` (Windows git; WSL git reports repository-wide CRLF noise on this checkout)

## Coverage note
Current no-default LCOV showed the fallback `compute_commitments` body in `crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs` as uncovered. This PR targets only that slice and leaves final payable-line accounting to the maintainer/Algora baseline.