### PR TITLE
test: cover vec commitment extension

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -171,7 +171,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{


### PR DESCRIPTION
## Summary
- run `VecCommitmentExt` tests under normal test builds instead of gating them on `blitzar`
- adds no-blitzar coverage for commitment conversion, append, extend, add, sub, and mismatch paths

/claim #560

## Verification
- cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features test vec_commitment_ext -- --nocapture\n- cargo fmt --all -- --check\n- git diff --check\n- bash scripts/check_commits.sh