### PR TITLE
Add FixedSizeBinary column support

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -7,9 +7,10 @@ use crate::base::{
 };
 use arrow::{
     array::{
-        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, FixedSizeBinaryArray,
+        Int16Array, Int32Array, Int64Array, Int8Array, LargeBinaryArray, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, TimeUnit as ArrowTimeUnit},
 };
@@ -305,6 +306,29 @@ impl ArrayRefExt for ArrayRef {
                     };
 
                     Ok(Column::VarBinary((vals, scals)))
+                } else {
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
+                }
+            }
+            DataType::FixedSizeBinary(size) if (1..=32).contains(size) => {
+                if let Some(array) = self.as_any().downcast_ref::<FixedSizeBinaryArray>() {
+                    let vals = alloc
+                        .alloc_slice_fill_with(range.end - range.start, |i| -> &'a [u8] {
+                            array.value(range.start + i)
+                        });
+
+                    let scals = if let Some(scals) = precomputed_scals {
+                        &scals[range.start..range.end]
+                    } else {
+                        alloc.alloc_slice_fill_with(vals.len(), |i| {
+                            S::from_fixed_size_byte_slice(vals[i])
+                                .expect("fixed-size binary width is supported")
+                        })
+                    };
+
+                    Ok(Column::FixedSizeBinary(*size, (vals, scals)))
                 } else {
                     Err(ArrowArrayToColumnConversionError::UnsupportedType {
                         datatype: self.data_type().clone(),
@@ -1032,6 +1056,60 @@ mod tests {
                 .to_column::<DoryScalar>(&alloc, &(0..2), None)
                 .unwrap(),
             Column::VarBinary((&data[..], &scals[..]))
+        );
+    }
+
+    #[test]
+    fn we_can_convert_valid_fixed_size_binary_array_refs_into_valid_columns() {
+        let alloc = Bump::new();
+        let data = vec![
+            b"abcdefghijklmnopqrst".as_slice(),
+            b"bcdefghijklmnopqrstu".as_slice(),
+        ];
+        let scals: Vec<_> = data
+            .iter()
+            .copied()
+            .map(|bytes| DoryScalar::from_fixed_size_byte_slice(bytes).unwrap())
+            .collect();
+        let array: ArrayRef = Arc::new(
+            FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                data.iter().copied().map(Some),
+                20,
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(0..2), None)
+                .unwrap(),
+            Column::FixedSizeBinary(20, (&data[..], &scals[..]))
+        );
+    }
+
+    #[test]
+    fn we_hash_fixed_size_binary_32_byte_array_refs() {
+        let alloc = Bump::new();
+        let data = vec![[42_u8; 32], [43_u8; 32]];
+        let data_refs: Vec<_> = data.iter().map(|bytes| bytes.as_ref()).collect();
+        let scals: Vec<_> = data_refs
+            .iter()
+            .copied()
+            .map(DoryScalar::from_byte_slice_via_hash)
+            .collect();
+        let array: ArrayRef = Arc::new(
+            FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                data_refs.iter().copied().map(Some),
+                32,
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(0..2), None)
+                .unwrap(),
+            Column::FixedSizeBinary(32, (data_refs.as_slice(), scals.as_slice()))
         );
     }
 

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -22,6 +22,7 @@ impl From<&ColumnType> for DataType {
             }
             ColumnType::VarChar => DataType::Utf8,
             ColumnType::VarBinary => DataType::LargeBinary,
+            ColumnType::FixedSizeBinary(size) => DataType::FixedSizeBinary(*size),
             ColumnType::Scalar => unimplemented!("Cannot convert Scalar type to arrow type"),
             ColumnType::TimestampTZ(timeunit, timezone) => {
                 let arrow_timezone = Some(Arc::from(timezone.to_string()));
@@ -67,6 +68,12 @@ impl TryFrom<DataType> for ColumnType {
             }
             DataType::Utf8 => Ok(ColumnType::VarChar),
             DataType::LargeBinary => Ok(ColumnType::VarBinary),
+            DataType::FixedSizeBinary(size) if (1..=32).contains(&size) => {
+                Ok(ColumnType::FixedSizeBinary(size))
+            }
+            DataType::FixedSizeBinary(size) => Err(format!(
+                "Unsupported FixedSizeBinary width {size}; supported widths are 1..=32"
+            )),
             _ => Err(format!("Unsupported arrow data type {data_type:?}")),
         }
     }
@@ -95,5 +102,20 @@ mod tests {
 
             prop_assert_eq!(actual, column_type);
         }
+    }
+
+    #[test]
+    fn we_can_convert_fixed_size_binary_column_type_to_arrow_and_back() {
+        let column_type = ColumnType::FixedSizeBinary(32);
+        let arrow = DataType::from(&column_type);
+
+        assert_eq!(arrow, DataType::FixedSizeBinary(32));
+        assert_eq!(ColumnType::try_from(arrow).unwrap(), column_type);
+    }
+
+    #[test]
+    fn we_reject_unsupported_fixed_size_binary_widths() {
+        assert!(ColumnType::try_from(DataType::FixedSizeBinary(0)).is_err());
+        assert!(ColumnType::try_from(DataType::FixedSizeBinary(33)).is_err());
     }
 }

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -23,9 +23,10 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Int16Array,
+        Int32Array, Int64Array, Int8Array, LargeBinaryArray, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
     error::ArrowError,
@@ -99,6 +100,13 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
             OwnedColumn::VarBinary(col) => Arc::new(LargeBinaryArray::from_iter_values(
                 col.iter().map(Vec::as_slice),
             )),
+            OwnedColumn::FixedSizeBinary(size, col) => Arc::new(
+                FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                    col.iter().map(|value| Some(value.as_slice())),
+                    size,
+                )
+                .unwrap(),
+            ),
             OwnedColumn::TimestampTZ(time_unit, _, col) => match time_unit {
                 PoSQLTimeUnit::Second => Arc::new(TimestampSecondArray::from(col)),
                 PoSQLTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(col)),
@@ -239,6 +247,18 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .map(|s| s.map(<[u8]>::to_vec).unwrap())
                     .collect(),
             )),
+            DataType::FixedSizeBinary(size) if (1..=32).contains(size) => {
+                Ok(Self::FixedSizeBinary(
+                    *size,
+                    value
+                        .as_any()
+                        .downcast_ref::<FixedSizeBinaryArray>()
+                        .unwrap()
+                        .iter()
+                        .map(|s| s.map(<[u8]>::to_vec).unwrap())
+                        .collect(),
+                ))
+            }
             DataType::Timestamp(time_unit, timezone) => match time_unit {
                 ArrowTimeUnit::Second => {
                     let array = value
@@ -325,5 +345,26 @@ impl<S: Scalar> TryFrom<RecordBatch> for OwnedTable<S> {
         } else {
             Err(OwnedArrowConversionError::DuplicateIdents)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_roundtrip_owned_fixed_size_binary_through_arrow() {
+        let column = OwnedColumn::<TestScalar>::FixedSizeBinary(
+            20,
+            vec![
+                b"abcdefghijklmnopqrst".to_vec(),
+                b"bcdefghijklmnopqrstu".to_vec(),
+            ],
+        );
+
+        let arrow = ArrayRef::from(column.clone());
+        assert_eq!(arrow.data_type(), &DataType::FixedSizeBinary(20));
+        assert_eq!(OwnedColumn::try_from(&arrow).unwrap(), column);
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -239,6 +239,7 @@ impl ColumnBounds {
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
             | CommittableColumn::VarBinary(_)
+            | CommittableColumn::FixedSizeBinary(_, _)
             | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
         }
     }

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -55,6 +55,7 @@ impl ColumnCommitmentMetadata {
                 ColumnType::Boolean
                 | ColumnType::VarChar
                 | ColumnType::VarBinary
+                | ColumnType::FixedSizeBinary(_)
                 | ColumnType::Scalar
                 | ColumnType::Decimal75(..),
                 ColumnBounds::NoOrder,

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -48,6 +48,8 @@ pub enum CommittableColumn<'a> {
     VarChar(Vec<[u64; 4]>),
     /// Column of limbs for committing to scalars, hashed from a `Binary` column.
     VarBinary(Vec<[u64; 4]>),
+    /// Column of limbs for committing to scalars, converted from a fixed-size binary column.
+    FixedSizeBinary(i32, Vec<[u64; 4]>),
     /// Borrowed Timestamp column with Timezone, mapped to `i64`.
     TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, &'a [i64]),
 }
@@ -66,7 +68,8 @@ impl CommittableColumn<'_> {
             CommittableColumn::Decimal75(_, _, col)
             | CommittableColumn::Scalar(col)
             | CommittableColumn::VarChar(col)
-            | CommittableColumn::VarBinary(col) => col.len(),
+            | CommittableColumn::VarBinary(col)
+            | CommittableColumn::FixedSizeBinary(_, col) => col.len(),
             CommittableColumn::Boolean(col) => col.len(),
         }
     }
@@ -99,6 +102,7 @@ impl<'a> From<&CommittableColumn<'a>> for ColumnType {
             CommittableColumn::Scalar(_) => ColumnType::Scalar,
             CommittableColumn::VarChar(_) => ColumnType::VarChar,
             CommittableColumn::VarBinary(_) => ColumnType::VarBinary,
+            CommittableColumn::FixedSizeBinary(size, _) => ColumnType::FixedSizeBinary(*size),
             CommittableColumn::Boolean(_) => ColumnType::Boolean,
             CommittableColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
         }
@@ -127,6 +131,10 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::VarBinary((_, scalars)) => {
                 let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
                 CommittableColumn::VarBinary(as_limbs)
+            }
+            Column::FixedSizeBinary(size, (_, scalars)) => {
+                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                CommittableColumn::FixedSizeBinary(*size, as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
         }
@@ -170,6 +178,17 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 bytes
                     .iter()
                     .map(|b| S::from_byte_slice_via_hash(b))
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+            OwnedColumn::FixedSizeBinary(size, bytes) => CommittableColumn::FixedSizeBinary(
+                *size,
+                bytes
+                    .iter()
+                    .map(|b| {
+                        S::from_fixed_size_byte_slice(b)
+                            .expect("fixed-size binary width is supported")
+                    })
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),
@@ -240,7 +259,8 @@ impl<'a, 'b> From<&'a CommittableColumn<'b>> for Sequence<'a> {
             CommittableColumn::Decimal75(_, _, limbs)
             | CommittableColumn::Scalar(limbs)
             | CommittableColumn::VarChar(limbs)
-            | CommittableColumn::VarBinary(limbs) => Sequence::from(limbs),
+            | CommittableColumn::VarBinary(limbs)
+            | CommittableColumn::FixedSizeBinary(_, limbs) => Sequence::from(limbs),
             CommittableColumn::Boolean(bools) => Sequence::from(*bools),
             CommittableColumn::TimestampTZ(_, _, times) => Sequence::from(*times),
         }

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -148,7 +148,8 @@ impl Commitment for NaiveCommitment {
                         scalar_vec.iter().map(core::convert::Into::into).collect()
                     }
                     CommittableColumn::VarChar(varchar_vec)
-                    | CommittableColumn::VarBinary(varchar_vec) => {
+                    | CommittableColumn::VarBinary(varchar_vec)
+                    | CommittableColumn::FixedSizeBinary(_, varchar_vec) => {
                         varchar_vec.iter().map(core::convert::Into::into).collect()
                     }
                     CommittableColumn::TimestampTZ(_, _, i64_vec) => {

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -47,6 +47,8 @@ pub enum Column<'a, S: Scalar> {
     Scalar(&'a [S]),
     /// Variable length binary columns
     VarBinary((&'a [&'a [u8]], &'a [S])),
+    /// Fixed length binary columns
+    FixedSizeBinary(i32, (&'a [&'a [u8]], &'a [S])),
 }
 
 impl<'a, S: Scalar> Column<'a, S> {
@@ -68,6 +70,7 @@ impl<'a, S: Scalar> Column<'a, S> {
                 ColumnType::TimestampTZ(*time_unit, *timezone)
             }
             Self::VarBinary(..) => ColumnType::VarBinary,
+            Self::FixedSizeBinary(size, ..) => ColumnType::FixedSizeBinary(*size),
         }
     }
     /// Returns the length of the column.
@@ -87,6 +90,10 @@ impl<'a, S: Scalar> Column<'a, S> {
                 col.len()
             }
             Self::VarBinary((col, scals)) => {
+                assert_eq!(col.len(), scals.len());
+                col.len()
+            }
+            Self::FixedSizeBinary(_, (col, scals)) => {
                 assert_eq!(col.len(), scals.len());
                 col.len()
             }
@@ -198,6 +205,23 @@ impl<'a, S: Scalar> Column<'a, S> {
                     alloc.alloc_slice_copy(scalars.as_slice()),
                 ))
             }
+            OwnedColumn::FixedSizeBinary(size, col) => {
+                let scalars = col
+                    .iter()
+                    .map(|b| {
+                        S::from_fixed_size_byte_slice(b)
+                            .expect("fixed-size binary width is supported")
+                    })
+                    .collect::<Vec<_>>();
+                let bytes = col.iter().map(|s| s as &'a [u8]).collect::<Vec<_>>();
+                Column::FixedSizeBinary(
+                    *size,
+                    (
+                        alloc.alloc_slice_clone(&bytes),
+                        alloc.alloc_slice_copy(scalars.as_slice()),
+                    ),
+                )
+            }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col.as_slice()),
         }
     }
@@ -290,6 +314,14 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
 
+    /// Returns the column as a slice of byte slices and scalars if it is a fixed-size binary column.
+    pub(crate) fn as_fixed_size_binary(&self) -> Option<(i32, &'a [&'a [u8]], &'a [S])> {
+        match self {
+            Self::FixedSizeBinary(size, (col, scals)) => Some((*size, col, scals)),
+            _ => None,
+        }
+    }
+
     /// Returns the column as a slice of i64 if it is a timestamp column. Otherwise, returns None.
     pub(crate) fn as_timestamptz(&self) -> Option<&'a [i64]> {
         match self {
@@ -311,7 +343,9 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::BigInt(col) | Self::TimestampTZ(_, _, col) => S::from(col[index]),
             Self::Int128(col) => S::from(col[index]),
             Self::Scalar(col) | Self::Decimal75(_, _, col) => col[index],
-            Self::VarChar((_, scals)) | Self::VarBinary((_, scals)) => scals[index],
+            Self::VarChar((_, scals))
+            | Self::VarBinary((_, scals))
+            | Self::FixedSizeBinary(_, (_, scals)) => scals[index],
         })
     }
 
@@ -323,6 +357,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::Decimal75(_, _, col) => slice_cast_with(col, |s| *s),
             Self::VarChar((_, values)) => slice_cast_with(values, |s| *s),
             Self::VarBinary((_, values)) => slice_cast_with(values, |s| *s),
+            Self::FixedSizeBinary(_, (_, values)) => slice_cast_with(values, |s| *s),
             Self::Uint8(col) => slice_cast_with(col, |i| S::from(i)),
             Self::TinyInt(col) => slice_cast_with(col, |i| S::from(i)),
             Self::SmallInt(col) => slice_cast_with(col, |i| S::from(i)),

--- a/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
@@ -44,6 +44,9 @@ pub trait ComparisonOp {
     /// Return an error if op is not implemented for string
     fn string_op(lhs: &[String], rhs: &[String]) -> ColumnOperationResult<Vec<bool>>;
 
+    /// Return an error if op is not implemented for binary data
+    fn bytes_op(lhs: &[Vec<u8>], rhs: &[Vec<u8>]) -> ColumnOperationResult<Vec<bool>>;
+
     #[expect(clippy::too_many_lines)]
     fn owned_column_element_wise_comparison<S: Scalar>(
         lhs: &OwnedColumn<S>,
@@ -265,6 +268,11 @@ pub trait ComparisonOp {
                 Ok(slice_binary_op(lhs, rhs, Self::op))
             }
             (OwnedColumn::VarChar(lhs), OwnedColumn::VarChar(rhs)) => Self::string_op(lhs, rhs),
+            (OwnedColumn::VarBinary(lhs), OwnedColumn::VarBinary(rhs)) => Self::bytes_op(lhs, rhs),
+            (
+                OwnedColumn::FixedSizeBinary(left_size, lhs),
+                OwnedColumn::FixedSizeBinary(right_size, rhs),
+            ) if left_size == right_size => Self::bytes_op(lhs, rhs),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: "ComparisonOp".to_string(),
                 left_type: lhs.column_type(),
@@ -311,6 +319,10 @@ impl ComparisonOp for EqualOp {
     }
 
     fn string_op(lhs: &[String], rhs: &[String]) -> ColumnOperationResult<Vec<bool>> {
+        Ok(lhs.iter().zip(rhs.iter()).map(|(l, r)| l == r).collect())
+    }
+
+    fn bytes_op(lhs: &[Vec<u8>], rhs: &[Vec<u8>]) -> ColumnOperationResult<Vec<bool>> {
         Ok(lhs.iter().zip(rhs.iter()).map(|(l, r)| l == r).collect())
     }
 }
@@ -363,6 +375,14 @@ impl ComparisonOp for GreaterThanOp {
             right_type: ColumnType::VarChar,
         })
     }
+
+    fn bytes_op(_lhs: &[Vec<u8>], _rhs: &[Vec<u8>]) -> ColumnOperationResult<Vec<bool>> {
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType {
+            operator: ">".to_string(),
+            left_type: ColumnType::VarBinary,
+            right_type: ColumnType::VarBinary,
+        })
+    }
 }
 
 pub struct LessThanOp {}
@@ -412,5 +432,53 @@ impl ComparisonOp for LessThanOp {
             left_type: ColumnType::VarChar,
             right_type: ColumnType::VarChar,
         })
+    }
+
+    fn bytes_op(_lhs: &[Vec<u8>], _rhs: &[Vec<u8>]) -> ColumnOperationResult<Vec<bool>> {
+        Err(ColumnOperationError::BinaryOperationInvalidColumnType {
+            operator: "<".to_string(),
+            left_type: ColumnType::VarBinary,
+            right_type: ColumnType::VarBinary,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_compare_fixed_size_binary_for_equality() {
+        let lhs = OwnedColumn::<TestScalar>::FixedSizeBinary(
+            20,
+            vec![
+                b"abcdefghijklmnopqrst".to_vec(),
+                b"bcdefghijklmnopqrstu".to_vec(),
+            ],
+        );
+        let rhs = OwnedColumn::<TestScalar>::FixedSizeBinary(
+            20,
+            vec![
+                b"abcdefghijklmnopqrst".to_vec(),
+                b"abcdefghijklmnopqrst".to_vec(),
+            ],
+        );
+
+        assert_eq!(
+            EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap(),
+            OwnedColumn::Boolean(vec![true, false])
+        );
+    }
+
+    #[test]
+    fn fixed_size_binary_ordering_comparisons_are_rejected() {
+        let lhs =
+            OwnedColumn::<TestScalar>::FixedSizeBinary(20, vec![b"abcdefghijklmnopqrst".to_vec()]);
+        let rhs =
+            OwnedColumn::<TestScalar>::FixedSizeBinary(20, vec![b"bcdefghijklmnopqrstu".to_vec()]);
+
+        assert!(GreaterThanOp::owned_column_element_wise_comparison(&lhs, &rhs).is_err());
+        assert!(LessThanOp::owned_column_element_wise_comparison(&lhs, &rhs).is_err());
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -103,6 +103,20 @@ where
                 alloc.alloc_slice_copy(&scalars) as &[_],
             )))
         }
+        ColumnType::FixedSizeBinary(size) => {
+            let (_, raw_values, raw_scalars) = column
+                .as_fixed_size_binary()
+                .expect("Column types should match");
+            let raw_values = apply_slice_to_indexes(raw_values, indexes)?;
+            let scalars = apply_slice_to_indexes(raw_scalars, indexes)?;
+            Ok(Column::FixedSizeBinary(
+                size,
+                (
+                    alloc.alloc_slice_clone(&raw_values) as &[_],
+                    alloc.alloc_slice_copy(&scalars) as &[_],
+                ),
+            ))
+        }
         ColumnType::TimestampTZ(tu, tz) => {
             let raw_values = apply_slice_to_indexes(
                 column.as_timestamptz().expect("Column types should match"),

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -119,6 +119,30 @@ pub trait RepetitionOp {
                     }) as &[_],
                 ))
             }
+            ColumnType::FixedSizeBinary(size) => {
+                let (_, raw_result, raw_scalars) = column
+                    .as_fixed_size_binary()
+                    .expect("Column types should match");
+
+                let mut result_iter = Self::op(raw_result, n);
+                let mut scalar_iter = Self::op(raw_scalars, n);
+
+                Column::FixedSizeBinary(
+                    size,
+                    (
+                        alloc.alloc_slice_fill_with(len, |_| {
+                            result_iter
+                                .next()
+                                .expect("Iterator should have enough elements")
+                        }) as &[_],
+                        alloc.alloc_slice_fill_with(len, |_| {
+                            scalar_iter
+                                .next()
+                                .expect("Iterator should have enough elements")
+                        }) as &[_],
+                    ),
+                )
+            }
             ColumnType::TimestampTZ(tu, tz) => {
                 let mut iter = Self::op(
                     column.as_timestamptz().expect("Column types should match"),

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -56,6 +56,10 @@ pub enum ColumnType {
     /// Mapped to [u8]
     #[serde(alias = "BINARY", alias = "BINARY")]
     VarBinary,
+    /// Mapped to fixed-width [u8]
+    #[serde(alias = "FIXED_SIZE_BINARY", alias = "fixed_size_binary")]
+    #[cfg_attr(test, proptest(skip))]
+    FixedSizeBinary(i32),
 }
 
 impl ColumnType {
@@ -187,7 +191,7 @@ impl ColumnType {
             // Scalars are not in database & are only used for typeless comparisons for testing so we return 0
             // so that they do not cause errors when used in comparisons.
             Self::Scalar => Some(0_u8),
-            Self::Boolean | Self::VarChar | Self::VarBinary => None,
+            Self::Boolean | Self::VarChar | Self::VarBinary | Self::FixedSizeBinary(_) => None,
         }
     }
     /// Returns scale of a [`ColumnType`] if it is convertible to a decimal wrapped in `Some()`. Otherwise return None.
@@ -202,7 +206,7 @@ impl ColumnType {
             | Self::BigInt
             | Self::Int128
             | Self::Scalar => Some(0),
-            Self::Boolean | Self::VarBinary | Self::VarChar => None,
+            Self::Boolean | Self::VarBinary | Self::FixedSizeBinary(_) | Self::VarChar => None,
             Self::TimestampTZ(tu, _) => match tu {
                 PoSQLTimeUnit::Second => Some(0),
                 PoSQLTimeUnit::Millisecond => Some(3),
@@ -223,9 +227,11 @@ impl ColumnType {
             Self::Int => size_of::<i32>(),
             Self::BigInt | Self::TimestampTZ(_, _) => size_of::<i64>(),
             Self::Int128 => size_of::<i128>(),
-            Self::Scalar | Self::Decimal75(_, _) | Self::VarBinary | Self::VarChar => {
-                size_of::<[u64; 4]>()
-            }
+            Self::Scalar
+            | Self::Decimal75(_, _)
+            | Self::VarBinary
+            | Self::FixedSizeBinary(_)
+            | Self::VarChar => size_of::<[u64; 4]>(),
         }
     }
 
@@ -249,6 +255,7 @@ impl ColumnType {
             Self::Decimal75(_, _)
             | Self::Scalar
             | Self::VarBinary
+            | Self::FixedSizeBinary(_)
             | Self::VarChar
             | Self::Boolean
             | Self::Uint8 => false,
@@ -289,6 +296,7 @@ impl Display for ColumnType {
             }
             ColumnType::VarChar => write!(f, "VARCHAR"),
             ColumnType::VarBinary => write!(f, "BINARY"),
+            ColumnType::FixedSizeBinary(size) => write!(f, "FIXED_SIZE_BINARY({size})"),
             ColumnType::Scalar => write!(f, "SCALAR"),
             ColumnType::TimestampTZ(timeunit, timezone) => {
                 write!(f, "TIMESTAMP(TIMEUNIT: {timeunit}, TIMEZONE: {timezone})")

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -275,6 +275,10 @@ pub fn try_equals_types(lhs: ColumnType, rhs: ColumnType) -> ColumnOperationResu
         (lhs, rhs),
         (ColumnType::VarChar, ColumnType::VarChar)
             | (ColumnType::VarBinary, ColumnType::VarBinary)
+            | (
+                ColumnType::FixedSizeBinary(_),
+                ColumnType::FixedSizeBinary(_)
+            )
             | (ColumnType::Boolean, ColumnType::Boolean)
             | (_, ColumnType::Scalar)
             | (ColumnType::Scalar, _)
@@ -349,6 +353,10 @@ pub fn try_equals_types_with_scaling(
         (lhs, rhs),
         (ColumnType::VarChar, ColumnType::VarChar)
             | (ColumnType::VarBinary, ColumnType::VarBinary)
+            | (
+                ColumnType::FixedSizeBinary(_),
+                ColumnType::FixedSizeBinary(_)
+            )
             | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
             | (ColumnType::Boolean, ColumnType::Boolean)
             | (_, ColumnType::Scalar)

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -69,6 +69,13 @@ pub fn filter_column_by_index<'a, S: Scalar>(
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
         )),
+        Column::FixedSizeBinary(size, (col, scals)) => Column::FixedSizeBinary(
+            *size,
+            (
+                alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+                alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
+            ),
+        ),
         Column::Scalar(col) => {
             Column::Scalar(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -170,7 +170,8 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         Column::VarChar(_)
         | Column::TimestampTZ(_, _, _)
         | Column::Boolean(_)
-        | Column::VarBinary(_) => {
+        | Column::VarBinary(_)
+        | Column::FixedSizeBinary(..) => {
             unreachable!("SUM can not be applied to non-numeric types")
         }
     }
@@ -203,8 +204,8 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
             max_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarBinary(_) => {
-            unreachable!("MAX can not be applied to varbinary")
+        Column::VarBinary(_) | Column::FixedSizeBinary(..) => {
+            unreachable!("MAX can not be applied to binary data")
         }
         // The following should never be reached because the `MAX` function can't be applied to varchar.
         Column::VarChar(_) => {
@@ -240,7 +241,9 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
             min_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarBinary(_) => unreachable!("MIN can not be applied to varbinary"),
+        Column::VarBinary(_) | Column::FixedSizeBinary(..) => {
+            unreachable!("MIN can not be applied to binary data")
+        }
         // The following should never be reached because the `MIN` function can't be applied to varchar.
         Column::VarChar(_) => {
             unreachable!("MIN can not be applied to varchar")

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -26,6 +26,7 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
             Column::Scalar(col) => col[i].cmp(&col[j]),
             Column::VarChar((col, _)) => col[i].cmp(col[j]),
             Column::VarBinary((col, _)) => col[i].cmp(col[j]),
+            Column::FixedSizeBinary(_, (col, _)) => col[i].cmp(col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)
@@ -86,6 +87,13 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
                 left_col[left_row_index].cmp(&right_col[right_row_index])
             }
             (Column::VarChar((left_col, _)), Column::VarChar((right_col, _))) => {
+                left_col[left_row_index].cmp(right_col[right_row_index])
+            }
+            (
+                Column::FixedSizeBinary(_, (left_col, _)),
+                Column::FixedSizeBinary(_, (right_col, _)),
+            )
+            | (Column::VarBinary((left_col, _)), Column::VarBinary((right_col, _))) => {
                 left_col[left_row_index].cmp(right_col[right_row_index])
             }
             // Should never happen since we checked the column types

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -51,6 +51,9 @@ pub enum OwnedColumn<S: Scalar> {
     Scalar(Vec<S>),
     /// Variable length binary columns
     VarBinary(Vec<Vec<u8>>),
+    /// Fixed length binary columns
+    #[cfg_attr(test, proptest(skip))]
+    FixedSizeBinary(i32, Vec<Vec<u8>>),
 }
 
 impl<S: Scalar> OwnedColumn<S> {
@@ -67,6 +70,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             OwnedColumn::VarChar(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::VarBinary(col) => inner_product_with_bytes(col, vec),
+            OwnedColumn::FixedSizeBinary(_, col) => inner_product_with_bytes(col, vec),
             OwnedColumn::Int128(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => {
                 inner_product_ref_cast(col, vec)
@@ -86,6 +90,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.len(),
             OwnedColumn::VarChar(col) => col.len(),
             OwnedColumn::VarBinary(col) => col.len(),
+            OwnedColumn::FixedSizeBinary(_, col) => col.len(),
             OwnedColumn::Int128(col) => col.len(),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col.len(),
         }
@@ -102,6 +107,9 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) => OwnedColumn::BigInt(permutation.try_apply(col)?),
             OwnedColumn::VarChar(col) => OwnedColumn::VarChar(permutation.try_apply(col)?),
             OwnedColumn::VarBinary(col) => OwnedColumn::VarBinary(permutation.try_apply(col)?),
+            OwnedColumn::FixedSizeBinary(size, col) => {
+                OwnedColumn::FixedSizeBinary(*size, permutation.try_apply(col)?)
+            }
             OwnedColumn::Int128(col) => OwnedColumn::Int128(permutation.try_apply(col)?),
             OwnedColumn::Decimal75(precision, scale, col) => {
                 OwnedColumn::Decimal75(*precision, *scale, permutation.try_apply(col)?)
@@ -125,6 +133,9 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) => OwnedColumn::BigInt(col[start..end].to_vec()),
             OwnedColumn::VarChar(col) => OwnedColumn::VarChar(col[start..end].to_vec()),
             OwnedColumn::VarBinary(col) => OwnedColumn::VarBinary(col[start..end].to_vec()),
+            OwnedColumn::FixedSizeBinary(size, col) => {
+                OwnedColumn::FixedSizeBinary(*size, col[start..end].to_vec())
+            }
             OwnedColumn::Int128(col) => OwnedColumn::Int128(col[start..end].to_vec()),
             OwnedColumn::Decimal75(precision, scale, col) => {
                 OwnedColumn::Decimal75(*precision, *scale, col[start..end].to_vec())
@@ -148,6 +159,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.is_empty(),
             OwnedColumn::VarChar(col) => col.is_empty(),
             OwnedColumn::VarBinary(col) => col.is_empty(),
+            OwnedColumn::FixedSizeBinary(_, col) => col.is_empty(),
             OwnedColumn::Int128(col) => col.is_empty(),
             OwnedColumn::Scalar(col) | OwnedColumn::Decimal75(_, _, col) => col.is_empty(),
         }
@@ -164,6 +176,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(_) => ColumnType::BigInt,
             OwnedColumn::VarChar(_) => ColumnType::VarChar,
             OwnedColumn::VarBinary(_) => ColumnType::VarBinary,
+            OwnedColumn::FixedSizeBinary(size, _) => ColumnType::FixedSizeBinary(*size),
             OwnedColumn::Int128(_) => ColumnType::Int128,
             OwnedColumn::Scalar(_) => ColumnType::Scalar,
             OwnedColumn::Decimal75(precision, scale, _) => {
@@ -254,10 +267,12 @@ impl<S: Scalar> OwnedColumn<S> {
                 Ok(OwnedColumn::TimestampTZ(tu, tz, raw_values))
             }
             // Can not convert scalars to VarChar
-            ColumnType::VarChar | ColumnType::VarBinary => Err(OwnedColumnError::TypeCastError {
-                from_type: ColumnType::Scalar,
-                to_type: ColumnType::VarChar,
-            }),
+            ColumnType::VarChar | ColumnType::VarBinary | ColumnType::FixedSizeBinary(_) => {
+                Err(OwnedColumnError::TypeCastError {
+                    from_type: ColumnType::Scalar,
+                    to_type: column_type,
+                })
+            }
         }
     }
 
@@ -373,6 +388,10 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for OwnedColumn<S> {
             Column::VarBinary((col, _)) => {
                 OwnedColumn::VarBinary(col.iter().map(|slice| slice.to_vec()).collect())
             }
+            Column::FixedSizeBinary(size, (col, _)) => OwnedColumn::FixedSizeBinary(
+                *size,
+                col.iter().map(|slice| slice.to_vec()).collect(),
+            ),
             Column::Int128(col) => OwnedColumn::Int128(col.to_vec()),
             Column::Decimal75(precision, scale, col) => {
                 OwnedColumn::Decimal75(*precision, *scale, col.to_vec())

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -126,6 +126,18 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
 
                 Column::VarBinary((col_as_slices, scals))
             }
+            OwnedColumn::FixedSizeBinary(size, col) => {
+                let col_as_slices: &mut [&[u8]] = self
+                    .alloc
+                    .alloc_slice_fill_iter(col.iter().map(Vec::as_slice));
+                let scals: &mut [CP::Scalar] =
+                    self.alloc.alloc_slice_fill_iter(col.iter().map(|b| {
+                        CP::Scalar::from_fixed_size_byte_slice(b.as_slice())
+                            .expect("fixed-size binary width is supported")
+                    }));
+
+                Column::FixedSizeBinary(*size, (col_as_slices, scals))
+            }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col),
         }
     }

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -183,6 +183,36 @@ pub fn column_union<'a, S: Scalar>(
                 }) as &[_],
             ))
         }
+        ColumnType::FixedSizeBinary(size) => {
+            let (nested_results, nested_scalars): (Vec<_>, Vec<_>) = columns
+                .iter()
+                .map(|col| {
+                    let (_, raw_values, scalars) = col
+                        .as_fixed_size_binary()
+                        .expect("Column types should match");
+                    (raw_values, scalars)
+                })
+                .unzip();
+
+            let mut result_iter = nested_results.into_iter().flatten().copied();
+            let mut scalar_iter = nested_scalars.into_iter().flatten().copied();
+
+            Column::FixedSizeBinary(
+                size,
+                (
+                    alloc.alloc_slice_fill_with(len, |_| {
+                        result_iter
+                            .next()
+                            .expect("Iterator should have enough elements")
+                    }) as &[_],
+                    alloc.alloc_slice_fill_with(len, |_| {
+                        scalar_iter
+                            .next()
+                            .expect("Iterator should have enough elements")
+                    }) as &[_],
+                ),
+            )
+        }
         ColumnType::TimestampTZ(tu, tz) => {
             let mut iter = columns
                 .iter()

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -102,6 +102,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
             Column::Uint8(c) => c.inner_product(evaluation_vec),
             Column::TinyInt(c) => c.inner_product(evaluation_vec),
@@ -118,6 +119,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => {
                 c.mul_add(res, multiplier);
             }
@@ -136,6 +138,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
             Column::Uint8(c) => c.to_sumcheck_term(num_vars),
             Column::TinyInt(c) => c.to_sumcheck_term(num_vars),
@@ -152,6 +155,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
             Column::Uint8(c) => MultilinearExtension::<S>::id(c),
             Column::TinyInt(c) => MultilinearExtension::<S>::id(c),

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -51,6 +51,25 @@ pub trait ScalarExt: Scalar {
         let masked_val = hashed_val & Self::CHALLENGE_MASK;
         Self::from_wrapping(masked_val)
     }
+
+    /// Converts a fixed-size byte slice to a Scalar.
+    ///
+    /// Fixed-size binary values up to 31 bytes are naturally embedded into the
+    /// scalar field. 32-byte values are hashed because they may exceed the
+    /// supported scalar range.
+    ///
+    /// Returns `None` if the input has more than 32 bytes.
+    #[must_use]
+    fn from_fixed_size_byte_slice(bytes: &[u8]) -> Option<Self> {
+        match bytes.len() {
+            0..=31 => {
+                let value = U256::from_le_slice(bytes)?;
+                Some(Self::from_wrapping(value))
+            }
+            32 => Some(Self::from_byte_slice_via_hash(bytes)),
+            _ => None,
+        }
+    }
 }
 
 impl<S: Scalar> ScalarExt for S {}
@@ -108,6 +127,34 @@ mod tests {
             scalar_from_bytes, scalar_from_ref,
             "The masked keccak v256 of 'abc' must match"
         );
+    }
+
+    #[test]
+    fn we_can_naturally_embed_fixed_size_binary_up_to_31_bytes() {
+        let bytes = [1_u8, 2, 3, 4, 5];
+        let scalar = TestScalar::from_fixed_size_byte_slice(&bytes).unwrap();
+
+        let expected_limbs = [0x0504_0302_01, 0, 0, 0];
+        let expected = TestScalar::from(expected_limbs);
+
+        assert_eq!(scalar, expected);
+    }
+
+    #[test]
+    fn fixed_size_binary_32_bytes_uses_hash_embedding() {
+        let bytes = [42_u8; 32];
+
+        assert_eq!(
+            TestScalar::from_fixed_size_byte_slice(&bytes).unwrap(),
+            TestScalar::from_byte_slice_via_hash(&bytes)
+        );
+    }
+
+    #[test]
+    fn fixed_size_binary_rejects_values_larger_than_32_bytes() {
+        let bytes = [0_u8; 33];
+
+        assert_eq!(TestScalar::from_fixed_size_byte_slice(&bytes), None);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -41,6 +41,7 @@ pub const fn min_as_f(column_type: ColumnType) -> F {
         | ColumnType::Scalar
         | ColumnType::VarChar
         | ColumnType::VarBinary
+        | ColumnType::FixedSizeBinary(_)
         | ColumnType::Boolean => MontFp!("0"),
     }
 }
@@ -133,7 +134,8 @@ fn copy_column_data_to_slice(
         CommittableColumn::Scalar(column)
         | CommittableColumn::Decimal75(_, _, column)
         | CommittableColumn::VarChar(column)
-        | CommittableColumn::VarBinary(column) => {
+        | CommittableColumn::VarBinary(column)
+        | CommittableColumn::FixedSizeBinary(_, column) => {
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -77,6 +77,9 @@ fn compute_dory_commitment(
         }
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::VarBinary(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::FixedSizeBinary(_, column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -83,6 +83,7 @@ fn compute_dory_commitment(
         CommittableColumn::Int128(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::VarChar(column)
         | CommittableColumn::VarBinary(column)
+        | CommittableColumn::FixedSizeBinary(_, column)
         | CommittableColumn::Decimal75(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -448,7 +448,8 @@ pub fn bit_table_and_scalars_for_packed_msm(
             CommittableColumn::Decimal75(_, _, column)
             | CommittableColumn::Scalar(column)
             | CommittableColumn::VarChar(column)
-            | CommittableColumn::VarBinary(column) => {
+            | CommittableColumn::VarBinary(column)
+            | CommittableColumn::FixedSizeBinary(_, column) => {
                 pack_bit(
                     column,
                     &mut packed_scalars,

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -156,7 +156,8 @@ fn compute_commitments_impl(
             CommittableColumn::Decimal75(_, _, vals)
             | CommittableColumn::Scalar(vals)
             | CommittableColumn::VarChar(vals)
-            | CommittableColumn::VarBinary(vals) => {
+            | CommittableColumn::VarBinary(vals)
+            | CommittableColumn::FixedSizeBinary(_, vals) => {
                 compute_commitment_generic_impl(setup, offset, vals)
             }
         })

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
@@ -94,7 +94,8 @@ mod tests {
                 CommittableColumn::Decimal75(_, _, vals)
                 | CommittableColumn::Scalar(vals)
                 | CommittableColumn::VarChar(vals)
-                | CommittableColumn::VarBinary(vals) => {
+                | CommittableColumn::VarBinary(vals)
+                | CommittableColumn::FixedSizeBinary(_, vals) => {
                     expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
                 }
             }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -124,6 +124,13 @@ impl ProvableQueryResult {
                         let x = S::from_byte_slice_via_hash(raw_bytes);
                         Ok((x, used))
                     }
+                    ColumnType::FixedSizeBinary(_) => {
+                        let (raw_bytes, used) =
+                            decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;
+                        let x = S::from_fixed_size_byte_slice(raw_bytes)
+                            .ok_or(QueryError::MiscellaneousEvaluationError)?;
+                        Ok((x, used))
+                    }
                     ColumnType::TimestampTZ(_, _) => {
                         decode_and_convert::<i64, S>(&self.data[offset..])
                     }
@@ -212,6 +219,15 @@ impl ProvableQueryResult {
                         let col_vec = decoded_slices.into_iter().map(<[u8]>::to_vec).collect();
 
                         Ok((field.name(), OwnedColumn::VarBinary(col_vec)))
+                    }
+                    ColumnType::FixedSizeBinary(size) => {
+                        let (decoded_slices, num_read) =
+                            decode_multiple_elements::<&[u8]>(&self.data[offset..], n)?;
+                        offset += num_read;
+
+                        let col_vec = decoded_slices.into_iter().map(<[u8]>::to_vec).collect();
+
+                        Ok((field.name(), OwnedColumn::FixedSizeBinary(size, col_vec)))
                     }
                     ColumnType::Scalar => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -41,6 +41,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) | Column::Scalar(col) => col.num_bytes(length),
             Column::VarChar((col, _)) => col.num_bytes(length),
             Column::VarBinary((col, _)) => col.num_bytes(length),
+            Column::FixedSizeBinary(_, (col, _)) => col.num_bytes(length),
         }
     }
 
@@ -56,6 +57,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) | Column::Scalar(col) => col.write(out, length),
             Column::VarChar((col, _)) => col.write(out, length),
             Column::VarBinary((col, _)) => col.write(out, length),
+            Column::FixedSizeBinary(_, (col, _)) => col.write(out, length),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -111,6 +111,12 @@ fn append_single_row_to_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedColum
         OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.push(0),
         OwnedColumn::VarChar(col) => col.push(String::new()),
         OwnedColumn::VarBinary(col) => col.push(vec![0u8]),
+        OwnedColumn::FixedSizeBinary(size, col) => {
+            col.push(vec![
+                0u8;
+                usize::try_from(*size).expect("width should be valid")
+            ]);
+        }
         OwnedColumn::Int128(col) => col.push(0),
         OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col.push(S::ZERO),
     }
@@ -148,6 +154,7 @@ pub fn tamper_first_row_of_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedCo
         }
         OwnedColumn::VarChar(col) => col[0].push('1'),
         OwnedColumn::VarBinary(col) => col[0].push(1u8),
+        OwnedColumn::FixedSizeBinary(_, col) => col[0][0] ^= 1u8,
         OwnedColumn::Int128(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col[0] += S::ONE,
     }


### PR DESCRIPTION
Closes #229.

## Summary
- Add `ColumnType::FixedSizeBinary(i32)` and preserve the fixed width through `Column`, `OwnedColumn`, `CommittableColumn`, Arrow conversion, serialization, indexing, filtering, union, repetition, ordering, commitments, and result decoding paths.
- Add scalar conversion for fixed-size binary values: <=31 bytes are naturally embedded, 32 bytes are hashed, and larger widths are rejected.
- Support equality comparisons for fixed-size binary columns while keeping ordering comparisons rejected.

## Tests
- `cargo fmt --all`
- `cargo check -p proof-of-sql --lib --no-default-features --features arrow,test`
- `cargo test -p proof-of-sql --no-default-features --features arrow,test fixed_size_binary`
- `cargo test -p proof-of-sql --no-default-features --features arrow,test base::arrow::`