### PR TITLE
test: assert dory scalar overflow conversions

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -122,22 +122,24 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        base::{
-            commitment::{naive_commitment::NaiveCommitment, Bounds, ColumnBounds},
-            database::{
-                owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableTestAccessor,
-                TestAccessor,
-            },
-            scalar::test_scalar::TestScalar,
+    use crate::base::{
+        commitment::{
+            naive_commitment::NaiveCommitment, naive_evaluation_proof::NaiveEvaluationProof,
+            Bounds, ColumnBounds,
         },
-        proof_primitive::dory::{
-            test_rng, DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup, ProverSetup,
-            PublicParameters,
+        database::{
+            owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableTestAccessor, TestAccessor,
         },
+        scalar::test_scalar::TestScalar,
+    };
+
+    #[cfg(feature = "blitzar")]
+    use crate::proof_primitive::dory::{
+        test_rng, DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup, ProverSetup,
+        PublicParameters,
     };
 
     #[test]
@@ -317,6 +319,97 @@ mod tests {
     }
 
     #[expect(clippy::similar_names)]
+    #[test]
+    fn we_can_get_query_commitments_from_naive_accessor() {
+        let column_a_id: Ident = "column_a".into();
+        let column_b_id: Ident = "column_b".into();
+
+        let table_a = owned_table([
+            bigint(column_a_id.value.as_str(), [1, 2, 3, 4]),
+            varchar(
+                column_b_id.value.as_str(),
+                ["Lorem", "ipsum", "dolor", "sit"],
+            ),
+        ]);
+        let table_b = owned_table([
+            scalar(column_a_id.value.as_str(), [1, 2]),
+            int128(column_b_id.value.as_str(), [1, 2]),
+        ]);
+        let table_a_id = TableRef::new("table", "a");
+        let table_b_id = TableRef::new("table", "b");
+
+        let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+        accessor.add_table(table_a_id.clone(), table_a, 2);
+        accessor.add_table(table_b_id.clone(), table_b, 5);
+
+        let query_commitments = QueryCommitments::<NaiveCommitment>::from_accessor_with_max_bounds(
+            [
+                ColumnRef::new(table_a_id.clone(), column_b_id.clone(), ColumnType::VarChar),
+                ColumnRef::new(table_b_id.clone(), column_b_id.clone(), ColumnType::Int128),
+                ColumnRef::new(table_a_id.clone(), column_a_id.clone(), ColumnType::BigInt),
+            ],
+            &accessor,
+        );
+
+        let table_a_commitment = query_commitments.get(&table_a_id).unwrap();
+        assert_eq!(table_a_commitment.range(), &(2..6));
+        assert_eq!(
+            query_commitments.lookup_schema(&table_a_id),
+            vec![
+                (column_a_id.clone(), ColumnType::BigInt),
+                (column_b_id.clone(), ColumnType::VarChar),
+            ]
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_a_id, &column_a_id),
+            accessor.get_commitment(&table_a_id, &column_a_id)
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_a_id, &column_b_id),
+            accessor.get_commitment(&table_a_id, &column_b_id)
+        );
+        assert_eq!(
+            table_a_commitment
+                .column_commitments()
+                .column_metadata()
+                .get(&column_a_id)
+                .unwrap()
+                .bounds(),
+            &ColumnBounds::BigInt(Bounds::bounded(i64::MIN, i64::MAX).unwrap())
+        );
+        assert_eq!(
+            table_a_commitment
+                .column_commitments()
+                .column_metadata()
+                .get(&column_b_id)
+                .unwrap()
+                .bounds(),
+            &ColumnBounds::NoOrder
+        );
+
+        let table_b_commitment = query_commitments.get(&table_b_id).unwrap();
+        assert_eq!(table_b_commitment.range(), &(5..7));
+        assert_eq!(
+            query_commitments.lookup_schema(&table_b_id),
+            vec![(column_b_id.clone(), ColumnType::Int128)]
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_b_id, &column_b_id),
+            accessor.get_commitment(&table_b_id, &column_b_id)
+        );
+        assert_eq!(
+            table_b_commitment
+                .column_commitments()
+                .column_metadata()
+                .get(&column_b_id)
+                .unwrap()
+                .bounds(),
+            &ColumnBounds::Int128(Bounds::bounded(i128::MIN, i128::MAX).unwrap())
+        );
+    }
+
+    #[expect(clippy::similar_names)]
+    #[cfg(feature = "blitzar")]
     #[test]
     fn we_can_get_query_commitments_from_accessor() {
         let public_parameters = PublicParameters::test_rand(4, &mut test_rng());

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
@@ -11,18 +11,18 @@ fn test_dory_scalar_to_bool() {
 
 #[test]
 fn test_dory_scalar_to_bool_overflow() {
-    matches!(
+    assert!(matches!(
         bool::try_from(DoryScalar::from(2)),
         Err(ScalarConversionError::Overflow { .. })
-    );
-    matches!(
+    ));
+    assert!(matches!(
         bool::try_from(DoryScalar::from(-1)),
         Err(ScalarConversionError::Overflow { .. })
-    );
-    matches!(
+    ));
+    assert!(matches!(
         bool::try_from(DoryScalar::from(-2)),
         Err(ScalarConversionError::Overflow { .. })
-    );
+    ));
 }
 
 #[test]
@@ -36,14 +36,14 @@ fn test_dory_scalar_to_i8() {
 
 #[test]
 fn test_dory_scalar_to_i8_overflow() {
-    matches!(
+    assert!(matches!(
         i8::try_from(DoryScalar::from(i128::from(i8::MAX) + 1)),
         Err(ScalarConversionError::Overflow { .. })
-    );
-    matches!(
+    ));
+    assert!(matches!(
         i8::try_from(DoryScalar::from(i128::from(i8::MIN) - 1)),
         Err(ScalarConversionError::Overflow { .. })
-    );
+    ));
 }
 
 #[test]
@@ -57,14 +57,14 @@ fn test_dory_scalar_to_i16() {
 
 #[test]
 fn test_dory_scalar_to_i16_overflow() {
-    matches!(
+    assert!(matches!(
         i16::try_from(DoryScalar::from(i128::from(i16::MAX) + 1)),
         Err(ScalarConversionError::Overflow { .. })
-    );
-    matches!(
+    ));
+    assert!(matches!(
         i16::try_from(DoryScalar::from(i128::from(i16::MIN) - 1)),
         Err(ScalarConversionError::Overflow { .. })
-    );
+    ));
 }
 
 #[test]
@@ -78,14 +78,14 @@ fn test_dory_scalar_to_i32() {
 
 #[test]
 fn test_dory_scalar_to_i32_overflow() {
-    matches!(
+    assert!(matches!(
         i32::try_from(DoryScalar::from(i128::from(i32::MAX) + 1)),
         Err(ScalarConversionError::Overflow { .. })
-    );
-    matches!(
+    ));
+    assert!(matches!(
         i32::try_from(DoryScalar::from(i128::from(i32::MIN) - 1)),
         Err(ScalarConversionError::Overflow { .. })
-    );
+    ));
 }
 
 #[test]
@@ -99,14 +99,14 @@ fn test_dory_scalar_to_i64() {
 
 #[test]
 fn test_dory_scalar_to_i64_overflow() {
-    matches!(
+    assert!(matches!(
         i64::try_from(DoryScalar::from(i128::from(i64::MAX) + 1)),
         Err(ScalarConversionError::Overflow { .. })
-    );
-    matches!(
+    ));
+    assert!(matches!(
         i64::try_from(DoryScalar::from(i128::from(i64::MIN) - 1)),
         Err(ScalarConversionError::Overflow { .. })
-    );
+    ));
 }
 
 #[test]
@@ -126,14 +126,14 @@ fn test_dory_scalar_to_i128() {
 
 #[test]
 fn test_dory_scalar_to_i128_overflow() {
-    matches!(
+    assert!(matches!(
         i128::try_from(DoryScalar::from(i128::MAX) + DoryScalar::ONE),
         Err(ScalarConversionError::Overflow { .. })
-    );
-    matches!(
+    ));
+    assert!(matches!(
         i128::try_from(DoryScalar::from(i128::MIN) - DoryScalar::ONE),
         Err(ScalarConversionError::Overflow { .. })
-    );
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`. Not run verbatim on this Windows checkout; focused/full local checks are listed below.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md. On Windows I ran it through `bash -lc "tr -d '\r' < scripts/check_commits.sh | bash"` to avoid CRLF shell parsing.
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

/claim #560

This is a non-overlapping test-only coverage and quality slice for #560.

First, the Dory scalar overflow tests were using bare `matches!(...)` expressions, so the match result was discarded. That meant these tests would still pass even if an overflow conversion stopped returning `ScalarConversionError::Overflow`.

Second, `query_commitments.rs` already had useful unit coverage, but the whole test module was gated behind `feature = "blitzar"`. The #560 no-default coverage path therefore missed the file. This PR keeps the existing Dory/blitzar-specific accessor test behind `#[cfg(feature = "blitzar")]`, while letting the NaiveCommitment-based tests run in the no-default test profile and adding one focused NaiveEvaluationProof accessor test for `QueryCommitments::from_accessor_with_max_bounds`.

I checked #560 comments, open PR titles/bodies, and the latest 120 open PR file lists before adding the second commit. I found no active claim touching `crates/proof-of-sql/src/base/commitment/query_commitments.rs`, and the first commit remains limited to the previously checked Dory scalar overflow test file.

# What changes are included in this PR?

- Wrap the Dory scalar overflow `matches!(...)` checks in `assert!(...)`.
- Allow the existing `QueryCommitments` NaiveCommitment tests to run without `blitzar`.
- Add a no-blitzar `QueryCommitments::from_accessor_with_max_bounds` test using `NaiveEvaluationProof`.
- Keep the Dory-specific accessor test gated behind `#[cfg(feature = "blitzar")]`.
- No production behavior changes.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql --lib --no-default-features --features test dory_commitment_test -- --nocapture` - 14 passed.
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/dory-scalar-overflow-after.lcov -- dory_commitment_test` - 14 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test query_commitments -- --nocapture` - 4 passed.
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/query-commitments-after.lcov -- query_commitments` - 4 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test` - 964 passed.
- `cargo fmt --all -- --check`.
- `git diff --check origin/main...HEAD`.
- `bash -lc "tr -d '\r' < scripts/check_commits.sh | bash"` - 2 commits checked, 0 failed.

Coverage evidence from local LCOV comparison:

- Baseline `lcov-baseline.info`: `dory_commitment_test.rs` had 13 uncovered lines.
- Focused after LCOV `target/dory-scalar-overflow-after.lcov`: `dory_commitment_test.rs` has 0 uncovered lines.
- Newly covered baseline-uncovered Dory lines: 14, 18, 22, 39, 43, 60, 64, 81, 85, 102, 106, 129, 133.
- Baseline `lcov-baseline.info`: `query_commitments.rs` had 68 uncovered lines.
- Focused after LCOV `target/query-commitments-after.lcov`: `query_commitments.rs` has 0 uncovered baseline lines remaining.
- Newly covered baseline-uncovered query commitment lines: 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 66, 67, 68, 69, 73, 74, 75, 76, 78, 79, 80, 81, 88, 89, 91, 92, 93, 94, 95, 99, 100, 102, 103, 104, 105, 106, 111, 112, 114, 115, 116, 117, 118, 119, 120, 121, 122.
- Total newly covered baseline-uncovered lines in this PR: 81.
- Estimated bounty value: $8.10 at $0.10 per newly covered line.
