### PR TITLE
test: cover dynamic vec panic path

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/standard_basis_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/standard_basis_helper.rs
@@ -707,6 +707,13 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Values in point cannot be 1.")]
+    fn we_cannot_compute_dynamic_vecs_from_point_with_one() {
+        let point = vec![DoryScalar::from(1)];
+        compute_dynamic_vecs(&point);
+    }
+
+    #[test]
     fn we_can_compute_dynamic_vecs_that_matches_evaluation_vec() {
         use ark_std::UniformRand;
         let mut rng = ark_std::test_rng();


### PR DESCRIPTION
## Summary
- add focused coverage for compute_dynamic_vecs when a point coordinate is exactly 1
- assert the existing panic message for the documented invalid input path

/claim #560

## Validation
- cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features test we_cannot_compute_dynamic_vecs_from_point_with_one -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- bash scripts/check_commits.sh

## Deconfliction
Checked current open #560 PRs for standard_basis_helper, dynamic standard basis, compute_dynamic_vecs point=1, and the exact panic message. No active overlapping slice found.