### PR TITLE
test: cover query coercion error mapping

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,47 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_coercion_overflow_maps_to_query_overflow() {
+        let error = TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::Overflow,
+        };
+
+        assert!(matches!(QueryError::from(error), QueryError::Overflow));
+    }
+
+    #[test]
+    fn invalid_table_type_coercion_maps_to_proof_error() {
+        let error = TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::InvalidTypeCoercion,
+        };
+
+        assert!(matches!(
+            QueryError::from(error),
+            QueryError::ProofError {
+                source: ProofError::InvalidTypeCoercion
+            }
+        ));
+    }
+
+    #[test]
+    fn table_shape_mismatches_map_to_proof_errors() {
+        assert!(matches!(
+            QueryError::from(TableCoercionError::NameMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldNamesMismatch
+            }
+        ));
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCountMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldCountMismatch
+            }
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for `QueryError::from(TableCoercionError)`
- verify column coercion overflow stays a query overflow
- verify invalid type coercion, name mismatch, and column count mismatch map to proof errors

## Non-overlap
This PR is limited to `crates/proof-of-sql/src/sql/proof/query_result.rs` and does not overlap my standard serialization, Arrow schema, table-ref, or Dory coverage PRs.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features std query_result -- --nocapture`
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: default features pull in `blitzar-sys`, whose build script rejects Windows, so this focused local test uses `--no-default-features --features std` to exercise this module without Blitzar.