### PR TITLE
test: cover database parse error display

### DIFF
--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,37 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn invalid_table_reference_display_includes_the_rejected_reference() {
+        let error = ParseError::InvalidTableReference {
+            table_reference: "catalog.schema.table".to_string(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Invalid table reference: catalog.schema.table"
+        );
+    }
+
+    #[test]
+    fn invalid_table_reference_equality_tracks_the_original_reference() {
+        let first = ParseError::InvalidTableReference {
+            table_reference: "schema.table".to_string(),
+        };
+        let second = ParseError::InvalidTableReference {
+            table_reference: "schema.table".to_string(),
+        };
+        let different = ParseError::InvalidTableReference {
+            table_reference: "catalog.schema.table".to_string(),
+        };
+
+        assert_eq!(first, second);
+        assert_ne!(first, different);
+    }
+}


### PR DESCRIPTION
/claim #560

Adds a focused test-only coverage slice for `ParseError::InvalidTableReference` in `crates/proof-of-sql/src/base/database/error.rs`.

Scope:
- covers the display output for invalid table-reference parse errors
- verifies equality remains keyed by the rejected reference text
- keeps production code unchanged
- avoids the current `table_ref.rs` coverage PRs and other active #560 file slices

Validation:
- `CARGO_TARGET_DIR=/tmp/sxt-proof-of-sql-target CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --lib --no-default-features --features test base::database::error::tests -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `tr -d '\r' < scripts/check_commits.sh | bash`