### PR TITLE
test: cover curve scalar and sumcheck MLE helpers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
@@ -39,6 +39,17 @@ fn test_dalek_interop_m1() {
 }
 
 #[test]
+fn curve25519_scalar_multiplies_ristretto_points_from_both_sides() {
+    let point = curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
+    let expected = curve25519_dalek::scalar::Scalar::from(7u64) * point;
+
+    assert_eq!(Curve25519Scalar::from(7u64) * point, expected);
+    assert_eq!(Curve25519Scalar::from(7u64) * &point, expected);
+    assert_eq!(point * Curve25519Scalar::from(7u64), expected);
+    assert_eq!((&point) * Curve25519Scalar::from(7u64), expected);
+}
+
+#[test]
 fn test_add() {
     let one = Curve25519Scalar::from(1u64);
     let two = Curve25519Scalar::from(2u64);

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
@@ -1,5 +1,6 @@
 use super::SumcheckMleEvaluations;
 use crate::{
+    base::polynomial::compute_rho_eval,
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::SumcheckRandomScalars,
 };
@@ -47,4 +48,44 @@ fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
         *evals.chi_evaluations.values().next().unwrap(),
         expected_eval
     );
+}
+
+#[test]
+fn we_can_track_rho_256_and_pcs_evaluations() {
+    let one = Curve25519Scalar::one();
+    let zero = Curve25519Scalar::from(0u64);
+    let evaluation_point = [
+        one,
+        zero,
+        one,
+        zero,
+        zero,
+        zero,
+        zero,
+        zero,
+        Curve25519Scalar::from(3u64),
+    ];
+    let sumcheck_random_scalars = SumcheckRandomScalars::new(&evaluation_point, 3, 9);
+    let first_round_evals = [Curve25519Scalar::from(11u64), Curve25519Scalar::from(13u64)];
+    let final_round_evals = [Curve25519Scalar::from(17u64)];
+
+    let evals = SumcheckMleEvaluations::new(
+        3,
+        [1, 3],
+        [2, 2],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &first_round_evals,
+        &final_round_evals,
+    );
+
+    let expected_rho_256 =
+        Curve25519Scalar::from(5u64) * (Curve25519Scalar::one() - Curve25519Scalar::from(3u64));
+    assert_eq!(evals.rho_256_evaluation, Some(expected_rho_256));
+    assert_eq!(
+        evals.rho_evaluations[&2],
+        compute_rho_eval(2, &evaluation_point)
+    );
+    assert_eq!(evals.first_round_pcs_proof_evaluations, first_round_evals);
+    assert_eq!(evals.final_round_pcs_proof_evaluations, final_round_evals);
 }


### PR DESCRIPTION
/claim #560

## Summary
- Covers `Curve25519Scalar` Ristretto point multiplication impls from both scalar/point sides.
- Covers the `SumcheckMleEvaluations::new` `rho_256` path, duplicate rho evaluation insertion, and PCS evaluation slice retention.

## Coverage evidence
Baseline: `target/codex-baseline.lcov`
After: `target/curve-sumcheck-after.lcov`

Lines moved from uncovered (`0`) to covered:
- `crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_scalar.rs`: 28-30, 35-37, 42-44, 49-51 (12 lines)
- `crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations.rs`: 65-69, 71-74 (9 lines)

Total newly covered bounty lines: 21 (estimated $2.10 at $0.10/line).

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --no-default-features --features="test" curve25519_scalar_multiplies_ristretto_points_from_both_sides --lib`
- `cargo test -p proof-of-sql --no-default-features --features="test" we_can_track_rho_256_and_pcs_evaluations --lib`
- `cargo test -p proof-of-sql --no-default-features --features="test" --lib` (962 passed)
- `LLVM_COV=/usr/local/opt/llvm@21/bin/llvm-cov LLVM_PROFDATA=/usr/local/opt/llvm@21/bin/llvm-profdata cargo llvm-cov test -p proof-of-sql --no-default-features --features="test" --lib --no-clean --lcov --output-path target/curve-sumcheck-after.lcov -- we_can_track_rho_256_and_pcs_evaluations`
- `bash scripts/check_commits.sh`
