### PR TITLE
test: cover column reference accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,32 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_retrieve_column_reference_parts() {
+        let table_ref = TableRef::new("sxt", "trades");
+        let column_id = Ident::new("amount");
+        let column_type = ColumnType::BigInt;
+
+        let column_ref = ColumnRef::new(table_ref.clone(), column_id.clone(), column_type);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), column_id);
+        assert_eq!(column_ref.column_type(), &column_type);
+    }
+
+    #[test]
+    fn we_can_clone_column_references() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("sxt", "trades"),
+            Ident::new("price"),
+            ColumnType::BigInt,
+        );
+
+        assert_eq!(column_ref.clone(), column_ref);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit coverage for `ColumnRef` accessor methods
- verify cloned column references preserve table, column, and type data

/claim #560

## Verification
- cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features test column_ref -- --nocapture\n- cargo fmt --all -- --check\n- git diff --check\n- bash scripts/check_commits.sh