### PR TITLE
test: cover evm proof plan errors

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,52 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn evm_proof_plan_errors_have_stable_display_messages() {
+        let cases = [
+            (EVMProofPlanError::NotSupported, "plan not yet supported"),
+            (EVMProofPlanError::ColumnNotFound, "column not found"),
+            (EVMProofPlanError::TableNotFound, "table not found"),
+            (
+                EVMProofPlanError::InvalidTableName,
+                "table name can not be parsed into TableRef",
+            ),
+            (
+                EVMProofPlanError::InvalidOutputColumnName,
+                "invalid or missing output column name",
+            ),
+            (
+                EVMProofPlanError::InconsistentGroupByColumnCounts,
+                "column counts in group by plans are inconsistent",
+            ),
+            (
+                EVMProofPlanError::IncorrectScalingFactor,
+                "incorrect scaling factor",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn evm_proof_plan_error_transparently_displays_analyze_errors() {
+        let error = EVMProofPlanError::AnalyzeError {
+            source: AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::Boolean,
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Expression has datatype BOOLEAN, which was not valid"
+        );
+    }
+}


### PR DESCRIPTION
﻿/claim #560

## Summary
- add focused display coverage for `EVMProofPlanError`
- verify all explicit EVM proof plan error variants keep stable messages
- verify transparent AnalyzeError wrapping preserves the underlying analyze error display

## Non-overlap
This PR is limited to `crates/proof-of-sql/src/sql/evm_proof_plan/error.rs` and does not overlap my proof error, query error, result-column, U256, standard serialization, Arrow schema, table-ref, or Dory coverage PRs.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features std evm_proof_plan::error -- --nocapture`
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

Note: default features pull in `blitzar-sys`, whose build script rejects Windows, so this focused local test uses `--no-default-features --features std` to exercise this module without Blitzar.
