### PR TITLE
test: cover slice and union without blitzar

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -51,6 +51,8 @@ mod slice_exec;
 pub(crate) use slice_exec::SliceExec;
 #[cfg(all(test, feature = "blitzar"))]
 mod slice_exec_test;
+#[cfg(test)]
+mod slice_union_exec_no_blitzar_test;
 
 mod union_exec;
 pub(crate) use union_exec::UnionExec;

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_union_exec_no_blitzar_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_union_exec_no_blitzar_test.rs
@@ -1,0 +1,89 @@
+use super::test_utility::*;
+use crate::{
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        database::{
+            owned_table_utility::*, ColumnType, OwnedTableTestAccessor, TableRef, TestAccessor,
+        },
+    },
+    sql::proof::VerifiableQueryResult,
+};
+
+#[test]
+fn we_can_prove_a_slice_with_the_naive_commitment_backend() {
+    let data = owned_table([
+        bigint("a", [1_i64, 2, 3, 4, 5]),
+        varchar("b", ["one", "two", "three", "four", "five"]),
+    ]);
+    let table_ref: TableRef = "sxt.slice_source".parse().unwrap();
+    let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        table_ref.clone(),
+        data,
+        0,
+        (),
+    );
+
+    let plan = slice_exec(
+        table_exec(
+            table_ref.clone(),
+            vec![
+                column_field("a", ColumnType::BigInt),
+                column_field("b", ColumnType::VarChar),
+            ],
+        ),
+        1,
+        Some(2),
+    );
+
+    let result = VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[])
+        .unwrap()
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    let expected = owned_table([bigint("a", [2_i64, 3]), varchar("b", ["two", "three"])]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_prove_a_union_with_the_naive_commitment_backend() {
+    let left = owned_table([
+        bigint("a", [1_i64, 2, 3]),
+        varchar("b", ["one", "two", "three"]),
+    ]);
+    let right = owned_table([bigint("a", [4_i64, 5]), varchar("b", ["four", "five"])]);
+    let left_ref = TableRef::new("sxt", "left_union");
+    let right_ref = TableRef::new("sxt", "right_union");
+    let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    accessor.add_table(left_ref.clone(), left, 0);
+    accessor.add_table(right_ref.clone(), right, 0);
+
+    let plan = union_exec(vec![
+        table_exec(
+            left_ref,
+            vec![
+                column_field("a", ColumnType::BigInt),
+                column_field("b", ColumnType::VarChar),
+            ],
+        ),
+        table_exec(
+            right_ref,
+            vec![
+                column_field("a", ColumnType::BigInt),
+                column_field("b", ColumnType::VarChar),
+            ],
+        ),
+    ]);
+
+    let result = VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[])
+        .unwrap()
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    let expected = owned_table([
+        bigint("a", [1_i64, 2, 3, 4, 5]),
+        varchar("b", ["one", "two", "three", "four", "five"]),
+    ]);
+    assert_eq!(result, expected);
+}


### PR DESCRIPTION
/claim #560

Summary:
- Adds no-default-features tests for SliceExec and UnionExec using NaiveEvaluationProof so they run without blitzar.
- Exercises end-to-end proving and verification through VerifiableQueryResult for slice and union plans.

Coverage:
- slice_exec.rs: 15/156 -> 145/156 covered (+130 previously uncovered executable lines)
- union_exec.rs: 14/133 -> 131/133 covered (+117 previously uncovered executable lines)
- Estimated bounty line value: $24.70 at $0.10 per newly covered line.

Validation:
- cargo test -p proof-of-sql --no-default-features --features test slice_union_exec_no_blitzar --lib
- cargo llvm-cov --no-default-features --features test --lib -p proof-of-sql --lcov --output-path /tmp/sxt-proof-of-sql-slice-union.lcov
- rustfmt --edition 2021 --check crates/proof-of-sql/src/sql/proof_plans/mod.rs crates/proof-of-sql/src/sql/proof_plans/slice_union_exec_no_blitzar_test.rs
- git diff --check