### PR TITLE
test: protect empty slice cast behavior

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
@@ -1,5 +1,42 @@
 use super::*;
 use crate::base::scalar::test_scalar::TestScalar;
+
+#[test]
+fn test_slice_cast_with_empty_slice() {
+    let input: Vec<u32> = vec![];
+    let output: Vec<u64> = slice_cast_with(&input, |&x| u64::from(x));
+
+    assert_eq!(output, Vec::<u64>::new());
+}
+
+#[test]
+fn test_slice_cast_empty_slice() {
+    let input: Vec<u32> = vec![];
+    let output: Vec<TestScalar> = slice_cast(&input);
+
+    assert_eq!(output, Vec::<TestScalar>::new());
+}
+
+#[test]
+fn test_slice_cast_mut_with_empty_slice() {
+    let input: Vec<u32> = vec![];
+    let mut output: Vec<u64> = vec![];
+
+    slice_cast_mut_with(&input, &mut output, |&x| u64::from(x));
+
+    assert_eq!(output, Vec::<u64>::new());
+}
+
+#[test]
+fn test_slice_cast_mut_empty_slice() {
+    let input: Vec<u32> = vec![];
+    let mut output: Vec<TestScalar> = vec![];
+
+    slice_cast_mut(&input, &mut output);
+
+    assert_eq!(output, Vec::<TestScalar>::new());
+}
+
 #[test]
 fn test_slice_map_to_vec() {
     let a: Vec<u32> = vec![1, 2, 3, 4];


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`. Local note: on this macOS shell the script extracted YAML commands with the literal `run:` prefix and could not execute them, so I also ran the relevant package/fmt checks listed below.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Related to #560.

This adds focused boundary coverage for the slice cast helpers. The existing tests cover non-empty slices and randomized values, but they do not assert that empty input slices are handled consistently by both the vector-returning helpers and the in-place helpers.

# What changes are included in this PR?

- Add empty-slice tests for `slice_cast_with` and `slice_cast`.
- Add empty-slice tests for `slice_cast_mut_with` and `slice_cast_mut`.
- Keep the change test-only; no production behavior changes.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql --no-default-features --features test base::slice_ops::slice_cast_test` - 11 passed.
- `cargo check -p proof-of-sql --no-default-features` - passed.
- `cargo check -p proof-of-sql --no-default-features --features test` - passed.
- `cargo fmt --all -- --check` - passed.
- `git diff --check` - passed.
- `source scripts/check_commits.sh` - passed.

Additional local notes:

- `source scripts/run_ci_checks.sh` was attempted, but on this macOS/BSD `sed` environment it emitted commands like `run: cargo check ...`, so the script itself could not execute its extracted commands locally.
- Full workspace `cargo check --no-default-features` was also attempted and hit the existing aarch64 platform limitation from `halo2curves`: `Currently feature asm can only be enabled on x86_64 arch.`

Bounty: #560