### PR TITLE
test: cover PoSQL time unit conversions

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -69,6 +69,31 @@ mod time_unit_tests {
     }
 
     #[test]
+    fn test_time_unit_into_u64_precision() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn test_time_unit_display_includes_precision() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
+
+    #[test]
     fn test_invalid_precision() {
         let invalid_precisions = [
             "1", "2", "4", "5", "7", "8", "10", "zero", "three", "cat", "-1", "-2",


### PR DESCRIPTION
/claim #560

## Summary
- Adds unit coverage for the `PoSQLTimeUnit` to-precision `u64` mapping.
- Adds unit coverage for the `Display` strings for every supported timestamp precision.
- Keeps the change test-only with no runtime behavior changes.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test time_unit_tests -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`