### PR TITLE
test: cover hyperkzg public setup reader errors

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
@@ -122,6 +122,14 @@ pub fn load_small_setup_for_testing() -> (
 mod std_tests {
     use super::*;
 
+    struct FailingReader;
+
+    impl std::io::Read for FailingReader {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("forced read failure"))
+        }
+    }
+
     #[test]
     fn we_can_deserialize_empty_setup_from_slice() {
         assert_eq!(
@@ -138,6 +146,17 @@ mod std_tests {
             deserialize_flat_compressed_hyperkzg_public_setup_from_reader(empty, Validate::Yes)
                 .unwrap(),
             Vec::<G1Affine>::new(),
+        );
+    }
+
+    #[test]
+    fn we_error_when_reader_fails() {
+        assert!(
+            deserialize_flat_compressed_hyperkzg_public_setup_from_reader(
+                FailingReader,
+                Validate::Yes
+            )
+            .is_err()
         );
     }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`. Not run verbatim on Windows; focused local checks are listed below.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a tiny test-only coverage slice for #560. The reader-backed HyperKZG public setup deserializer already handled I/O errors, but the `Err(e) => Some(Err(e.into()))` branch was not exercised by the existing empty/successful reader tests.

/claim #560

# What changes are included in this PR?

- Add a local `FailingReader` test helper in `public_setup.rs` tests.
- Add `we_error_when_reader_fails` to verify `deserialize_flat_compressed_hyperkzg_public_setup_from_reader` returns an error when `Read::read` fails.
- No production logic changes.

# Are these changes tested?

Yes.

- `cargo +1.91.1 test -p proof-of-sql --lib --no-default-features --features test hyperkzg::public_setup::std_tests -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target\public-setup-reader-error.lcov -- hyperkzg::public_setup::std_tests`
- `cargo +1.91.1 fmt --all -- --check`
- `cargo +1.91.1 test -p proof-of-sql --lib --no-default-features --features test`
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe scripts/check_commits.sh`

Coverage evidence:
- Baseline `target\coverage-baseline.lcov`: `crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs` line 39 was `DA:39,0`.
- Focused LCOV after this test: the same line is `DA:39,1`.

Final checks before opening:
- Overlap check: open PR search for `public_setup`, `HyperKZGPublicSetup`, and `deserialize_flat_compressed` returned no open PRs; #560 comments only showed a separate Dory public setup slice plus my attempt note.
- Scope check: `git diff` contains only a test helper and one test in `crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs`.
- Validation check: focused tests/LCOV, fmt, full no-default lib tests, diff check, and commit check passed.