### PR TITLE
test: cover log helpers

### DIFF
--- a/crates/proof-of-sql/src/base/math/log.rs
+++ b/crates/proof-of-sql/src/base/math/log.rs
@@ -71,6 +71,40 @@ mod tests {
         assert_eq!(log2_up(4u32), 2);
     }
 
+    #[test]
+    fn test_is_pow2_for_unsigned_integers() {
+        for value in [1u64, 2, 4, 8, 16, 1024, 1 << 31] {
+            assert!(is_pow2(value), "{value} should be a power of two");
+        }
+        for value in [3u64, 5, 6, 7, 9, 1023, 1025] {
+            assert!(!is_pow2(value), "{value} should not be a power of two");
+        }
+    }
+
+    #[test]
+    fn test_is_pow2_bytes() {
+        assert!(is_pow2_bytes(&[0, 0, 0, 0]));
+        assert!(is_pow2_bytes(&[1, 0, 0, 0]));
+        assert!(is_pow2_bytes(&[0, 1, 0, 0]));
+        assert!(is_pow2_bytes(&[0, 0, 128, 0]));
+
+        assert!(!is_pow2_bytes(&[3, 0, 0, 0]));
+        assert!(!is_pow2_bytes(&[1, 1, 0, 0]));
+        assert!(!is_pow2_bytes(&[0, 128, 1, 0]));
+    }
+
+    #[test]
+    fn test_log2_bytes_floor() {
+        assert_eq!(log2_down_bytes(&[0, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[1, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[2, 0, 0, 0]), 1);
+        assert_eq!(log2_down_bytes(&[3, 0, 0, 0]), 1);
+        assert_eq!(log2_down_bytes(&[0, 1, 0, 0]), 8);
+        assert_eq!(log2_down_bytes(&[0, 255, 0, 0]), 15);
+        assert_eq!(log2_down_bytes(&[0, 0, 0, 128]), 31);
+        assert_eq!(log2_down_bytes(&[255, 255, 255, 255]), 31);
+    }
+
     #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     #[test]
     fn test_log2_bytes_ceil() {


### PR DESCRIPTION
/claim #560

## Summary
- Adds unit coverage for integer `is_pow2` helper behavior.
- Adds unit coverage for byte-array power-of-two checks.
- Adds unit coverage for byte-array floor log2 edge cases.
- Keeps the change test-only with no runtime behavior changes.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test base::math::log -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`