### PR TITLE
test: cover invalid sumcheck proof size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
@@ -7,7 +7,7 @@ use super::test_cases::sumcheck_test_cases;
 use crate::{
     base::{
         polynomial::CompositePolynomial,
-        proof::Transcript as _,
+        proof::{ProofError, Transcript as _},
         scalar::{test_scalar::TestScalar, MontScalar, Scalar},
     },
     proof_primitive::{
@@ -234,6 +234,22 @@ fn we_can_verify_many_random_test_cases() {
             "verification should fail when the proof is modified"
         );
     }
+}
+
+#[test]
+fn we_cannot_verify_sumcheck_proof_with_invalid_size() {
+    let proof = SumcheckProof {
+        coefficients: vec![TestScalar::ONE],
+    };
+    let mut transcript = Transcript::new(b"sumchecktest");
+    let actual = proof.verify_without_evaluation(&mut transcript, 2, &TestScalar::ONE);
+
+    assert!(matches!(
+        actual,
+        Err(ProofError::VerificationError {
+            error: "invalid proof size"
+        })
+    ));
 }
 
 #[test]


### PR DESCRIPTION
/claim #560

## Summary
- Add a focused test for invalid sumcheck proof sizes.
- Verify that `verify_without_evaluation` rejects coefficient lengths that are not a multiple of the variable count.

## Coverage
This covers previously uncovered lines in `crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs`:

73, 74, 75

That is 3 previously uncovered lines, or approximately $0.30 at $0.10/line.

## Tests
- `cargo test --package proof-of-sql --lib we_cannot_verify_sumcheck_proof_with_invalid_size --no-default-features --features test`
- `cargo fmt --check`
- `git diff --check`
- `cargo llvm-cov --no-report --package proof-of-sql --lib --no-default-features --features test -- we_cannot_verify_sumcheck_proof_with_invalid_size`
- `cargo llvm-cov report --lcov --output-path /tmp/sxt-sumcheck-proof-size-lcov.info --ignore-filename-regex evm_tests`
- `bash scripts/check_commits.sh`
