### PR TITLE
test: cover analyze error conversions

### DIFF
--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,37 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_convert_analyze_errors_to_strings() {
+        let error = AnalyzeError::DataTypeMismatch {
+            left_type: "INT".to_string(),
+            right_type: "BOOLEAN".to_string(),
+        };
+
+        let error_string: String = error.into();
+
+        assert_eq!(
+            error_string,
+            "Left side has 'INT' type but right side has 'BOOLEAN' type"
+        );
+    }
+
+    #[test]
+    fn we_can_convert_intermediate_decimal_errors_to_analyze_errors() {
+        let error = AnalyzeError::from(IntermediateDecimalError::LossyCast);
+
+        assert!(matches!(
+            error,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::LossyCast
+                }
+            }
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Cover remaining AnalyzeError conversion/display paths.

## Coverage
This covers 8 previously uncovered lines, or approximately $0.80 at $0.10/line.

crates/proof-of-sql/src/sql/error.rs: 59, 60, 61, 65, 66, 67, 68, 69

## Tests
- `cargo test --package proof-of-sql --lib analyze_errors --no-default-features --features test`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
