### PR TITLE
test: cover dory offset byte conversions

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -60,3 +60,63 @@ impl OffsetToBytes<32> for [u64; 4] {
         bytemuck::cast(*self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OffsetToBytes;
+
+    #[test]
+    fn we_can_convert_unsigned_and_bool_offsets_to_bytes() {
+        assert_eq!(0_u8.offset_to_bytes(), [0]);
+        assert_eq!(255_u8.offset_to_bytes(), [255]);
+        assert_eq!(false.offset_to_bytes(), [0]);
+        assert_eq!(true.offset_to_bytes(), [1]);
+
+        let value = 0x0102_0304_0506_0708_u64;
+        assert_eq!(value.offset_to_bytes(), [8, 7, 6, 5, 4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn we_can_convert_signed_offsets_to_order_preserving_bytes() {
+        assert_eq!(i8::MIN.offset_to_bytes(), [0]);
+        assert_eq!(0_i8.offset_to_bytes(), [128]);
+        assert_eq!(i8::MAX.offset_to_bytes(), [255]);
+
+        assert_eq!(i16::MIN.offset_to_bytes(), [0, 0]);
+        assert_eq!(0_i16.offset_to_bytes(), [0, 128]);
+        assert_eq!(i16::MAX.offset_to_bytes(), [255, 255]);
+
+        assert_eq!(i32::MIN.offset_to_bytes(), [0, 0, 0, 0]);
+        assert_eq!(0_i32.offset_to_bytes(), [0, 0, 0, 128]);
+        assert_eq!(i32::MAX.offset_to_bytes(), [255, 255, 255, 255]);
+
+        assert_eq!(i64::MIN.offset_to_bytes(), [0; 8]);
+        assert_eq!(0_i64.offset_to_bytes(), [0, 0, 0, 0, 0, 0, 0, 128]);
+        assert_eq!(i64::MAX.offset_to_bytes(), [255; 8]);
+
+        assert_eq!(i128::MIN.offset_to_bytes(), [0; 16]);
+        assert_eq!(
+            0_i128.offset_to_bytes(),
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128]
+        );
+        assert_eq!(i128::MAX.offset_to_bytes(), [255; 16]);
+    }
+
+    #[test]
+    fn we_can_convert_u64_limbs_to_bytes() {
+        let limbs = [
+            0x0102_0304_0506_0708_u64,
+            0x1112_1314_1516_1718,
+            0x2122_2324_2526_2728,
+            0x3132_3334_3536_3738,
+        ];
+
+        assert_eq!(
+            limbs.offset_to_bytes(),
+            [
+                8, 7, 6, 5, 4, 3, 2, 1, 24, 23, 22, 21, 20, 19, 18, 17, 40, 39, 38, 37, 36, 35, 34,
+                33, 56, 55, 54, 53, 52, 51, 50, 49,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused coverage for Dory `OffsetToBytes` conversions.
- Cover unsigned, bool, signed integer offset shifting, u64 little-endian bytes, and `[u64; 4]` limb casting.
- Keep the change test-only with no runtime behavior changes.

## Non-overlap
I checked current open PR titles/bodies for offset_to_bytes, OffsetToBytes, offset bytes, scalar product, and pairings before opening this PR and did not find an active overlapping claim for these conversion helpers.

## Validation
- cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check
- cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test offset_to_bytes -- --nocapture
- git diff --check
- bash scripts/check_commits.sh

Local note: the focused test run passed 3 tests; warnings emitted are pre-existing warnings outside this slice.