### PR TITLE
test: cover table accessor helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -168,3 +168,55 @@ impl<'a, S: Scalar> core::ops::Index<&str> for Table<'a, S> {
         self.table.get(&Ident::new(index)).unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Column, Table, TableOptions};
+    use crate::base::{database::ColumnType, map::IndexMap, scalar::test_scalar::TestScalar};
+    use bumpalo::Bump;
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn table_iterators_and_index_preserve_ordered_columns() {
+        let ids = [10_i64, 20_i64];
+        let flags = [true, false];
+        let table = Table::<TestScalar>::try_from_iter([
+            (Ident::new("id"), Column::BigInt(&ids)),
+            (Ident::new("flag"), Column::Boolean(&flags)),
+        ])
+        .unwrap();
+
+        assert!(!table.is_empty());
+        assert_eq!(
+            table
+                .column_names()
+                .map(|name| name.value.as_str())
+                .collect::<Vec<_>>(),
+            ["id", "flag"]
+        );
+        assert_eq!(
+            table.columns().map(Column::column_type).collect::<Vec<_>>(),
+            [ColumnType::BigInt, ColumnType::Boolean]
+        );
+        assert_eq!(table["id"], Column::BigInt(&ids));
+        assert_eq!(table["flag"], Column::Boolean(&flags));
+
+        let alloc = Bump::new();
+        let table_with_rho = table.add_rho_column(&alloc);
+        assert_eq!(table_with_rho["rho"], Column::Int128(&[0_i128, 1_i128]));
+    }
+
+    #[test]
+    fn empty_table_with_row_count_reports_empty_iterators() {
+        let table = Table::<TestScalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions::new(Some(3)),
+        )
+        .unwrap();
+
+        assert!(table.is_empty());
+        assert_eq!(table.num_rows(), 3);
+        assert_eq!(table.column_names().count(), 0);
+        assert_eq!(table.columns().count(), 0);
+    }
+}


### PR DESCRIPTION
/claim #560

This test-only PR covers `Table` helper behavior that was previously uncovered:
- `Table::is_empty`
- `Table::column_names`
- `Table::columns`
- the test-only `Index<&str>` implementation

Coverage evidence:
- Baseline `origin/main` LCOV from `cargo llvm-cov --no-report -p proof-of-sql --no-default-features --features="std"` showed `crates/proof-of-sql/src/base/database/table.rs` lines 108-110, 130-132, 134-136, and 167-169 at count 0.
- Focused coverage after this PR with `base::database::table::tests` hits those same 12 executable lines.
- Estimated claim: 12 previously uncovered source lines, about $1.20 at $0.10/line. Final accounting is up to maintainers.

Validation:
- `cargo test -p proof-of-sql --no-default-features --features="std" base::database::table::tests -- --nocapture`
- `cargo llvm-cov clean --workspace && cargo llvm-cov --no-report -p proof-of-sql --no-default-features --features="std" -- base::database::table::tests --nocapture && cargo llvm-cov report --lcov --output-path /tmp/sxt-table-accessors-lcov.info`
- `cargo fmt --all -- --check`
- `git diff --check`