### PR TITLE
test: reuse cached dory setup in proof tests

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    test_dory_setup, test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar,
+    DoryVerifierPublicSetup, ProverSetup, PublicParameters,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -8,45 +8,45 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(4);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(prover_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(prover_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(6);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(prover_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(4);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(prover_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(prover_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(6);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(prover_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
@@ -55,15 +55,15 @@ fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
     let setup_setup = [(4, 4), (4, 3), (6, 2)];
     for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let cached_setup = test_dory_setup(setup_p.0);
+        let prover_setup = &cached_setup.prover_setup;
+        let verifier_setup = &cached_setup.verifier_setup;
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
-                &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &DoryProverPublicSetup::new(prover_setup, setup_p.1),
+                &DoryVerifierPublicSetup::new(verifier_setup, setup_p.1),
             );
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
+    test_dory_setup, test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup,
+    PublicParameters,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -7,53 +8,51 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(4);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_simple_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &prover_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(4);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     test_commitment_evaluation_proof_with_length_1::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &prover_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 #[should_panic = "verification improperly failed"]
 fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = &test_dory_setup(6).prover_setup;
+    let verifier_setup = &test_dory_setup(2).verifier_setup;
     test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
         128,
         0,
-        &&prover_setup,
-        &&verifier_setup,
+        &prover_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let cached_setup = test_dory_setup(6);
+    let prover_setup = &cached_setup.prover_setup;
+    let verifier_setup = &cached_setup.verifier_setup;
     for length in lengths {
         test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
             length,
             0,
-            &&prover_setup,
-            &&verifier_setup,
+            &prover_setup,
+            &verifier_setup,
         );
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -88,3 +88,81 @@ pub(crate) use extended_dory_inner_product::{
 
 #[cfg(test)]
 mod extended_dory_inner_product_test;
+
+mod public_parameters;
+pub use public_parameters::PublicParameters;
+
+mod eval_vmv_re;
+pub(crate) use eval_vmv_re::{eval_vmv_re_prove, eval_vmv_re_verify};
+
+#[cfg(test)]
+mod eval_vmv_re_test;
+
+mod vmv_state;
+#[cfg(test)]
+use vmv_state::VMV;
+pub(crate) use vmv_state::{VMVProverState, VMVVerifierState};
+
+#[cfg(test)]
+mod vmv_state_test;
+
+mod dory_public_setup;
+pub use dory_public_setup::{DoryProverPublicSetup, DoryVerifierPublicSetup};
+
+mod dory_commitment;
+#[cfg(test)]
+mod dory_commitment_test;
+
+#[cfg(not(feature = "blitzar"))]
+mod dory_commitment_helper_cpu;
+#[cfg(not(feature = "blitzar"))]
+use dory_commitment_helper_cpu::compute_dory_commitments;
+#[cfg(feature = "blitzar")]
+mod dory_commitment_helper_gpu;
+pub use dory_commitment::{DoryCommitment, DoryScalar};
+#[cfg(feature = "blitzar")]
+use dory_commitment_helper_gpu::compute_dory_commitments;
+#[cfg(test)]
+mod dory_compute_commitments_test;
+
+mod dory_vmv_helper;
+use dory_vmv_helper::{
+    compute_L_R_vec, compute_T_vec_prime, compute_l_r_tensors, compute_nu, compute_v_vec,
+};
+mod build_vmv_state;
+use build_vmv_state::{build_vmv_prover_state, build_vmv_verifier_state};
+
+mod dory_commitment_evaluation_proof;
+pub use dory_commitment_evaluation_proof::DoryEvaluationProof;
+#[cfg(test)]
+mod dory_commitment_evaluation_proof_test;
+
+mod deferred_msm;
+type DeferredGT = deferred_msm::DeferredMSM<GT, F>;
+type DeferredG1 = deferred_msm::DeferredMSM<G1Affine, F>;
+type DeferredG2 = deferred_msm::DeferredMSM<G2Affine, F>;
+
+mod blitzar_metadata_table;
+mod offset_to_bytes;
+mod pack_scalars;
+mod pairings;
+mod transpose;
+
+mod dynamic_build_vmv_state;
+#[cfg(not(feature = "blitzar"))]
+mod dynamic_dory_commitment_helper_cpu;
+#[cfg(feature = "blitzar")]
+mod dynamic_dory_commitment_helper_gpu;
+mod dynamic_dory_helper;
+#[cfg(not(feature = "blitzar"))]
+use dynamic_dory_commitment_helper_cpu::compute_dynamic_dory_commitments;
+#[cfg(feature = "blitzar")]
+use dynamic_dory_commitment_helper_gpu::compute_dynamic_dory_commitments;
+mod dynamic_dory_commitment;
+mod dynamic_dory_commitment_evaluation_proof;
+#[cfg(test)]
+mod dynamic_dory_compute_commitments_test;
+pub use dynamic_dory_commitment::DynamicDoryCommitment;
+#[cfg(test)]
+mod dynamic_dory_commitment_evaluation_proof_test;
+pub use dynamic_dory_commitment_evaluation_proof::DynamicDoryEvaluationProof;

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -38,6 +38,10 @@ mod dory_messages_test;
 mod setup;
 pub use setup::{ProverSetup, VerifierSetup};
 #[cfg(test)]
+mod test_setup;
+#[cfg(test)]
+use test_setup::test_dory_setup;
+#[cfg(test)]
 mod setup_test;
 
 mod state;
@@ -84,81 +88,3 @@ pub(crate) use extended_dory_inner_product::{
 
 #[cfg(test)]
 mod extended_dory_inner_product_test;
-
-mod public_parameters;
-pub use public_parameters::PublicParameters;
-
-mod eval_vmv_re;
-pub(crate) use eval_vmv_re::{eval_vmv_re_prove, eval_vmv_re_verify};
-
-#[cfg(test)]
-mod eval_vmv_re_test;
-
-mod vmv_state;
-#[cfg(test)]
-use vmv_state::VMV;
-pub(crate) use vmv_state::{VMVProverState, VMVVerifierState};
-
-#[cfg(test)]
-mod vmv_state_test;
-
-mod dory_public_setup;
-pub use dory_public_setup::{DoryProverPublicSetup, DoryVerifierPublicSetup};
-
-mod dory_commitment;
-#[cfg(test)]
-mod dory_commitment_test;
-
-#[cfg(not(feature = "blitzar"))]
-mod dory_commitment_helper_cpu;
-#[cfg(not(feature = "blitzar"))]
-use dory_commitment_helper_cpu::compute_dory_commitments;
-#[cfg(feature = "blitzar")]
-mod dory_commitment_helper_gpu;
-pub use dory_commitment::{DoryCommitment, DoryScalar};
-#[cfg(feature = "blitzar")]
-use dory_commitment_helper_gpu::compute_dory_commitments;
-#[cfg(test)]
-mod dory_compute_commitments_test;
-
-mod dory_vmv_helper;
-use dory_vmv_helper::{
-    compute_L_R_vec, compute_T_vec_prime, compute_l_r_tensors, compute_nu, compute_v_vec,
-};
-mod build_vmv_state;
-use build_vmv_state::{build_vmv_prover_state, build_vmv_verifier_state};
-
-mod dory_commitment_evaluation_proof;
-pub use dory_commitment_evaluation_proof::DoryEvaluationProof;
-#[cfg(test)]
-mod dory_commitment_evaluation_proof_test;
-
-mod deferred_msm;
-type DeferredGT = deferred_msm::DeferredMSM<GT, F>;
-type DeferredG1 = deferred_msm::DeferredMSM<G1Affine, F>;
-type DeferredG2 = deferred_msm::DeferredMSM<G2Affine, F>;
-
-mod blitzar_metadata_table;
-mod offset_to_bytes;
-mod pack_scalars;
-mod pairings;
-mod transpose;
-
-mod dynamic_build_vmv_state;
-#[cfg(not(feature = "blitzar"))]
-mod dynamic_dory_commitment_helper_cpu;
-#[cfg(feature = "blitzar")]
-mod dynamic_dory_commitment_helper_gpu;
-mod dynamic_dory_helper;
-#[cfg(not(feature = "blitzar"))]
-use dynamic_dory_commitment_helper_cpu::compute_dynamic_dory_commitments;
-#[cfg(feature = "blitzar")]
-use dynamic_dory_commitment_helper_gpu::compute_dynamic_dory_commitments;
-mod dynamic_dory_commitment;
-mod dynamic_dory_commitment_evaluation_proof;
-#[cfg(test)]
-mod dynamic_dory_compute_commitments_test;
-pub use dynamic_dory_commitment::DynamicDoryCommitment;
-#[cfg(test)]
-mod dynamic_dory_commitment_evaluation_proof_test;
-pub use dynamic_dory_commitment_evaluation_proof::DynamicDoryEvaluationProof;

--- a/crates/proof-of-sql/src/proof_primitive/dory/test_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/test_setup.rs
@@ -1,0 +1,45 @@
+use super::{rand_util::test_seed_rng, ProverSetup, PublicParameters, VerifierSetup};
+use std::sync::OnceLock;
+
+pub(crate) struct TestDorySetup {
+    pub(crate) prover_setup: ProverSetup<'static>,
+    pub(crate) verifier_setup: VerifierSetup,
+}
+
+pub(crate) fn test_dory_setup(max_nu: usize) -> &'static TestDorySetup {
+    match max_nu {
+        2 => setup_for::<2>(),
+        4 => setup_for::<4>(),
+        5 => setup_for::<5>(),
+        6 => setup_for::<6>(),
+        _ => panic!("missing cached Dory test setup for nu {max_nu}"),
+    }
+}
+
+fn setup_for<const MAX_NU: usize>() -> &'static TestDorySetup {
+    static SETUP_2: OnceLock<TestDorySetup> = OnceLock::new();
+    static SETUP_4: OnceLock<TestDorySetup> = OnceLock::new();
+    static SETUP_5: OnceLock<TestDorySetup> = OnceLock::new();
+    static SETUP_6: OnceLock<TestDorySetup> = OnceLock::new();
+
+    match MAX_NU {
+        2 => SETUP_2.get_or_init(|| setup_with_max_nu(MAX_NU)),
+        4 => SETUP_4.get_or_init(|| setup_with_max_nu(MAX_NU)),
+        5 => SETUP_5.get_or_init(|| setup_with_max_nu(MAX_NU)),
+        6 => SETUP_6.get_or_init(|| setup_with_max_nu(MAX_NU)),
+        _ => unreachable!("unsupported cached Dory test setup"),
+    }
+}
+
+fn setup_with_max_nu(max_nu: usize) -> TestDorySetup {
+    let mut rng = test_seed_rng([max_nu as u8; 32]);
+    let public_parameters =
+        Box::leak(Box::new(PublicParameters::test_rand(max_nu, &mut rng)));
+    let prover_setup = ProverSetup::from(&*public_parameters);
+    let verifier_setup = VerifierSetup::from(&*public_parameters);
+
+    TestDorySetup {
+        prover_setup,
+        verifier_setup,
+    }
+}


### PR DESCRIPTION
Fixes #557

## Summary

- Adds a shared `test_dory_setup(max_nu)` helper for Dory tests, backed by `OnceLock` and deterministic test parameters.
- Reuses cached prover/verifier setups in `dory_commitment_evaluation_proof_test` and `dynamic_dory_commitment_evaluation_proof_test` instead of rebuilding `PublicParameters`, `ProverSetup`, and `VerifierSetup` in each long-running test.
- Keeps the existing proof assertions and test coverage intact; this only removes repeated setup work.

This complements #1637 by applying the same CI/runtime-improvement idea to the lower-level Dory proof primitive tests rather than the planner e2e tests.

## Validation

- `git diff --check`

Not run in this Codex runtime:

- `cargo fmt --check`
- `cargo test ...`

Reason: this runtime does not have `cargo` or `rustup` installed. I am relying on repository CI for the Rust validation and will follow up if CI reports failures.

## Disclosure

This contribution was prepared with AI assistance as part of a transparent autonomous earning experiment. The code changes were inspected against the issue requirements and no unperformed validation is claimed.

/claim #557