### PR TITLE
test: reduce repeated Dory public parameter generation

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
@@ -2,6 +2,32 @@ use super::{test_rng, ProverSetup, PublicParameters, VerifierSetup};
 use ark_ec::pairing::Pairing;
 use std::{fs, path::Path};
 
+const SETUP_TEST_MAX_NU: usize = 4;
+
+fn public_parameters_by_nu() -> Vec<PublicParameters> {
+    let mut rng = test_rng();
+    let public_parameters = PublicParameters::test_rand(SETUP_TEST_MAX_NU, &mut rng);
+    // Reuse prefixes from one max-size setup so each test still covers every nu
+    // without repeating random affine generation for every size.
+    (0..=SETUP_TEST_MAX_NU)
+        .map(|nu| public_parameters_for_nu(&public_parameters, nu))
+        .collect()
+}
+
+fn public_parameters_for_nu(
+    public_parameters: &PublicParameters,
+    max_nu: usize,
+) -> PublicParameters {
+    PublicParameters {
+        Gamma_1: public_parameters.Gamma_1[..(1 << max_nu)].to_vec(),
+        Gamma_2: public_parameters.Gamma_2[..(1 << max_nu)].to_vec(),
+        H_1: public_parameters.H_1,
+        H_2: public_parameters.H_2,
+        Gamma_2_fin: public_parameters.Gamma_2_fin,
+        max_nu,
+    }
+}
+
 #[test]
 fn we_can_create_and_manually_check_a_small_prover_setup() {
     let mut rng = test_rng();
@@ -94,10 +120,8 @@ fn we_can_create_save_load_and_manually_check_a_small_verifier_setup() {
 
 #[test]
 fn we_can_create_prover_setups_with_various_sizes() {
-    let mut rng = test_rng();
-    for nu in 0..5 {
-        let pp = PublicParameters::test_rand(nu, &mut rng);
-        let setup = ProverSetup::from(&pp);
+    for (nu, pp) in public_parameters_by_nu().iter().enumerate() {
+        let setup = ProverSetup::from(pp);
         assert_eq!(setup.Gamma_1.len(), nu + 1);
         assert_eq!(setup.Gamma_2.len(), nu + 1);
         for k in 0..=nu {
@@ -113,10 +137,8 @@ fn we_can_create_prover_setups_with_various_sizes() {
 
 #[test]
 fn we_can_create_verifier_setups_with_various_sizes() {
-    let mut rng = test_rng();
-    for nu in 0..5 {
-        let pp = PublicParameters::test_rand(nu, &mut rng);
-        let setup = VerifierSetup::from(&pp);
+    for (nu, pp) in public_parameters_by_nu().iter().enumerate() {
+        let setup = VerifierSetup::from(pp);
         assert_eq!(setup.Delta_1L.len(), nu + 1);
         assert_eq!(setup.Delta_1R.len(), nu + 1);
         assert_eq!(setup.Delta_2L.len(), nu + 1);
@@ -150,10 +172,8 @@ fn we_can_create_verifier_setups_with_various_sizes() {
 // nu size 5 = 15410 bytes
 #[test]
 fn we_can_serialize_and_deserialize_verifier_setups() {
-    let mut rng = test_rng();
-    for nu in 0..5 {
-        let pp = PublicParameters::test_rand(nu, &mut rng);
-        let setup = VerifierSetup::from(&pp);
+    for pp in public_parameters_by_nu().iter() {
+        let setup = VerifierSetup::from(pp);
         let serialized = postcard::to_allocvec(&setup).unwrap();
         let deserialized: VerifierSetup = postcard::from_bytes(&serialized).unwrap();
         assert_eq!(setup, deserialized);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #557

## Summary
- generate one max-size Dory `PublicParameters` value for the setup size tests
- derive the `nu=0..4` test inputs from prefixes of that value instead of calling `PublicParameters::test_rand` for every size
- keep the existing prover setup, verifier setup, and verifier setup serialization assertions over the same size range

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test setup_test -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: `cargo nextest` is not installed in my local environment, so I could not run the exact nextest command from the issue.