### PR TITLE
test: cover sql proof expression wrappers

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -10,3 +10,35 @@ pub struct AliasedDynProofExpr {
     /// The alias for the expression.
     pub alias: Ident,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::LiteralValue;
+
+    #[test]
+    fn aliased_dyn_proof_expr_round_trips_through_json() {
+        let expr = AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::BigInt(42)),
+            alias: Ident::new("answer"),
+        };
+
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: AliasedDynProofExpr = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, expr);
+    }
+
+    #[test]
+    fn aliased_dyn_proof_expr_clone_preserves_expr_and_alias() {
+        let expr = AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+            alias: Ident::new("is_selected"),
+        };
+
+        let cloned = expr.clone();
+
+        assert_eq!(cloned.expr, expr.expr);
+        assert_eq!(cloned.alias, expr.alias);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -7,3 +7,31 @@ pub struct TableExpr {
     /// The `TableRef` for the table
     pub table_ref: TableRef,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_expr_round_trips_through_json() {
+        let expr = TableExpr {
+            table_ref: TableRef::new("sxt", "orders"),
+        };
+
+        let serialized = serde_json::to_string(&expr).unwrap();
+        let deserialized: TableExpr = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, expr);
+    }
+
+    #[test]
+    fn table_expr_clone_preserves_table_ref() {
+        let expr = TableExpr {
+            table_ref: TableRef::new("analytics", "events"),
+        };
+
+        let cloned = expr.clone();
+
+        assert_eq!(cloned.table_ref, expr.table_ref);
+    }
+}


### PR DESCRIPTION
﻿/claim #560

## Summary
- add focused no-Blitzar coverage for `AliasedDynProofExpr`
- verify alias/expression JSON round-trip behavior and clone preservation
- add matching coverage for `TableExpr` table-ref JSON round-trip and clone preservation
- keep the change test-only with no runtime behavior changes

## Non-overlap
I checked current open #560 PR titles/bodies for `AliasedDynProofExpr`, `aliased_dyn_proof_expr`, `TableExpr`, and `table_expr` before opening this PR and did not find an active overlapping claim for these wrapper structs.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features std proof_exprs -- --nocapture`
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
