### PR TITLE
test: cover bigdecimal parsing edge cases

### DIFF
--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,26 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn we_can_ignore_non_bigdecimal_columns_and_non_create_statements() {
+        let sql = "SELECT 1;
+
+        CREATE TABLE IF NOT EXISTS ETHEREUM.TRACES(
+            TRACE_ID BIGINT NOT NULL,
+            STANDARD_DECIMAL DECIMAL(38, 2),
+            UNSCALED_DECIMAL DECIMAL(78),
+            BIG_DECIMAL DECIMAL(39, 4),
+            PRIMARY KEY(TRACE_ID)
+        );
+
+        INSERT INTO ETHEREUM.TRACES VALUES (1, 2, 3, 4);";
+
+        let bigdecimals = find_bigdecimals(sql);
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("ETHEREUM.TRACES").unwrap(),
+            &[("BIG_DECIMAL".to_string(), 39, 4)]
+        );
+    }
 }


### PR DESCRIPTION
/claim #560

Summary:
- add focused coverage for `utils::parse::find_bigdecimals`
- verify non-CREATE statements are ignored while CREATE TABLE statements are still collected
- verify DECIMAL columns without `(precision, scale)` and precision <= 38 are ignored
- keep the change test-only with no runtime behavior changes

Validation:
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test utils::parse::tests -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`
