### PR TITLE
test: cover dory commitment serialization

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -499,4 +499,15 @@ mod tests {
             commitment2.to_transcript_bytes()
         );
     }
+
+    #[test]
+    fn we_can_roundtrip_dory_commitment_through_postcard() {
+        let mut rng = StdRng::seed_from_u64(43);
+        let commitment = DoryCommitment(GT::rand(&mut rng));
+
+        let encoded = postcard::to_allocvec(&commitment).unwrap();
+        let decoded: DoryCommitment = postcard::from_bytes(&encoded).unwrap();
+
+        assert_eq!(decoded, commitment);
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for `DoryCommitment` postcard serialization.
- Exercise the checked ark serde macro on a non-default random commitment.
- Keep the change test-only with no runtime behavior changes.

## Non-overlap
I checked current open PR titles/bodies for DoryCommitment serde, DoryCommitment serialization, dory commitment serialization, and postcard DoryCommitment before opening this PR and did not find an active overlapping claim.

## Validation
- cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check
- cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test dory_commitment -- --nocapture
- git diff --check
- bash scripts/check_commits.sh

Local note: this Windows host needs the workspace w64devkit/bin and Rust self-contained bin directories on PATH so dlltool.exe is available for the GNU toolchain. The focused test filter passed 65 tests; warnings emitted are pre-existing warnings outside this slice.