### PR TITLE
test: cover scalar error and log helpers

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,21 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_can_display_scalar_conversion_overflow_errors() {
+        let error = ScalarConversionError::Overflow {
+            error: "value exceeds scalar modulus".to_string(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Overflow error: value exceeds scalar modulus"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -30,3 +30,13 @@ pub fn log_memory_usage(name: &str) {
         );
     }
 }
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_skip_memory_logging_when_trace_is_disabled() {
+        log_memory_usage("trace-disabled");
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused display coverage for `ScalarConversionError::Overflow`.
- Add focused coverage for calling `utils::log::log_memory_usage` when TRACE is disabled.
- Keep the change test-only with no runtime behavior changes.

## Non-overlap
I checked recent open #560 PR titles/bodies for `ScalarConversionError`, `scalar error`, `base::scalar::error`, `log_memory_usage`, and `utils::log` before taking this slice and did not find an active overlapping claim for these exact helper targets.

## Validation
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features std base::scalar::error -- --nocapture`
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --lib --no-default-features --features std utils::log -- --nocapture`
- `cargo +1.91.1-x86_64-pc-windows-gnu fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

Local note: the focused tests passed after pointing the portable GNU toolchain at the workspace `w64devkit` library paths. The warnings emitted by the focused test build are pre-existing warnings outside this slice.