### PR TITLE
test: cover sumcheck random scalars

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -33,6 +33,8 @@ mod sumcheck_mle_evaluations_test;
 
 mod sumcheck_random_scalars;
 pub(crate) use sumcheck_random_scalars::SumcheckRandomScalars;
+#[cfg(test)]
+mod sumcheck_random_scalars_test;
 
 mod proof_plan;
 pub use proof_plan::ProofPlan;

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars_test.rs
@@ -1,0 +1,39 @@
+use super::SumcheckRandomScalars;
+use crate::base::scalar::test_scalar::TestScalar;
+
+#[test]
+fn new_splits_subpolynomial_multipliers_from_entrywise_point() {
+    let scalars = [
+        TestScalar::from(11_u64),
+        TestScalar::from(22_u64),
+        TestScalar::from(2_u64),
+        TestScalar::from(3_u64),
+    ];
+
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 3, 2);
+
+    assert_eq!(random_scalars.subpolynomial_multipliers, &scalars[..2]);
+    assert_eq!(random_scalars.entrywise_point, &scalars[2..]);
+    assert_eq!(random_scalars.table_length, 3);
+}
+
+#[test]
+fn compute_entrywise_multipliers_returns_truncated_evaluation_vector() {
+    let scalars = [TestScalar::from(9_u64), TestScalar::from(2_u64)];
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 2, 1);
+
+    let multipliers = random_scalars.compute_entrywise_multipliers();
+
+    assert_eq!(
+        multipliers,
+        vec![TestScalar::from(-1_i64), TestScalar::from(2_u64)]
+    );
+}
+
+#[test]
+fn compute_entrywise_multipliers_allows_empty_tables() {
+    let scalars = [TestScalar::from(5_u64)];
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 0, 1);
+
+    assert!(random_scalars.compute_entrywise_multipliers().is_empty());
+}


### PR DESCRIPTION
/claim #560

Summary:
- add focused coverage for `sql::proof::SumcheckRandomScalars::new` slice partitioning
- cover `compute_entrywise_multipliers` for a truncated evaluation vector
- cover empty-table multiplier generation
- no production behavior changes

Validation:
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test sumcheck_random_scalars -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`
