### PR TITLE
test: cover sumcheck subpolynomial compose paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -91,7 +91,10 @@ impl<'a, S: Scalar> SumcheckSubpolynomial<'a, S> {
 
 #[cfg(test)]
 mod tests {
-    use super::{SumcheckSubpolynomial, SumcheckSubpolynomialTerm, SumcheckSubpolynomialType};
+    use super::{
+        CompositePolynomialBuilder, SumcheckSubpolynomial, SumcheckSubpolynomialTerm,
+        SumcheckSubpolynomialType,
+    };
     use crate::base::scalar::test_scalar::TestScalar;
     use alloc::boxed::Box;
 
@@ -118,5 +121,55 @@ mod tests {
         assert_eq!(coeff, TestScalar::from(15));
 
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_compose_identity_subpolynomial_uses_fr_multiplicand() {
+        let fr = [TestScalar::from(1), TestScalar::from(2)];
+        let mle = vec![TestScalar::from(3), TestScalar::from(5)];
+        let terms: Vec<SumcheckSubpolynomialTerm<_>> =
+            vec![(TestScalar::from(7), vec![Box::new(&mle)])];
+        let subpoly = SumcheckSubpolynomial::new(SumcheckSubpolynomialType::Identity, terms);
+        let mut builder = CompositePolynomialBuilder::new(1, &fr);
+
+        subpoly.compose(&mut builder, TestScalar::from(11));
+        let polynomial = builder.make_composite_polynomial();
+        let point = [TestScalar::from(13)];
+        let m0 = TestScalar::from(1) - point[0];
+        let m1 = point[0];
+        let eval_fr = fr[0] * m0 + fr[1] * m1;
+        let eval_mle = mle[0] * m0 + mle[1] * m1;
+
+        assert_eq!(
+            subpoly.subpolynomial_type(),
+            SumcheckSubpolynomialType::Identity
+        );
+        assert_eq!(
+            polynomial.evaluate(&point),
+            eval_fr * TestScalar::from(77) * eval_mle
+        );
+    }
+
+    #[test]
+    fn test_compose_zero_sum_subpolynomial_uses_zerosum_multiplicand() {
+        let fr = [TestScalar::from(1), TestScalar::from(2)];
+        let mle = vec![TestScalar::from(3), TestScalar::from(5)];
+        let terms: Vec<SumcheckSubpolynomialTerm<_>> =
+            vec![(TestScalar::from(7), vec![Box::new(&mle)])];
+        let subpoly = SumcheckSubpolynomial::new(SumcheckSubpolynomialType::ZeroSum, terms);
+        let mut builder = CompositePolynomialBuilder::new(1, &fr);
+
+        subpoly.compose(&mut builder, TestScalar::from(11));
+        let polynomial = builder.make_composite_polynomial();
+        let point = [TestScalar::from(13)];
+        let m0 = TestScalar::from(1) - point[0];
+        let m1 = point[0];
+        let eval_mle = mle[0] * m0 + mle[1] * m1;
+
+        assert_eq!(
+            subpoly.subpolynomial_type(),
+            SumcheckSubpolynomialType::ZeroSum
+        );
+        assert_eq!(polynomial.evaluate(&point), TestScalar::from(77) * eval_mle);
     }
 }


### PR DESCRIPTION
## Summary
- Add focused tests for `SumcheckSubpolynomial::compose` covering both `Identity` and `ZeroSum` subpolynomial paths.
- Assert the composed polynomial evaluation for the `f_r`-multiplicand path and the zero-sum multiplicand path.
- Cover `subpolynomial_type()` while keeping production code unchanged.

## Coverage evidence
Focused LCOV comparison for `crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs`:
- Baseline full-lib LCOV uncovered lines: 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 59
- Focused LCOV after this change covers all of those lines.
- Newly covered baseline-uncovered lines: 13
- Estimated bounty value: $1.30 at $0.10/line.

## Validation
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS='' cargo test --features test -p proof-of-sql sumcheck_subpolynomial --lib` -> 3 passed
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS='' cargo llvm-cov --features test -p proof-of-sql --lib --lcov --output-path /tmp/sxt_sumcheck.lcov -- sumcheck_subpolynomial` -> LCOV generated and target file has no uncovered lines in the focused run
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc RUSTFLAGS='' cargo test --features test -p proof-of-sql --lib` -> 1401 passed, 0 failed, 1 ignored
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

/claim #560