### PR TITLE
test: cover limb serialization order

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,41 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn serializes_limbs_in_reverse_order() {
+        let wrapper = LimbWrapper {
+            limbs: [11, 22, 33, 44],
+        };
+
+        let serialized = serde_json::to_string(&wrapper).unwrap();
+
+        assert_eq!(serialized, r#"{"limbs":[44,33,22,11]}"#);
+    }
+
+    #[test]
+    fn deserializes_reversed_limbs_to_internal_order() {
+        let wrapper: LimbWrapper = serde_json::from_str(r#"{"limbs":[44,33,22,11]}"#).unwrap();
+
+        assert_eq!(
+            wrapper,
+            LimbWrapper {
+                limbs: [11, 22, 33, 44]
+            }
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused tests for the standard limb serialization helpers
- verify serialization emits limbs in the external reversed order
- verify deserialization restores the internal limb order through the same Serde attributes used by callers

## Non-overlap
This PR is limited to `crates/proof-of-sql/src/base/standard_serializations/limbs.rs` and does not overlap my standard binary, Arrow schema, table-ref, or Dory coverage PRs.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features std standard_serializations::limbs -- --nocapture`
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: default features pull in `blitzar-sys`, whose build script rejects Windows, so this focused local test uses `--no-default-features --features std` to exercise this module without Blitzar.