### PR TITLE
test: cover sort merge join without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -59,6 +59,8 @@ mod union_exec_test;
 
 mod sort_merge_join_exec;
 pub use sort_merge_join_exec::SortMergeJoinExec;
+#[cfg(test)]
+mod sort_merge_join_exec_no_blitzar_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod sort_merge_join_exec_test;
 

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_no_blitzar_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_no_blitzar_test.rs
@@ -1,0 +1,72 @@
+use super::test_utility::*;
+use crate::{
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        database::{
+            owned_table_utility::*, table_utility::*, ColumnType, TableRef, TableTestAccessor,
+            TestAccessor,
+        },
+    },
+    sql::proof::VerifiableQueryResult,
+};
+use bumpalo::Bump;
+use sqlparser::ast::Ident;
+
+#[test]
+fn we_can_prove_a_sort_merge_join_with_the_naive_commitment_backend() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    let left = table([
+        borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
+        borrowed_varchar(
+            "name",
+            ["Chloe", "Margaret", "Prudence", "Lucy", "Pepper"],
+            &alloc,
+        ),
+    ]);
+    let left_ref: TableRef = "sxt.cats".parse().unwrap();
+    let right = table([
+        borrowed_bigint("id", [1_i64, 2, 98, 4, 1, 2, 7], &alloc),
+        borrowed_varchar(
+            "human",
+            ["Cassia", "Cassia", "Gretta", "Gretta", "Ian", "Ian", "Erik"],
+            &alloc,
+        ),
+    ]);
+    let right_ref: TableRef = "sxt.cat_details".parse().unwrap();
+    accessor.add_table(left_ref.clone(), left, 0);
+    accessor.add_table(right_ref.clone(), right, 0);
+
+    let plan = sort_merge_join(
+        table_exec(
+            left_ref.clone(),
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("name", ColumnType::VarChar),
+            ],
+        ),
+        table_exec(
+            right_ref,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("human", ColumnType::VarChar),
+            ],
+        ),
+        vec![0],
+        vec![0],
+        vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
+    );
+
+    let result = VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[])
+        .unwrap()
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    let expected = owned_table([
+        bigint("id", [1_i64, 1, 2, 2, 4]),
+        varchar("name", ["Chloe", "Chloe", "Margaret", "Margaret", "Lucy"]),
+        varchar("human", ["Cassia", "Ian", "Cassia", "Ian", "Gretta"]),
+    ]);
+    assert_eq!(result, expected);
+}


### PR DESCRIPTION
/claim #560

## Summary
- add a no-blitzar sort-merge-join proof test using `NaiveEvaluationProof`
- verify the joined result end to end through `VerifiableQueryResult::new` and `verify`
- keep existing blitzar-gated sort-merge-join tests unchanged

## Coverage
- `sort_merge_join_exec.rs` improves from 73/431 covered lines to 419/431 under the bounty LCOV target
- baseline uncovered sort-merge-join lines: 358
- after this PR: 12 uncovered sort-merge-join lines

## Verification
- `cargo test -p proof-of-sql --no-default-features --features test sort_merge_join_exec_no_blitzar --lib`
- `cargo llvm-cov --no-default-features --features test --lib -p proof-of-sql --lcov --output-path /tmp/sxt-proof-of-sql-sort-merge.lcov` (961 passed)
- `rustfmt --edition 2021 --check crates/proof-of-sql/src/sql/proof_plans/mod.rs crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_no_blitzar_test.rs`
- `git diff --check`