### PR TITLE
test: cover column_type and arrow_schema_utility methods

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility_test.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility_test.rs
@@ -1,0 +1,89 @@
+use super::arrow_schema_utility::get_posql_compatible_schema;
+use alloc::sync::Arc;
+use arrow::datatypes::{DataType, Field, Schema};
+
+#[test]
+fn empty_schema_returns_empty_schema() {
+    let schema = Arc::new(Schema::empty());
+    let result = get_posql_compatible_schema(&schema);
+    assert_eq!(result.fields().len(), 0);
+}
+
+#[test]
+fn float16_is_converted_to_decimal256() {
+    let schema = Arc::new(Schema::new(vec![Field::new("f16", DataType::Float16, true)]));
+    let result = get_posql_compatible_schema(&schema);
+    assert_eq!(result.field(0).data_type(), &DataType::Decimal256(20, 10));
+    assert!(result.field(0).is_nullable());
+}
+
+#[test]
+fn float32_is_converted_to_decimal256() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "f32",
+        DataType::Float32,
+        false,
+    )]));
+    let result = get_posql_compatible_schema(&schema);
+    assert_eq!(result.field(0).data_type(), &DataType::Decimal256(20, 10));
+    assert!(!result.field(0).is_nullable());
+}
+
+#[test]
+fn float64_is_converted_to_decimal256() {
+    let schema = Arc::new(Schema::new(vec![Field::new("f64", DataType::Float64, true)]));
+    let result = get_posql_compatible_schema(&schema);
+    assert_eq!(result.field(0).data_type(), &DataType::Decimal256(20, 10));
+}
+
+#[test]
+fn non_float_types_are_preserved() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("int32", DataType::Int32, true),
+        Field::new("utf8", DataType::Utf8, false),
+        Field::new("bool", DataType::Boolean, true),
+        Field::new("int64", DataType::Int64, false),
+    ]));
+    let result = get_posql_compatible_schema(&schema);
+    assert_eq!(result.field(0).data_type(), &DataType::Int32);
+    assert_eq!(result.field(1).data_type(), &DataType::Utf8);
+    assert_eq!(result.field(2).data_type(), &DataType::Boolean);
+    assert_eq!(result.field(3).data_type(), &DataType::Int64);
+}
+
+#[test]
+fn mixed_float_and_non_float_types() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Float32, true),
+        Field::new("b", DataType::Int32, false),
+        Field::new("c", DataType::Float64, true),
+        Field::new("d", DataType::Utf8, false),
+    ]));
+    let result = get_posql_compatible_schema(&schema);
+    assert_eq!(result.field(0).data_type(), &DataType::Decimal256(20, 10));
+    assert_eq!(result.field(1).data_type(), &DataType::Int32);
+    assert_eq!(result.field(2).data_type(), &DataType::Decimal256(20, 10));
+    assert_eq!(result.field(3).data_type(), &DataType::Utf8);
+}
+
+#[test]
+fn field_names_are_preserved() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("my_col", DataType::Float32, true),
+        Field::new("other_col", DataType::Int64, false),
+    ]));
+    let result = get_posql_compatible_schema(&schema);
+    assert_eq!(result.field(0).name(), "my_col");
+    assert_eq!(result.field(1).name(), "other_col");
+}
+
+#[test]
+fn nullability_is_preserved() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("nullable_float", DataType::Float64, true),
+        Field::new("non_nullable_float", DataType::Float32, false),
+    ]));
+    let result = get_posql_compatible_schema(&schema);
+    assert!(result.field(0).is_nullable());
+    assert!(!result.field(1).is_nullable());
+}

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -673,4 +673,242 @@ mod tests {
             assert_eq!(column_type.sqrt_negative_min(), None);
         }
     }
+
+    #[test]
+    fn is_numeric_returns_true_for_numeric_types() {
+        assert!(ColumnType::Uint8.is_numeric());
+        assert!(ColumnType::TinyInt.is_numeric());
+        assert!(ColumnType::SmallInt.is_numeric());
+        assert!(ColumnType::Int.is_numeric());
+        assert!(ColumnType::BigInt.is_numeric());
+        assert!(ColumnType::Int128.is_numeric());
+        assert!(ColumnType::Scalar.is_numeric());
+        assert!(ColumnType::Decimal75(Precision::new(10).unwrap(), 2).is_numeric());
+    }
+
+    #[test]
+    fn is_numeric_returns_false_for_non_numeric_types() {
+        assert!(!ColumnType::Boolean.is_numeric());
+        assert!(!ColumnType::VarChar.is_numeric());
+        assert!(!ColumnType::VarBinary.is_numeric());
+        assert!(!ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).is_numeric());
+    }
+
+    #[test]
+    fn is_integer_returns_true_for_integer_types() {
+        assert!(ColumnType::Uint8.is_integer());
+        assert!(ColumnType::TinyInt.is_integer());
+        assert!(ColumnType::SmallInt.is_integer());
+        assert!(ColumnType::Int.is_integer());
+        assert!(ColumnType::BigInt.is_integer());
+        assert!(ColumnType::Int128.is_integer());
+    }
+
+    #[test]
+    fn is_integer_returns_false_for_non_integer_types() {
+        assert!(!ColumnType::Boolean.is_integer());
+        assert!(!ColumnType::VarChar.is_integer());
+        assert!(!ColumnType::VarBinary.is_integer());
+        assert!(!ColumnType::Scalar.is_integer());
+        assert!(!ColumnType::Decimal75(Precision::new(10).unwrap(), 2).is_integer());
+        assert!(!ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).is_integer());
+    }
+
+    #[test]
+    fn max_integer_type_returns_larger_type() {
+        assert_eq!(
+            ColumnType::TinyInt.max_integer_type(&ColumnType::BigInt),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::Int.max_integer_type(&ColumnType::SmallInt),
+            Some(ColumnType::Int)
+        );
+        assert_eq!(
+            ColumnType::Uint8.max_integer_type(&ColumnType::Int128),
+            Some(ColumnType::Int128)
+        );
+        assert_eq!(
+            ColumnType::BigInt.max_integer_type(&ColumnType::BigInt),
+            Some(ColumnType::BigInt)
+        );
+    }
+
+    #[test]
+    fn max_integer_type_returns_none_for_non_integer_types() {
+        assert_eq!(
+            ColumnType::Boolean.max_integer_type(&ColumnType::Int),
+            None
+        );
+        assert_eq!(
+            ColumnType::Int.max_integer_type(&ColumnType::VarChar),
+            None
+        );
+        assert_eq!(
+            ColumnType::Scalar.max_integer_type(&ColumnType::BigInt),
+            None
+        );
+    }
+
+    #[test]
+    fn max_unsigned_integer_type_returns_larger_type() {
+        assert_eq!(
+            ColumnType::TinyInt.max_unsigned_integer_type(&ColumnType::BigInt),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::Uint8),
+            Some(ColumnType::Uint8)
+        );
+    }
+
+    #[test]
+    fn max_unsigned_integer_type_returns_none_for_non_integer_types() {
+        assert_eq!(
+            ColumnType::Boolean.max_unsigned_integer_type(&ColumnType::Int),
+            None
+        );
+    }
+
+    #[test]
+    fn precision_value_returns_correct_values() {
+        assert_eq!(ColumnType::Uint8.precision_value(), Some(3));
+        assert_eq!(ColumnType::TinyInt.precision_value(), Some(3));
+        assert_eq!(ColumnType::SmallInt.precision_value(), Some(5));
+        assert_eq!(ColumnType::Int.precision_value(), Some(10));
+        assert_eq!(ColumnType::BigInt.precision_value(), Some(19));
+        assert_eq!(ColumnType::Int128.precision_value(), Some(39));
+        assert_eq!(ColumnType::Scalar.precision_value(), Some(0));
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).precision_value(),
+            Some(19)
+        );
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(42).unwrap(), 5).precision_value(),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn precision_value_returns_none_for_non_numeric_types() {
+        assert_eq!(ColumnType::Boolean.precision_value(), None);
+        assert_eq!(ColumnType::VarChar.precision_value(), None);
+        assert_eq!(ColumnType::VarBinary.precision_value(), None);
+    }
+
+    #[test]
+    fn scale_returns_correct_values() {
+        assert_eq!(ColumnType::TinyInt.scale(), Some(0));
+        assert_eq!(ColumnType::Uint8.scale(), Some(0));
+        assert_eq!(ColumnType::SmallInt.scale(), Some(0));
+        assert_eq!(ColumnType::Int.scale(), Some(0));
+        assert_eq!(ColumnType::BigInt.scale(), Some(0));
+        assert_eq!(ColumnType::Int128.scale(), Some(0));
+        assert_eq!(ColumnType::Scalar.scale(), Some(0));
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 5).scale(),
+            Some(5)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).scale(),
+            Some(0)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()).scale(),
+            Some(3)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc()).scale(),
+            Some(6)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc()).scale(),
+            Some(9)
+        );
+    }
+
+    #[test]
+    fn scale_returns_none_for_non_numeric_types() {
+        assert_eq!(ColumnType::Boolean.scale(), None);
+        assert_eq!(ColumnType::VarChar.scale(), None);
+        assert_eq!(ColumnType::VarBinary.scale(), None);
+    }
+
+    #[test]
+    fn byte_size_returns_correct_values() {
+        assert_eq!(ColumnType::Boolean.byte_size(), 1);
+        assert_eq!(ColumnType::Uint8.byte_size(), 1);
+        assert_eq!(ColumnType::TinyInt.byte_size(), 1);
+        assert_eq!(ColumnType::SmallInt.byte_size(), 2);
+        assert_eq!(ColumnType::Int.byte_size(), 4);
+        assert_eq!(ColumnType::BigInt.byte_size(), 8);
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).byte_size(),
+            8
+        );
+        assert_eq!(ColumnType::Int128.byte_size(), 16);
+        assert_eq!(ColumnType::Scalar.byte_size(), 32);
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 2).byte_size(),
+            32
+        );
+        assert_eq!(ColumnType::VarChar.byte_size(), 32);
+        assert_eq!(ColumnType::VarBinary.byte_size(), 32);
+    }
+
+    #[test]
+    fn bit_size_returns_byte_size_times_eight() {
+        assert_eq!(ColumnType::Boolean.bit_size(), 8);
+        assert_eq!(ColumnType::Uint8.bit_size(), 8);
+        assert_eq!(ColumnType::SmallInt.bit_size(), 16);
+        assert_eq!(ColumnType::Int.bit_size(), 32);
+        assert_eq!(ColumnType::BigInt.bit_size(), 64);
+        assert_eq!(ColumnType::Int128.bit_size(), 128);
+        assert_eq!(ColumnType::Scalar.bit_size(), 256);
+    }
+
+    #[test]
+    fn is_signed_returns_correct_values() {
+        assert!(ColumnType::TinyInt.is_signed());
+        assert!(ColumnType::SmallInt.is_signed());
+        assert!(ColumnType::Int.is_signed());
+        assert!(ColumnType::BigInt.is_signed());
+        assert!(ColumnType::Int128.is_signed());
+        assert!(ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).is_signed());
+
+        assert!(!ColumnType::Boolean.is_signed());
+        assert!(!ColumnType::Uint8.is_signed());
+        assert!(!ColumnType::VarChar.is_signed());
+        assert!(!ColumnType::VarBinary.is_signed());
+        assert!(!ColumnType::Scalar.is_signed());
+        assert!(!ColumnType::Decimal75(Precision::new(10).unwrap(), 2).is_signed());
+    }
+
+    #[test]
+    fn display_shows_correct_names() {
+        assert_eq!(format!("{}", ColumnType::Boolean), "BOOLEAN");
+        assert_eq!(format!("{}", ColumnType::Uint8), "UINT8");
+        assert_eq!(format!("{}", ColumnType::TinyInt), "TINYINT");
+        assert_eq!(format!("{}", ColumnType::SmallInt), "SMALLINT");
+        assert_eq!(format!("{}", ColumnType::Int), "INT");
+        assert_eq!(format!("{}", ColumnType::BigInt), "BIGINT");
+        assert_eq!(format!("{}", ColumnType::Int128), "DECIMAL");
+        assert_eq!(format!("{}", ColumnType::VarChar), "VARCHAR");
+        assert_eq!(format!("{}", ColumnType::VarBinary), "BINARY");
+        assert_eq!(format!("{}", ColumnType::Scalar), "SCALAR");
+    }
+
+    #[test]
+    fn display_shows_precision_and_scale_for_decimal75() {
+        let col = ColumnType::Decimal75(Precision::new(42).unwrap(), 7);
+        assert_eq!(format!("{}", col), "DECIMAL75(PRECISION: 42, SCALE: 7)");
+    }
+
+    #[test]
+    fn display_shows_timeunit_and_timezone_for_timestamptz() {
+        let col = ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc());
+        let display = format!("{}", col);
+        assert!(display.starts_with("TIMESTAMP("));
+        assert!(display.contains("Second"));
+    }
 }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -70,6 +70,8 @@ pub use table_ref::TableRef;
 
 #[cfg(feature = "arrow")]
 pub mod arrow_schema_utility;
+#[cfg(all(test, feature = "arrow"))]
+mod arrow_schema_utility_test;
 
 mod owned_column;
 pub use owned_column::OwnedColumn;


### PR DESCRIPTION
## Summary
- Add tests for `ColumnType` methods previously without coverage: `is_numeric`, `is_integer`, `max_integer_type`, `max_unsigned_integer_type`, `precision_value`, `scale`, `byte_size`, `bit_size`, `is_signed`, and `Display` formatting
- Add tests for `arrow_schema_utility::get_posql_compatible_schema`: float type conversion, non-float preservation, mixed schemas, nullability, and field name preservation
- Keep production behavior unchanged

/claim #560

## Validation
- `git diff --check` — passed
- CI tests will validate all new test cases

I could not run `cargo test` locally because the MinGW linker on Windows does not support Unicode characters in the username path (`yellow鹏`). The CI environment does not have this limitation.

## Deconfliction
Checked current open PRs and #560 comments for `column_type`, `arrow_schema_utility`, `is_numeric`, `is_integer`, `precision_value`, `byte_size`, and `is_signed`. No active overlap found — other PRs focus on different modules (dory, sumcheck, scalar operations, planner, etc.).

AI-assisted with Claude Code; I reviewed the diff and test logic before submitting.