### PR TITLE
test: cover table evaluation accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -102,6 +102,8 @@ pub mod table_utility;
 
 mod table_evaluation;
 pub use table_evaluation::TableEvaluation;
+#[cfg(test)]
+mod table_evaluation_test;
 
 mod test_accessor;
 pub use test_accessor::TestAccessor;

--- a/crates/proof-of-sql/src/base/database/table_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation_test.rs
@@ -1,0 +1,21 @@
+use super::TableEvaluation;
+use crate::base::scalar::test_scalar::TestScalar;
+
+#[test]
+fn table_evaluation_preserves_column_evaluations_and_chi() {
+    let column_evals = vec![TestScalar::from(3), TestScalar::from(5)];
+    let chi = (TestScalar::from(8), 13);
+    let evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+    assert_eq!(evaluation.column_evals(), column_evals);
+    assert_eq!(evaluation.chi_eval(), chi.0);
+    assert_eq!(evaluation.chi(), chi);
+}
+
+#[test]
+fn cloned_table_evaluation_preserves_values() {
+    let evaluation = TableEvaluation::new(vec![TestScalar::from(2)], (TestScalar::from(7), 11));
+    let cloned = evaluation.clone();
+
+    assert_eq!(cloned, evaluation);
+}


### PR DESCRIPTION
/claim #560

## Summary
- add direct coverage for `TableEvaluation` construction and accessors
- verify cloned evaluations preserve their values

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql table_evaluation --no-default-features --features="std arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"`
- `cargo test -p proof-of-sql --no-default-features --features="std arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"`

Related to #560