### PR TITLE
test: cover bit mask boundaries

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils_test.rs
@@ -31,6 +31,18 @@ fn we_can_make_negative_bit_mask() {
 }
 
 #[test]
+fn we_can_make_boundary_bit_masks() {
+    let msb_mask = U256::ONE.shl(255);
+
+    assert_eq!(make_bit_mask(TestScalar::ZERO), msb_mask);
+    assert_eq!(
+        make_bit_mask(TestScalar::MAX_SIGNED),
+        msb_mask + TestScalar::MAX_SIGNED_U256
+    );
+    assert_eq!(make_bit_mask(-TestScalar::ONE), msb_mask - U256::ONE);
+}
+
+#[test]
 fn we_can_verify_positive_bit_mask_is_positive_representation() {
     // ARRANGE
     let positive_scalar = TestScalar::TWO;


### PR DESCRIPTION
## Summary
- add boundary coverage for `make_bit_mask` at zero and `MAX_SIGNED`
- verify the `-1` representation sits just below the sign mask

/claim #560

## Verification
- cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features test bit_mask -- --nocapture\n- cargo fmt --all -- --check\n- git diff --check\n- bash scripts/check_commits.sh