### PR TITLE
test: cover planner binary operator errors

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -626,6 +626,60 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn we_cannot_convert_binary_expr_with_invalid_operand_types() {
+        let boolean_expr = Expr::Literal(ScalarValue::Boolean(Some(true)));
+        let int_expr = Expr::Literal(ScalarValue::Int32(Some(1)));
+
+        for op in [Operator::And, Operator::Or] {
+            let expr = Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(int_expr.clone()),
+                right: Box::new(int_expr.clone()),
+                op,
+            });
+            assert!(matches!(
+                expr_to_proof_expr(&expr, &Vec::new()),
+                Err(PlannerError::AnalyzeError { .. })
+            ));
+        }
+
+        for op in [Operator::Multiply, Operator::Plus, Operator::Minus] {
+            let expr = Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(boolean_expr.clone()),
+                right: Box::new(boolean_expr.clone()),
+                op,
+            });
+            assert!(matches!(
+                expr_to_proof_expr(&expr, &Vec::new()),
+                Err(PlannerError::AnalyzeError { .. })
+            ));
+        }
+
+        for op in [Operator::Eq, Operator::NotEq] {
+            let expr = Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(boolean_expr.clone()),
+                right: Box::new(int_expr.clone()),
+                op,
+            });
+            assert!(matches!(
+                expr_to_proof_expr(&expr, &Vec::new()),
+                Err(PlannerError::AnalyzeError { .. })
+            ));
+        }
+
+        for op in [Operator::Lt, Operator::Gt, Operator::LtEq, Operator::GtEq] {
+            let expr = Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(boolean_expr.clone()),
+                right: Box::new(int_expr.clone()),
+                op,
+            });
+            assert!(matches!(
+                expr_to_proof_expr(&expr, &Vec::new()),
+                Err(PlannerError::AnalyzeError { .. })
+            ));
+        }
+    }
+
     // Literal
     #[test]
     fn we_can_convert_literal_expr_to_proof_expr() {


### PR DESCRIPTION
/claim #560

This is a small, test-only planner coverage slice for `crates/proof-of-sql-planner/src/expr.rs`. It covers invalid operand type handling for planner binary operator conversion so each supported operator branch exercises `AnalyzeError` propagation instead of only the success path.

I checked the current #560 issue comments/open PR titles for direct `proof-of-sql-planner/src/expr.rs` overlap and did not find an active same-file planner expression slice.

Coverage evidence:
- Baseline LCOV missed `expr.rs` lines 72, 77, 81, 85, 91, 96, 101, 107, 112, and 116.
- After this test, `expr.rs` reports 660/660 covered lines and those 10 previously missed production lines are covered.
- Conservative bounty estimate: 10 newly covered production lines / $1.00 at $0.10 per covered line, subject to maintainer review and final accounting.

Validation:
- `cargo test -p proof-of-sql-planner expr::tests`
- `cargo llvm-cov -p proof-of-sql-planner --ignore-filename-regex evm_tests --lcov --output-path /tmp/sxt-planner-after.lcov`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and validation before submitting.