### PR TITLE
test: cover standard binary serialization edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -28,6 +28,7 @@ pub fn try_standard_binary_deserialization<D: for<'a> Deserialize<'a>>(
 #[cfg(test)]
 mod tests {
     use super::{try_standard_binary_deserialization, try_standard_binary_serialization};
+    use bincode::error::DecodeError;
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -50,5 +51,30 @@ mod tests {
         assert_eq!(obj, deserialized);
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
+    }
+
+    #[test]
+    fn serialization_uses_fixed_width_big_endian_integers() {
+        let serialized = try_standard_binary_serialization(0x0102_0304_u32).unwrap();
+        assert_eq!(serialized, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn deserialization_reports_consumed_bytes_with_trailing_payload() {
+        let mut serialized = try_standard_binary_serialization(0x0102_0304_u32).unwrap();
+        serialized.extend_from_slice(&[0xaa, 0xbb]);
+
+        let (deserialized, consumed): (u32, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, 0x0102_0304);
+        assert_eq!(consumed, 4);
+        assert_eq!(&serialized[consumed..], &[0xaa, 0xbb]);
+    }
+
+    #[test]
+    fn deserialization_rejects_incomplete_fixed_width_integer() {
+        let err = try_standard_binary_deserialization::<u32>(&[1, 2, 3]).unwrap_err();
+        assert!(matches!(err, DecodeError::UnexpectedEnd { .. }));
     }
 }


### PR DESCRIPTION
/claim #560

## Summary

Adds focused unit coverage for standard binary serialization in `base::standard_serializations::binary`.

This is a small, non-overlapping test-only slice for the open coverage bounty. It documents and verifies the wire-format assumptions used by `standard_binary_config()`:

- fixed-width integer encoding is used;
- integer bytes are emitted in big-endian order;
- deserialization reports the number of bytes consumed when trailing payload remains;
- incomplete fixed-width payloads fail with `DecodeError::UnexpectedEnd`.

No production behavior changes.

## Validation

```bash
cargo fmt --all -- --check
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --features test --lib standard_serializations::binary -- --nocapture
git diff --check
```

Focused test result:

```text
running 4 tests
test base::standard_serializations::binary::tests::deserialization_rejects_incomplete_fixed_width_integer ... ok
test base::standard_serializations::binary::tests::deserialization_reports_consumed_bytes_with_trailing_payload ... ok
test base::standard_serializations::binary::tests::round_trip ... ok
test base::standard_serializations::binary::tests::serialization_uses_fixed_width_big_endian_integers ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1399 filtered out
```