### PR TITLE
perf: cache dory commitment test setup

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -1,30 +1,27 @@
+use super::test_setup::test_dory_setup;
 use crate::{
     base::{
         commitment::CommittableColumn,
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
-    proof_primitive::dory::{
-        compute_dory_commitments, DoryProverPublicSetup, ProverSetup, PublicParameters, F, GT,
-    },
+    proof_primitive::dory::{compute_dory_commitments, DoryProverPublicSetup, F, GT},
 };
 use ark_ec::pairing::Pairing;
-use ark_std::test_rng;
 use num_traits::Zero;
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_varbinary_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
 
     let data = [[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]];
     let col = CommittableColumn::VarBinary(data.to_vec());
 
     let res = compute_dory_commitments(&[col], 0, &setup);
 
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(1u64)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(2u64)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(3u64);
@@ -34,12 +31,11 @@ fn we_can_compute_a_dory_commitment_with_varbinary_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_int128_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::Int128(&[0, -1, 2])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0_i128)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(-1_i128)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2_i128);
@@ -48,16 +44,15 @@ fn we_can_compute_a_dory_commitment_with_int128_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_boolean_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::Boolean(&[true, false, true])],
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(true)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(false)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(true);
@@ -66,12 +61,11 @@ fn we_can_compute_a_dory_commitment_with_boolean_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2);
@@ -80,12 +74,11 @@ fn we_can_compute_a_dory_commitment_with_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -95,12 +88,11 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[2, 3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(3);
     assert_eq!(res[0].0, expected);
@@ -108,12 +100,11 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with_signed_data() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(-3);
     assert_eq!(res[0].0, expected);
@@ -121,16 +112,15 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -146,9 +136,8 @@ fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -156,8 +145,8 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -182,12 +171,11 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1])], 5, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -195,16 +183,15 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -220,9 +207,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns()
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -230,8 +216,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -256,9 +242,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
 
 #[test]
 fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[
@@ -274,8 +259,8 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -342,9 +327,8 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
 
 #[test]
 fn we_can_compute_an_empty_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (_, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
     assert_eq!(res[0].0, GT::zero());
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 5, &setup);
@@ -385,12 +369,11 @@ fn we_can_compute_an_empty_dory_commitment() {
 
 #[test]
 fn test_compute_dory_commitment_when_sigma_is_zero() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 0);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(2)
@@ -401,12 +384,11 @@ fn test_compute_dory_commitment_when_sigma_is_zero() {
 
 #[test]
 fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 0);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 5, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[5]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[6]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[7]) * F::from(2)
@@ -417,9 +399,8 @@ fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[0, 1]),
@@ -444,8 +425,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -494,9 +475,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_fewer_rows_than_columns(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[0, 1]),
@@ -521,8 +501,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
         2,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -570,9 +550,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[-2, -1, 0, 1, 2]),
@@ -597,8 +576,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(0)
@@ -659,9 +638,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let setup = DoryProverPublicSetup::new(prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[-2, -1, 0, 1, 2]),
@@ -686,8 +664,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
         4,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[1]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(0)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
@@ -1,38 +1,35 @@
+use super::test_setup::test_dory_setup;
 use crate::{
     base::{
         commitment::CommittableColumn,
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
-    proof_primitive::dory::{
-        compute_dynamic_dory_commitments, test_rng, ProverSetup, PublicParameters, F, GT,
-    },
+    proof_primitive::dory::{compute_dynamic_dory_commitments, F, GT},
 };
 use ark_ec::pairing::Pairing;
 use num_traits::Zero;
 
 #[test]
 fn we_can_handle_calling_with_an_empty_committable_column() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
-    let res = compute_dynamic_dory_commitments(&[], 0, &setup);
+    let (_, prover_setup) = test_dory_setup();
+    let res = compute_dynamic_dory_commitments(&[], 0, prover_setup);
 
     assert!(res.is_empty());
 }
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, prover_setup) = test_dory_setup();
     let res = compute_dynamic_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ])],
         0,
-        &setup,
+        prover_setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(2)
@@ -57,17 +54,16 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, prover_setup) = test_dory_setup();
     let res = compute_dynamic_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ])],
         5,
-        &setup,
+        prover_setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[3]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[3]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[3]) * F::from(2)
@@ -92,11 +88,11 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_o
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_signed_bigint_values_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
-    let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let (public_parameters, prover_setup) = test_dory_setup();
+    let res =
+        compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, prover_setup);
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[2]) * F::from(-3);
     assert_eq!(res[0].0, expected);
@@ -104,8 +100,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_signed_bigint_values_and_an_off
 
 #[test]
 fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, prover_setup) = test_dory_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::BigInt(&[
@@ -119,10 +114,10 @@ fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset
             ]),
         ],
         5,
-        &setup,
+        prover_setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[3]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[3]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[3]) * F::from(2)
@@ -189,13 +184,15 @@ fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset
 
 #[test]
 fn we_can_compute_an_empty_dynamic_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
-    let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
+    let (_, prover_setup) = test_dory_setup();
+    let res =
+        compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, prover_setup);
     assert_eq!(res[0].0, GT::zero());
-    let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 5, &setup);
+    let res =
+        compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 5, prover_setup);
     assert_eq!(res[0].0, GT::zero());
-    let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 20, &setup);
+    let res =
+        compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 20, prover_setup);
     assert_eq!(res[0].0, GT::zero());
     let res = compute_dynamic_dory_commitments(
         &[
@@ -203,7 +200,7 @@ fn we_can_compute_an_empty_dynamic_dory_commitment() {
             CommittableColumn::BigInt(&[0; 0]),
         ],
         0,
-        &setup,
+        prover_setup,
     );
     assert_eq!(res[0].0, GT::zero());
     assert_eq!(res[1].0, GT::zero());
@@ -213,7 +210,7 @@ fn we_can_compute_an_empty_dynamic_dory_commitment() {
             CommittableColumn::BigInt(&[0; 0]),
         ],
         5,
-        &setup,
+        prover_setup,
     );
     assert_eq!(res[0].0, GT::zero());
     assert_eq!(res[1].0, GT::zero());
@@ -223,7 +220,7 @@ fn we_can_compute_an_empty_dynamic_dory_commitment() {
             CommittableColumn::BigInt(&[0; 0]),
         ],
         20,
-        &setup,
+        prover_setup,
     );
     assert_eq!(res[0].0, GT::zero());
     assert_eq!(res[1].0, GT::zero());
@@ -231,8 +228,7 @@ fn we_can_compute_an_empty_dynamic_dory_commitment() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, prover_setup) = test_dory_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[0, 1]),
@@ -255,10 +251,10 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
             ),
         ],
         0,
-        &setup,
+        prover_setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -306,8 +302,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, prover_setup) = test_dory_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[0, 1]),
@@ -330,10 +325,10 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
             ),
         ],
         2,
-        &setup,
+        prover_setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[2]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -381,8 +376,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, prover_setup) = test_dory_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[-2, -1, 0, 1, 2]),
@@ -405,10 +399,10 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
             ),
         ],
         0,
-        &setup,
+        prover_setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(-1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(0)
@@ -469,8 +463,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let (public_parameters, prover_setup) = test_dory_setup();
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[-2, -1, 0, 1, 2]),
@@ -493,10 +486,10 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
             ),
         ],
         4,
-        &setup,
+        prover_setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[3]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[3]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[3]) * F::from(0)

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -39,6 +39,8 @@ mod setup;
 pub use setup::{ProverSetup, VerifierSetup};
 #[cfg(test)]
 mod setup_test;
+#[cfg(test)]
+mod test_setup;
 
 mod state;
 pub(crate) use state::{ProverState, VerifierState};

--- a/crates/proof-of-sql/src/proof_primitive/dory/test_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/test_setup.rs
@@ -1,0 +1,19 @@
+use super::{test_rng, ProverSetup, PublicParameters};
+use std::cell::OnceCell;
+
+thread_local! {
+    static TEST_DORY_SETUP: OnceCell<(&'static PublicParameters, &'static ProverSetup<'static>)> =
+        const { OnceCell::new() };
+}
+
+pub(crate) fn test_dory_setup() -> (&'static PublicParameters, &'static ProverSetup<'static>) {
+    TEST_DORY_SETUP.with(|setup| {
+        *setup.get_or_init(|| {
+            let public_parameters =
+                Box::leak(Box::new(PublicParameters::test_rand(5, &mut test_rng())));
+            let prover_setup = Box::leak(Box::new(ProverSetup::from(&*public_parameters)));
+
+            (public_parameters, prover_setup)
+        })
+    })
+}


### PR DESCRIPTION
Refs #557

Problem
- The Dory commitment computation tests rebuild random public parameters and prover setup in every test case.
- That repeated setup work adds avoidable runtime to the test suite targeted by the performance bounty.

Root cause
- Each static and dynamic Dory commitment test constructs equivalent test setup independently before exercising the commitment logic.

Solution
- Add a test-only thread-local Dory setup helper.
- Reuse the cached public parameters and prover setup across Dory commitment computation tests while keeping each assertion unchanged.
- Keep the cache thread-local so feature-gated setup internals do not need to be shared across test threads.

Testing
- cargo fmt --check
- cargo test -p proof-of-sql --lib dory_compute_commitments_test --no-default-features --features="std"