### PR TITLE
test: cover SQL test utility helpers

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -225,3 +225,146 @@ pub fn sum_expr(expr: DynProofExpr, alias: &str) -> AliasedDynProofExpr {
         alias: alias.into(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof,
+            database::{table_utility::*, ColumnType, TableRef, TableTestAccessor},
+            math::decimal::Precision,
+            scalar::test_scalar::TestScalar,
+        },
+        sql::proof_exprs::ProofExpr,
+    };
+    use bumpalo::Bump;
+
+    #[test]
+    fn test_utility_builds_proof_expressions_and_aliases() {
+        let alloc = Bump::new();
+        let table_ref = TableRef::new("sxt", "proof_expr_test_utility");
+        let data = table([
+            borrowed_bigint("id", [1, 2], &alloc),
+            borrowed_int("quantity", [3, 4], &alloc),
+            borrowed_boolean("is_active", [true, false], &alloc),
+            borrowed_varchar("label", ["a", "b"], &alloc),
+        ]);
+        let accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            data,
+            0,
+            (),
+        );
+
+        let id_ref = col_ref(&table_ref, "id", &accessor);
+        assert_eq!(id_ref.table_ref(), table_ref);
+        assert_eq!(id_ref.column_id().to_string(), "id");
+        assert_eq!(*id_ref.column_type(), ColumnType::BigInt);
+
+        assert!(matches!(
+            column(&table_ref, "id", &accessor),
+            DynProofExpr::Column(_)
+        ));
+        assert_eq!(
+            col_expr(&table_ref, "quantity", &accessor).data_type(),
+            ColumnType::Int
+        );
+        assert_eq!(
+            cols_expr(&table_ref, &["id", "quantity"], &accessor).len(),
+            2
+        );
+
+        assert_eq!(
+            equal(const_int(1), const_int(1)).data_type(),
+            ColumnType::Boolean
+        );
+        assert_eq!(
+            lt(const_int(1), const_int(2)).data_type(),
+            ColumnType::Boolean
+        );
+        assert_eq!(
+            gt(const_int(2), const_int(1)).data_type(),
+            ColumnType::Boolean
+        );
+        assert_eq!(
+            lte(const_int(1), const_int(2)).data_type(),
+            ColumnType::Boolean
+        );
+        assert_eq!(
+            gte(const_int(2), const_int(1)).data_type(),
+            ColumnType::Boolean
+        );
+        assert_eq!(not(const_bool(false)).data_type(), ColumnType::Boolean);
+        assert_eq!(
+            and(const_bool(true), const_bool(false)).data_type(),
+            ColumnType::Boolean
+        );
+        assert_eq!(
+            or(const_bool(true), const_bool(false)).data_type(),
+            ColumnType::Boolean
+        );
+
+        assert!(matches!(
+            add(const_bigint(1), const_bigint(2)),
+            DynProofExpr::Add(_)
+        ));
+        assert!(matches!(
+            subtract(const_bigint(3), const_bigint(2)),
+            DynProofExpr::Subtract(_)
+        ));
+        assert!(matches!(
+            multiply(const_bigint(3), const_bigint(2)),
+            DynProofExpr::Multiply(_)
+        ));
+        assert_eq!(
+            cast(const_smallint(7), ColumnType::BigInt).data_type(),
+            ColumnType::BigInt
+        );
+
+        let scaled_decimal_type = ColumnType::Decimal75(Precision::new(11).unwrap(), 1);
+        assert_eq!(
+            scaling_cast(const_int(12), scaled_decimal_type).data_type(),
+            scaled_decimal_type
+        );
+        let literal_decimal_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
+        assert_eq!(
+            const_decimal75(10, 2, 123_i32).data_type(),
+            literal_decimal_type
+        );
+
+        assert_eq!(const_bool(true).data_type(), ColumnType::Boolean);
+        assert_eq!(const_smallint(1).data_type(), ColumnType::SmallInt);
+        assert_eq!(const_int(1).data_type(), ColumnType::Int);
+        assert_eq!(const_bigint(1).data_type(), ColumnType::BigInt);
+        assert_eq!(const_int128(1).data_type(), ColumnType::Int128);
+        assert_eq!(const_varchar("value").data_type(), ColumnType::VarChar);
+        assert_eq!(const_varbinary(b"value").data_type(), ColumnType::VarBinary);
+        assert_eq!(
+            const_scalar::<TestScalar, _>(1_i64).data_type(),
+            ColumnType::Scalar
+        );
+
+        let placeholder = aliased_placeholder(1, ColumnType::BigInt, "p");
+        assert_eq!(placeholder.alias.to_string(), "p");
+        assert!(matches!(placeholder.expr, DynProofExpr::Placeholder(_)));
+
+        assert_eq!(tab(&table_ref).table_ref, table_ref);
+
+        let aliased_literal = aliased_plan(const_bool(true), "flag");
+        assert_eq!(aliased_literal.alias.to_string(), "flag");
+        assert_eq!(aliased_literal.expr.data_type(), ColumnType::Boolean);
+
+        let aliased_column = col_expr_plan(&table_ref, "id", &accessor);
+        assert_eq!(aliased_column.alias.to_string(), "id");
+        assert_eq!(aliased_column.expr.data_type(), ColumnType::BigInt);
+        assert_eq!(
+            cols_expr_plan(&table_ref, &["id", "quantity"], &accessor).len(),
+            2
+        );
+
+        let aliased_sum = sum_expr(const_bigint(10), "total");
+        assert_eq!(aliased_sum.alias.to_string(), "total");
+        assert_eq!(aliased_sum.expr.data_type(), ColumnType::BigInt);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
@@ -106,3 +106,166 @@ pub fn sort_merge_join(
         result_idents,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof,
+            database::{table_utility::*, TableTestAccessor},
+        },
+        sql::proof_exprs::{test_utility::*, ProofExpr},
+    };
+    use bumpalo::Bump;
+
+    #[test]
+    fn test_utility_builds_proof_plan_variants() {
+        let alloc = Bump::new();
+        let table_ref = TableRef::new("sxt", "proof_plan_test_utility");
+        let data = table([
+            borrowed_bigint("id", [1, 2], &alloc),
+            borrowed_int("value", [3, 4], &alloc),
+        ]);
+        let accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            data,
+            0,
+            (),
+        );
+        let schema = vec![
+            column_field("id", ColumnType::BigInt),
+            column_field("value", ColumnType::Int),
+        ];
+
+        assert_eq!(schema[0].name().to_string(), "id");
+        assert_eq!(schema[0].data_type(), ColumnType::BigInt);
+
+        assert!(matches!(empty_exec(), DynProofPlan::Empty(_)));
+
+        let table_plan = table_exec(table_ref.clone(), schema.clone());
+        match &table_plan {
+            DynProofPlan::Table(plan) => {
+                assert_eq!(plan.table_ref(), &table_ref);
+                assert_eq!(plan.schema(), schema.as_slice());
+            }
+            _ => panic!("expected table plan"),
+        }
+
+        let aliased_id = col_expr_plan(&table_ref, "id", &accessor);
+        let projected = projection(vec![aliased_id.clone()], table_plan.clone());
+        match &projected {
+            DynProofPlan::Projection(plan) => {
+                assert_eq!(plan.aliased_results(), &[aliased_id.clone()]);
+                assert_eq!(plan.input(), &table_plan);
+            }
+            _ => panic!("expected projection plan"),
+        }
+
+        let table_expr = tab(&table_ref);
+        let where_clause = equal(column(&table_ref, "id", &accessor), const_bigint(1));
+        let legacy_filtered = legacy_filter(
+            vec![aliased_id.clone()],
+            table_expr.clone(),
+            where_clause.clone(),
+        );
+        match &legacy_filtered {
+            DynProofPlan::LegacyFilter(plan) => {
+                assert_eq!(plan.aliased_results(), &[aliased_id.clone()]);
+                assert_eq!(plan.table(), &table_expr);
+                assert_eq!(plan.where_clause(), &where_clause);
+            }
+            _ => panic!("expected legacy filter plan"),
+        }
+
+        let filtered = filter(
+            vec![aliased_id.clone()],
+            table_plan.clone(),
+            where_clause.clone(),
+        );
+        match &filtered {
+            DynProofPlan::Filter(plan) => {
+                assert_eq!(plan.aliased_results(), &[aliased_id.clone()]);
+                assert_eq!(plan.input(), &table_plan);
+                assert_eq!(plan.where_clause(), &where_clause);
+            }
+            _ => panic!("expected filter plan"),
+        }
+
+        let id_expr = col_expr(&table_ref, "id", &accessor);
+        let value_sum = sum_expr(column(&table_ref, "value", &accessor), "value_sum");
+        let grouped = group_by(
+            vec![id_expr.clone()],
+            vec![value_sum.clone()],
+            "row_count",
+            table_expr.clone(),
+            where_clause.clone(),
+        );
+        match &grouped {
+            DynProofPlan::GroupBy(plan) => {
+                assert_eq!(plan.group_by_exprs(), &[id_expr.clone()]);
+                assert_eq!(plan.sum_expr(), &[value_sum.clone()]);
+                assert_eq!(plan.count_alias().to_string(), "row_count");
+                assert_eq!(plan.table(), &table_expr);
+                assert_eq!(plan.where_clause(), &where_clause);
+            }
+            _ => panic!("expected group-by plan"),
+        }
+
+        let aggregate_group = aliased_plan(column(&table_ref, "id", &accessor), "id");
+        let aggregated = aggregate(
+            vec![aggregate_group.clone()],
+            vec![value_sum.clone()],
+            "row_count",
+            table_plan.clone(),
+            where_clause.clone(),
+        );
+        match &aggregated {
+            DynProofPlan::Aggregate(plan) => {
+                assert_eq!(plan.group_by_exprs(), &[aggregate_group.clone()]);
+                assert_eq!(plan.sum_expr(), &[value_sum.clone()]);
+                assert_eq!(plan.count_alias().to_string(), "row_count");
+                assert_eq!(plan.input(), &table_plan);
+                assert_eq!(plan.where_clause(), &where_clause);
+            }
+            _ => panic!("expected aggregate plan"),
+        }
+
+        let sliced = slice_exec(table_plan.clone(), 1, Some(2));
+        match &sliced {
+            DynProofPlan::Slice(plan) => {
+                assert_eq!(plan.input(), &table_plan);
+                assert_eq!(plan.skip(), 1);
+                assert_eq!(plan.fetch(), Some(2));
+            }
+            _ => panic!("expected slice plan"),
+        }
+
+        let unioned = union_exec(vec![table_plan.clone(), table_plan.clone()]);
+        match &unioned {
+            DynProofPlan::Union(plan) => assert_eq!(plan.input_plans().len(), 2),
+            _ => panic!("expected union plan"),
+        }
+
+        let joined = sort_merge_join(
+            table_plan.clone(),
+            table_plan.clone(),
+            vec![0],
+            vec![0],
+            vec!["id".into(), "left_value".into(), "right_value".into()],
+        );
+        match &joined {
+            DynProofPlan::SortMergeJoin(plan) => {
+                assert_eq!(plan.left_plan(), &table_plan);
+                assert_eq!(plan.right_plan(), &table_plan);
+                assert_eq!(plan.left_join_column_indexes(), &vec![0]);
+                assert_eq!(plan.right_join_column_indexes(), &vec![0]);
+                assert_eq!(plan.result_idents().len(), 3);
+                assert_eq!(plan.result_idents()[0].to_string(), "id");
+            }
+            _ => panic!("expected sort merge join plan"),
+        }
+
+        assert_eq!(aliased_id.expr.data_type(), ColumnType::BigInt);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add no-default tests for `sql/proof_exprs/test_utility.rs` helper constructors and aliases
- add no-default tests for `sql/proof_plans/test_utility.rs` plan helper constructors
- use `NaiveEvaluationProof` so this slice runs without the `blitzar` feature

## Coverage evidence
Compared a full `origin/main` baseline LCOV at `/tmp/sxt-baseline.lcov` against the patched full LCOV at `/tmp/sxt-patched-final.lcov` with:

```bash
BLITZAR_BACKEND=cpu cargo llvm-cov --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm" -p proof-of-sql --lib --lcov --output-path <path>
```

Target non-overlap lines newly covered:
- `crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs`: 109 lines: 9-13, 18-22, 41-43, 48-50, 55-57, 105-107, 109-111, 113-115, 117-119, 121-123, 125-127, 129-131, 134-136, 139-141, 146-152, 155-160, 162-166, 171-176, 182-191, 193-202, 204-206, 208-217, 222-227
- `crates/proof-of-sql/src/sql/proof_plans/test_utility.rs`: 80 lines: 12-14, 16-18, 20-22, 24-26, 28-34, 36-42, 47-64, 69-81, 83-84, 86-88, 90-92, 94-108

Target total: 189 baseline-uncovered lines, estimated at $18.90 at $0.10/line. The same run also covered incidental shared-helper lines, but this claim is only for the two `test_utility.rs` files above.

## Validation
- `BLITZAR_BACKEND=cpu cargo test --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm" -p proof-of-sql --lib test_utility`
- full patched LCOV command above: 1055 passed, 0 failed
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
