### PR TITLE
Cache Dory setup in planner e2e tests

### DIFF
--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -18,6 +18,7 @@ use proof_of_sql::{
     sql::proof::VerifiableQueryResult,
 };
 use proof_of_sql_planner::sql_to_proof_plans;
+use std::sync::OnceLock;
 use sqlparser::{dialect::GenericDialect, parser::Parser};
 
 /// Get a new `TableTestAccessor` with the provided tables
@@ -30,6 +31,18 @@ fn new_test_accessor<'a, CP: CommitmentEvaluationProof>(
         accessor.add_table(table_ref.clone(), table.clone(), 0);
     }
     accessor
+}
+
+fn dynamic_dory_setup() -> (ProverSetup<'static>, &'static VerifierSetup) {
+    static SETUP: OnceLock<(&'static PublicParameters, VerifierSetup)> = OnceLock::new();
+
+    let (public_parameters, verifier_setup) = SETUP.get_or_init(|| {
+        let public_parameters: &'static PublicParameters =
+            Box::leak(Box::new(PublicParameters::test_rand(5, &mut test_rng())));
+        (public_parameters, VerifierSetup::from(public_parameters))
+    });
+
+    (ProverSetup::from(*public_parameters), verifier_setup)
 }
 
 /// Test setup
@@ -63,17 +76,14 @@ fn posql_end_to_end_test<'a, CP: CommitmentEvaluationProof>(
 /// Empty SQL should return no plans
 #[test]
 fn test_empty_sql() {
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         "",
         &indexmap! {},
         &[],
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -100,17 +110,14 @@ fn test_tableless_queries() {
         owned_table([varchar("name", ["Katy"]), bigint("age", [0_i64])]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[
             LiteralValue::VarChar("Katy".to_string()),
             LiteralValue::BigInt(0),
@@ -154,17 +161,14 @@ fn test_simple_filter_queries() {
         ]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[LiteralValue::VarChar("Katy".to_string())],
     );
 }
@@ -212,16 +216,14 @@ fn test_complex_filter_queries() {
         ]),
     ];
 
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[LiteralValue::VarChar("Buddy".to_string())],
     );
 }
@@ -256,17 +258,14 @@ fn test_projection() {
         ]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[LiteralValue::Boolean(true)],
     );
 }
@@ -289,17 +288,14 @@ fn test_projection_scaling() {
     let expected_results: Vec<OwnedTable<DoryScalar>> =
         vec![owned_table([decimal75("res", 7, 2, [15, 26, 37, 48])])];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -326,17 +322,14 @@ fn test_slicing_limit() {
         int("price", [1200, 800]),
     ])];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -415,17 +408,14 @@ fn test_group_by() {
         owned_table([bigint("COUNT(*)", [5_i64])]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[LiteralValue::BigInt(2)],
     );
 }
@@ -467,17 +457,14 @@ fn test_coin() {
         bigint("num_transactions", [5_i64]),
     ])];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[LiteralValue::VarChar("0x2".to_string())],
     );
 }
@@ -518,16 +505,13 @@ fn test_join() {
         owned_table([decimal75("product", 21, 0, [14, 24, 40, 50])]),
         owned_table([decimal75("sum_result", 11, 0, [11, 15, 14])]),
     ];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -619,16 +603,13 @@ JOIN (
             ],
         ),
     ])];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -664,16 +645,13 @@ fn test_union() {
             "Chocolate",
         ],
     )])];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[],
     );
 }
@@ -694,16 +672,13 @@ fn test_implicit_casts() {
         boolean("compared", [true, true, false, false]),
         decimal75("product", 14, 1, [300, 800, 30, 8]),
     ])];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let (prover_setup, verifier_setup) = dynamic_dory_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
         &prover_setup,
-        &verifier_setup,
+        verifier_setup,
         &[],
     );
 }


### PR DESCRIPTION
Contributor: Tristan Tang

## Summary
- Cache the Dynamic Dory public parameters and verifier setup once for the planner e2e test module.
- Reuse the cached verifier setup across e2e cases instead of generating fresh public parameters in every test.
- Preserve each test's existing prover setup behavior by constructing a `ProverSetup` from the cached public parameters per call.

## Verification
- `git diff --check`
- `rg "OnceLock|dynamic_dory_setup|VerifierSetup::from\(|PublicParameters::test_rand" crates/proof-of-sql-planner/tests/e2e_tests.rs -n`
- GitHub check-runs observed on the PR head: Orca Security Vulnerabilities, Secrets, and Infrastructure as Code all succeeded.

Attempted locally but blocked by Windows toolchain:
- `cargo test -p proof-of-sql-planner --test e2e_tests --all-features`
- The Rust toolchain is installed, but this Windows environment does not have the MSVC linker (`link.exe`) / Visual Studio Build Tools available, so build scripts fail before project tests compile.

Closes #557.