### PR TITLE
test: reduce more planner example setup sizes

### DIFF
--- a/crates/proof-of-sql-planner/examples/albums/main.rs
+++ b/crates/proof-of-sql-planner/examples/albums/main.rs
@@ -30,7 +30,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 4;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"32f7f321c4ab1234d5e6f7a8b9c0d1e2";
 

--- a/crates/proof-of-sql-planner/examples/avocado-prices/main.rs
+++ b/crates/proof-of-sql-planner/examples/avocado-prices/main.rs
@@ -37,7 +37,7 @@ use std::{fs::File, time::Instant};
 // max_nu = 15 => max table size is 0.5 billion rows
 // max_nu = 20 => max table size is 0.5 trillion rows
 // Note: we will eventually load these from a file.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 4;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"len 32 rng seed - Space and Time";
 

--- a/crates/proof-of-sql-planner/examples/books/main.rs
+++ b/crates/proof-of-sql-planner/examples/books/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"ebab60d58dee4cc69658939b7c2a582d";
 

--- a/crates/proof-of-sql-planner/examples/brands/main.rs
+++ b/crates/proof-of-sql-planner/examples/brands/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"8f3a2e1c5b9d7f0a6e4d2c8b7a9f1e3d";
 

--- a/crates/proof-of-sql-planner/examples/countries/main.rs
+++ b/crates/proof-of-sql-planner/examples/countries/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 4;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"7a1b3c8d2e4f9g6h5i0j7k2l8m3n9o1p";
 

--- a/crates/proof-of-sql-planner/examples/dinosaurs/main.rs
+++ b/crates/proof-of-sql-planner/examples/dinosaurs/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"262a6aa18b5c43d589677c13dd33e6dc";
 

--- a/crates/proof-of-sql-planner/examples/rockets/main.rs
+++ b/crates/proof-of-sql-planner/examples/rockets/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"7a1b3c8d2e4f9g6h5i0j7k2l8m3n9o1p";
 

--- a/crates/proof-of-sql-planner/examples/vehicles/main.rs
+++ b/crates/proof-of-sql-planner/examples/vehicles/main.rs
@@ -30,7 +30,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"97b13c8che4f9g4050jjkk2l5m3nbo1p";
 


### PR DESCRIPTION
/claim #557

## Summary

This is a small, non-overlapping planner-example runtime slice. It reduces over-provisioned Dory setup generation for eight checked-in examples while keeping the SQL queries, CSV fixtures, proof generation, verification, and result handling unchanged.

The setup sizes are now the smallest values that cover each fixed CSV row count under the existing capacity rule `2^(2 * max_nu - 1)`:

| Example | CSV rows | New max_nu | Capacity |
| --- | ---: | ---: | ---: |
| albums | 99 | 4 | 128 |
| avocado-prices | 35 | 4 | 128 |
| countries | 34 | 4 | 128 |
| books | 20 | 3 | 32 |
| brands | 25 | 3 | 32 |
| dinosaurs | 10 | 3 | 32 |
| rockets | 27 | 3 | 32 |
| vehicles | 10 | 3 | 32 |

I checked open/all-state #557 PR searches and issue comments for this exact example group before taking the slice.

## Validation

- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu check -p proof-of-sql-planner --example albums --example avocado-prices --example books --example brands --example countries --example dinosaurs --example rockets --example vehicles --no-default-features --features cpu-perf`
- `git diff --check`
- `bash scripts/check_commits.sh`