### PR TITLE
test: cover borrowed uint8 helper

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -363,3 +363,19 @@ pub fn borrowed_timestamptz<S: Scalar>(
         Column::TimestampTZ(time_unit, timezone, alloc_data),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_create_borrowed_uint8_columns() {
+        let alloc = Bump::new();
+
+        let (name, column) = borrowed_uint8::<TestScalar>("byte_col", [1_u8, 2, 3], &alloc);
+
+        assert_eq!(name, Ident::new("byte_col"));
+        assert_eq!(column, Column::Uint8(&[1, 2, 3]));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Cover the borrowed Uint8 table helper constructor path.

## Coverage
This covers 9 previously uncovered lines, or approximately $0.90 at $0.10/line.

crates/proof-of-sql/src/base/database/table_utility.rs: 86, 87, 88, 89, 90, 91, 92, 93, 94

## Tests
- `cargo test --package proof-of-sql --lib we_can_create_borrowed_uint8_columns --no-default-features --features test`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
