### PR TITLE
test: cover arrow column type conversions

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -87,6 +87,29 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
+    #[test]
+    #[should_panic(expected = "Cannot convert Scalar type to arrow type")]
+    fn we_cannot_convert_scalar_column_type_to_arrow() {
+        let _ = DataType::from(&ColumnType::Scalar);
+    }
+
+    #[test]
+    fn we_can_roundtrip_timestamp_column_types() {
+        let time_zone = PoSQLTimeZone::new(3_600);
+        for time_unit in [
+            PoSQLTimeUnit::Second,
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeUnit::Microsecond,
+            PoSQLTimeUnit::Nanosecond,
+        ] {
+            let column_type = ColumnType::TimestampTZ(time_unit, time_zone);
+            let arrow = DataType::from(&column_type);
+            let actual = ColumnType::try_from(arrow).unwrap();
+
+            assert_eq!(actual, column_type);
+        }
+    }
+
     proptest! {
         #[test]
         fn we_can_roundtrip_arbitrary_column_type(column_type: ColumnType) {


### PR DESCRIPTION
/claim #560

## Summary
- Cover Arrow timestamp column type roundtrips and scalar conversion rejection.

## Coverage
This covers 12 previously uncovered lines, or approximately $1.20 at $0.10/line.

crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs: 25, 30, 31, 32, 56, 57, 58, 59, 60, 61, 64, 65

## Tests
- `cargo test --package proof-of-sql --lib we_can_roundtrip_timestamp_column_types --no-default-features --features test,arrow`
- `cargo test --package proof-of-sql --lib we_cannot_convert_scalar_column_type_to_arrow --no-default-features --features test,arrow`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
