### PR TITLE
test: reduce eval vmv setup size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re_test.rs
@@ -35,12 +35,12 @@ fn we_can_prove_and_verify_an_eval_vmv_re() {
 #[test]
 fn we_can_prove_and_verify_an_eval_vmv_re_for_multiple_nu_values() {
     let mut rng = test_rng();
-    let max_nu = 5;
+    let max_nu = 4;
     let pp = PublicParameters::test_rand(max_nu, &mut rng);
     let prover_setup = (&pp).into();
     let verifier_setup = (&pp).into();
 
-    for nu in 0..max_nu {
+    for nu in 0..=max_nu {
         let vmv = VMV::rand(nu, &mut rng);
         let prover_state = vmv.calculate_prover_state(&prover_setup);
         let verifier_state = vmv.calculate_verifier_state(&prover_setup);


### PR DESCRIPTION
﻿/claim #557

## Summary

This is a small, non-overlapping Dory test runtime slice. The `eval_vmv_re` multiple-nu test previously generated public parameters for `max_nu = 5` while iterating `0..max_nu`, so it only exercised nu values 0 through 4. This changes the setup to `max_nu = 4` and iterates `0..=max_nu`, preserving the exact same tested nu values while avoiding unused setup generation.

## Non-overlap check

I searched open PRs for `eval_vmv_re`, `eval_vmv_re_test`, and related Dory setup-size work before taking this slice. I did not find an open PR covering this specific test.

## Validation

- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features test eval_vmv_re_test -- --nocapture` - 8 passed.
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`.
- `git diff --check`.
- `bash scripts/check_commits.sh` - 1 commit checked, 0 failed. It printed the known `bash: reduce: unknown operand` warning after the successful summary.
