### PR TITLE
test: cover constant sumcheck terms

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
@@ -141,3 +141,36 @@ impl<'a, S: Scalar + 'a> IntoIterator for &'a OptimizedSumcheckTerms<'a, S> {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{SumcheckTerm, SumcheckTermOptimizer};
+    use crate::{base::scalar::test_scalar::TestScalar, sql::proof::SumcheckSubpolynomialType};
+    use alloc::vec::Vec;
+
+    #[test]
+    fn we_can_merge_constant_terms() {
+        let empty_term: SumcheckTerm<'_, TestScalar> = Vec::new();
+        let terms = [
+            (
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::from(2),
+                &empty_term,
+            ),
+            (
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::from(3),
+                &empty_term,
+            ),
+        ];
+        let optimizer = SumcheckTermOptimizer::new(terms.into_iter(), 4);
+        let optimized_terms = optimizer.terms();
+        let terms: Vec<_> = (&optimized_terms).into_iter().collect();
+
+        assert_eq!(terms.len(), 1);
+        let (ty, coeff, multiplicands) = terms[0];
+        assert_eq!(ty, SumcheckSubpolynomialType::Identity);
+        assert_eq!(coeff, TestScalar::from(5));
+        assert!(multiplicands.is_empty());
+    }
+}


### PR DESCRIPTION
/claim #560

Adds focused coverage for the SumcheckTermOptimizer branch that merges constant-only terms into a synthetic optimized term. This is intentionally narrow and only exercises an existing optimizer path; production behavior is unchanged.

The full no-default LCOV baseline I generated before this change showed `crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs` missing lines 31-33. The focused coverage run after this change records those lines as hit (`DA:31,1`, `DA:32,1`, `DA:33,1`).

Validation:
- `cargo fmt --check`
- `git diff --check`
- `RUSTUP_TOOLCHAIN=stable cargo test -p proof-of-sql --lib --no-default-features --features test sumcheck_term_optimizer -- --nocapture` (1 passed)
- `RUSTUP_TOOLCHAIN=stable cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/sumcheck-term-optimizer.lcov -- sumcheck_term_optimizer` (1 passed; lines 31-33 hit)
- `RUSTUP_TOOLCHAIN=stable cargo test -p proof-of-sql --lib --no-default-features --features test` (961 passed)
- `source scripts/check_commits.sh` (1 commit checked, 0 failed)