### PR TITLE
test: cover record batch column conversion

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -99,6 +99,46 @@ impl<C: Commitment> TableCommitment<C> {
     }
 }
 
+#[cfg(test)]
+mod batch_to_columns_tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use arrow::{
+        array::{Int64Array, StringArray},
+        datatypes::{DataType, Field, Schema},
+    };
+    use std::sync::Arc;
+
+    #[test]
+    fn converts_record_batch_fields_and_values_to_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["one", "two"])),
+            ],
+        )
+        .unwrap();
+        let alloc = Bump::new();
+
+        let columns = batch_to_columns::<TestScalar>(&batch, &alloc).unwrap();
+        let expected_scalars = ["one".into(), "two".into()];
+
+        assert_eq!(columns[0], ("id".into(), Column::BigInt(&[1, 2])));
+        assert_eq!(
+            columns[1],
+            (
+                "name".into(),
+                Column::VarChar((&["one", "two"], &expected_scalars))
+            )
+        );
+    }
+}
+
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -102,9 +102,11 @@ impl<C: Commitment> TableCommitment<C> {
 #[cfg(test)]
 mod batch_to_columns_tests {
     use super::*;
-    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::{
+        commitment::naive_commitment::NaiveCommitment, scalar::test_scalar::TestScalar,
+    };
     use arrow::{
-        array::{Int64Array, StringArray},
+        array::{Float64Array, Int64Array, StringArray},
         datatypes::{DataType, Field, Schema},
     };
     use std::sync::Arc;
@@ -136,6 +138,65 @@ mod batch_to_columns_tests {
                 Column::VarChar((&["one", "two"], &expected_scalars))
             )
         );
+    }
+
+    #[test]
+    fn rejects_unsupported_arrow_column_types() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Float64,
+            false,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Float64Array::from(vec![1.0]))]).unwrap();
+
+        assert!(batch_to_columns::<TestScalar>(&batch, &Bump::new()).is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "RecordBatches cannot have duplicate identifiers")]
+    fn rejects_duplicate_identifiers_when_creating_commitment() {
+        let batch = duplicate_identifier_batch();
+
+        TableCommitment::<NaiveCommitment>::try_from_record_batch(&batch, &()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "RecordBatches cannot have duplicate identifiers")]
+    fn rejects_duplicate_identifiers_when_appending_commitment() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::Int64, false),
+        ]));
+        let initial = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1])),
+                Arc::new(Int64Array::from(vec![2])),
+            ],
+        )
+        .unwrap();
+        let mut commitment =
+            TableCommitment::<NaiveCommitment>::try_from_record_batch(&initial, &()).unwrap();
+
+        commitment
+            .try_append_record_batch(&duplicate_identifier_batch(), &())
+            .unwrap();
+    }
+
+    fn duplicate_identifier_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("a", DataType::Int64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1])),
+                Arc::new(Int64Array::from(vec![2])),
+            ],
+        )
+        .unwrap()
     }
 }
 

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -154,6 +154,32 @@ mod batch_to_columns_tests {
     }
 
     #[test]
+    fn rejects_mismatched_column_types_when_appending_commitment() {
+        let initial = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "value",
+                DataType::Int64,
+                false,
+            )])),
+            vec![Arc::new(Int64Array::from(vec![1]))],
+        )
+        .unwrap();
+        let appended = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "value",
+                DataType::Utf8,
+                false,
+            )])),
+            vec![Arc::new(StringArray::from(vec!["one"]))],
+        )
+        .unwrap();
+        let mut commitment =
+            TableCommitment::<NaiveCommitment>::try_from_record_batch(&initial, &()).unwrap();
+
+        assert!(commitment.try_append_record_batch(&appended, &()).is_err());
+    }
+
+    #[test]
     #[should_panic(expected = "RecordBatches cannot have duplicate identifiers")]
     fn rejects_duplicate_identifiers_when_creating_commitment() {
         let batch = duplicate_identifier_batch();

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -139,7 +139,7 @@ mod batch_to_columns_tests {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{


### PR DESCRIPTION
/claim #560

## Summary
- add ungated `batch_to_columns` tests for Arrow record batches
- run the existing `NaiveCommitment` record-batch test without the unrelated Linux-only `blitzar` feature
- cover field-name preservation, `BigInt` / `VarChar` conversion, unsupported Arrow types, duplicate identifier rejection, table commitment creation, and append paths on the CPU-compatible profile

## Coverage
`base/arrow/record_batch_conversion.rs` reaches `96.60%` line coverage and `100%` function coverage in the CPU-compatible targeted profile.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql record_batch_conversion --no-default-features --features="std arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"`
- `cargo test -p proof-of-sql --no-default-features --features="std arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features="std arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm" --text --show-missing-lines -- record_batch_conversion`
- `cargo llvm-cov report --summary-only`