### PR TITLE
test: cover fold log expression

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
@@ -83,3 +83,110 @@ impl<S: Scalar> FoldLogExpr<S> {
         self.final_round_evaluate_with_chi(builder, alloc, columns, length, chi)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{database::Column, scalar::test_scalar::TestScalar},
+        sql::proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
+    };
+    use alloc::{collections::VecDeque, vec, vec::Vec};
+    use ark_ff::One;
+
+    fn sample_columns<'a>(
+        left: &'a [TestScalar],
+        right: &'a [TestScalar],
+    ) -> Vec<Column<'a, TestScalar>> {
+        vec![Column::Scalar(left), Column::Scalar(right)]
+    }
+
+    fn expected_fold(left: &[TestScalar], right: &[TestScalar]) -> Vec<TestScalar> {
+        left.iter()
+            .zip(right)
+            .map(|(&a, &b)| TestScalar::from(2) * (a * TestScalar::from(3) + b))
+            .collect()
+    }
+
+    #[test]
+    fn final_round_evaluate_produces_fold_star_and_identity_constraint() {
+        let alloc = Bump::new();
+        let left = [
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+            TestScalar::from(4),
+        ];
+        let right = [
+            TestScalar::from(10),
+            TestScalar::from(20),
+            TestScalar::from(30),
+            TestScalar::from(40),
+        ];
+        let columns = sample_columns(&left, &right);
+        let expr = FoldLogExpr::new(TestScalar::from(2), TestScalar::from(3));
+        let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+
+        let (star, fold) = expr.final_round_evaluate(&mut builder, &alloc, &columns, left.len());
+
+        assert_eq!(fold, expected_fold(&left, &right).as_slice());
+        assert_eq!(builder.pcs_proof_mles().len(), 1);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 1);
+        for (&star_value, &fold_value) in star.iter().zip(fold) {
+            assert_eq!(
+                (TestScalar::one() + fold_value) * star_value,
+                TestScalar::one()
+            );
+        }
+    }
+
+    #[test]
+    fn verify_evaluate_consumes_star_and_records_matching_identity_evaluations() {
+        let alloc = Bump::new();
+        let left = [
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+            TestScalar::from(4),
+        ];
+        let right = [
+            TestScalar::from(10),
+            TestScalar::from(20),
+            TestScalar::from(30),
+            TestScalar::from(40),
+        ];
+        let columns = sample_columns(&left, &right);
+        let expr = FoldLogExpr::new(TestScalar::from(2), TestScalar::from(3));
+        let mut final_round_builder = FinalRoundBuilder::new(2, VecDeque::new());
+        let (star, fold) =
+            expr.final_round_evaluate(&mut final_round_builder, &alloc, &columns, left.len());
+        let final_round_mles = star.iter().map(|&value| vec![value]).collect();
+        let mut verification_builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            final_round_mles,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        for row in 0..left.len() {
+            let (star_eval, fold_eval) = expr
+                .verify_evaluate(
+                    &mut verification_builder,
+                    &[left[row], right[row]],
+                    TestScalar::one(),
+                )
+                .unwrap();
+            assert_eq!(star_eval, star[row]);
+            assert_eq!(fold_eval, fold[row]);
+            verification_builder.increment_row_index();
+        }
+
+        assert_eq!(
+            verification_builder.get_identity_results(),
+            vec![vec![true], vec![true], vec![true], vec![true]]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/fold_log_expr.rs
@@ -88,7 +88,9 @@ impl<S: Scalar> FoldLogExpr<S> {
 mod tests {
     use super::*;
     use crate::{
-        base::{database::Column, scalar::test_scalar::TestScalar},
+        base::{
+            database::Column, proof::ProofSizeMismatch, scalar::test_scalar::TestScalar,
+        },
         sql::proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
     };
     use alloc::{collections::VecDeque, vec, vec::Vec};
@@ -188,5 +190,34 @@ mod tests {
             verification_builder.get_identity_results(),
             vec![vec![true], vec![true], vec![true], vec![true]]
         );
+    }
+
+    #[test]
+    fn verify_evaluate_reports_missing_final_round_mle() {
+        let expr = FoldLogExpr::new(TestScalar::from(2), TestScalar::from(3));
+        let mut verification_builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            vec![Vec::new()],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let error = expr
+            .verify_evaluate(
+                &mut verification_builder,
+                &[TestScalar::from(1), TestScalar::from(10)],
+                TestScalar::one(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewMLEEvaluations
+            }
+        ));
     }
 }


### PR DESCRIPTION
/claim #560

# Rationale for this change

Improve test coverage for `FoldLogExpr`, including its final-round witness construction and verifier-side identity evaluation.

# What changes are included in this PR?

- Add a test for `final_round_evaluate` that checks:
  - the expected folded values;
  - one PCS proof MLE is registered;
  - one sumcheck subpolynomial is registered;
  - `(1 + fold) * star == 1` for every row.
- Add a test for `verify_evaluate` that checks:
  - row-by-row verifier output matches the final-round witness values;
  - identity results are recorded successfully for every row.

# Are these changes tested?

Yes.

```bash
cargo test -p proof-of-sql --lib --no-default-features --features test fold_log_expr -- --nocapture
cargo fmt --all -- --check

Local result:

running 2 tests
test sql::proof_gadgets::fold_log_expr::tests::final_round_evaluate_produces_fold_star_and_identity_constraint ... ok
test sql::proof_gadgets::fold_log_expr::tests::verify_evaluate_consumes_star_and_records_matching_identity_evaluations ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 960 filtered out; finished in 0.00s