### PR TITLE
test: cover scalar wrapping conversions

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -133,10 +133,25 @@ mod tests {
         let two = TestScalar::TWO;
         let max = TestScalar::MAX_SIGNED;
         let min = max + one;
+        assert_eq!(zero.signed_cmp(&zero), Ordering::Equal);
         assert_eq!(max.signed_cmp(&one), Ordering::Greater);
         assert_eq!(one.signed_cmp(&zero), Ordering::Greater);
         assert_eq!(min.signed_cmp(&zero), Ordering::Less);
         assert_eq!((two * max).signed_cmp(&zero), Ordering::Less);
         assert_eq!(two * max + one, zero);
+    }
+
+    #[test]
+    fn wrapping_u256_conversion_preserves_limbs() {
+        let value = U256::from([
+            0x0123_4567_89ab_cdef,
+            0xfedc_ba98_7654_3210,
+            0x0f0f_f0f0_aaaa_5555,
+            0x0000_0000_0000_0000,
+        ]);
+
+        let scalar = TestScalar::from_wrapping(value);
+
+        assert_eq!(scalar.into_u256_wrapping(), value);
     }
 }


### PR DESCRIPTION
## Summary
- Adds focused coverage for `ScalarExt::signed_cmp` equality behavior.
- Adds a deterministic round-trip test for `ScalarExt::from_wrapping` / `into_u256_wrapping` preserving `U256` limbs.
- Keeps the slice limited to `crates/proof-of-sql/src/base/scalar/scalar_ext.rs` and does not overlap existing #560 claims for serialization, ref_into, column comparison, literal/placeholder/demo/slice decimal coverage.

Refs #560

/claim #560

## Test Plan
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --lib --no-default-features --features test scalar_ext -- --nocapture` -> 5 passed
- `git diff --check`

Note: `cargo fmt` / `rustfmt` is not available in this container (`rustfmt`/`rustup` missing), but the diff is minimal and whitespace check is clean.
