### PR TITLE
test: cover decimal proof expr helpers

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -2,6 +2,8 @@
 mod proof_expr;
 pub(crate) use proof_expr::DecimalProofExpr;
 pub use proof_expr::ProofExpr;
+#[cfg(test)]
+mod proof_expr_decimal_trait_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod proof_expr_test;
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_decimal_trait_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_decimal_trait_test.rs
@@ -1,0 +1,120 @@
+use super::{AddExpr, DecimalProofExpr, DynProofExpr, MultiplyExpr, ProofExpr};
+use crate::base::{
+    database::{Column, ColumnType, LiteralValue, Table, TableOptions},
+    map::IndexMap,
+    math::decimal::Precision,
+    scalar::test_scalar::TestScalar,
+};
+use bumpalo::Bump;
+
+fn decimal_literal(precision: u8, scale: i8, value: i32) -> DynProofExpr {
+    DynProofExpr::new_literal(LiteralValue::Decimal75(
+        Precision::new(precision).unwrap(),
+        scale,
+        value.into(),
+    ))
+}
+
+fn empty_table_with_rows<'a>(row_count: usize) -> Table<'a, TestScalar> {
+    Table::try_new_with_options(IndexMap::default(), TableOptions::new(Some(row_count))).unwrap()
+}
+
+#[test]
+fn add_expr_decimal_helpers_use_result_type() {
+    let expr = AddExpr::try_new(
+        Box::new(decimal_literal(20, 3, 10)),
+        Box::new(decimal_literal(10, 3, 200)),
+    )
+    .unwrap();
+
+    assert_eq!(
+        expr.data_type(),
+        ColumnType::Decimal75(Precision::new(21).unwrap(), 3)
+    );
+    assert_eq!(expr.precision(), Precision::new(21).unwrap());
+    assert_eq!(expr.scale(), 3);
+    assert_eq!(
+        expr.lhs().data_type(),
+        ColumnType::Decimal75(Precision::new(20).unwrap(), 3)
+    );
+    assert_eq!(
+        expr.rhs().data_type(),
+        ColumnType::Decimal75(Precision::new(10).unwrap(), 3)
+    );
+}
+
+#[test]
+fn add_expr_first_round_evaluate_repeats_decimal_result_for_empty_table() {
+    let alloc = Bump::new();
+    let table = empty_table_with_rows(3);
+    let expr = AddExpr::try_new(
+        Box::new(decimal_literal(20, 3, 10)),
+        Box::new(decimal_literal(10, 3, 200)),
+    )
+    .unwrap();
+
+    let result = expr
+        .first_round_evaluate::<TestScalar>(&alloc, &table, &[])
+        .unwrap();
+
+    assert_eq!(
+        result,
+        Column::Decimal75(
+            Precision::new(21).unwrap(),
+            3,
+            &[
+                TestScalar::from(210),
+                TestScalar::from(210),
+                TestScalar::from(210)
+            ]
+        )
+    );
+}
+
+#[test]
+fn multiply_expr_decimal_helpers_use_result_type() {
+    let expr = MultiplyExpr::try_new(
+        Box::new(decimal_literal(20, 3, 20)),
+        Box::new(decimal_literal(10, 2, 30)),
+    )
+    .unwrap();
+
+    assert_eq!(
+        expr.data_type(),
+        ColumnType::Decimal75(Precision::new(31).unwrap(), 5)
+    );
+    assert_eq!(expr.precision(), Precision::new(31).unwrap());
+    assert_eq!(expr.scale(), 5);
+    assert_eq!(
+        expr.lhs().data_type(),
+        ColumnType::Decimal75(Precision::new(20).unwrap(), 3)
+    );
+    assert_eq!(
+        expr.rhs().data_type(),
+        ColumnType::Decimal75(Precision::new(10).unwrap(), 2)
+    );
+}
+
+#[test]
+fn multiply_expr_first_round_evaluate_repeats_decimal_result_for_empty_table() {
+    let alloc = Bump::new();
+    let table = empty_table_with_rows(2);
+    let expr = MultiplyExpr::try_new(
+        Box::new(decimal_literal(20, 3, 20)),
+        Box::new(decimal_literal(10, 2, 30)),
+    )
+    .unwrap();
+
+    let result = expr
+        .first_round_evaluate::<TestScalar>(&alloc, &table, &[])
+        .unwrap();
+
+    assert_eq!(
+        result,
+        Column::Decimal75(
+            Precision::new(31).unwrap(),
+            5,
+            &[TestScalar::from(600), TestScalar::from(600)]
+        )
+    );
+}


### PR DESCRIPTION
/claim #560

Summary:
- Adds no-default-features/no-blitzar tests for DecimalProofExpr helper behavior on AddExpr and MultiplyExpr.
- Verifies precision/scale report the computed result type rather than the input operand types.
- Verifies first_round_evaluate repeats decimal literal results over empty tables with explicit row counts.

Validation:
- cargo fmt --check
- cargo test --package proof-of-sql --lib --no-default-features --features='arrow rayon' proof_expr_decimal_trait_test
- cargo llvm-cov --package proof-of-sql --lib --no-default-features --features='arrow rayon' --text --show-missing-lines --output-path /tmp/sxt-proof-expr-decimal-coverage.txt -- proof_expr_decimal_trait_test