### PR TITLE
test: cover no-blitzar literal and placeholder paths

### DIFF
--- a/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
@@ -472,6 +472,137 @@ mod test {
     use crate::base::scalar::test_scalar::TestScalar;
 
     #[test]
+    fn we_can_compare_decimal_columns_with_equal_and_reverse_extreme_scales() {
+        let same_scale_lhs = [2_i16, -3, 5]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let same_scale_rhs = [2_i16, 4, -5]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let same_scale_type = ColumnType::Decimal75(Precision::new(12).unwrap(), 2);
+
+        assert_eq!(
+            eq_decimal_columns(
+                &same_scale_lhs,
+                &same_scale_rhs,
+                same_scale_type,
+                same_scale_type
+            ),
+            vec![true, false, false]
+        );
+        assert_eq!(
+            le_decimal_columns(
+                &same_scale_lhs,
+                &same_scale_rhs,
+                same_scale_type,
+                same_scale_type
+            ),
+            vec![true, true, false]
+        );
+        assert_eq!(
+            ge_decimal_columns(
+                &same_scale_lhs,
+                &same_scale_rhs,
+                same_scale_type,
+                same_scale_type
+            ),
+            vec![true, false, true]
+        );
+
+        let fine_scale_lhs = [0_i16, 1, -1, 1]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let coarse_scale_rhs = [0_i64, 0, 0, 1]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let fine_scale_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 26);
+        let coarse_scale_type = ColumnType::Decimal75(Precision::new(40).unwrap(), -50);
+
+        assert_eq!(
+            eq_decimal_columns(
+                &fine_scale_lhs,
+                &coarse_scale_rhs,
+                fine_scale_type,
+                coarse_scale_type
+            ),
+            vec![true, false, false, false]
+        );
+        assert_eq!(
+            le_decimal_columns(
+                &fine_scale_lhs,
+                &coarse_scale_rhs,
+                fine_scale_type,
+                coarse_scale_type
+            ),
+            vec![true, false, true, true]
+        );
+        assert_eq!(
+            ge_decimal_columns(
+                &fine_scale_lhs,
+                &coarse_scale_rhs,
+                fine_scale_type,
+                coarse_scale_type
+            ),
+            vec![true, true, false, false]
+        );
+    }
+
+    #[test]
+    fn we_can_cover_reverse_upscale_decimal_arithmetic_and_division_errors() {
+        let lhs = [1_i16, 2]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let rhs = [3_i64, 4]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let left_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 3);
+        let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
+
+        assert_eq!(
+            try_add_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap(),
+            (
+                Precision::new(12).unwrap(),
+                3,
+                vec![TestScalar::from(31), TestScalar::from(42)]
+            )
+        );
+        assert_eq!(
+            try_subtract_decimal_columns(&lhs, &rhs, left_column_type, right_column_type).unwrap(),
+            (
+                Precision::new(12).unwrap(),
+                3,
+                vec![TestScalar::from(-29), TestScalar::from(-38)]
+            )
+        );
+
+        let divide_by_zero: ColumnOperationResult<(Precision, i8, Vec<TestScalar>)> =
+            try_divide_decimal_columns(&[1_i64], &[0_i64], ColumnType::BigInt, ColumnType::BigInt);
+        assert!(matches!(
+            divide_by_zero,
+            Err(ColumnOperationError::DivisionByZero)
+        ));
+
+        let left_column_type = ColumnType::Decimal75(Precision::new(75).unwrap(), 10);
+        let right_column_type = ColumnType::Decimal75(Precision::new(2).unwrap(), -50);
+        assert_eq!(
+            try_divide_decimal_columns::<TestScalar, _, _>(
+                &[TestScalar::from(123_456_i64)],
+                &[TestScalar::from(2_i64)],
+                left_column_type,
+                right_column_type
+            )
+            .unwrap(),
+            (Precision::new(28).unwrap(), 13, vec![TestScalar::from(0)])
+        );
+    }
+
+    #[test]
     fn we_can_eq_decimal_columns() {
         // lhs is integer and rhs is decimal with nonnegative scale
         let lhs = [1_i8, -2, 3];

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -1,7 +1,7 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
             Table, TableRef,
@@ -9,9 +9,7 @@ use crate::{
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
-        proof_plans::test_utility::*,
+        proof::VerifiableQueryResult, proof_exprs::test_utility::*, proof_plans::test_utility::*,
     },
 };
 use bumpalo::Bump;
@@ -41,7 +39,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -59,8 +57,8 @@ fn test_random_tables_with_given_offset(offset: usize) {
             ),
             const_bool(lit),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-        exercise_verification(&verifiable_res, &ast, &accessor, &t);
+        let verifiable_res =
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
             .unwrap()
@@ -102,14 +100,14 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
     let expected_res = data.clone();
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -122,14 +120,14 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
     let data = owned_table([bigint("a", [123_i64])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         cols_expr_plan(&t, &["a"], &accessor),
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(false),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -25,12 +25,12 @@ pub use dyn_proof_expr::DynProofExpr;
 
 mod literal_expr;
 pub(crate) use literal_expr::LiteralExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod literal_expr_test;
 
 mod placeholder_expr;
 pub(crate) use placeholder_expr::PlaceholderExpr;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod placeholder_expr_test;
 
 mod and_expr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
@@ -1,14 +1,14 @@
 use super::{DynProofExpr, PlaceholderExpr, ProofExpr};
 use crate::{
+    base::scalar::test_scalar::TestScalar,
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, LiteralValue,
             OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
         },
         proof::{PlaceholderError, ProofError},
     },
-    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{QueryError, VerifiableQueryResult},
         proof_exprs::test_utility::*,
@@ -52,7 +52,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
 
         // Create and verify proof
         let t = TableRef::new("sxt", "t");
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             t.clone(),
             data.clone(),
             offset,
@@ -78,7 +78,8 @@ fn test_random_tables_with_given_offset(offset: usize) {
         );
         let params = vec![random_bigint_literal, random_varchar_literal];
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &params).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &params)
+                .unwrap();
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &params)
             .unwrap()
@@ -118,13 +119,13 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
     let expected_res = owned_table([boolean("p1", [true])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+    let verifiable_res = VerifiableQueryResult::<NaiveEvaluationProof>::new(
         &ast,
         &accessor,
         &(),
@@ -144,13 +145,13 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
     let expected_res = owned_table([boolean("p1", [true; 0])]);
     let t = TableRef::new("sxt", "t");
     let accessor =
-        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+        OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(false),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+    let verifiable_res = VerifiableQueryResult::<NaiveEvaluationProof>::new(
         &ast,
         &accessor,
         &(),
@@ -167,8 +168,7 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
 #[test]
 fn we_can_compute_the_correct_output_of_a_placeholder_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
-    let data: Table<Curve25519Scalar> =
-        table([borrowed_bigint("a", [123_i64, 456, 789, 1011], &alloc)]);
+    let data: Table<TestScalar> = table([borrowed_bigint("a", [123_i64, 456, 789, 1011], &alloc)]);
     let placeholder_expr: DynProofExpr =
         DynProofExpr::try_new_placeholder(1, ColumnType::BigInt).unwrap();
     let res = placeholder_expr
@@ -181,16 +181,17 @@ fn we_can_compute_the_correct_output_of_a_placeholder_expr_using_first_round_eva
 #[test]
 fn we_cannot_prove_placeholder_expr_if_interpolate_fails() {
     let alloc = Bump::new();
-    let data: Table<Curve25519Scalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
+    let data: Table<TestScalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
     let t = TableRef::new("sxt", "t");
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let accessor =
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
     assert!(matches!(
-        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[],),
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&ast, &accessor, &(), &[],),
         Err(PlaceholderError::InvalidPlaceholderIndex { .. })
     ));
 }
@@ -198,15 +199,16 @@ fn we_cannot_prove_placeholder_expr_if_interpolate_fails() {
 #[test]
 fn we_cannot_verify_placeholder_expr_if_interpolate_fails() {
     let alloc = Bump::new();
-    let data: Table<Curve25519Scalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
+    let data: Table<TestScalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
     let t = TableRef::new("sxt", "t");
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let accessor =
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![aliased_placeholder(1, ColumnType::Boolean, "p1")],
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+    let verifiable_res = VerifiableQueryResult::<NaiveEvaluationProof>::new(
         &ast,
         &accessor,
         &(),
@@ -224,9 +226,10 @@ fn we_cannot_verify_placeholder_expr_if_interpolate_fails() {
 #[test]
 fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_same_valid_params() {
     let alloc = Bump::new();
-    let data: Table<Curve25519Scalar> = table([borrowed_bigint("a", [123_i64, 456], &alloc)]);
+    let data: Table<TestScalar> = table([borrowed_bigint("a", [123_i64, 456], &alloc)]);
     let t = TableRef::new("sxt", "t");
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let accessor =
+        TableTestAccessor::<NaiveEvaluationProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
         vec![
             col_expr_plan(&t, "a", &accessor),
@@ -236,20 +239,22 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
         table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
-        &ast,
-        &accessor,
-        &(),
-        &[
-            LiteralValue::BigInt(504_i64),
-            LiteralValue::VarChar("abc".to_string()),
-        ],
-    )
-    .unwrap();
+    let new_verifiable_res = || {
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(
+            &ast,
+            &accessor,
+            &(),
+            &[
+                LiteralValue::BigInt(504_i64),
+                LiteralValue::VarChar("abc".to_string()),
+            ],
+        )
+        .unwrap()
+    };
 
     // Try some wrong values
     assert!(matches!(
-        verifiable_res.clone().verify(
+        new_verifiable_res().verify(
             &ast,
             &accessor,
             &(),
@@ -262,7 +267,7 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
     ));
 
     assert!(matches!(
-        verifiable_res.clone().verify(
+        new_verifiable_res().verify(
             &ast,
             &accessor,
             &(),
@@ -275,7 +280,7 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
     ));
 
     assert!(matches!(
-        verifiable_res.clone().verify(
+        new_verifiable_res().verify(
             &ast,
             &accessor,
             &(),
@@ -288,7 +293,7 @@ fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_sa
     ));
 
     // Now try the correct values
-    let res = verifiable_res
+    let res = new_verifiable_res()
         .verify(
             &ast,
             &accessor,

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -80,31 +80,29 @@ impl ProverEvaluate for DemoMockPlan {
 mod tests {
     use super::DemoMockPlan;
     use crate::{
+        base::commitment::naive_evaluation_proof::NaiveEvaluationProof,
         base::database::{
             owned_table_utility::{bigint, owned_table},
             ColumnRef, ColumnType, OwnedTableTestAccessor, TableRef,
         },
         sql::proof::VerifiableQueryResult,
     };
-    #[cfg(feature = "blitzar")]
-    use blitzar::proof::InnerProductProof;
 
     #[test]
-    #[cfg(feature = "blitzar")]
     fn we_can_create_and_prove_a_demo_mock_plan() {
         let table_ref = "namespace.table_name".parse::<TableRef>().unwrap();
         let table = owned_table([bigint("column_name", [0, 1, 2, 3])]);
         let column_ref =
             ColumnRef::new(table_ref.clone(), "column_name".into(), ColumnType::BigInt);
         let plan = DemoMockPlan { column: column_ref };
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
             table_ref,
             table.clone(),
             0_usize,
             (),
         );
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+            VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .expect("verification should suceeed")


### PR DESCRIPTION
/claim #560

## Summary

- Enables the literal and placeholder proof-expression tests to run under the no-Blitzar test configuration by using `NaiveEvaluationProof`.
- Enables the demo mock plan test under the same no-Blitzar configuration.
- Adds focused decimal column-operation tests for same-scale comparison, reverse extreme-scale comparison, reverse upscale add/subtract, division by zero, and the negative applied-scale divide path.

## Coverage

Using `cargo llvm-cov -p proof-of-sql --no-default-features --features test --lib --lcov`, this covers 156 lines that were uncovered in the baseline:

- `crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs`: 33 newly covered lines
- `crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs`: 38 newly covered lines
- `crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs`: 41 newly covered lines
- `crates/proof-of-sql/src/base/database/slice_decimal_operation.rs`: 44 newly covered lines

At $0.10 per previously uncovered covered line, that is an estimated $15.60 claim.

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test literal_expr_test -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test placeholder_expr -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test demo_mock_plan -- --nocapture`
- `cargo test -p proof-of-sql --lib --no-default-features --features test slice_decimal_operation -- --nocapture`
- `LLVM_COV=$(xcrun -find llvm-cov) LLVM_PROFDATA=$(xcrun -find llvm-profdata) cargo llvm-cov -p proof-of-sql --no-default-features --features test --lib --lcov --output-path /tmp/sxt_after_final.lcov`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
