### PR TITLE
test: cover ref into blanket conversion

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,26 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+
+    struct LocalValue(u64);
+
+    impl From<&LocalValue> for u64 {
+        fn from(value: &LocalValue) -> Self {
+            value.0
+        }
+    }
+
+    #[test]
+    fn we_can_convert_from_a_reference_without_consuming_the_value() {
+        let value = LocalValue(42);
+
+        let converted: u64 = value.ref_into();
+
+        assert_eq!(converted, 42);
+        assert_eq!(value.0, 42);
+    }
+}


### PR DESCRIPTION
/claim #560

Summary:
- add focused coverage for the `RefInto` blanket implementation
- verify a reference conversion dispatches through `ref_into` without consuming the original value
- keep the change test-only with no runtime behavior changes

Validation:
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test ref_into -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`
