### PR TITLE
test: cover dory message serialization

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
@@ -3,6 +3,23 @@ use ark_std::UniformRand;
 use merlin::Transcript;
 
 #[test]
+fn we_can_roundtrip_dory_messages_through_postcard() {
+    let mut rng = test_rng();
+    let mut messages = DoryMessages::default();
+    let mut transcript = Transcript::new(b"serde_test");
+
+    messages.prover_send_F_message(&mut transcript, F::rand(&mut rng));
+    messages.prover_send_G1_message(&mut transcript, G1Affine::rand(&mut rng));
+    messages.prover_send_G2_message(&mut transcript, G2Affine::rand(&mut rng));
+    messages.prover_send_GT_message(&mut transcript, GT::rand(&mut rng));
+
+    let encoded = postcard::to_allocvec(&messages).unwrap();
+    let decoded: DoryMessages = postcard::from_bytes(&encoded).unwrap();
+
+    assert_eq!(decoded, messages);
+}
+
+#[test]
 fn we_can_send_and_receive_the_correct_messages_in_the_same_order() {
     let mut rng = test_rng();
     let mut messages = DoryMessages::default();


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for `DoryMessages` postcard serialization.
- Exercise the checked ark serde macro on non-empty F/G1/G2/GT prover message queues.
- Keep the change test-only with no runtime behavior changes.

## Non-overlap
I checked current open PR titles/bodies for dory message serialization, DoryMessages serde, ark serialize, and impl_serde before opening this PR and did not find an active overlapping claim for this exact serialization round-trip path.

## Validation
- cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check
- cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test dory_messages -- --nocapture
- git diff --check
- bash scripts/check_commits.sh

Local note: `cargo llvm-cov` is installed in this Windows workspace, but the GNU toolchain cannot compile the coverage build here because `profiler_builtins` is unavailable. The focused normal test run passed 5 dory message tests; warnings emitted are pre-existing warnings outside this slice.