### PR TITLE
test: cover proof error display

### DIFF
--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,137 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn proof_error_display_includes_static_context() {
+        let verification_error = ProofError::VerificationError {
+            error: "sumcheck failed",
+        };
+        let unsupported_query_plan = ProofError::UnsupportedQueryPlan {
+            error: "window function",
+        };
+
+        assert_eq!(
+            verification_error.to_string(),
+            "Verification error: sumcheck failed"
+        );
+        assert_eq!(
+            unsupported_query_plan.to_string(),
+            "Unsupported query plan: window function"
+        );
+    }
+
+    #[test]
+    fn proof_error_transparent_variants_delegate_display_to_the_source() {
+        let proof_size_error = ProofError::ProofSizeMismatch {
+            source: ProofSizeMismatch::TooFewRhoLengths,
+        };
+        let placeholder_error = ProofError::PlaceholderError {
+            source: PlaceholderError::ZeroPlaceholderId,
+        };
+
+        assert_eq!(
+            proof_size_error.to_string(),
+            "Proof has too few rho lengths"
+        );
+        assert_eq!(
+            placeholder_error.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn proof_size_mismatch_display_messages_are_stable() {
+        let cases = [
+            (
+                ProofSizeMismatch::SumcheckProofTooSmall,
+                "Sumcheck proof is too small",
+            ),
+            (
+                ProofSizeMismatch::TooFewMLEEvaluations,
+                "Proof has too few MLE evaluations",
+            ),
+            (
+                ProofSizeMismatch::PostResultCountMismatch,
+                "Post result challenge count mismatch",
+            ),
+            (
+                ProofSizeMismatch::ConstraintCountMismatch,
+                "Constraint count mismatch",
+            ),
+            (
+                ProofSizeMismatch::TooFewBitDistributions,
+                "Proof has too few bit distributions",
+            ),
+            (
+                ProofSizeMismatch::TooFewChiLengths,
+                "Proof has too few one lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewRhoLengths,
+                "Proof has too few rho lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewSumcheckVariables,
+                "Proof has too few sumcheck variables",
+            ),
+            (
+                ProofSizeMismatch::ChiLengthNotFound,
+                "Proof doesn't have requested one length",
+            ),
+            (
+                ProofSizeMismatch::RhoLengthNotFound,
+                "Proof doesn't have requested rho length",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn placeholder_error_display_and_equality_track_the_rejected_placeholder() {
+        let invalid_index = PlaceholderError::InvalidPlaceholderIndex {
+            index: 4,
+            num_params: 3,
+        };
+        let invalid_type = PlaceholderError::InvalidPlaceholderType {
+            index: 2,
+            expected: ColumnType::Int,
+            actual: ColumnType::VarChar,
+        };
+
+        assert_eq!(
+            invalid_index.to_string(),
+            "Invalid placeholder index: 4, number of params: 3"
+        );
+        assert_eq!(
+            invalid_type.to_string(),
+            "Invalid placeholder type: 2, expected: INT, actual: VARCHAR"
+        );
+        assert_eq!(
+            PlaceholderError::ZeroPlaceholderId.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+        assert_eq!(
+            invalid_index,
+            PlaceholderError::InvalidPlaceholderIndex {
+                index: 4,
+                num_params: 3
+            }
+        );
+        assert_ne!(
+            invalid_index,
+            PlaceholderError::InvalidPlaceholderIndex {
+                index: 3,
+                num_params: 3
+            }
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

Adds a focused test-only coverage slice for proof error display paths in `crates/proof-of-sql/src/base/proof/error.rs`.

Scope:
- covers `ProofError` display output with static context
- verifies transparent `ProofError` variants delegate display text to their source errors
- covers all `ProofSizeMismatch` display strings
- covers `PlaceholderError` display and equality behavior for rejected placeholder metadata
- keeps production code unchanged
- avoids currently active #560 PR files and the crowded database/table-ref coverage slices

Validation:
- `CARGO_TARGET_DIR=/tmp/sxt-proof-of-sql-target-proof-error CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --lib --no-default-features --features test base::proof::error::tests -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `tr -d '\r' < scripts/check_commits.sh | bash`