### PR TITLE
test: cover equals expression helpers

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -213,3 +213,101 @@ pub fn verifier_evaluate_equals_zero<S: Scalar>(
 
     Ok(selection_eval)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        final_round_evaluate_equals_zero, first_round_evaluate_equals_zero,
+        verifier_evaluate_equals_zero,
+    };
+    use crate::{
+        base::scalar::test_scalar::TestScalar,
+        sql::proof::{
+            mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder,
+            SumcheckSubpolynomialType,
+        },
+    };
+    use alloc::collections::VecDeque;
+    use bumpalo::Bump;
+
+    #[test]
+    fn first_round_equals_zero_marks_exact_zero_entries() {
+        let alloc = Bump::new();
+        let lhs = [
+            TestScalar::from(0),
+            TestScalar::from(5),
+            TestScalar::from(0),
+            TestScalar::from(9),
+        ];
+
+        let selection = first_round_evaluate_equals_zero(lhs.len(), &alloc, &lhs);
+
+        assert_eq!(selection, &[true, false, true, false]);
+    }
+
+    #[test]
+    fn final_round_equals_zero_produces_selection_and_constraints() {
+        let alloc = Bump::new();
+        let lhs = alloc.alloc_slice_copy(&[
+            TestScalar::from(0),
+            TestScalar::from(5),
+            TestScalar::from(7),
+            TestScalar::from(0),
+        ]);
+        let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
+
+        let selection =
+            final_round_evaluate_equals_zero(lhs.len(), &mut builder, &alloc, lhs as &[_]);
+
+        assert_eq!(selection, &[true, false, false, true]);
+        assert_eq!(builder.pcs_proof_mles().len(), 2);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 2);
+        assert!(builder
+            .sumcheck_subpolynomials()
+            .iter()
+            .all(|subpoly| subpoly.subpolynomial_type() == SumcheckSubpolynomialType::Identity));
+    }
+
+    #[test]
+    fn verifier_equals_zero_uses_final_round_mles_and_records_identity_checks() {
+        let mut builder = MockVerificationBuilder::new(
+            vec![],
+            3,
+            vec![],
+            vec![vec![TestScalar::from(3), TestScalar::from(2)]],
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        let selection_eval =
+            verifier_evaluate_equals_zero(&mut builder, TestScalar::from(1), TestScalar::from(5))
+                .unwrap();
+
+        assert_eq!(selection_eval, TestScalar::from(2));
+        assert_eq!(
+            builder.identity_subpolynomial_evaluations,
+            vec![vec![TestScalar::from(2), TestScalar::from(0)]]
+        );
+    }
+
+    #[test]
+    fn verifier_equals_zero_errors_when_final_round_mles_are_missing() {
+        let mut builder = MockVerificationBuilder::new(
+            vec![],
+            3,
+            vec![],
+            vec![vec![TestScalar::from(3)]],
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        assert!(verifier_evaluate_equals_zero(
+            &mut builder,
+            TestScalar::from(1),
+            TestScalar::from(5)
+        )
+        .is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -218,17 +218,41 @@ pub fn verifier_evaluate_equals_zero<S: Scalar>(
 mod tests {
     use super::{
         final_round_evaluate_equals_zero, first_round_evaluate_equals_zero,
-        verifier_evaluate_equals_zero,
+        verifier_evaluate_equals_zero, EqualsExpr,
     };
     use crate::{
-        base::scalar::test_scalar::TestScalar,
-        sql::proof::{
-            mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder,
-            SumcheckSubpolynomialType,
+        base::{
+            database::{
+                table_utility::{borrowed_bigint, borrowed_boolean, table},
+                ColumnRef, ColumnType, LiteralValue, TableRef,
+            },
+            map::{IndexMap, IndexSet},
+            scalar::test_scalar::TestScalar,
+        },
+        sql::{
+            proof::{
+                mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder,
+                SumcheckSubpolynomialType,
+            },
+            proof_exprs::{DynProofExpr, ProofExpr},
+            AnalyzeError,
         },
     };
     use alloc::collections::VecDeque;
     use bumpalo::Bump;
+    use sqlparser::ast::Ident;
+
+    fn bigint_literal(value: i64) -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(value))
+    }
+
+    fn bigint_column(table_ref: &TableRef, column: &str) -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            table_ref.clone(),
+            Ident::new(column),
+            ColumnType::BigInt,
+        ))
+    }
 
     #[test]
     fn first_round_equals_zero_marks_exact_zero_entries() {
@@ -243,6 +267,110 @@ mod tests {
         let selection = first_round_evaluate_equals_zero(lhs.len(), &alloc, &lhs);
 
         assert_eq!(selection, &[true, false, true, false]);
+    }
+
+    #[test]
+    fn equals_expr_constructor_accessors_and_references_are_direct() {
+        let lhs = bigint_literal(10);
+        let rhs = bigint_literal(10);
+
+        let expr = EqualsExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap();
+
+        assert_eq!(expr.lhs(), &lhs);
+        assert_eq!(expr.rhs(), &rhs);
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+
+        let mismatch = EqualsExpr::try_new(
+            Box::new(lhs),
+            Box::new(DynProofExpr::new_literal(LiteralValue::VarChar(
+                "not numeric".into(),
+            ))),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            mismatch,
+            AnalyzeError::DataTypeMismatch {
+                left_type: _,
+                right_type: _
+            }
+        ));
+
+        let table_ref = TableRef::new("sxt", "t");
+        let lhs_ref = ColumnRef::new(table_ref.clone(), Ident::new("a"), ColumnType::BigInt);
+        let rhs_ref = ColumnRef::new(table_ref.clone(), Ident::new("b"), ColumnType::BigInt);
+        let expr = EqualsExpr::try_new(
+            Box::new(DynProofExpr::new_column(lhs_ref.clone())),
+            Box::new(DynProofExpr::new_column(rhs_ref.clone())),
+        )
+        .unwrap();
+        let mut column_references = IndexSet::default();
+
+        expr.get_column_references(&mut column_references);
+
+        assert_eq!(column_references.len(), 2);
+        assert!(column_references.contains(&lhs_ref));
+        assert!(column_references.contains(&rhs_ref));
+    }
+
+    #[test]
+    fn equals_expr_evaluates_columns_without_blitzar() {
+        let alloc = Bump::new();
+        let table_ref = TableRef::new("sxt", "t");
+        let data = table::<TestScalar>([
+            borrowed_bigint("a", [1_i64, 2, 2, 4], &alloc),
+            borrowed_bigint("b", [1_i64, 3, 2, 0], &alloc),
+        ]);
+        let expr = EqualsExpr::try_new(
+            Box::new(bigint_column(&table_ref, "a")),
+            Box::new(bigint_column(&table_ref, "b")),
+        )
+        .unwrap();
+        let expected = borrowed_boolean("expected", [true, false, true, false], &alloc).1;
+
+        let first_round = expr.first_round_evaluate(&alloc, &data, &[]).unwrap();
+
+        assert_eq!(first_round, expected);
+
+        let mut final_round_builder = FinalRoundBuilder::new(2, VecDeque::new());
+        let final_round = expr
+            .final_round_evaluate(&mut final_round_builder, &alloc, &data, &[])
+            .unwrap();
+
+        assert_eq!(final_round, expected);
+        assert_eq!(final_round_builder.pcs_proof_mles().len(), 2);
+        assert_eq!(final_round_builder.num_sumcheck_subpolynomials(), 2);
+    }
+
+    #[test]
+    fn equals_expr_verifier_evaluates_columns_and_records_constraints() {
+        let table_ref = TableRef::new("sxt", "t");
+        let expr = EqualsExpr::try_new(
+            Box::new(bigint_column(&table_ref, "a")),
+            Box::new(bigint_column(&table_ref, "b")),
+        )
+        .unwrap();
+        let mut accessor = IndexMap::default();
+        accessor.insert(Ident::new("a"), TestScalar::from(7));
+        accessor.insert(Ident::new("b"), TestScalar::from(7));
+        let mut builder = MockVerificationBuilder::new(
+            vec![],
+            3,
+            vec![],
+            vec![vec![TestScalar::from(0), TestScalar::from(5)]],
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        let selection_eval = expr
+            .verifier_evaluate(&mut builder, &accessor, TestScalar::from(5), &[])
+            .unwrap();
+
+        assert_eq!(selection_eval, TestScalar::from(5));
+        assert_eq!(
+            builder.identity_subpolynomial_evaluations,
+            vec![vec![TestScalar::from(0), TestScalar::from(0)]]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #560

# Rationale for this change

This is a small, non-overlapping test-coverage slice for bounty #560.

The existing end-to-end equality expression tests are gated behind `feature = "blitzar"`. The helper and direct expression paths in `equals_expr.rs` can be covered without Blitzar, so this PR adds no-Blitzar unit coverage for the equals-zero helper functions and the `EqualsExpr` constructor/evaluation paths.

# What changes are included in this PR?

- Add focused tests for `first_round_evaluate_equals_zero` selection output.
- Add focused tests for `final_round_evaluate_equals_zero` selection output, intermediate MLE production, and identity subpolynomial registration.
- Add focused verifier-helper tests for `verifier_evaluate_equals_zero`, including successful final-round MLE consumption and the missing-MLE error path.
- Add direct `EqualsExpr` coverage for constructor/accessors, datatype mismatch, column-reference forwarding, first/final column evaluation, and verifier evaluation.
- No production logic changes.

# Are these changes tested?

Local validation:

- `cargo test -p proof-of-sql --lib --no-default-features --features test equals_expr -- --nocapture` (`9 passed; 0 failed`)
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

AI-assisted disclosure: prepared with OpenAI Codex and manually reviewed before submission.
