### PR TITLE
test: cover standard binary serialization details

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,23 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn serializes_in_fixed_width_big_endian_order() {
+        let serialized = try_standard_binary_serialization(0x0102_0304_u32).unwrap();
+
+        assert_eq!(serialized, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn deserializes_value_and_reports_consumed_byte_count() {
+        let mut serialized = try_standard_binary_serialization(0x0a0b_u16).unwrap();
+        serialized.extend_from_slice(&[0xcc, 0xdd]);
+
+        let (deserialized, consumed): (u16, _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+
+        assert_eq!(deserialized, 0x0a0b);
+        assert_eq!(consumed, 2);
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for the standard binary serialization helper
- verify integer serialization uses the configured fixed-width big-endian representation
- verify deserialization returns both the decoded value and the consumed byte count when trailing bytes are present

## Non-overlap
This is limited to `crates/proof-of-sql/src/base/standard_serializations/binary.rs` and does not overlap my table-ref, Arrow schema, or Dory setup coverage PRs.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features std standard_serializations::binary -- --nocapture`
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: default features pull in `blitzar-sys`, whose build script rejects Windows (`Unsupported OS. Only Linux is supported`), so the focused local test uses `--no-default-features --features std` to exercise this module without Blitzar.