### PR TITLE
test: cover record batch errors

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -29,3 +29,50 @@ pub enum AppendRecordBatchTableCommitmentError {
         source: RecordBatchToColumnsError,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+    use arrow::datatypes::DataType;
+
+    #[test]
+    fn record_batch_to_columns_error_displays_arrow_conversion_source() {
+        let error = RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+            source: ArrowArrayToColumnConversionError::UnsupportedType {
+                datatype: DataType::Null,
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "unsupported type: attempted conversion from ArrayRef of type Null to OwnedColumn"
+        );
+    }
+
+    #[test]
+    fn append_record_batch_error_displays_arrow_batch_source() {
+        let error = AppendRecordBatchTableCommitmentError::ArrowBatchToColumnError {
+            source: RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                source: ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 3 },
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "index out of bounds: the len is 2 but the index is 3"
+        );
+    }
+
+    #[test]
+    fn append_record_batch_error_displays_commitment_mismatch_source() {
+        let error = AppendRecordBatchTableCommitmentError::ColumnCommitmentsMismatch {
+            source: ColumnCommitmentsMismatch::NumColumns,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "commitments with different column counts cannot operate with each other"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds focused tests for record batch error display behavior.
- Covers transparent Arrow conversion errors through RecordBatchToColumnsError.
- Covers AppendRecordBatchTableCommitmentError sources for Arrow batch conversion and commitment mismatches.

## Validation
- cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check
- cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test,arrow record_batch_to_columns_error -- --nocapture
- cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test,arrow append_record_batch_error -- --nocapture
- git diff --check
- bash scripts/check_commits.sh