### PR TITLE
test: cover scaled batch inversion

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
@@ -56,6 +56,29 @@ fn we_can_pseudo_invert_arrays_of_length_bigger_than_1_with_zeros_and_non_zeros(
 }
 
 #[test]
+fn we_can_pseudo_invert_and_multiply_by_a_coefficient() {
+    let input = [
+        TestScalar::from(0_u32),
+        TestScalar::from(2_u32),
+        TestScalar::from(5_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(7_u32),
+    ];
+    let coeff = TestScalar::from(11_u32);
+    let mut res = input.to_vec();
+
+    slice_ops::batch_inversion_and_mul(&mut res[..], coeff);
+
+    for (input_val, res_val) in input.iter().zip(res) {
+        if input_val.is_zero() {
+            assert_eq!(TestScalar::zero(), res_val);
+        } else {
+            assert_eq!(input_val.inv().unwrap() * coeff, res_val);
+        }
+    }
+}
+
+#[test]
 fn we_can_pseudo_invert_arrays_with_nonzero_count_bigger_than_min_chunking_size_with_zeros_and_non_zeros(
 ) {
     let input: Vec<_> = vec![


### PR DESCRIPTION
/claim #560

Summary:
- add focused coverage for `base::slice_ops::batch_inversion_and_mul`
- verify a non-identity scaling coefficient is applied to non-zero inverses
- verify zero entries remain zero while neighboring non-zero values are scaled
- no production behavior changes

Validation:
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test batch_inverse -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`
