### PR TITLE
test: cover column field round trip

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field_test.rs
+++ b/crates/proof-of-sql/src/base/database/column_field_test.rs
@@ -1,0 +1,21 @@
+use super::{ColumnField, ColumnType};
+use sqlparser::ast::Ident;
+
+#[test]
+fn column_field_preserves_name_and_type() {
+    let name = Ident::new("total");
+    let field = ColumnField::new(name.clone(), ColumnType::BigInt);
+
+    assert_eq!(field.name(), name);
+    assert_eq!(field.data_type(), ColumnType::BigInt);
+}
+
+#[test]
+fn column_field_json_round_trip_preserves_quoted_name() {
+    let field = ColumnField::new(Ident::with_quote('"', "Mixed Name"), ColumnType::VarChar);
+
+    let json = serde_json::to_string(&field).unwrap();
+    let deserialized: ColumnField = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized, field);
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -17,6 +17,8 @@ pub use column_ref::ColumnRef;
 
 mod column_field;
 pub use column_field::ColumnField;
+#[cfg(test)]
+mod column_field_test;
 
 #[cfg_attr(not(test), expect(dead_code))]
 pub(crate) mod slice_operation;


### PR DESCRIPTION
/claim #560

## Summary
- add direct coverage for `ColumnField` construction and accessors
- verify JSON round trips preserve quoted identifiers

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql column_field --no-default-features --features="std arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"`
- `cargo test -p proof-of-sql --no-default-features --features="std arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"`

Related to #560