### PR TITLE
test: cover table evaluation accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,31 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar;
+
+    #[test]
+    fn we_can_retrieve_column_and_chi_evaluations() {
+        let column_evals = vec![Curve25519Scalar::from(3), Curve25519Scalar::from(5)];
+        let chi = (Curve25519Scalar::from(7), 2);
+
+        let evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+        assert_eq!(evaluation.column_evals(), column_evals.as_slice());
+        assert_eq!(evaluation.chi_eval(), chi.0);
+        assert_eq!(evaluation.chi(), chi);
+    }
+
+    #[test]
+    fn we_can_clone_table_evaluations() {
+        let evaluation = TableEvaluation::new(
+            vec![Curve25519Scalar::from(11), Curve25519Scalar::from(13)],
+            (Curve25519Scalar::from(17), 3),
+        );
+
+        assert_eq!(evaluation.clone(), evaluation);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit coverage for `TableEvaluation` column and chi accessors
- verify clone and equality behavior for stored evaluations

/claim #560

## Verification
- cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features test table_evaluation -- --nocapture\n- cargo fmt --all -- --check\n- git diff --check\n- bash scripts/check_commits.sh