### PR TITLE
test: cover provable result column serialization

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -69,3 +69,48 @@ impl<'a, T: ProvableResultElement<'a>, const N: usize> ProvableResultColumn for 
         (&self[..]).write(out, length)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::proof::decode_multiple_elements;
+    use alloc::vec;
+
+    #[test]
+    fn slice_column_reports_and_writes_encoded_bytes() {
+        let column = [121_i64, -345_i64, 666_i64];
+        let column_slice = &column[..];
+        let expected_len = column
+            .iter()
+            .map(ProvableResultElement::required_bytes)
+            .sum();
+        let mut out = vec![0_u8; expected_len];
+
+        assert_eq!(column_slice.num_bytes(column.len() as u64), expected_len);
+        assert_eq!(
+            column_slice.write(&mut out, column.len() as u64),
+            expected_len
+        );
+
+        let (decoded, bytes_read) = decode_multiple_elements::<i64>(&out, column.len()).unwrap();
+        assert_eq!(decoded, column);
+        assert_eq!(bytes_read, expected_len);
+    }
+
+    #[test]
+    fn array_column_delegates_to_slice_serialization() {
+        let column = ["alpha", "", "omega"];
+        let expected_len = column
+            .iter()
+            .map(ProvableResultElement::required_bytes)
+            .sum();
+        let mut out = vec![0_u8; expected_len];
+
+        assert_eq!(column.num_bytes(column.len() as u64), expected_len);
+        assert_eq!(column.write(&mut out, column.len() as u64), expected_len);
+
+        let (decoded, bytes_read) = decode_multiple_elements::<&str>(&out, column.len()).unwrap();
+        assert_eq!(decoded, column);
+        assert_eq!(bytes_read, expected_len);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for `ProvableResultColumn` serialization
- verify slice-backed columns report the encoded byte count and write decodable bytes
- verify fixed-size arrays delegate to the slice serialization path for string columns

## Non-overlap
This PR is limited to `crates/proof-of-sql/src/sql/proof/provable_result_column.rs` and does not overlap my U256, query error, standard serialization, Arrow schema, table-ref, or Dory coverage PRs.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features std provable_result_column -- --nocapture`
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: default features pull in `blitzar-sys`, whose build script rejects Windows, so this focused local test uses `--no-default-features --features std` to exercise this module without Blitzar.