### PR TITLE
test: cover limb standard serialization

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,41 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    struct LimbSerdeTest {
+        #[serde(
+            deserialize_with = "deserialize_to_limbs",
+            serialize_with = "serialize_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn we_can_serialize_limbs_in_standard_order() {
+        let value = LimbSerdeTest {
+            limbs: [1, 2, 3, 4],
+        };
+
+        let serialized = serde_json::to_string(&value).unwrap();
+
+        assert_eq!(serialized, r#"{"limbs":[4,3,2,1]}"#);
+    }
+
+    #[test]
+    fn we_can_deserialize_limbs_from_standard_order() {
+        let deserialized: LimbSerdeTest = serde_json::from_str(r#"{"limbs":[4,3,2,1]}"#).unwrap();
+
+        assert_eq!(
+            deserialized,
+            LimbSerdeTest {
+                limbs: [1, 2, 3, 4]
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Refs #560.

The limb standard serialization helpers did not have focused test coverage. These helpers intentionally reverse limb order during serde serialization and deserialization, so tests should lock in that behavior.

## Solution

Added tests covering both directions:

- serializing internal limb order `[1, 2, 3, 4]` to standard order `[4, 3, 2, 1]`
- deserializing standard order `[4, 3, 2, 1]` back to internal order `[1, 2, 3, 4]`

## Testing

- `cargo fmt --check`
- `cargo test -p proof-of-sql --lib standard_serializations::limbs --no-default-features --features="std"`
- `cargo test -p proof-of-sql --lib --no-default-features --features="std"`