### PR TITLE
test: cover join utility index edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -900,6 +900,35 @@ mod tests {
     }
 
     #[test]
+    fn we_can_get_sort_merge_join_indexes_for_multiple_join_columns() {
+        let left_on = vec![
+            Column::<TestScalar>::Int(&[1_i32, 1, 1, 2, 2, 3]),
+            Column::<TestScalar>::SmallInt(&[10_i16, 10, 11, 20, 21, 30]),
+        ];
+        let right_on = vec![
+            Column::<TestScalar>::Int(&[1_i32, 1, 2, 2, 2, 4]),
+            Column::<TestScalar>::SmallInt(&[10_i16, 11, 20, 20, 21, 40]),
+        ];
+
+        let row_indexes = get_sort_merge_join_indexes(&left_on, &right_on, 6, 6);
+
+        assert_eq!(
+            row_indexes,
+            vec![(0, 0), (1, 0), (2, 1), (3, 2), (3, 3), (4, 4)]
+        );
+    }
+
+    #[test]
+    fn we_get_no_sort_merge_join_indexes_for_incompatible_join_columns() {
+        let left_on = vec![Column::<TestScalar>::Int(&[1_i32, 2, 3])];
+        let right_on = vec![Column::<TestScalar>::BigInt(&[1_i64, 2, 3])];
+
+        let row_indexes = get_sort_merge_join_indexes(&left_on, &right_on, 3, 3);
+
+        assert!(row_indexes.is_empty());
+    }
+
+    #[test]
     fn we_can_get_sort_merge_join_indexes_two_tables_with_empty_results() {
         let left_on = vec![Column::<TestScalar>::Int(&[3_i32, 15, 9, 14, 15, 7])];
         let right_on = vec![Column::<TestScalar>::Int(&[10_i32, 11, 6, 5, 5, 4, 8])];


### PR DESCRIPTION
/claim #560

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a small, non-overlapping test-only coverage slice for #560. The sort-merge join index helper already had single-column and empty-result coverage, but its multi-column duplicate-key path and incompatible-type early return were not directly locked down.

# What changes are included in this PR?

- Add direct coverage for `get_sort_merge_join_indexes` with two join columns and duplicate keys, verifying the full cartesian set of matching row pairs.
- Add direct coverage for incompatible join-column types returning no row-index matches.
- No production behavior changes.

# Are these changes tested?

Yes.

```
PATH="/Users/dracoglasser/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin:$PATH" /Users/dracoglasser/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin/cargo test -p proof-of-sql --lib --no-default-features --features="test" base::database::join_util::tests -- --nocapture
```

Result: 21 passed; 0 failed; 941 filtered out.

Additional checks:

```
PATH="/Users/dracoglasser/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin:$PATH" /Users/dracoglasser/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin/cargo fmt --all -- --check
git diff --check
bash scripts/check_commits.sh
```

Note: I did not run the full `source scripts/run_ci_checks.sh` locally because this is a narrow test-only slice and the focused package tests above cover the touched module.