### PR TITLE
test: reduce query commitments setup size

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -319,7 +319,7 @@ mod tests {
     #[expect(clippy::similar_names)]
     #[test]
     fn we_can_get_query_commitments_from_accessor() {
-        let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 3);
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -5,48 +5,62 @@ use super::{
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
 use merlin::Transcript;
+use std::sync::LazyLock;
+
+static PUBLIC_PARAMETERS_NU_4: LazyLock<PublicParameters> =
+    LazyLock::new(|| PublicParameters::test_rand(4, &mut test_rng()));
+static PUBLIC_PARAMETERS_NU_6: LazyLock<PublicParameters> =
+    LazyLock::new(|| PublicParameters::test_rand(6, &mut test_rng()));
+static VERIFIER_SETUP_NU_4: LazyLock<VerifierSetup> =
+    LazyLock::new(|| VerifierSetup::from(&*PUBLIC_PARAMETERS_NU_4));
+static VERIFIER_SETUP_NU_6: LazyLock<VerifierSetup> =
+    LazyLock::new(|| VerifierSetup::from(&*PUBLIC_PARAMETERS_NU_6));
+
+fn test_setup(max_nu: usize) -> (&'static PublicParameters, &'static VerifierSetup) {
+    match max_nu {
+        4 => (&*PUBLIC_PARAMETERS_NU_4, &*VERIFIER_SETUP_NU_4),
+        6 => (&*PUBLIC_PARAMETERS_NU_6, &*VERIFIER_SETUP_NU_6),
+        _ => unreachable!("test setup is only cached for max_nu 4 and 6"),
+    }
+}
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (public_parameters, verifier_setup) = test_setup(4);
+    let prover_setup = ProverSetup::from(public_parameters);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (public_parameters, verifier_setup) = test_setup(6);
+    let prover_setup = ProverSetup::from(public_parameters);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (public_parameters, verifier_setup) = test_setup(4);
+    let prover_setup = ProverSetup::from(public_parameters);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryVerifierPublicSetup::new(verifier_setup, 4),
     );
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryVerifierPublicSetup::new(verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (public_parameters, verifier_setup) = test_setup(6);
+    let prover_setup = ProverSetup::from(public_parameters);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
         &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryVerifierPublicSetup::new(verifier_setup, 2),
     );
 }
 
@@ -55,15 +69,14 @@ fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
     let setup_setup = [(4, 4), (4, 3), (6, 2)];
     for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let (public_parameters, verifier_setup) = test_setup(setup_p.0);
+        let prover_setup = ProverSetup::from(public_parameters);
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
                 &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &DoryVerifierPublicSetup::new(verifier_setup, setup_p.1),
             );
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -4,56 +4,82 @@ use super::{
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
 use merlin::Transcript;
+use std::sync::LazyLock;
+
+static PUBLIC_PARAMETERS_NU_2: LazyLock<PublicParameters> =
+    LazyLock::new(|| PublicParameters::test_rand(2, &mut test_rng()));
+static PUBLIC_PARAMETERS_NU_4: LazyLock<PublicParameters> =
+    LazyLock::new(|| PublicParameters::test_rand(4, &mut test_rng()));
+static PUBLIC_PARAMETERS_NU_6: LazyLock<PublicParameters> =
+    LazyLock::new(|| PublicParameters::test_rand(6, &mut test_rng()));
+static VERIFIER_SETUP_NU_2: LazyLock<VerifierSetup> =
+    LazyLock::new(|| VerifierSetup::from(&*PUBLIC_PARAMETERS_NU_2));
+static VERIFIER_SETUP_NU_4: LazyLock<VerifierSetup> =
+    LazyLock::new(|| VerifierSetup::from(&*PUBLIC_PARAMETERS_NU_4));
+static VERIFIER_SETUP_NU_6: LazyLock<VerifierSetup> =
+    LazyLock::new(|| VerifierSetup::from(&*PUBLIC_PARAMETERS_NU_6));
+
+fn public_parameters(max_nu: usize) -> &'static PublicParameters {
+    match max_nu {
+        4 => &PUBLIC_PARAMETERS_NU_4,
+        6 => &PUBLIC_PARAMETERS_NU_6,
+        _ => unreachable!("test public parameters are only cached for max_nu 4 and 6"),
+    }
+}
+
+fn verifier_setup(max_nu: usize) -> &'static VerifierSetup {
+    match max_nu {
+        2 => &VERIFIER_SETUP_NU_2,
+        4 => &VERIFIER_SETUP_NU_4,
+        6 => &VERIFIER_SETUP_NU_6,
+        _ => unreachable!("test verifier setup is only cached for max_nu 2, 4, and 6"),
+    }
+}
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = ProverSetup::from(public_parameters(4));
+    let verifier_setup = verifier_setup(4);
     test_simple_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
         &&prover_setup,
-        &&verifier_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = ProverSetup::from(public_parameters(4));
+    let verifier_setup = verifier_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DynamicDoryEvaluationProof>(
         &&prover_setup,
-        &&verifier_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 #[should_panic = "verification improperly failed"]
 fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = ProverSetup::from(public_parameters(6));
+    let verifier_setup = verifier_setup(2);
     test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
         128,
         0,
         &&prover_setup,
-        &&verifier_setup,
+        &verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = ProverSetup::from(public_parameters(6));
+    let verifier_setup = verifier_setup(6);
     for length in lengths {
         test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
             length,
             0,
             &&prover_setup,
-            &&verifier_setup,
+            &verifier_setup,
         );
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #557

# Rationale for this change

This is a narrow test-performance PR for bounty #557. It keeps production logic unchanged and only reduces repeated setup work in tests.

There are two slices:

1. `we_can_get_query_commitments_from_accessor` generated `PublicParameters::test_rand(4, ...)`, but the test immediately builds `DoryProverPublicSetup::new(&prover_setup, 3)`. The test only needs the `sigma = 3` setup surface for the owned tables and query-commitment accessor assertions, so `max_nu = 4` generated unused Dory setup data.
2. The fixed and dynamic Dory commitment evaluation proof test modules repeatedly generated the same expensive public parameters and verifier setups. Those tests now cache the shared `PublicParameters` / `VerifierSetup` values with `LazyLock` and still build fresh prover public setup wrappers and random proof inputs inside the tests.

# What changes are included in this PR?

- Reduce the query-commitment accessor test's Dory public parameter generation from `max_nu = 4` to `max_nu = 3`.
- Cache fixed Dory evaluation proof test setups for `max_nu = 4` and `max_nu = 6`.
- Cache dynamic Dory evaluation proof public parameters / verifier setups for `max_nu = 2`, `4`, and `6`.
- Keep the same assertions, table data, proof lengths, panic expectation, serialization checks, and query-commitment behavior.
- No production logic changes.

# Are these changes tested?

Local validation:

- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::dory::dory_commitment_evaluation_proof_test -- --nocapture` (`4 passed; 0 failed`)
- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::dory::dynamic_dory_commitment_evaluation_proof_test -- --nocapture` (`5 passed; 0 failed`)
- `cargo test -p proof-of-sql --lib --no-default-features --features test -- --list` confirmed the non-`blitzar` test binary builds, but the query-commitment accessor test is gated behind `#[cfg(all(test, feature = "blitzar"))]`.

Attempted focused `blitzar` test:

- `BLITZAR_BACKEND=cpu cargo test -p proof-of-sql --lib --no-default-features --features 'test blitzar' we_can_get_query_commitments_from_accessor -- --nocapture`

This cannot run on this macOS runner because `blitzar-sys` fails in its build script with `Unsupported OS. Only Linux is supported.` CI/Linux should provide the executable signal for the `blitzar`-gated test.

AI-assisted disclosure: prepared with OpenAI Codex and manually reviewed before submission.