### PR TITLE
test: cover empty byte matrix

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -39,6 +39,30 @@ mod tests {
     use bumpalo::Bump;
 
     #[test]
+    fn we_can_compute_empty_varying_byte_matrix_for_empty_scalars() {
+        let alloc = Bump::new();
+        let scalars: Vec<TestScalar> = Vec::new();
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
+    fn we_can_compute_empty_varying_byte_matrix_for_constant_scalars() {
+        let alloc = Bump::new();
+        let scalars = vec![TestScalar::from(257); 3];
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
     fn we_can_compute_varying_byte_matrix_for_small_scalars() {
         let alloc = Bump::new();
         let scalars: Vec<TestScalar> = [1, 2, 3, 255, 256, 257]


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for compute_varying_byte_matrix when no bytes vary.
- Cover empty input and constant scalar input returning an empty byte matrix.
- Keep the change test-only with no runtime behavior changes.

## Non-overlap
I checked current open PR titles/bodies for byte_matrix, compute_varying_byte_matrix, ByteDistribution, and byte distribution before opening this PR and did not find an active overlapping claim for this byte matrix no-varying path.

## Validation
- cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check
- cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test byte_matrix_utils -- --nocapture
- git diff --check
- bash scripts/check_commits.sh

Local note: this Windows host needs the workspace w64devkit/bin and Rust self-contained bin directories on PATH so dlltool.exe is available for the GNU toolchain. The focused test run passed 4 tests; warnings emitted are pre-existing unused/dead-code warnings outside this test slice.