### PR TITLE
test: cover decimal conversion edges

### DIFF
--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -175,6 +175,30 @@ mod scale_adjust_test {
     use num_bigint::BigInt;
 
     #[test]
+    fn we_can_convert_decimal_errors_to_strings() {
+        let error = DecimalError::InvalidPrecision {
+            error: "0".to_string(),
+        };
+
+        let error_string: String = error.into();
+
+        assert_eq!(error_string, "Decimal precision is not valid: 0");
+    }
+
+    #[test]
+    fn we_can_try_precision_from_u64() {
+        assert_eq!(Precision::try_from(75_u64).unwrap().value(), 75);
+        assert!(matches!(
+            Precision::try_from(0_u64),
+            Err(DecimalError::InvalidPrecision { .. })
+        ));
+        assert!(matches!(
+            Precision::try_from(u64::from(u8::MAX) + 1),
+            Err(DecimalError::InvalidPrecision { .. })
+        ));
+    }
+
+    #[test]
     fn we_cannot_scale_past_max_precision() {
         let decimal = "12345678901234567890123456789012345678901234567890123456789012345678900.0"
             .parse()


### PR DESCRIPTION
/claim #560

## Summary
- Cover decimal error string conversion and u64 precision conversion edge paths.

## Coverage
This covers 11 previously uncovered lines, or approximately $1.10 at $0.10/line.

crates/proof-of-sql/src/base/math/decimal.rs: 84, 85, 86, 116, 117, 118, 119, 120, 121, 122, 124

## Tests
- `cargo test --package proof-of-sql --lib scale_adjust_test --no-default-features --features test`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
