### PR TITLE
test: reduce append rows bench setup size

### DIFF
--- a/crates/proof-of-sql-benches/benches/bench_append_rows.rs
+++ b/crates/proof-of-sql-benches/benches/bench_append_rows.rs
@@ -27,6 +27,8 @@ use proof_of_sql::{
 };
 use rand::Rng;
 
+const APPEND_ROWS_BENCH_MAX_NU: usize = 6;
+
 /// Bench dory performance when appending rows to a table. This includes the computation of
 /// commitments. Chose the number of columns to randomly generate across supported `PoSQL`
 /// data types, and choose the number of rows to append at a time.
@@ -44,7 +46,7 @@ use rand::Rng;
 ///
 /// Will panic if the row appending operation fails due to invalid data or if the local commitment has reached an invalid state.
 fn bench_append_rows(c: &mut Criterion, cols: usize, rows: usize) {
-    let public_parameters = PublicParameters::test_rand(10, &mut test_rng());
+    let public_parameters = PublicParameters::test_rand(APPEND_ROWS_BENCH_MAX_NU, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
     c.bench_function("append_rows_to_table_commitment", |b| {


### PR DESCRIPTION
/claim #557

## Summary
- Reduce the append rows benchmark Dory setup size from max_nu 10 to max_nu 6.
- Keep the parameter named in a local constant so the benchmark's required capacity is explicit.

## Rationale
The largest benchmark case starts with 1000 rows and appends 1000 more rows, so max_nu 6 still covers the 2000-row workload while avoiding extra unused setup generation during local benchmark runs.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

`cargo +1.91.1-x86_64-pc-windows-gnu check -p proof-of-sql-benches --bench bench_append_rows --no-default-features` was attempted locally, but the Windows environment stops in `blitzar-sys` with `Unsupported OS. Only Linux is supported.`