### PR TITLE
test: cover column type integer helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -645,6 +645,75 @@ mod tests {
     }
 
     #[test]
+    fn we_can_get_max_integer_types() {
+        assert_eq!(
+            ColumnType::Uint8.max_integer_type(&ColumnType::TinyInt),
+            Some(ColumnType::TinyInt)
+        );
+        assert_eq!(
+            ColumnType::SmallInt.max_integer_type(&ColumnType::TinyInt),
+            Some(ColumnType::SmallInt)
+        );
+        assert_eq!(
+            ColumnType::Int.max_integer_type(&ColumnType::SmallInt),
+            Some(ColumnType::Int)
+        );
+        assert_eq!(
+            ColumnType::BigInt.max_integer_type(&ColumnType::Int),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::Int128.max_integer_type(&ColumnType::BigInt),
+            Some(ColumnType::Int128)
+        );
+        assert_eq!(
+            ColumnType::Boolean.max_integer_type(&ColumnType::BigInt),
+            None
+        );
+    }
+
+    #[test]
+    fn we_can_get_max_unsigned_integer_types() {
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::Uint8),
+            Some(ColumnType::Uint8)
+        );
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::SmallInt),
+            None
+        );
+        assert_eq!(
+            ColumnType::VarChar.max_unsigned_integer_type(&ColumnType::Uint8),
+            None
+        );
+    }
+
+    #[test]
+    fn we_can_get_scalar_and_non_numeric_precision_values() {
+        assert_eq!(ColumnType::Scalar.precision_value(), Some(0));
+        assert_eq!(ColumnType::Boolean.precision_value(), None);
+        assert_eq!(ColumnType::VarChar.precision_value(), None);
+        assert_eq!(ColumnType::VarBinary.precision_value(), None);
+    }
+
+    #[test]
+    fn we_can_get_timestamp_scales() {
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc()).scale(),
+            Some(9)
+        );
+    }
+
+    #[test]
+    fn we_can_display_decimal_and_timestamp_column_types() {
+        assert_eq!(ColumnType::Int128.to_string(), "DECIMAL");
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).to_string(),
+            "TIMESTAMP(TIMEUNIT: seconds (precision: 0), TIMEZONE: +00:00)"
+        );
+    }
+
+    #[test]
     fn we_can_get_sqrt_negative_min() {
         for column_type in [
             ColumnType::TinyInt,


### PR DESCRIPTION
/claim #560

## Summary
- Cover integer helper ordering, unsigned integer helper ordering, precision values, timestamp scale, and display paths.

## Coverage
This covers 46 previously uncovered lines, or approximately $4.60 at $0.10/line.

crates/proof-of-sql/src/base/database/column_type.rs: 110, 111, 112, 113, 114, 115, 116, 119, 124, 125, 126, 127, 128, 129, 130, 133, 138, 139, 140, 141, 143, 149, 151, 152, 153, 154, 155, 156, 157, 158, 159, 165, 167, 168, 169, 170, 171, 172, 173, 174, 175, 189, 190, 282, 293, 294

## Tests
- `cargo test --package proof-of-sql --lib column_type::tests::we_can --no-default-features --features test`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
