### PR TITLE
test: reduce remaining planner example setup sizes

### DIFF
--- a/crates/proof-of-sql-planner/examples/census/main.rs
+++ b/crates/proof-of-sql-planner/examples/census/main.rs
@@ -36,7 +36,7 @@ use std::{fs::File, time::Instant};
 // max_nu = 15 => max table size is 0.5 billion rows
 // max_nu = 20 => max table size is 0.5 trillion rows
 // Note: we will eventually load these from a file.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 4;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"len 32 rng seed - Space and Time";
 

--- a/crates/proof-of-sql-planner/examples/dog_breeds/main.rs
+++ b/crates/proof-of-sql-planner/examples/dog_breeds/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"93c0d245eb104663bfdcd25e36bc3f97";
 

--- a/crates/proof-of-sql-planner/examples/space/main.rs
+++ b/crates/proof-of-sql-planner/examples/space/main.rs
@@ -38,7 +38,7 @@ use std::{fs::File, time::Instant};
 // max_nu = 15 => max table size is 0.5 billion rows
 // max_nu = 20 => max table size is 0.5 trillion rows
 // Note: we will eventually load these from a file.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"len 32 rng seed - Space and Time";
 

--- a/crates/proof-of-sql-planner/examples/wood_types/main.rs
+++ b/crates/proof-of-sql-planner/examples/wood_types/main.rs
@@ -29,7 +29,7 @@ use std::{fs::File, time::Instant};
 
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
-const DORY_SETUP_MAX_NU: usize = 8;
+const DORY_SETUP_MAX_NU: usize = 3;
 // This should be a "nothing-up-my-sleeve" phrase or number.
 const DORY_SEED: [u8; 32] = *b"f3a8d12e6b7c4590a1f2e3d4b5c6a7b8";
 


### PR DESCRIPTION
/claim #557

## Summary

This is another small, non-overlapping planner-example runtime slice. It reduces over-provisioned Dory setup generation for four checked-in examples while keeping SQL queries, CSV fixtures, proof generation, verification, and result handling unchanged.

The setup sizes are now the smallest values that cover each fixed CSV row count under the existing capacity rule `2^(2 * max_nu - 1)`:

| Example | CSV rows | New max_nu | Capacity |
| --- | ---: | ---: | ---: |
| census | 52 | 4 | 128 |
| dog_breeds | 25 | 3 | 32 |
| space/planets | 13 | 3 | 32 |
| wood_types | 10 | 3 | 32 |

I checked open #557 PR searches and issue comments for these exact fixture/example names before taking the slice.

## Validation

- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +1.91.1-x86_64-pc-windows-gnu check -p proof-of-sql-planner --example census --example dog_breeds --example space --example wood_types --no-default-features --features cpu-perf`
- `git diff --check`
- `bash scripts/check_commits.sh`