### PR TITLE
test: cover bit distribution errors

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::base::{
+    proof::ProofError,
     scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
     try_standard_binary_deserialization, try_standard_binary_serialization,
 };
@@ -430,4 +431,20 @@ fn we_can_serialize_round_trip() {
 
     let deserialized: BitDistribution = try_standard_binary_deserialization(&serialized).unwrap().0;
     assert_eq!(deserialized, bit_distribution);
+}
+
+#[test]
+fn we_can_convert_bit_distribution_verification_error_to_proof_error() {
+    let proof_error = ProofError::from(BitDistributionError::Verification);
+
+    assert_eq!(
+        proof_error.to_string(),
+        "Verification error: invalid bit_decomposition"
+    );
+}
+
+#[test]
+#[should_panic(expected = "No lead bit available despite variable lead bit.")]
+fn we_panic_when_converting_missing_lead_bit_error_to_proof_error() {
+    let _ = ProofError::from(BitDistributionError::NoLeadBit);
 }


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for BitDistributionError conversion paths.
- Verify the Verification variant maps to the expected ProofError display message.
- Verify the NoLeadBit conversion keeps its intentional panic behavior.
- Keep the change test-only with no runtime behavior changes.

## Non-overlap
I checked current open PR titles/bodies for bit_distribution, BitDistribution, and bit distribution before opening this PR and did not find an active overlapping claim for these error conversion paths.

## Validation
- cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check
- cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test bit_distribution -- --nocapture
- git diff --check
- bash scripts/check_commits.sh

Local note: this Windows host needs the workspace w64devkit/bin and Rust self-contained bin directories on PATH so dlltool.exe is available for the GNU toolchain. The focused test run passed 29 tests; warnings emitted are pre-existing unused/dead-code warnings outside this test slice.