### PR TITLE
test: cover big decimal bigint conversion

### DIFF
--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -89,4 +89,24 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, IntermediateDecimalError::ConversionFailure));
     }
+
+    #[test]
+    fn we_can_convert_decimal_to_bigint_with_matching_precision_and_scale() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+        let bigint = big_decimal
+            .try_into_bigint_with_precision_and_scale(5, 2)
+            .unwrap();
+
+        assert_eq!(bigint.to_string(), "12345");
+    }
+
+    #[test]
+    fn we_can_catch_lossy_cast_when_scaled_digits_exceed_precision() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+        let err = big_decimal
+            .try_into_bigint_with_precision_and_scale(4, 2)
+            .unwrap_err();
+
+        assert!(matches!(err, IntermediateDecimalError::LossyCast));
+    }
 }

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,22 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn test_find_bigdecimals_ignores_non_create_table_statements_and_small_decimals() {
+        let sql = "SELECT 1;
+        CREATE TABLE ETHEREUM.AMOUNTS(
+            SMALL_DECIMAL DECIMAL(38, 2),
+            BIG_DECIMAL DECIMAL(39, 3),
+            AMOUNT_COUNT INT
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("ETHEREUM.AMOUNTS").unwrap(),
+            &[("BIG_DECIMAL".to_string(), 39, 3)]
+        );
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary

- Adds focused tests for `BigDecimalExt::try_into_bigint_with_precision_and_scale`
- Covers the successful conversion path for matching precision and scale
- Covers the `LossyCast` path when scaled digits exceed the allowed precision
- Adds parser coverage for ignoring non-`CREATE TABLE` statements and decimals at the precision threshold

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test big_decimal_ext -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test find_bigdecimals -- --nocapture`

Note: `npm run build` was attempted, but this repo has no `build` script in `package.json`.
