### PR TITLE
test: reduce small planner example setup sizes

### DIFF
--- a/crates/proof-of-sql-planner/examples/plastics/main.rs
+++ b/crates/proof-of-sql-planner/examples/plastics/main.rs
@@ -29,7 +29,8 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+// The checked-in plastics CSV has 18 rows, which fits under the 32-row capacity for max_nu = 3.
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"32f7f321c4ab1234d5e6f7a8b9c0d1e2";
 

--- a/crates/proof-of-sql-planner/examples/programming_books/main.rs
+++ b/crates/proof-of-sql-planner/examples/programming_books/main.rs
@@ -27,7 +27,8 @@ use rand::{rngs::StdRng, SeedableRng};
 use sqlparser::{dialect::GenericDialect, parser::Parser};
 use std::{fs::File, time::Instant};
 
-const DORY_SETUP_MAX_NU: usize = 8;
+// The checked-in programming_books CSV has 10 rows, which fits under the 32-row capacity for max_nu = 3.
+const DORY_SETUP_MAX_NU: usize = 3;
 const DORY_SEED: [u8; 32] = *b"ebab60d58dee4cc69658939b7c2a582d";
 
 /// # Panics

--- a/crates/proof-of-sql-planner/examples/stocks/main.rs
+++ b/crates/proof-of-sql-planner/examples/stocks/main.rs
@@ -29,7 +29,8 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The max_nu should be set such that the maximum table size is less than 2^(2*max_nu-1).
-const DORY_SETUP_MAX_NU: usize = 8;
+// The checked-in stocks CSV has 18 rows, which fits under the 32-row capacity for max_nu = 3.
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"f9d2e8c1b7a654309cfe81d2b7a3c940";
 

--- a/crates/proof-of-sql-planner/examples/sushi/main.rs
+++ b/crates/proof-of-sql-planner/examples/sushi/main.rs
@@ -23,7 +23,9 @@ use proof_of_sql_planner::sql_to_proof_plans;
 use rand::{rngs::StdRng, SeedableRng};
 use sqlparser::{dialect::GenericDialect, parser::Parser};
 use std::{fs::File, time::Instant};
-const DORY_SETUP_MAX_NU: usize = 8;
+
+// The checked-in fish CSV has 12 rows, which fits under the 32-row capacity for max_nu = 3.
+const DORY_SETUP_MAX_NU: usize = 3;
 const DORY_SEED: [u8; 32] = *b"sushi-is-the-best-food-available";
 
 /// # Panics

--- a/crates/proof-of-sql-planner/examples/tech_gadget_prices/main.rs
+++ b/crates/proof-of-sql-planner/examples/tech_gadget_prices/main.rs
@@ -26,7 +26,8 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+// The checked-in tech_gadget_prices CSV has 8 rows, which fits under the 32-row capacity for max_nu = 3.
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"tech-gadget-prices-dataset-seed!";
 


### PR DESCRIPTION
/claim #557

## Summary
- reduce Dory setup generation for five small checked-in planner examples
- change `DORY_SETUP_MAX_NU` from `8` to `3` for `plastics`, `programming_books`, `stocks`, `sushi`, and `tech_gadget_prices`
- keep CSV fixtures, SQL queries, proof generation, verification, and result handling unchanged

## Why this helps
Issue #557 asks for test/CI/runtime improvements without weakening coverage or behavior. These examples were generating Dory public parameters for table sizes below `2^(2*8-1) = 32768` rows, but their fixed CSV fixtures are much smaller:

| Example | CSV rows | New capacity with `max_nu = 3` |
| --- | ---: | ---: |
| `plastics` | 18 | 32 |
| `programming_books` | 10 | 32 |
| `stocks` | 18 | 32 |
| `sushi` | 12 | 32 |
| `tech_gadget_prices` | 8 | 32 |

This trims unused Dory setup work while preserving the same example data and queries.

## Non-overlap check
Before changing these files, I searched open/all-state #557 PRs and issue comments for each example name. I found existing claims for nearby planner examples, but no claim for these five example names.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`
- `tr -d '\015' < scripts/check_commits.sh | bash`
- `cargo check -p proof-of-sql-planner --example plastics --example programming_books --example stocks --example sushi --example tech_gadget_prices --no-default-features --features cpu-perf`
- `cargo run -q -p proof-of-sql-planner --example plastics --no-default-features --features cpu-perf` (all three plastics queries generated and verified proofs)