### PR TITLE
test: cover HyperKZG Nova engine helpers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs
@@ -57,3 +57,85 @@ pub fn nova_commitment_key_to_hyperkzg_public_setup(
 ) -> HyperKZGPublicSetupOwned {
     slice_ops::slice_cast_with(setup.ck(), convert_g1_affine_from_halo2_to_ark)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::hyperkzg::convert_g1_affine_from_halo2_to_ark;
+    use halo2curves::group::prime::PrimeCurveAffine;
+    use nova_snark::traits::{Engine, TranscriptEngineTrait, TranscriptReprTrait};
+
+    struct TranscriptBytes(Vec<u8>);
+
+    impl TranscriptReprTrait<<HyperKZGEngine as Engine>::GE> for TranscriptBytes {
+        fn to_transcript_bytes(&self) -> Vec<u8> {
+            self.0.clone()
+        }
+    }
+
+    #[test]
+    fn keccak_transcript_engine_labels_and_domain_separators_are_noops() {
+        let mut first = <Keccak256Transcript as TranscriptEngineTrait<HyperKZGEngine>>::new(
+            b"first label is ignored",
+        );
+        let mut second = <Keccak256Transcript as TranscriptEngineTrait<HyperKZGEngine>>::new(
+            b"second label is ignored",
+        );
+
+        TranscriptEngineTrait::<HyperKZGEngine>::dom_sep(&mut first, b"ignored separator");
+
+        assert_eq!(
+            TranscriptEngineTrait::<HyperKZGEngine>::squeeze(&mut first, b"first")
+                .expect("squeeze succeeds"),
+            TranscriptEngineTrait::<HyperKZGEngine>::squeeze(&mut second, b"second")
+                .expect("squeeze succeeds")
+        );
+    }
+
+    #[test]
+    fn keccak_transcript_engine_absorb_and_squeeze_update_state() {
+        let mut empty = <Keccak256Transcript as TranscriptEngineTrait<HyperKZGEngine>>::new(b"");
+        let mut absorbed = <Keccak256Transcript as TranscriptEngineTrait<HyperKZGEngine>>::new(b"");
+
+        TranscriptEngineTrait::<HyperKZGEngine>::absorb(
+            &mut absorbed,
+            b"ignored label",
+            &TranscriptBytes(vec![1, 2, 3, 4]),
+        );
+
+        let empty_challenge =
+            TranscriptEngineTrait::<HyperKZGEngine>::squeeze(&mut empty, b"challenge")
+                .expect("squeeze succeeds");
+        let first_absorbed_challenge =
+            TranscriptEngineTrait::<HyperKZGEngine>::squeeze(&mut absorbed, b"challenge")
+                .expect("squeeze succeeds");
+        let second_absorbed_challenge =
+            TranscriptEngineTrait::<HyperKZGEngine>::squeeze(&mut absorbed, b"challenge")
+                .expect("squeeze succeeds");
+
+        assert_ne!(empty_challenge, first_absorbed_challenge);
+        assert_ne!(first_absorbed_challenge, second_absorbed_challenge);
+    }
+
+    #[test]
+    fn nova_commitment_key_conversion_preserves_ck_points() {
+        let ck = vec![
+            halo2curves::bn256::G1Affine::generator(),
+            halo2curves::bn256::G1Affine::identity(),
+        ];
+        let setup = CommitmentKey::<HyperKZGEngine>::new(
+            ck.clone(),
+            halo2curves::bn256::G1Affine::generator(),
+            halo2curves::bn256::G2Affine::generator(),
+        );
+
+        let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&setup);
+
+        assert_eq!(
+            public_setup,
+            ck.iter()
+                .map(convert_g1_affine_from_halo2_to_ark)
+                .collect::<Vec<_>>()
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused HyperKZG Nova engine tests for the Keccak transcript engine adapter
- cover label/domain-separator no-op behavior, absorb/squeeze state changes, and Nova commitment-key to HyperKZG public setup conversion

## Duplicate check
Before taking this slice, I checked the current open/all PR list and #560 traffic for overlapping terms:
- `halo2 conversion OR halo2_conversions OR nova engine OR NovaEngine OR hyperkzg nova`
- Results only showed historical merged HyperKZG setup work (#674, #1008, #1010), with no active/open `nova_engine.rs` test coverage PR.

## Coverage evidence
Focused LCOV with `hyperkzg_proof` enabled reports `nova_engine.rs` as fully hit by these tests:
- `LF:69`
- `LH:69`

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features 'test,hyperkzg_proof' proof_primitive::hyperkzg::nova_engine::tests -- --nocapture`
- `cargo llvm-cov --package proof-of-sql --lib --no-default-features --features 'test,hyperkzg_proof' --lcov --output-path /tmp/sxt-proof-of-sql-nova-engine.lcov -- proof_primitive::hyperkzg::nova_engine::tests`
- `rustfmt --check crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_engine.rs`
- `git diff --check`
