### PR TITLE
test: reduce planner example Dory setup sizes

### DIFF
--- a/crates/proof-of-sql-planner/examples/dog_breeds/main.rs
+++ b/crates/proof-of-sql-planner/examples/dog_breeds/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"93c0d245eb104663bfdcd25e36bc3f97";
 

--- a/crates/proof-of-sql-planner/examples/hello_world/main.rs
+++ b/crates/proof-of-sql-planner/examples/hello_world/main.rs
@@ -20,6 +20,9 @@ use std::{
     io::{stdout, Write},
     time::Instant,
 };
+
+const DORY_SETUP_MAX_NU: usize = 3;
+
 /// # Panics
 ///
 /// Will panic if flushing the output fails, which can happen due to issues with the underlying output stream.
@@ -45,7 +48,7 @@ fn main() {
     let timer = start_timer("Loading data");
     // Use a fixed seed for deterministic results
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let public_parameters = PublicParameters::rand(5, &mut rng);
+    let public_parameters = PublicParameters::rand(DORY_SETUP_MAX_NU, &mut rng);
     let prover_setup = ProverSetup::from(&public_parameters);
     let verifier_setup = VerifierSetup::from(&public_parameters);
     let mut accessor =

--- a/crates/proof-of-sql-planner/examples/space/main.rs
+++ b/crates/proof-of-sql-planner/examples/space/main.rs
@@ -38,7 +38,7 @@ use std::{fs::File, time::Instant};
 // max_nu = 15 => max table size is 0.5 billion rows
 // max_nu = 20 => max table size is 0.5 trillion rows
 // Note: we will eventually load these from a file.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 6;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"len 32 rng seed - Space and Time";
 

--- a/crates/proof-of-sql-planner/examples/wood_types/main.rs
+++ b/crates/proof-of-sql-planner/examples/wood_types/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"f3a8d12e6b7c4590a1f2e3d4b5c6a7b8";
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #557

## Summary
- Reduce over-provisioned Dory setup sizes in the planner examples that run in CI.
- Add a named `DORY_SETUP_MAX_NU` constant for `hello_world` so the setup size is documented like the CSV examples.
- Keep the example queries, fixtures, assertions, and proof verification behavior unchanged.

## Rationale
The existing example comments say `max_nu` should cover table sizes below `2^(2*max_nu-1)`. These examples were generating larger setup data than their fixed inputs need:

| Example | Input size | New max_nu | Capacity |
| --- | ---: | ---: | ---: |
| `hello_world` | 4 rows | 3 | 32 rows |
| `space` | 643 traveller rows, 13 planet rows | 6 | 2048 rows |
| `dog_breeds` | verified 25 rows | 3 | 32 rows |
| `wood_types` | verified 10 rows | 3 | 32 rows |

This should reduce setup generation time in the examples CI job without weakening what the examples prove or verify.

## Validation
- `mise x rust@1.91.1 -- cargo fmt --all -- --check`
- `git diff --check`
- `mise x rust@1.91.1 -- cargo check -p proof-of-sql-planner --lib --no-default-features`
- `mise x rust@1.91.1 -- cargo check -p proof-of-sql-planner --example hello_world --features proof-of-sql/test`
- `mise x rust@1.91.1 -- cargo check -p proof-of-sql-planner --example space`
- `mise x rust@1.91.1 -- cargo check -p proof-of-sql-planner --example dog_breeds`
- `mise x rust@1.91.1 -- cargo check -p proof-of-sql-planner --example wood_types`
- `mise x rust@1.91.1 -- cargo run -p proof-of-sql-planner --example hello_world --features proof-of-sql/test`
- `mise x rust@1.91.1 -- cargo run -p proof-of-sql-planner --example hello_world --no-default-features --features "proof-of-sql/rayon proof-of-sql/test"`
- `mise x rust@1.91.1 -- cargo run -p proof-of-sql-planner --example hello_world --no-default-features --features proof-of-sql/test`
- `mise x rust@1.91.1 -- cargo run -p proof-of-sql-planner --example space`
- `mise x rust@1.91.1 -- cargo run -p proof-of-sql-planner --example dog_breeds`
- `mise x rust@1.91.1 -- cargo run -p proof-of-sql-planner --example wood_types`