### PR TITLE
test: cover standard limb serialization helpers

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,47 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use alloc::vec::Vec;
+    use bincode::config::Config;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    fn fixed_big_endian_config() -> impl Config {
+        bincode::config::legacy()
+            .with_fixed_int_encoding()
+            .with_big_endian()
+    }
+
+    #[test]
+    fn limb_helpers_serialize_in_big_endian_word_order() {
+        let wrapper = LimbWrapper {
+            limbs: [1, 2, 3, 4],
+        };
+
+        let serialized =
+            bincode::serde::encode_to_vec(&wrapper, fixed_big_endian_config()).unwrap();
+
+        let mut expected = Vec::new();
+        for limb in [4_u64, 3, 2, 1] {
+            expected.extend_from_slice(&limb.to_be_bytes());
+        }
+        assert_eq!(serialized, expected);
+
+        let (deserialized, bytes_read): (LimbWrapper, usize) =
+            bincode::serde::decode_from_slice(&serialized, fixed_big_endian_config()).unwrap();
+        assert_eq!(deserialized, wrapper);
+        assert_eq!(bytes_read, serialized.len());
+    }
+}


### PR DESCRIPTION
/claim #560

Part of #560.

## Summary

- Adds direct unit coverage for the standard limb serde helpers.
- Verifies that `[u64; 4]` limbs serialize in reversed word order using the repository's fixed-width big-endian bincode convention.
- Verifies that deserialization restores the original limb order and consumes the full encoded payload.

## Verification

Because my local WSL environment does not have `clang`/`lld`, I used the system C compiler for local verification without changing repository config:

```bash
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc \
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS= \
cargo test -p proof-of-sql standard_serializations --no-default-features --features=std
```

Result: 2 passed, 0 failed.

Also run locally:

```bash
cargo fmt --all -- --config imports_granularity=Crate,group_imports=One
git diff --check
```
