### PR TITLE
test: reduce dory inner product setup work

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_inner_product_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_inner_product_test.rs
@@ -1,6 +1,6 @@
 use super::{
     dory_inner_product_prove, dory_inner_product_verify, rand_G_vecs, test_rng, DoryMessages,
-    G1Affine, ProverState, PublicParameters, GT,
+    G1Affine, ProverState, PublicParameters, VerifierSetup, VerifierState, GT,
 };
 use ark_std::UniformRand;
 use merlin::Transcript;
@@ -56,8 +56,21 @@ fn we_can_prove_and_verify_a_dory_inner_product_for_multiple_nu_values() {
     }
 }
 
+fn assert_dory_inner_product_rejects(
+    mut messages: DoryMessages,
+    verifier_state: VerifierState,
+    verifier_setup: &VerifierSetup,
+) {
+    let mut transcript = Transcript::new(b"dory_inner_product_test");
+    assert!(!dory_inner_product_verify(
+        &mut messages,
+        &mut transcript,
+        verifier_state,
+        verifier_setup
+    ));
+}
 #[test]
-fn we_fail_to_verify_a_dory_inner_product_when_a_message_is_modified() {
+fn we_reject_malformed_dory_inner_product_proofs_with_one_setup() {
     let mut rng = test_rng();
     let nu = 3;
     let pp = PublicParameters::test_rand(nu, &mut rng);
@@ -68,122 +81,37 @@ fn we_fail_to_verify_a_dory_inner_product_when_a_message_is_modified() {
     let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
 
     let mut transcript = Transcript::new(b"dory_inner_product_test");
-    let mut messages = DoryMessages::default();
-    dory_inner_product_prove(&mut messages, &mut transcript, prover_state, &prover_setup);
+    let mut base_messages = DoryMessages::default();
+    dory_inner_product_prove(
+        &mut base_messages,
+        &mut transcript,
+        prover_state,
+        &prover_setup,
+    );
 
+    let mut messages = base_messages.clone();
     messages.GT_messages[0] = GT::rand(&mut rng);
+    assert_dory_inner_product_rejects(messages, verifier_state.clone(), &verifier_setup);
 
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    assert!(!dory_inner_product_verify(
-        &mut messages,
-        &mut transcript,
-        verifier_state,
-        &verifier_setup
-    ));
-}
-
-#[test]
-fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_few_GT_messages() {
-    let mut rng = test_rng();
-    let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
-    let (v1, v2) = rand_G_vecs(nu, &mut rng);
-    let prover_state = ProverState::new(v1, v2, nu);
-    let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
-
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    let mut messages = DoryMessages::default();
-    dory_inner_product_prove(&mut messages, &mut transcript, prover_state, &prover_setup);
-
+    let mut messages = base_messages.clone();
     messages.GT_messages.pop();
+    assert_dory_inner_product_rejects(messages, verifier_state.clone(), &verifier_setup);
 
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    assert!(!dory_inner_product_verify(
-        &mut messages,
-        &mut transcript,
-        verifier_state,
-        &verifier_setup
-    ));
-}
-
-#[test]
-fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_many_GT_messages() {
-    let mut rng = test_rng();
-    let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
-    let (v1, v2) = rand_G_vecs(nu, &mut rng);
-    let prover_state = ProverState::new(v1, v2, nu);
-    let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
-
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    let mut messages = DoryMessages::default();
-    dory_inner_product_prove(&mut messages, &mut transcript, prover_state, &prover_setup);
-
+    let mut messages = base_messages.clone();
     messages.GT_messages.push(GT::rand(&mut rng));
+    assert_dory_inner_product_rejects(messages, verifier_state.clone(), &verifier_setup);
 
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    assert!(!dory_inner_product_verify(
-        &mut messages,
-        &mut transcript,
-        verifier_state,
-        &verifier_setup
-    ));
-}
-
-#[test]
-fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_few_G1_messages() {
-    let mut rng = test_rng();
-    let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
-    let (v1, v2) = rand_G_vecs(nu, &mut rng);
-    let prover_state = ProverState::new(v1, v2, nu);
-    let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
-
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    let mut messages = DoryMessages::default();
-    dory_inner_product_prove(&mut messages, &mut transcript, prover_state, &prover_setup);
-
+    let mut messages = base_messages.clone();
     messages.G1_messages.pop();
+    assert_dory_inner_product_rejects(messages, verifier_state.clone(), &verifier_setup);
 
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    assert!(!dory_inner_product_verify(
-        &mut messages,
-        &mut transcript,
-        verifier_state,
-        &verifier_setup
-    ));
-}
-
-#[test]
-fn we_fail_to_verify_a_dory_inner_product_when_there_are_too_many_G1_messages() {
-    let mut rng = test_rng();
-    let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
-    let (v1, v2) = rand_G_vecs(nu, &mut rng);
-    let prover_state = ProverState::new(v1, v2, nu);
-    let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
-
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    let mut messages = DoryMessages::default();
-    dory_inner_product_prove(&mut messages, &mut transcript, prover_state, &prover_setup);
-
+    let mut messages = base_messages.clone();
     messages.G1_messages.push(G1Affine::rand(&mut rng));
+    assert_dory_inner_product_rejects(messages, verifier_state.clone(), &verifier_setup);
 
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    assert!(!dory_inner_product_verify(
-        &mut messages,
-        &mut transcript,
-        verifier_state,
-        &verifier_setup
-    ));
+    let mut verifier_state = verifier_state;
+    verifier_state.C = GT::rand(&mut rng).into();
+    assert_dory_inner_product_rejects(base_messages, verifier_state, &verifier_setup);
 }
 
 #[test]
@@ -209,7 +137,6 @@ fn we_fail_to_verify_a_dory_inner_product_when_the_transcripts_differ() {
         &verifier_setup
     ));
 }
-
 #[test]
 fn we_fail_to_verify_a_dory_inner_product_when_the_setups_differ() {
     let mut rng = test_rng();
@@ -227,32 +154,6 @@ fn we_fail_to_verify_a_dory_inner_product_when_the_setups_differ() {
     dory_inner_product_prove(&mut messages, &mut transcript, prover_state, &prover_setup);
 
     messages.GT_messages[0] = GT::rand(&mut rng);
-
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    assert!(!dory_inner_product_verify(
-        &mut messages,
-        &mut transcript,
-        verifier_state,
-        &verifier_setup
-    ));
-}
-
-#[test]
-fn we_fail_to_verify_a_dory_inner_product_when_the_commitment_is_wrong() {
-    let mut rng = test_rng();
-    let nu = 3;
-    let pp = PublicParameters::test_rand(nu, &mut rng);
-    let prover_setup = (&pp).into();
-    let verifier_setup = (&pp).into();
-    let (v1, v2) = rand_G_vecs(nu, &mut rng);
-    let prover_state = ProverState::new(v1, v2, nu);
-    let mut verifier_state = prover_state.calculate_verifier_state(&prover_setup);
-
-    verifier_state.C = GT::rand(&mut rng).into();
-
-    let mut transcript = Transcript::new(b"dory_inner_product_test");
-    let mut messages = DoryMessages::default();
-    dory_inner_product_prove(&mut messages, &mut transcript, prover_state, &prover_setup);
 
     let mut transcript = Transcript::new(b"dory_inner_product_test");
     assert!(!dory_inner_product_verify(

--- a/crates/proof-of-sql/src/proof_primitive/dory/state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/state.rs
@@ -49,7 +49,7 @@ impl ProverState {
 /// This is initially created from a type of commitment to the witness, which the prover typically sends to the verifier.
 /// This is essentially what the verifier is trying to verify.
 /// See the beginning of section 3 of <https://eprint.iacr.org/2020/1274.pdf> for details.
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(Clone, PartialEq))]
 #[derive(Debug)]
 pub struct VerifierState {
     /// The inner pairing product of the witness. This should be <v1,v2>. This will be mutated during the proof verification.


### PR DESCRIPTION
/claim #557

## Summary
- Consolidates related malformed-message Dory inner-product rejection checks so they reuse one generated `PublicParameters`/setup/proof.
- Keeps the same rejection assertions for modified GT messages, missing/extra GT and G1 messages, and an incorrect verifier commitment.
- Derives `Clone` for `VerifierState` only in test builds so the shared fixture can be reused safely.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test dory_inner_product -- --nocapture`
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`