### PR TITLE
test: enable table commitment coverage without arrow

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -374,20 +374,24 @@ fn num_rows_of_columns<'a>(
     Ok(num_rows)
 }
 
-#[cfg(all(test, feature = "arrow", feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(all(feature = "arrow", feature = "blitzar"))]
+    use crate::base::database::Column;
     use crate::base::{
         commitment::naive_commitment::NaiveCommitment,
-        database::{owned_table_utility::*, Column, OwnedColumn},
+        database::{owned_table_utility::*, OwnedColumn},
         map::IndexMap,
         scalar::test_scalar::TestScalar,
     };
+    #[cfg(all(feature = "arrow", feature = "blitzar"))]
     use arrow::{
         array::{Int64Array, StringArray},
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
+    #[cfg(all(feature = "arrow", feature = "blitzar"))]
     use std::sync::Arc;
 
     #[test]
@@ -1151,6 +1155,7 @@ mod tests {
         ));
     }
 
+    #[cfg(all(feature = "arrow", feature = "blitzar"))]
     #[test]
     fn we_can_create_and_append_table_commitments_with_record_batches() {
         let schema = Arc::new(Schema::new(vec![


### PR DESCRIPTION
/claim #560

## Summary
- allow the existing `table_commitment` NaiveCommitment unit tests to run under the no-default `test` feature set
- keep the RecordBatch-specific test and arrow imports behind the existing `arrow + blitzar` gate
- no production behavior changes

## Coverage
The no-default LCOV baseline had `crates/proof-of-sql/src/base/commitment/table_commitment.rs` production lines uncovered. After this change, the focused table commitment coverage run hits 142 lines that were previously `DA:...,0` in the baseline.

Commands used for the comparison:
- baseline: `RUSTUP_TOOLCHAIN=stable cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/coverage-baseline.lcov` (960 passed)
- focused: `RUSTUP_TOOLCHAIN=stable cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/table-commitment.lcov -- table_commitment` (16 passed)

## Validation
- `RUSTUP_TOOLCHAIN=stable cargo test -p proof-of-sql --lib --no-default-features --features test table_commitment -- --nocapture` (16 passed)
- `RUSTUP_TOOLCHAIN=stable cargo test -p proof-of-sql --lib --no-default-features --features test` (976 passed)
- `RUSTUP_TOOLCHAIN=stable cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/table-commitment.lcov -- table_commitment` (16 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `source scripts/check_commits.sh`