### PR TITLE
test: cover scaling cast evaluator paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -81,5 +81,7 @@ mod cast_expr_test;
 
 mod scaling_cast_expr;
 pub(crate) use scaling_cast_expr::ScalingCastExpr;
+#[cfg(test)]
+mod scaling_cast_expr_eval_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod scaling_cast_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_eval_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_eval_test.rs
@@ -1,0 +1,86 @@
+use super::{DynProofExpr, ProofExpr, ScalingCastExpr};
+use crate::{
+    base::{
+        database::{Column, ColumnType, LiteralValue, Table, TableOptions},
+        map::{indexmap, IndexMap},
+        math::decimal::Precision,
+        scalar::test_scalar::TestScalar,
+    },
+    sql::proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
+};
+use alloc::{boxed::Box, collections::VecDeque, vec::Vec};
+use bumpalo::Bump;
+
+fn decimal_type(precision: u8, scale: i8) -> ColumnType {
+    ColumnType::Decimal75(
+        Precision::new(precision).expect("test precision should be valid"),
+        scale,
+    )
+}
+
+fn int_to_decimal_expr() -> ScalingCastExpr {
+    ScalingCastExpr::try_new(
+        Box::new(DynProofExpr::new_literal(LiteralValue::Int(7))),
+        decimal_type(11, 1),
+    )
+    .expect("int to decimal scaling cast should be valid")
+}
+
+fn empty_table_with_rows<'a>(row_count: usize) -> Table<'a, TestScalar> {
+    Table::try_new_with_options(IndexMap::default(), TableOptions::new(Some(row_count)))
+        .expect("empty test table with fixed row count should be valid")
+}
+
+fn assert_decimal_column(column: Column<TestScalar>, expected: &[TestScalar]) {
+    assert_eq!(column.column_type(), decimal_type(11, 1));
+    assert_eq!(
+        column.as_decimal75().expect("column should be decimal75"),
+        expected
+    );
+}
+
+fn new_mock_verification_builder() -> MockVerificationBuilder<TestScalar> {
+    MockVerificationBuilder::new(
+        Vec::new(),
+        0,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    )
+}
+
+#[test]
+fn we_can_evaluate_scaling_cast_expr_in_first_and_final_rounds() {
+    let expr = int_to_decimal_expr();
+    let alloc = Bump::new();
+    let table = empty_table_with_rows(3);
+    let expected = [
+        TestScalar::from(70),
+        TestScalar::from(70),
+        TestScalar::from(70),
+    ];
+
+    let first_round_column = expr
+        .first_round_evaluate(&alloc, &table, &[])
+        .expect("first-round scaling cast should evaluate");
+    assert_decimal_column(first_round_column, &expected);
+
+    let mut builder = FinalRoundBuilder::new(1, VecDeque::new());
+    let final_round_column = expr
+        .final_round_evaluate(&mut builder, &alloc, &table, &[])
+        .expect("final-round scaling cast should evaluate");
+    assert_decimal_column(final_round_column, &expected);
+}
+
+#[test]
+fn we_can_verify_scaling_cast_expr() {
+    let expr = int_to_decimal_expr();
+    let mut builder = new_mock_verification_builder();
+    let verified = expr
+        .verifier_evaluate(&mut builder, &indexmap! {}, TestScalar::from(3), &[])
+        .expect("scaling cast verifier evaluation should succeed");
+
+    assert_eq!(verified, TestScalar::from(210));
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add a no-default test module for `ScalingCastExpr` evaluator coverage.
- Exercise `first_round_evaluate` and `final_round_evaluate` on an int-to-decimal scaling cast, including the result column type and values.
- Exercise `verifier_evaluate` with the existing `MockVerificationBuilder` and assert the scaled scalar result.

## Coverage
Before this slice, `scaling_cast_expr.rs` was at `LH=19/LF=69`, with 49 missing production lines in the local no-default baseline.

This PR covers 40 previously missing production lines in that file: the first-round evaluator, final-round evaluator, and verifier paths (`66-78`, `80-95`, `97-107`). I kept constructor/accessor/error/column-reference coverage out of this branch because open PR #2054 already covers those areas.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test scaling_cast_expr_eval_test -- --nocapture` (2 passed)
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target/scaling-cast-eval-after.lcov -- scaling_cast_expr_eval_test`
- `cargo test -p proof-of-sql --lib --no-default-features --features test` (962 passed)
- `cargo check -p proof-of-sql --all-targets --no-default-features --features test`
- `cargo f --check`
- `git diff --cached --check`
- `scripts/check_commits.sh` via Git for Windows bash

Local note: `cargo cl -- -D warnings` does not complete on Windows because all-features builds pull in Linux-only `blitzar-sys`; the no-default clippy run is also blocked by existing unrelated lint warnings in this checkout.