### PR TITLE
test: cover table operation errors

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,81 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema(name: &str, data_type: ColumnType) -> Vec<ColumnField> {
+        vec![ColumnField::new(Ident::new(name), data_type)]
+    }
+
+    #[test]
+    fn we_can_display_table_operation_errors() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+        assert_eq!(
+            TableOperationError::JoinWithDifferentNumberOfColumns {
+                left_num_columns: 1,
+                right_num_columns: 2
+            }
+            .to_string(),
+            "Cannot join tables with different numbers of columns: 1 and 2"
+        );
+        assert_eq!(
+            TableOperationError::JoinIncompatibleTypes {
+                left_type: ColumnType::BigInt,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Cannot join tables on columns with incompatible types: BigInt and VarChar"
+        );
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+        assert_eq!(
+            TableOperationError::ColumnIndexOutOfBounds { column_index: 4 }.to_string(),
+            "Column index out of bounds: 4"
+        );
+    }
+
+    #[test]
+    fn we_can_display_schema_and_ident_table_operation_errors() {
+        let union_error = TableOperationError::UnionIncompatibleSchemas {
+            correct_schema: schema("id", ColumnType::BigInt),
+            actual_schema: schema("name", ColumnType::VarChar),
+        }
+        .to_string();
+
+        assert!(union_error.starts_with("Cannot union tables with incompatible schemas:"));
+        assert!(union_error.contains("BigInt"));
+        assert!(union_error.contains("VarChar"));
+        assert!(union_error.contains("id"));
+        assert!(union_error.contains("name"));
+
+        let missing_column_error = TableOperationError::ColumnDoesNotExist {
+            column_ident: Ident::new("missing"),
+        }
+        .to_string();
+
+        assert!(missing_column_error.starts_with("Column "));
+        assert!(missing_column_error.contains("missing"));
+        assert!(missing_column_error.ends_with(" does not exist in table"));
+    }
+
+    #[test]
+    fn we_can_display_column_operation_error_through_table_operation_error() {
+        let table_error = TableOperationError::from(ColumnOperationError::DifferentColumnLength {
+            len_a: 2,
+            len_b: 3,
+        });
+
+        assert_eq!(
+            table_error.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused unit coverage for TableOperationError display messages.
- Cover schema and missing-column display paths without changing runtime behavior.
- Cover the transparent ColumnOperationError wrapper path through TableOperationError.

## Non-overlap
I checked current open PR titles/bodies for table_operation_error, TableOperationError, table operation, ColumnOperationError, and related duplicate/missing-column terms before opening this PR and did not find an active overlapping claim.

## Validation
- cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check
- cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test table_operation_error -- --nocapture
- git diff --check
- bash scripts/check_commits.sh

Local note: this Windows host needs the workspace w64devkit/bin and Rust self-contained bin directories on PATH so dlltool.exe is available for the GNU toolchain. The test run passed 3 focused tests; warnings emitted are pre-existing unused/dead-code warnings outside this test slice.