### PR TITLE
test: reuse generated Dory setup in slow tests

### DIFF
--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -1,5 +1,4 @@
 //! In this file we run end-to-end tests for Proof of SQL.
-use ark_std::test_rng;
 use bumpalo::Bump;
 use datafusion::config::ConfigOptions;
 use indexmap::{indexmap, IndexMap};
@@ -19,6 +18,45 @@ use proof_of_sql::{
 };
 use proof_of_sql_planner::sql_to_proof_plans;
 use sqlparser::{dialect::GenericDialect, parser::Parser};
+use std::sync::OnceLock;
+
+struct SharedDynamicDoryTestSetup {
+    prover_setup: ProverSetup<'static>,
+    verifier_setup: VerifierSetup,
+}
+
+static DYNAMIC_DORY_TEST_SETUP: OnceLock<SharedDynamicDoryTestSetup> = OnceLock::new();
+
+fn dynamic_dory_test_setup() -> &'static SharedDynamicDoryTestSetup {
+    DYNAMIC_DORY_TEST_SETUP.get_or_init(|| {
+        let public_parameters = Box::leak(Box::new(PublicParameters::test_rand(
+            5,
+            &mut ark_std::test_rng(),
+        )));
+        SharedDynamicDoryTestSetup {
+            prover_setup: ProverSetup::from(&*public_parameters),
+            verifier_setup: VerifierSetup::from(&*public_parameters),
+        }
+    })
+}
+
+/// # Panics
+///
+/// Panics if the shared setup cache returns different setup instances.
+#[test]
+fn test_dynamic_dory_setup_is_reused() {
+    let first = dynamic_dory_test_setup();
+    let second = dynamic_dory_test_setup();
+
+    assert!(std::ptr::eq(
+        std::ptr::from_ref(&first.prover_setup),
+        std::ptr::from_ref(&second.prover_setup)
+    ));
+    assert!(std::ptr::eq(
+        std::ptr::from_ref(&first.verifier_setup),
+        std::ptr::from_ref(&second.verifier_setup)
+    ));
+}
 
 /// Get a new `TableTestAccessor` with the provided tables
 fn new_test_accessor<'a, CP: CommitmentEvaluationProof>(
@@ -63,17 +101,14 @@ fn posql_end_to_end_test<'a, CP: CommitmentEvaluationProof>(
 /// Empty SQL should return no plans
 #[test]
 fn test_empty_sql() {
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         "",
         &indexmap! {},
         &[],
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[],
     );
 }
@@ -100,17 +135,14 @@ fn test_tableless_queries() {
         owned_table([varchar("name", ["Katy"]), bigint("age", [0_i64])]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[
             LiteralValue::VarChar("Katy".to_string()),
             LiteralValue::BigInt(0),
@@ -154,17 +186,14 @@ fn test_simple_filter_queries() {
         ]),
     ];
 
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[LiteralValue::VarChar("Katy".to_string())],
     );
 }
@@ -211,17 +240,14 @@ fn test_complex_filter_queries() {
             decimal75("b", 39, 0, [100_i64, 100, 100]),
         ]),
     ];
-
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[LiteralValue::VarChar("Buddy".to_string())],
     );
 }
@@ -255,18 +281,14 @@ fn test_projection() {
             boolean("is_cute", [true; 4]),
         ]),
     ];
-
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[LiteralValue::Boolean(true)],
     );
 }
@@ -288,18 +310,14 @@ fn test_projection_scaling() {
 
     let expected_results: Vec<OwnedTable<DoryScalar>> =
         vec![owned_table([decimal75("res", 7, 2, [15, 26, 37, 48])])];
-
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[],
     );
 }
@@ -325,18 +343,14 @@ fn test_slicing_limit() {
         varchar("name", ["Laptop", "Phone"]),
         int("price", [1200, 800]),
     ])];
-
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[],
     );
 }
@@ -414,18 +428,14 @@ fn test_group_by() {
         owned_table([bigint("COUNT(cats.id)", [5_i64])]),
         owned_table([bigint("COUNT(*)", [5_i64])]),
     ];
-
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[LiteralValue::BigInt(2)],
     );
 }
@@ -466,18 +476,14 @@ fn test_coin() {
         decimal75("total_balance", 75, 0, [0]),
         bigint("num_transactions", [5_i64]),
     ])];
-
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
 
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[LiteralValue::VarChar("0x2".to_string())],
     );
 }
@@ -518,16 +524,13 @@ fn test_join() {
         owned_table([decimal75("product", 21, 0, [14, 24, 40, 50])]),
         owned_table([decimal75("sum_result", 11, 0, [11, 15, 14])]),
     ];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[],
     );
 }
@@ -619,16 +622,13 @@ JOIN (
             ],
         ),
     ])];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[],
     );
 }
@@ -664,16 +664,13 @@ fn test_union() {
             "Chocolate",
         ],
     )])];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[],
     );
 }
@@ -694,16 +691,13 @@ fn test_implicit_casts() {
         boolean("compared", [true, true, false, false]),
         decimal75("product", 14, 1, [300, 800, 30, 8]),
     ])];
-    // Create public parameters for DynamicDoryEvaluationProof
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = dynamic_dory_test_setup();
     posql_end_to_end_test::<DynamicDoryEvaluationProof>(
         sql,
         &tables,
         &expected_results,
-        &prover_setup,
-        &verifier_setup,
+        &setup.prover_setup,
+        &setup.verifier_setup,
         &[],
     );
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    shared_dory_test_setup, test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar,
+    DoryVerifierPublicSetup, ProverSetup, PublicParameters,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -8,45 +8,37 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = shared_dory_test_setup(4);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 4),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 4),
     );
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 3),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = shared_dory_test_setup(6);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 2),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 2),
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = shared_dory_test_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 4),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 4),
     );
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 3),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = shared_dory_test_setup(6);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 2),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 2),
     );
 }
 
@@ -55,15 +47,13 @@ fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
     let setup_setup = [(4, 4), (4, 3), (6, 2)];
     for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let setup = shared_dory_test_setup(setup_p.0);
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
-                &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &DoryProverPublicSetup::new(&setup.prover_setup, setup_p.1),
+                &DoryVerifierPublicSetup::new(&setup.verifier_setup, setup_p.1),
             );
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -5,26 +5,25 @@ use crate::{
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
     proof_primitive::dory::{
-        compute_dory_commitments, DoryProverPublicSetup, ProverSetup, PublicParameters, F, GT,
+        compute_dory_commitments, shared_dory_test_setup, DoryProverPublicSetup, F, GT,
     },
 };
 use ark_ec::pairing::Pairing;
-use ark_std::test_rng;
 use num_traits::Zero;
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_varbinary_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
 
     let data = [[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]];
     let col = CommittableColumn::VarBinary(data.to_vec());
 
     let res = compute_dory_commitments(&[col], 0, &setup);
 
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(1u64)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(2u64)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(3u64);
@@ -34,12 +33,12 @@ fn we_can_compute_a_dory_commitment_with_varbinary_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_int128_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::Int128(&[0, -1, 2])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0_i128)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(-1_i128)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2_i128);
@@ -48,16 +47,16 @@ fn we_can_compute_a_dory_commitment_with_int128_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_boolean_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::Boolean(&[true, false, true])],
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(true)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(false)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(true);
@@ -66,12 +65,12 @@ fn we_can_compute_a_dory_commitment_with_boolean_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2);
@@ -80,12 +79,12 @@ fn we_can_compute_a_dory_commitment_with_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -95,12 +94,12 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[2, 3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(3);
     assert_eq!(res[0].0, expected);
@@ -108,12 +107,12 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with_signed_data() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(-3);
     assert_eq!(res[0].0, expected);
@@ -121,16 +120,16 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -146,9 +145,9 @@ fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -156,8 +155,8 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -182,12 +181,12 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1])], 5, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -195,16 +194,16 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -220,9 +219,9 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns()
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -230,8 +229,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -256,9 +255,9 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
 
 #[test]
 fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[
@@ -274,8 +273,8 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -342,9 +341,8 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
 
 #[test]
 fn we_can_compute_an_empty_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
     assert_eq!(res[0].0, GT::zero());
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 5, &setup);
@@ -385,12 +383,12 @@ fn we_can_compute_an_empty_dory_commitment() {
 
 #[test]
 fn test_compute_dory_commitment_when_sigma_is_zero() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 0);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(2)
@@ -401,12 +399,12 @@ fn test_compute_dory_commitment_when_sigma_is_zero() {
 
 #[test]
 fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 0);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 5, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[5]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[6]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[7]) * F::from(2)
@@ -417,9 +415,9 @@ fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[0, 1]),
@@ -444,8 +442,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -494,9 +492,9 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_fewer_rows_than_columns(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[0, 1]),
@@ -521,8 +519,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
         2,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -570,9 +568,9 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[-2, -1, 0, 1, 2]),
@@ -597,8 +595,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(0)
@@ -659,9 +657,9 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+    let shared_setup = shared_dory_test_setup(5);
+    let public_parameters = shared_setup.public_parameters;
+    let setup = DoryProverPublicSetup::new(&shared_setup.prover_setup, 2);
     let res = compute_dory_commitments(
         &[
             CommittableColumn::BigInt(&[-2, -1, 0, 1, 2]),
@@ -686,8 +684,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
         4,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[1]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(0)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
+    shared_dory_test_setup, test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup,
+    PublicParameters, VerifierSetup,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -7,23 +8,19 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = shared_dory_test_setup(4);
     test_simple_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &&setup.prover_setup,
+        &&setup.verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = shared_dory_test_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &&setup.prover_setup,
+        &&setup.verifier_setup,
     );
 }
 
@@ -45,15 +42,13 @@ fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = shared_dory_test_setup(6);
     for length in lengths {
         test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
             length,
             0,
-            &&prover_setup,
-            &&verifier_setup,
+            &&setup.prover_setup,
+            &&setup.verifier_setup,
         );
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -39,6 +39,44 @@ mod setup;
 pub use setup::{ProverSetup, VerifierSetup};
 #[cfg(test)]
 mod setup_test;
+#[cfg(test)]
+mod test_setup {
+    use super::{test_rng, ProverSetup, PublicParameters, VerifierSetup};
+    use std::sync::OnceLock;
+
+    pub(crate) struct SharedDoryTestSetup {
+        pub public_parameters: &'static PublicParameters,
+        pub prover_setup: ProverSetup<'static>,
+        pub verifier_setup: VerifierSetup,
+    }
+
+    static DORY_TEST_SETUP_NU_2: OnceLock<SharedDoryTestSetup> = OnceLock::new();
+    static DORY_TEST_SETUP_NU_4: OnceLock<SharedDoryTestSetup> = OnceLock::new();
+    static DORY_TEST_SETUP_NU_5: OnceLock<SharedDoryTestSetup> = OnceLock::new();
+    static DORY_TEST_SETUP_NU_6: OnceLock<SharedDoryTestSetup> = OnceLock::new();
+
+    fn build_setup(nu: usize) -> SharedDoryTestSetup {
+        let public_parameters =
+            Box::leak(Box::new(PublicParameters::test_rand(nu, &mut test_rng())));
+        SharedDoryTestSetup {
+            public_parameters,
+            prover_setup: ProverSetup::from(&*public_parameters),
+            verifier_setup: VerifierSetup::from(&*public_parameters),
+        }
+    }
+
+    pub(crate) fn shared_dory_test_setup(nu: usize) -> &'static SharedDoryTestSetup {
+        match nu {
+            2 => DORY_TEST_SETUP_NU_2.get_or_init(|| build_setup(2)),
+            4 => DORY_TEST_SETUP_NU_4.get_or_init(|| build_setup(4)),
+            5 => DORY_TEST_SETUP_NU_5.get_or_init(|| build_setup(5)),
+            6 => DORY_TEST_SETUP_NU_6.get_or_init(|| build_setup(6)),
+            _ => panic!("unsupported shared dory test setup size: {nu}"),
+        }
+    }
+}
+#[cfg(test)]
+pub(super) use test_setup::shared_dory_test_setup;
 
 mod state;
 pub(crate) use state::{ProverState, VerifierState};

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
@@ -1,6 +1,25 @@
-use super::{test_rng, ProverSetup, PublicParameters, VerifierSetup};
+use super::{shared_dory_test_setup, test_rng, ProverSetup, PublicParameters, VerifierSetup};
 use ark_ec::pairing::Pairing;
 use std::{fs, path::Path};
+
+#[test]
+fn shared_dory_test_setup_reuses_generated_setup() {
+    let first = shared_dory_test_setup(5);
+    let second = shared_dory_test_setup(5);
+
+    assert!(std::ptr::eq(
+        first.public_parameters,
+        second.public_parameters
+    ));
+    assert!(std::ptr::eq(
+        std::ptr::from_ref(&first.prover_setup),
+        std::ptr::from_ref(&second.prover_setup)
+    ));
+    assert!(std::ptr::eq(
+        std::ptr::from_ref(&first.verifier_setup),
+        std::ptr::from_ref(&second.verifier_setup)
+    ));
+}
 
 #[test]
 fn we_can_create_and_manually_check_a_small_prover_setup() {


### PR DESCRIPTION
/claim #557

## Summary

- Add test-only shared Dory setup caches for repeated generated `PublicParameters`, `ProverSetup`, and `VerifierSetup` values.
- Reuse cached setup in planner e2e tests and core Dory commitment/proof tests that repeatedly created identical setup state.
- Add focused cache reuse tests so the performance-oriented behavior is covered directly.

## Tests

- `cargo fmt --check`
- `cargo clippy -p proof-of-sql -p proof-of-sql-planner --all-targets --all-features`
- `cargo test -p proof-of-sql-planner --test e2e_tests --all-features -- --nocapture`
- `cargo test -p proof-of-sql proof_primitive::dory::dory_compute_commitments_test --all-features -- --nocapture`
- `cargo test -p proof-of-sql commitment_evaluation_proof_test --all-features -- --nocapture`