### PR TITLE
test: cover monotonic gadget without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -118,23 +118,23 @@ impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         base::{
+            commitment::naive_evaluation_proof::NaiveEvaluationProof,
             database::{table_utility::*, ColumnType, TableTestAccessor},
             math::decimal::Precision,
             posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+            scalar::test_scalar::TestScalar,
         },
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
         sql::proof::{QueryError, VerifiableQueryResult},
     };
-    use blitzar::proof::InnerProductProof;
 
     fn check_monotonic<const STRICT: bool, const ASC: bool>(
         table_ref: TableRef,
-        accessor: &TableTestAccessor<InnerProductProof>,
+        accessor: &TableTestAccessor<NaiveEvaluationProof>,
         column_name: &str,
         column_type: ColumnType,
         shall_error: bool,
@@ -143,7 +143,7 @@ mod tests {
             column: ColumnRef::new(table_ref, column_name.into(), column_type),
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, accessor, &(), &[]).unwrap();
         let res = verifiable_res.verify(&plan, accessor, &(), &[]);
         if shall_error {
             assert!(matches!(
@@ -219,7 +219,7 @@ mod tests {
     /// non-monotonic
     fn check_monotonic_for_table<const STRICT: bool, const ASC: bool>(
         table_ref: TableRef,
-        accessor: &TableTestAccessor<InnerProductProof>,
+        accessor: &TableTestAccessor<NaiveEvaluationProof>,
         shall_error: bool,
     ) {
         let precision = Precision::new(50).unwrap();
@@ -269,12 +269,16 @@ mod tests {
 
     /// Run `check_monotonic_for_table` for all possible forms of monotonicity
     fn check_all_monotonic_for_table(
-        table: Table<Curve25519Scalar>,
+        table: Table<TestScalar>,
         expected_monotonicity: &Monotonicity,
     ) {
         let table_ref: TableRef = "sxt.table".parse().unwrap();
-        let accessor =
-            TableTestAccessor::<InnerProductProof>::new_from_table(table_ref.clone(), table, 0, ());
+        let accessor = TableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+            table_ref.clone(),
+            table,
+            0,
+            (),
+        );
         check_monotonic_for_table::<true, true>(
             table_ref.clone(),
             &accessor,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`. Not run verbatim on this Windows checkout; focused and full local no-default checks are listed below.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md. On Windows I ran it through Git Bash with `tr -d '\r' < scripts/check_commits.sh | bash`.
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

/claim #560

This is a focused, non-overlapping no-default coverage slice for #560.

The monotonic gadget tests were fully gated behind `feature = "blitzar"`, so the no-default coverage path missed both the `MonotonicTestPlan` wrapper in `monotonic_test.rs` and the production monotonic gadget in `monotonic.rs`. This PR keeps the existing monotonic behavior checks, but runs them with the existing test-only `NaiveEvaluationProof` and `TestScalar` instead of `InnerProductProof`.

I checked current #560 comments, current open PR titles/bodies, and current open PR file lists for `monotonic_test.rs`, `sql/proof_gadgets/monotonic_test.rs`, `monotonic.rs`, `sql/proof_gadgets/monotonic.rs`, and `MonotonicTestPlan`. I found no active exact-file or exact-plan overlap before opening this PR.

# What changes are included in this PR?

- Change `monotonic_test.rs` tests from `#[cfg(all(test, feature = "blitzar"))]` to `#[cfg(test)]`.
- Use `NaiveEvaluationProof` and `TestScalar` for the existing monotonic proof tests.
- Keep the monotonic cases and production behavior unchanged.

# Coverage evidence

Baseline: `../sxt-proof-of-sql-baseline.lcov`.
Focused after run: `target/monotonic-after.lcov`.

Baseline-uncovered lines newly covered by this PR:
- `crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs`: 72 lines: 30, 31, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 50, 52, 53, 54, 55, 56, 58, 59, 60, 61, 62, 63, 64, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 80, 81, 82, 83, 84, 88, 89, 90, 92, 93, 94, 97, 98, 99, 102, 103, 104, 105, 106, 107, 108, 110, 111, 113, 114, 116, 117, 118
- `crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs`: 62 lines: 15, 16, 17, 18, 19, 20, 21, 29, 30, 31, 32, 33, 34, 35, 36, 38, 40, 41, 42, 43, 44, 46, 48, 50, 52, 68, 69, 70, 71, 73, 76, 77, 79, 80, 81, 82, 83, 84, 85, 87, 88, 90, 91, 92, 94, 95, 96, 106, 107, 108, 109, 123, 124, 125, 126, 130, 131, 132, 133, 134, 135, 136

Total claimed newly covered baseline-uncovered lines: 134.
Estimated bounty value: $13.40 at $0.10 per newly covered line.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql --lib --no-default-features --features test monotonic_test -- --nocapture` - 8 passed.
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/monotonic-after.lcov -- monotonic_test` - 8 passed; LCOV generated.
- `cargo test -p proof-of-sql --lib --no-default-features --features test` - 968 passed, 0 failed.
- `cargo fmt --all -- --check`.
- `git diff --check`.
- `tr -d '\r' < scripts/check_commits.sh | bash` through Git Bash - 1 commit checked, 0 failed.
