### PR TITLE
test: cover owned column errors

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,55 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn test_type_cast_error_display_includes_column_types() {
+        let error = OwnedColumnError::TypeCastError {
+            from_type: ColumnType::Int,
+            to_type: ColumnType::BigInt,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Can not perform type casting from Int to BigInt"
+        );
+    }
+
+    #[test]
+    fn test_scalar_conversion_error_display_includes_source_error() {
+        let error = OwnedColumnError::ScalarConversionError {
+            error: "invalid scalar".to_string(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Error in converting scalars to a given column type: invalid scalar"
+        );
+    }
+
+    #[test]
+    fn test_unsupported_error_display_includes_source_error() {
+        let error = OwnedColumnError::Unsupported {
+            error: "nested arrays".to_string(),
+        };
+
+        assert_eq!(error.to_string(), "Unsupported operation: nested arrays");
+    }
+
+    #[test]
+    fn test_column_coercion_error_display_messages() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds unit coverage for `OwnedColumnError` display messages.
- Adds unit coverage for `ColumnCoercionError` display messages.
- Keeps the change test-only with no runtime behavior changes.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test owned_column_error -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`