### PR TITLE
test: cover uint8 column bounds

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -519,6 +519,14 @@ mod tests {
         let varchar_column_bounds = ColumnBounds::from_column(&committable_varchar_column);
         assert_eq!(varchar_column_bounds, ColumnBounds::NoOrder);
 
+        let uint8_column = OwnedColumn::<TestScalar>::Uint8([4, 2, 7, 4, 1].to_vec());
+        let committable_uint8_column = CommittableColumn::from(&uint8_column);
+        let uint8_column_bounds = ColumnBounds::from_column(&committable_uint8_column);
+        assert_eq!(
+            uint8_column_bounds,
+            ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 7 }))
+        );
+
         let tinyint_column = OwnedColumn::<TestScalar>::TinyInt([1, 2, 3, 1, 0].to_vec());
         let committable_tinyint_column = CommittableColumn::from(&tinyint_column);
         let tinyint_column_bounds = ColumnBounds::from_column(&committable_tinyint_column);
@@ -590,6 +598,13 @@ mod tests {
         let no_order = ColumnBounds::NoOrder;
         assert_eq!(no_order.try_union(no_order).unwrap(), no_order);
 
+        let uint8_a = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
+        let uint8_b = ColumnBounds::Uint8(Bounds::Bounded(BoundsInner { min: 4, max: 6 }));
+        assert_eq!(
+            uint8_a.try_union(uint8_b).unwrap(),
+            ColumnBounds::Uint8(Bounds::Bounded(BoundsInner { min: 1, max: 6 }))
+        );
+
         let tinyint_a = ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let tinyint_b = ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
         assert_eq!(
@@ -644,6 +659,7 @@ mod tests {
     #[test]
     fn we_cannot_union_mismatched_column_bounds() {
         let no_order = ColumnBounds::NoOrder;
+        let uint8 = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let tinyint = ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: -3, max: 3 }));
         let smallint = ColumnBounds::SmallInt(Bounds::Sharp(BoundsInner { min: -5, max: 5 }));
         let int = ColumnBounds::Int(Bounds::Sharp(BoundsInner { min: -10, max: 10 }));
@@ -653,6 +669,7 @@ mod tests {
 
         let bounds = [
             (no_order, "NoOrder"),
+            (uint8, "Uint8"),
             (tinyint, "TinyInt"),
             (smallint, "SmallInt"),
             (int, "Int"),
@@ -677,6 +694,13 @@ mod tests {
     fn we_can_difference_column_bounds_with_matching_variant() {
         let no_order = ColumnBounds::NoOrder;
         assert_eq!(no_order.try_difference(no_order).unwrap(), no_order);
+
+        let uint8_a = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 4 }));
+        let uint8_b = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 3, max: 6 }));
+        assert_eq!(
+            uint8_a.try_difference(uint8_b).unwrap(),
+            ColumnBounds::Uint8(Bounds::Bounded(BoundsInner { min: 1, max: 4 }))
+        );
 
         let tinyint_a = ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let tinyint_b = ColumnBounds::TinyInt(Bounds::Empty);
@@ -712,14 +736,21 @@ mod tests {
     #[test]
     fn we_cannot_difference_mismatched_column_bounds() {
         let no_order = ColumnBounds::NoOrder;
+        let uint8 = ColumnBounds::Uint8(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let bigint = ColumnBounds::BigInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let int128 = ColumnBounds::Int128(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
         let timestamp = ColumnBounds::TimestampTZ(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
         let tinyint = ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let smallint = ColumnBounds::SmallInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
 
+        assert!(no_order.try_difference(uint8).is_err());
+        assert!(uint8.try_difference(no_order).is_err());
+
         assert!(no_order.try_difference(bigint).is_err());
         assert!(bigint.try_difference(no_order).is_err());
+
+        assert!(uint8.try_difference(tinyint).is_err());
+        assert!(tinyint.try_difference(uint8).is_err());
 
         assert!(no_order.try_difference(int128).is_err());
         assert!(int128.try_difference(no_order).is_err());


### PR DESCRIPTION
/claim #560

Summary:
- add focused coverage for `ColumnBounds::Uint8`
- verify Uint8 bounds are built from committable columns
- verify Uint8 union, difference, and mismatch behavior
- keep the change test-only with no runtime behavior changes

Validation:
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test column_bounds -- --nocapture`
- `git diff --check`
- `bash scripts/check_commits.sh`
