### PR TITLE
test: cover union column variants

### DIFF
--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -245,7 +245,12 @@ pub fn table_union<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{map::IndexMap, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        map::IndexMap,
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn we_can_union_no_columns() {
@@ -278,6 +283,72 @@ mod tests {
         assert_eq!(
             result,
             Column::VarChar((&doubled_strings, &doubled_scalars))
+        );
+    }
+
+    #[test]
+    fn we_can_union_remaining_column_variants() {
+        let alloc = Bump::new();
+
+        let col0: Column<TestScalar> = Column::Uint8(&[1, 2]);
+        let col1: Column<TestScalar> = Column::Uint8(&[3, 4]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Uint8).unwrap();
+        assert_eq!(result, Column::Uint8(&[1, 2, 3, 4]));
+
+        let col0: Column<TestScalar> = Column::TinyInt(&[-1, 2]);
+        let col1: Column<TestScalar> = Column::TinyInt(&[3, -4]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::TinyInt).unwrap();
+        assert_eq!(result, Column::TinyInt(&[-1, 2, 3, -4]));
+
+        let col0: Column<TestScalar> = Column::Int128(&[-1, 2]);
+        let col1: Column<TestScalar> = Column::Int128(&[3, -4]);
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Int128).unwrap();
+        assert_eq!(result, Column::Int128(&[-1, 2, 3, -4]));
+
+        let scalar0 = [TestScalar::from(1_u64), TestScalar::from(2_u64)];
+        let scalar1 = [TestScalar::from(3_u64), TestScalar::from(4_u64)];
+        let col0 = Column::Scalar(scalar0.as_slice());
+        let col1 = Column::Scalar(scalar1.as_slice());
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::Scalar).unwrap();
+        let expected_scalars = [
+            TestScalar::from(1_u64),
+            TestScalar::from(2_u64),
+            TestScalar::from(3_u64),
+            TestScalar::from(4_u64),
+        ];
+        assert_eq!(result, Column::Scalar(expected_scalars.as_slice()));
+
+        let precision = Precision::new(6).unwrap();
+        let decimal0 = [TestScalar::from(123_u64), TestScalar::from(456_u64)];
+        let decimal1 = [TestScalar::from(789_u64), TestScalar::from(101_112_u64)];
+        let col0 = Column::Decimal75(precision, 2, decimal0.as_slice());
+        let col1 = Column::Decimal75(precision, 2, decimal1.as_slice());
+        let result =
+            column_union(&[&col0, &col1], &alloc, ColumnType::Decimal75(precision, 2)).unwrap();
+        let expected_decimals = [
+            TestScalar::from(123_u64),
+            TestScalar::from(456_u64),
+            TestScalar::from(789_u64),
+            TestScalar::from(101_112_u64),
+        ];
+        assert_eq!(
+            result,
+            Column::Decimal75(precision, 2, expected_decimals.as_slice())
+        );
+
+        let time_unit = PoSQLTimeUnit::Millisecond;
+        let time_zone = PoSQLTimeZone::new(3_600);
+        let col0: Column<TestScalar> = Column::TimestampTZ(time_unit, time_zone, &[10, 20]);
+        let col1: Column<TestScalar> = Column::TimestampTZ(time_unit, time_zone, &[30, 40]);
+        let result = column_union(
+            &[&col0, &col1],
+            &alloc,
+            ColumnType::TimestampTZ(time_unit, time_zone),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Column::TimestampTZ(time_unit, time_zone, &[10, 20, 30, 40])
         );
     }
 


### PR DESCRIPTION
/claim #560

## Summary
- Add union coverage for remaining column variants including Uint8, TinyInt, Int128, Scalar, Decimal75, and TimestampTZ.

## Coverage
This covers 48 previously uncovered lines, or approximately $4.80 at $0.10/line.

crates/proof-of-sql/src/base/database/union_util.rs: 57, 58, 59, 60, 62, 63, 64, 67, 68, 69, 70, 72, 73, 74, 107, 108, 109, 110, 112, 113, 114, 117, 118, 119, 120, 122, 123, 124, 126, 127, 128, 129, 130, 133, 134, 135, 136, 137, 186, 187, 188, 189, 190, 193, 194, 195, 196, 197

## Tests
- `cargo test --package proof-of-sql --lib union_util --no-default-features --features test`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
