### PR TITLE
test: cover utility helper paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -153,3 +153,82 @@ pub fn tamper_first_row_of_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedCo
     }
     column
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    };
+
+    #[test]
+    fn we_can_tamper_each_owned_column_variant() {
+        type S = Curve25519Scalar;
+
+        let cases = [
+            (
+                OwnedColumn::<S>::Boolean(vec![false]),
+                OwnedColumn::<S>::Boolean(vec![true]),
+            ),
+            (
+                OwnedColumn::<S>::Uint8(vec![1]),
+                OwnedColumn::<S>::Uint8(vec![2]),
+            ),
+            (
+                OwnedColumn::<S>::TinyInt(vec![-1]),
+                OwnedColumn::<S>::TinyInt(vec![0]),
+            ),
+            (
+                OwnedColumn::<S>::SmallInt(vec![2]),
+                OwnedColumn::<S>::SmallInt(vec![3]),
+            ),
+            (
+                OwnedColumn::<S>::Int(vec![3]),
+                OwnedColumn::<S>::Int(vec![4]),
+            ),
+            (
+                OwnedColumn::<S>::BigInt(vec![4]),
+                OwnedColumn::<S>::BigInt(vec![5]),
+            ),
+            (
+                OwnedColumn::<S>::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), vec![5]),
+                OwnedColumn::<S>::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), vec![6]),
+            ),
+            (
+                OwnedColumn::<S>::VarChar(vec!["value".into()]),
+                OwnedColumn::<S>::VarChar(vec!["value1".into()]),
+            ),
+            (
+                OwnedColumn::<S>::VarBinary(vec![vec![7]]),
+                OwnedColumn::<S>::VarBinary(vec![vec![7, 1]]),
+            ),
+            (
+                OwnedColumn::<S>::Int128(vec![8]),
+                OwnedColumn::<S>::Int128(vec![9]),
+            ),
+            (
+                OwnedColumn::<S>::Decimal75(Precision::new(10).unwrap(), 2, vec![S::ZERO]),
+                OwnedColumn::<S>::Decimal75(Precision::new(10).unwrap(), 2, vec![S::ONE]),
+            ),
+            (
+                OwnedColumn::<S>::Scalar(vec![S::ZERO]),
+                OwnedColumn::<S>::Scalar(vec![S::ONE]),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(tamper_first_row_of_column(&input), expected);
+        }
+    }
+
+    #[test]
+    fn tampered_table_adds_a_row_to_empty_row_tables() {
+        type S = Curve25519Scalar;
+
+        let table = owned_table([bigint("count", [0_i64; 0])]);
+        let tampered = tampered_table::<S>(&table);
+
+        assert_eq!(tampered.num_rows(), 1);
+    }
+}

--- a/crates/proof-of-sql/utils/commitment-utility/main.rs
+++ b/crates/proof-of-sql/utils/commitment-utility/main.rs
@@ -67,9 +67,22 @@ type CommitUtilityResult<T, E = CommitUtilityError> = std::result::Result<T, E>;
 
 fn main() -> CommitUtilityResult<()> {
     let cli = Cli::parse();
+    run(&cli)
+}
 
+fn run(cli: &Cli) -> CommitUtilityResult<()> {
     // Read input data
-    let input_data = if let Some(input_file) = &cli.input {
+    let input_data = read_input(cli.input.as_ref())?;
+
+    // Deserialize commitment based on the scheme
+    let human_readable = deserialize_commitment(&input_data, &cli.scheme)?;
+
+    // Write output data
+    write_output(cli.output.as_ref(), &human_readable)
+}
+
+fn read_input(input: Option<&PathBuf>) -> CommitUtilityResult<Vec<u8>> {
+    if let Some(input_file) = input {
         let mut file = File::open(input_file).map_err(|_| CommitUtilityError::OpenInputFile {
             filename: input_file.clone(),
         })?;
@@ -78,37 +91,42 @@ fn main() -> CommitUtilityResult<()> {
             .map_err(|_| CommitUtilityError::ReadInputFile {
                 filename: input_file.clone(),
             })?;
-        buffer
+        Ok(buffer)
     } else {
         let mut buffer = Vec::new();
         io::stdin()
             .read_to_end(&mut buffer)
             .map_err(|_| CommitUtilityError::ReadStdin)?;
-        buffer
-    };
+        Ok(buffer)
+    }
+}
 
-    // Deserialize commitment based on the scheme
-    let human_readable = match cli.scheme {
+fn deserialize_commitment(
+    input_data: &[u8],
+    scheme: &CommitmentScheme,
+) -> CommitUtilityResult<String> {
+    match scheme {
         CommitmentScheme::DynamicDory => {
             let commitment: TableCommitment<DynamicDoryCommitment> =
-                postcard::from_bytes(&input_data)
+                postcard::from_bytes(input_data)
                     .map_err(|_| CommitUtilityError::DeserializationError)?;
-            format!("{commitment:#?}")
+            Ok(format!("{commitment:#?}"))
         }
         CommitmentScheme::Dory => {
-            let commitment: TableCommitment<DoryCommitment> = postcard::from_bytes(&input_data)
+            let commitment: TableCommitment<DoryCommitment> = postcard::from_bytes(input_data)
                 .map_err(|_| CommitUtilityError::DeserializationError)?;
-            format!("{commitment:#?}")
+            Ok(format!("{commitment:#?}"))
         }
         CommitmentScheme::Ipa => {
-            let commitment: TableCommitment<RistrettoPoint> = postcard::from_bytes(&input_data)
+            let commitment: TableCommitment<RistrettoPoint> = postcard::from_bytes(input_data)
                 .map_err(|_| CommitUtilityError::DeserializationError)?;
-            format!("{commitment:#?}")
+            Ok(format!("{commitment:#?}"))
         }
-    };
+    }
+}
 
-    // Write output data
-    match &cli.output {
+fn write_output(output: Option<&PathBuf>, human_readable: &str) -> CommitUtilityResult<()> {
+    match output {
         Some(output_file) => {
             let mut file =
                 File::create(output_file).map_err(|_| CommitUtilityError::CreateOutputFile {
@@ -128,4 +146,88 @@ fn main() -> CommitUtilityResult<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn serialized_empty_commitment<C>() -> Vec<u8>
+    where
+        C: proof_of_sql::base::commitment::Commitment,
+        TableCommitment<C>: serde::Serialize,
+    {
+        postcard::to_allocvec(&TableCommitment::<C>::default()).unwrap()
+    }
+
+    #[test]
+    fn we_can_render_dynamic_dory_commitment() {
+        let rendered = deserialize_commitment(
+            &serialized_empty_commitment::<DynamicDoryCommitment>(),
+            &CommitmentScheme::DynamicDory,
+        )
+        .unwrap();
+
+        assert!(rendered.contains("TableCommitment"));
+        assert!(rendered.contains("column_commitments"));
+    }
+
+    #[test]
+    fn we_can_render_dory_commitment() {
+        let rendered = deserialize_commitment(
+            &serialized_empty_commitment::<DoryCommitment>(),
+            &CommitmentScheme::Dory,
+        )
+        .unwrap();
+
+        assert!(rendered.contains("TableCommitment"));
+        assert!(rendered.contains("range"));
+    }
+
+    #[test]
+    fn we_can_render_ipa_commitment() {
+        let rendered = deserialize_commitment(
+            &serialized_empty_commitment::<RistrettoPoint>(),
+            &CommitmentScheme::Ipa,
+        )
+        .unwrap();
+
+        assert!(rendered.contains("TableCommitment"));
+        assert!(rendered.contains("range"));
+    }
+
+    #[test]
+    fn we_reject_invalid_commitment_bytes() {
+        let err = deserialize_commitment(&[0xff], &CommitmentScheme::DynamicDory).unwrap_err();
+
+        assert!(matches!(err, CommitUtilityError::DeserializationError));
+    }
+
+    #[test]
+    fn we_can_read_input_from_file() {
+        let dir = tempdir().unwrap();
+        let input_path = dir.path().join("input.bin");
+        std::fs::write(&input_path, [1_u8, 2, 3]).unwrap();
+
+        assert_eq!(read_input(Some(&input_path)).unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn we_report_missing_input_file() {
+        let missing = PathBuf::from("/no/such/commitment.bin");
+        let err = read_input(Some(&missing)).unwrap_err();
+
+        assert!(matches!(err, CommitUtilityError::OpenInputFile { .. }));
+    }
+
+    #[test]
+    fn we_can_write_output_to_file() {
+        let dir = tempdir().unwrap();
+        let output_path = dir.path().join("output.txt");
+
+        write_output(Some(&output_path), "commitment").unwrap();
+
+        assert_eq!(std::fs::read_to_string(output_path).unwrap(), "commitment");
+    }
 }


### PR DESCRIPTION
## Summary

- split the `commitment-utility` CLI flow into small helpers so input, deserialization, and output behavior can be exercised directly
- add coverage for Dynamic Dory, Dory, and IPA commitment rendering plus invalid bytes and file I/O error/success paths
- add focused coverage for `verifiable_query_result_test_utility` table/column tampering helpers across all `OwnedColumn` variants

/claim #560

## Coverage

The current Codecov tree for `main` reports these target files as still having missed lines:

- `crates/proof-of-sql/utils/commitment-utility/main.rs`: 44 missed lines
- `crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs`: 10 missed lines

This PR targets those uncovered utility/helper paths. Estimated bounty value: up to 54 lines x $0.10 = $5.40, with final accounting left to the maintainer coverage baseline.

Focused local LCOV for the commitment utility covered 85 executable lines in `commitment-utility/main.rs`.

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
- `DOCS_RS=1 cargo test -p proof-of-sql --no-default-features --features "std blitzar utils" --bin commitment-utility -- --nocapture`
- `DOCS_RS=1 cargo llvm-cov test -p proof-of-sql --no-default-features --features "std blitzar utils" --bin commitment-utility --lcov --output-path /private/tmp/commitment_utility.lcov -- --nocapture`
- `DOCS_RS=1 cargo check -p proof-of-sql --no-default-features --features "test blitzar" --lib`

Note: this local machine is macOS/arm64, while `blitzar-sys` ships Linux/x86_64 native symbols. I used `DOCS_RS=1` only to skip the unsupported local native Blitzar link while type-checking and running the pure utility tests; Linux CI should be authoritative for the normal Blitzar-linked test run.
