### PR TITLE
test: cover inner product ref casting

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -162,3 +162,29 @@ fn test_inner_product_testscalar_uneven() {
     ];
     assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
+
+#[test]
+fn test_inner_product_ref_cast() {
+    let a = vec![
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
+        TestScalar::from(5u64),
+    ];
+    let b = vec![
+        TestScalar::from(7u64),
+        TestScalar::from(11u64),
+        TestScalar::from(13u64),
+    ];
+    assert_eq!(TestScalar::from(112u64), inner_product_ref_cast(&a, &b));
+}
+
+#[test]
+fn test_inner_product_ref_cast_uneven() {
+    let a = vec![
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
+        TestScalar::from(5u64),
+    ];
+    let b = vec![TestScalar::from(7u64), TestScalar::from(11u64)];
+    assert_eq!(TestScalar::from(47u64), inner_product_ref_cast(&a, &b));
+}


### PR DESCRIPTION
/claim #560

Summary:
- add focused coverage for `base::slice_ops::inner_product_ref_cast`
- verify reference-to-scalar conversion over equal-length inputs
- verify truncation behavior when the right-hand input is shorter
- no production behavior changes

Validation:
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test inner_product_ref_cast -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`
