### PR TITLE
test: cover provable result column serialization

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -69,3 +69,100 @@ impl<'a, T: ProvableResultElement<'a>, const N: usize> ProvableResultColumn for 
         (&self[..]).write(out, length)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::{test_scalar::TestScalar, ScalarExt},
+    };
+    use alloc::{vec, vec::Vec};
+
+    fn encode_column(column: Column<'_, TestScalar>, length: u64) -> Vec<u8> {
+        let mut out = vec![0; column.num_bytes(length)];
+        let written = column.write(&mut out, length);
+        assert_eq!(written, out.len());
+        out
+    }
+
+    fn encode_slice<'a, T: ProvableResultElement<'a>>(column: &'a [T]) -> Vec<u8> {
+        let length = column.len() as u64;
+        let mut out = vec![0; column.num_bytes(length)];
+        let written = column.write(&mut out, length);
+        assert_eq!(written, out.len());
+        out
+    }
+
+    fn assert_column_serializes_like_slice<'a, T: ProvableResultElement<'a>>(
+        column: Column<'_, TestScalar>,
+        values: &'a [T],
+    ) {
+        let length = values.len() as u64;
+        assert_eq!(column.num_bytes(length), values.num_bytes(length));
+        assert_eq!(encode_column(column, length), encode_slice(values));
+    }
+
+    #[test]
+    fn columns_report_bytes_and_write_like_their_value_slices() {
+        let bools = [true, false];
+        assert_column_serializes_like_slice(Column::Boolean(&bools), &bools);
+
+        let uints = [7_u8, 9];
+        assert_column_serializes_like_slice(Column::Uint8(&uints), &uints);
+
+        let tiny_ints = [-8_i8, 12];
+        assert_column_serializes_like_slice(Column::TinyInt(&tiny_ints), &tiny_ints);
+
+        let small_ints = [-16_i16, 24];
+        assert_column_serializes_like_slice(Column::SmallInt(&small_ints), &small_ints);
+
+        let ints = [-32_i32, 48];
+        assert_column_serializes_like_slice(Column::Int(&ints), &ints);
+
+        let big_ints = [-64_i64, 96];
+        assert_column_serializes_like_slice(Column::BigInt(&big_ints), &big_ints);
+        assert_column_serializes_like_slice(
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &big_ints),
+            &big_ints,
+        );
+
+        let int128s = [-128_i128, 192];
+        assert_column_serializes_like_slice(Column::Int128(&int128s), &int128s);
+
+        let scalars = [TestScalar::from(3_u8), TestScalar::from(5_u8)];
+        assert_column_serializes_like_slice(Column::Scalar(&scalars), &scalars);
+        assert_column_serializes_like_slice(
+            Column::Decimal75(Precision::new(9).unwrap(), 2, &scalars),
+            &scalars,
+        );
+
+        let strings = ["proof", "sql"];
+        let string_scalars = [TestScalar::from(strings[0]), TestScalar::from(strings[1])];
+        assert_column_serializes_like_slice(Column::VarChar((&strings, &string_scalars)), &strings);
+
+        let first_bytes = [1_u8, 2, 3];
+        let second_bytes = [5_u8, 8];
+        let bytes: [&[u8]; 2] = [&first_bytes, &second_bytes];
+        let byte_scalars = [
+            TestScalar::from_byte_slice_via_hash(&first_bytes),
+            TestScalar::from_byte_slice_via_hash(&second_bytes),
+        ];
+        assert_column_serializes_like_slice(Column::VarBinary((&bytes, &byte_scalars)), &bytes);
+    }
+
+    #[test]
+    fn arrays_delegate_result_column_serialization_to_slices() {
+        let values = [1_i64, -2, 300];
+        let length = values.len() as u64;
+        let mut array_out = vec![0; values.num_bytes(length)];
+        let mut slice_out = vec![0; (&values[..]).num_bytes(length)];
+
+        let array_written = values.write(&mut array_out, length);
+        let slice_written = (&values[..]).write(&mut slice_out, length);
+
+        assert_eq!(array_written, slice_written);
+        assert_eq!(array_out, slice_out);
+    }
+}


### PR DESCRIPTION
/claim #560

This test-only PR covers `ProvableResultColumn` serialization across result column variants.

Coverage evidence:
- Baseline `origin/main` LCOV had these `crates/proof-of-sql/src/sql/proof/provable_result_column.rs` executable lines at count 0: 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27, 28, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 45, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 60, 64, 65, 66, 68, 69.
- Focused coverage with `sql::proof::provable_result_column::tests` hit all 43 of those lines.
- Estimated claim: 43 lines * $0.10 = $4.30. Final accounting is up to maintainers.

Validation:
- `cargo test -p proof-of-sql --no-default-features --features="std" sql::proof::provable_result_column::tests -- --nocapture`
- `cargo llvm-cov clean --workspace && cargo llvm-cov --no-report -p proof-of-sql --no-default-features --features="std" -- sql::proof::provable_result_column::tests --nocapture && cargo llvm-cov report --lcov --output-path /tmp/sxt-provable-result-column-lcov.info`
- `cargo fmt --all -- --check`
- `git diff --check`