### PR TITLE
test: cover first round builder state

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/first_round_builder_state_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder_state_test.rs
@@ -1,0 +1,31 @@
+use super::FirstRoundBuilder;
+use crate::proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar;
+
+#[test]
+fn range_length_only_grows() {
+    let mut builder = FirstRoundBuilder::<Curve25519Scalar>::new(4);
+    assert_eq!(builder.range_length(), 4);
+
+    builder.update_range_length(2);
+    assert_eq!(builder.range_length(), 4);
+
+    builder.update_range_length(4);
+    assert_eq!(builder.range_length(), 4);
+
+    builder.update_range_length(8);
+    assert_eq!(builder.range_length(), 8);
+}
+
+#[test]
+fn chi_and_rho_evaluation_lengths_are_tracked() {
+    let mut builder = FirstRoundBuilder::<Curve25519Scalar>::new(2);
+
+    builder.produce_chi_evaluation_length(5);
+    builder.produce_chi_evaluation_length(3);
+    builder.produce_rho_evaluation_length(7);
+    builder.produce_rho_evaluation_length(11);
+
+    assert_eq!(builder.chi_evaluation_lengths(), &[5, 3]);
+    assert_eq!(builder.rho_evaluation_lengths(), &[7, 11]);
+    assert_eq!(builder.range_length(), 5);
+}

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -68,6 +68,8 @@ pub(crate) use result_element_serialization::{
 
 mod first_round_builder;
 pub(crate) use first_round_builder::FirstRoundBuilder;
+#[cfg(test)]
+mod first_round_builder_state_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod first_round_builder_test;
 


### PR DESCRIPTION
/claim #560

Summary:
- add no-Blitzar coverage for `sql::proof::FirstRoundBuilder` state bookkeeping
- verify range length only grows when larger ranges are produced
- verify chi and rho evaluation lengths are tracked independently
- no production behavior changes

Validation:
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test first_round_builder_state -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: I first checked the existing Blitzar-gated test module, but local Blitzar validation is not possible on this Windows workspace because `blitzar-sys` supports Linux only. This PR keeps the new coverage in a separate no-Blitzar test module so it is locally verifiable.
