### PR TITLE
test: cover bool varint encoding

### DIFF
--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -238,6 +238,13 @@ fn we_can_encode_and_decode_small_u64_values() {
 }
 
 #[test]
+fn we_can_encode_and_decode_bool_values() {
+    test_encode_decode(false, [0]);
+    test_encode_decode(true, [1]);
+    assert_eq!(bool::decode_var(&[2]), None);
+}
+
+#[test]
 fn we_can_encode_and_decode_large_u64_values() {
     test_encode_decode(
         u64::MAX,


### PR DESCRIPTION
/claim #560

## Summary
- Add bool varint encoding coverage for previously untested true/false slice paths.

## Coverage
This covers 13 previously uncovered lines, or approximately $1.30 at $0.10/line.

crates/proof-of-sql/src/base/encode/varint_trait.rs: 136, 137, 138, 140, 141, 143, 144, 145, 146, 148, 150, 151, 152

## Tests
- `cargo test --package proof-of-sql --lib bool_values --no-default-features --features test`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
