### PR TITLE
test: cover dynamic vec zero coordinates

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/standard_basis_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/standard_basis_helper.rs
@@ -723,4 +723,22 @@ pub(crate) mod tests {
             }
         }
     }
+
+    #[test]
+    fn we_can_compute_dynamic_vecs_that_match_evaluation_vec_with_zero_coordinates() {
+        let point = [
+            DoryScalar::from(0),
+            DoryScalar::from(2),
+            DoryScalar::from(0),
+            DoryScalar::from(3),
+            DoryScalar::from(5),
+        ];
+        let (lo_vec, hi_vec) = compute_dynamic_vecs(&point);
+        let mut eval_vec = vec![DoryScalar::ZERO; 1 << point.len()];
+        compute_evaluation_vector(&mut eval_vec, &point);
+        for (i, val) in eval_vec.into_iter().enumerate() {
+            let (row, column) = row_and_column_from_index(i);
+            assert_eq!(hi_vec[row] * lo_vec[column], val);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a deterministic `compute_dynamic_vecs` coverage case with zero coordinates in the evaluation point
- verify the dynamic row/column factorization still matches the full evaluation vector for those zero-coordinate inputs
- keep production code unchanged

/claim #560

## Validation
- `git diff --check`

I could not run the focused cargo test locally because this Windows environment does not currently have `cargo`/`rustc` on PATH.

## Deconfliction
Checked current open PRs and #560 comments for `standard_basis_helper`, `standard basis`, `compute_dynamic_vecs`, and the existing dynamic-vector panic slice. This PR does not touch the already-open panic-path coverage in #2192.