### PR TITLE
test: cover projection exec without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -9,6 +9,8 @@ mod table_exec_test;
 
 mod projection_exec;
 pub(crate) use projection_exec::ProjectionExec;
+#[cfg(test)]
+mod projection_exec_no_blitzar_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod projection_exec_test;
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_no_blitzar_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_no_blitzar_test.rs
@@ -1,0 +1,98 @@
+use super::{test_utility::*, ProjectionExec};
+use crate::{
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        database::{
+            owned_table_utility::*, ColumnField, ColumnRef, ColumnType, OwnedTableTestAccessor,
+            TableRef, TestAccessor,
+        },
+        map::IndexSet,
+    },
+    sql::{
+        proof::{ProofPlan, VerifiableQueryResult},
+        proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr},
+    },
+};
+use alloc::boxed::Box;
+use sqlparser::ast::Ident;
+
+#[test]
+fn we_can_prove_a_projection_with_the_naive_commitment_backend() {
+    let data = owned_table([
+        bigint("a", [1_i64, 2, 3, 4]),
+        int128("b", [10_i128, 20, 30, 40]),
+    ]);
+    let table_ref = TableRef::new("sxt", "t");
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    accessor.add_table(table_ref.clone(), data, 0);
+
+    let plan = projection(
+        vec![
+            col_expr_plan(&table_ref, "b", &accessor),
+            aliased_plan(const_bigint(9), "nine"),
+        ],
+        table_exec(
+            table_ref.clone(),
+            vec![
+                ColumnField::new("a".into(), ColumnType::BigInt),
+                ColumnField::new("b".into(), ColumnType::Int128),
+            ],
+        ),
+    );
+
+    let result = VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[])
+        .unwrap()
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    let expected = owned_table([
+        int128("b", [10_i128, 20, 30, 40]),
+        bigint("nine", [9_i64; 4]),
+    ]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn projection_metadata_uses_aliases_and_forwards_input_references() {
+    let table_ref = TableRef::new("sxt", "t");
+    let projection = ProjectionExec::new(
+        vec![
+            aliased_plan(
+                DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
+                    table_ref.clone(),
+                    Ident::new("a"),
+                    ColumnType::BigInt,
+                ))),
+                "renamed_a",
+            ),
+            aliased_plan(const_bigint(7), "seven"),
+        ],
+        Box::new(table_exec(
+            table_ref.clone(),
+            vec![
+                ColumnField::new("a".into(), ColumnType::BigInt),
+                ColumnField::new("b".into(), ColumnType::Int128),
+            ],
+        )),
+    );
+
+    assert_eq!(
+        projection.get_column_result_fields(),
+        vec![
+            ColumnField::new("renamed_a".into(), ColumnType::BigInt),
+            ColumnField::new("seven".into(), ColumnType::BigInt),
+        ]
+    );
+    assert_eq!(
+        projection.get_column_references(),
+        IndexSet::from_iter([
+            ColumnRef::new(table_ref.clone(), Ident::new("a"), ColumnType::BigInt),
+            ColumnRef::new(table_ref.clone(), Ident::new("b"), ColumnType::Int128),
+        ])
+    );
+    assert_eq!(
+        projection.get_table_references(),
+        IndexSet::from_iter([table_ref])
+    );
+}


### PR DESCRIPTION
/claim #560

## Summary
- add no-blitzar projection execution tests using `NaiveEvaluationProof`
- cover full projection proof/verify flow plus alias/result metadata and forwarded input references
- keep the existing blitzar-gated projection tests unchanged

## Coverage
- `projection_exec.rs` improves from 20/110 covered lines to 110/110 under the bounty LCOV target
- baseline uncovered projection lines: 90
- after this PR: 0 uncovered projection lines

## Verification
- `cargo test -p proof-of-sql --no-default-features --features test projection_exec_no_blitzar --lib`
- `cargo llvm-cov --no-default-features --features test --lib -p proof-of-sql --lcov --output-path /tmp/sxt-proof-of-sql-projection.lcov` (962 passed)
- `rustfmt --edition 2021 --check crates/proof-of-sql/src/sql/proof_plans/mod.rs crates/proof-of-sql/src/sql/proof_plans/projection_exec_no_blitzar_test.rs`
- `git diff --check`

Note: `cargo fmt --all -- --check` reports an unrelated pre-existing import-order diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`; I left that file untouched.