### PR TITLE
test: cover add_const edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
@@ -7,3 +7,17 @@ fn test_add_const() {
     let b = vec![1 + 10, 2 + 10, 3 + 10, 4 + 10];
     assert_eq!(a, b);
 }
+
+#[test]
+fn test_add_const_empty_slice() {
+    let mut values: Vec<i64> = Vec::new();
+    add_const(&mut values, 5);
+    assert!(values.is_empty());
+}
+
+#[test]
+fn test_add_const_converts_addend() {
+    let mut values = vec![1_i64, -2, 3];
+    add_const(&mut values, 7_i32);
+    assert_eq!(values, vec![8, 5, 10]);
+}


### PR DESCRIPTION
/claim #560

Summary:
- add focused coverage for `base::slice_ops::add_const` empty-slice behavior
- cover the generic `S: Into<T>` addend conversion path by adding an `i32` value into an `i64` slice
- no production behavior changes

Validation:
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test add_const -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`
