### PR TITLE
Make scalar string hashing explicit

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -279,7 +279,7 @@ impl ArrayRefExt for ArrayRef {
                     let scals = if let Some(scals) = precomputed_scals {
                         &scals[range.start..range.end]
                     } else {
-                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S { vals[i].into() })
+                        alloc.alloc_slice_fill_with(vals.len(), |i| S::from_str_via_hash(vals[i]))
                     };
 
                     Ok(Column::VarChar((vals, scals)))
@@ -430,7 +430,10 @@ mod tests {
         let array: ArrayRef = Arc::new(StringArray::from(vec!["hello", "world", "test"]));
         let result = array.to_column::<TestScalar>(&alloc, &(1..3), None);
         let expected_vals = vec!["world", "test"];
-        let expected_scals: Vec<TestScalar> = expected_vals.iter().map(|&v| v.into()).collect();
+        let expected_scals: Vec<TestScalar> = expected_vals
+            .iter()
+            .map(|&v| TestScalar::from_str_via_hash(v))
+            .collect();
 
         assert_eq!(
             result.unwrap(),

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -162,7 +162,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
             OwnedColumn::VarChar(strings) => CommittableColumn::VarChar(
                 strings
                     .iter()
-                    .map(Into::<S>::into)
+                    .map(|s| S::from_str_via_hash(s))
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),
@@ -479,8 +479,7 @@ mod tests {
 
         let bigint_committable_column = CommittableColumn::VarChar(
             ["12", "34", "56"]
-                .map(Into::<String>::into)
-                .map(Into::<TestScalar>::into)
+                .map(TestScalar::from_str_via_hash)
                 .map(Into::<[u64; 4]>::into)
                 .into(),
         );
@@ -663,7 +662,7 @@ mod tests {
         assert_eq!(from_borrowed_column, CommittableColumn::VarChar(Vec::new()));
 
         let varchar_data = ["12", "34", "56"];
-        let scalars = varchar_data.map(TestScalar::from);
+        let scalars = varchar_data.map(TestScalar::from_str_via_hash);
         let from_borrowed_column =
             CommittableColumn::from(&Column::VarChar((&varchar_data, &scalars)));
         assert_eq!(
@@ -807,7 +806,12 @@ mod tests {
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
-            CommittableColumn::VarChar(strings.map(TestScalar::from).map(<[u64; 4]>::from).into())
+            CommittableColumn::VarChar(
+                strings
+                    .map(|s| TestScalar::from_str_via_hash(&s))
+                    .map(<[u64; 4]>::from)
+                    .into()
+            )
         );
     }
 
@@ -1032,7 +1036,9 @@ mod tests {
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);
-        let scalars = values.map(TestScalar::from).map(<[u64; 4]>::from);
+        let scalars = values
+            .map(|s| TestScalar::from_str_via_hash(&s))
+            .map(<[u64; 4]>::from);
         let sequence_expected = Sequence::from(scalars.as_slice());
         let mut commitment_buffer = [CompressedRistretto::default(); 2];
         compute_curve25519_commitments(

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -139,7 +139,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, S::from(string)),
+                alloc.alloc_slice_fill_copy(length, S::from_str_via_hash(string)),
             )),
             LiteralValue::VarBinary(bytes) => {
                 // Convert the bytes to a slice of bytes references
@@ -177,7 +177,10 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
             OwnedColumn::VarChar(col) => {
-                let scalars = col.iter().map(S::from).collect::<Vec<_>>();
+                let scalars = col
+                    .iter()
+                    .map(|s| S::from_str_via_hash(s))
+                    .collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)
@@ -460,7 +463,10 @@ mod tests {
             "Spațiu și Timp",
             "Spazju u Ħin",
         ];
-        let scalars = strs.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strs
+            .iter()
+            .map(|s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let owned_col = OwnedColumn::VarChar(
             strs.iter()
                 .map(ToString::to_string)

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -81,7 +81,7 @@ impl LiteralValue {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar(str) => str.into(),
+            Self::VarChar(str) => S::from_str_via_hash(str),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
     map::IndexMap,
-    scalar::ScalarExt,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
@@ -108,7 +108,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
                 let scals: &mut [_] = self
                     .alloc
-                    .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
+                    .alloc_slice_fill_iter(col.iter().map(|s| CP::Scalar::from_str_via_hash(s)));
                 Column::VarChar((col, scals))
             }
             OwnedColumn::VarBinary(col) => {

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -288,7 +288,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
         })
         .collect();
     let alloc_strings = alloc.alloc_slice_clone(&strings);
-    let scalars: Vec<S> = strings.iter().map(|s| (*s).into()).collect();
+    let scalars: Vec<S> = strings.iter().map(|s| S::from_str_via_hash(s)).collect();
     let alloc_scalars = alloc.alloc_slice_copy(&scalars);
     (name.into(), Column::VarChar((alloc_strings, alloc_scalars)))
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,7 +1,6 @@
 #![expect(clippy::module_inception)]
 
 use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
-use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
@@ -13,7 +12,6 @@ pub trait Scalar:
     + core::fmt::Display
     + PartialEq
     + Default
-    + for<'a> From<&'a str>
     + Sync
     + Send
     + num_traits::One
@@ -52,9 +50,7 @@ pub trait Scalar:
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
-    + for<'a> core::convert::From<&'a String>
     + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>
@@ -85,4 +81,10 @@ pub trait Scalar:
     const MAX_BITS: u8;
     /// A U256 representation of the largest signed value in the field.
     const MAX_SIGNED_U256: U256;
+
+    /// Hashes a string into a scalar.
+    #[must_use]
+    fn from_str_via_hash(val: &str) -> Self {
+        <Self as crate::base::scalar::ScalarExt>::from_byte_slice_via_hash(val.as_bytes())
+    }
 }


### PR DESCRIPTION
/claim #228

Part of #228. This PR handles the string conversion slice:
- removes From<&str>, From<&String>, and From<String> super-bounds from Scalar
- adds Scalar::from_str_via_hash defaulting to the existing byte hash path
- updates generic VarChar and literal conversion paths to call the explicit method

I intentionally leave limb conversion and VarInt work untouched because those are separate slices already being handled in related PRs.

Validation:
- git diff --check
- GitHub Orca checks passed
- local cargo/rustfmt unavailable in this workspace because cargo is not installed, so CI is needed for full Rust validation