### PR TITLE
test: reduce extended dory setup size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product_test.rs
@@ -35,12 +35,12 @@ fn we_can_prove_and_verify_an_extended_dory_inner_product() {
 #[test]
 fn we_can_prove_and_verify_an_extended_dory_inner_product_for_multiple_nu_values() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
     let verifier_setup = (&pp).into();
 
-    for nu in 0..max_nu {
+    for nu in 0..=max_nu {
         let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
         let (v1, v2) = rand_G_vecs(nu, &mut rng);
         let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

/claim #557

# Rationale for this change

This is a tiny non-overlapping test-performance slice for the extended Dory inner-product tests. The multi-`nu` test currently generates `PublicParameters::test_rand(5, ...)`, but the loop only exercises `nu` values 0 through 4. Generating setup with `max_nu = 4` is sufficient for the same highest exercised `nu` and avoids unused Dory setup generation.

# What changes are included in this PR?

- Change the generated setup size in `we_can_prove_and_verify_an_extended_dory_inner_product_for_multiple_nu_values` from `max_nu = 5` to `max_nu = 4`.
- Change the loop from `0..max_nu` to `0..=max_nu` so it still tests the same `nu` values: 0, 1, 2, 3, and 4.
- Leave proof generation, verification, assertions, transcript labels, and random fixture construction unchanged.

# Are these changes tested?

Local/static validation:

- `cargo fmt --all -- --check`
- `git diff --check` passed aside from local Windows line-ending warnings.

Attempted focused test:

- `cargo test -p proof-of-sql --lib --no-default-features --features=test extended_dory_inner_product`

This environment could fetch dependencies and start compiling, but could not link test binaries because the Windows MSVC linker (`link.exe`) is not installed. The Linux GitHub Actions run should provide the executable validation for this test-only change.

# Deconfliction note

I checked current open #557 PRs and issue comments for this exact extended Dory inner-product multi-`nu` setup-size slice. The closest open PR touching this file is #1740, which adds #560 setup-bound coverage at the end of the same test file; this PR changes only the existing multi-`nu` performance case near the top.