### PR TITLE
test: cover planner df utilities

### DIFF
--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -25,3 +25,42 @@ pub(crate) fn df_schema(table_name: &str, pairs: Vec<(&str, DataType)>) -> DFSch
     );
     DFSchema::try_from_qualified_schema(table_name, &arrow_schema).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{df_column, df_schema};
+    use arrow::datatypes::DataType;
+    use datafusion::{
+        catalog::TableReference,
+        common::Column,
+        logical_expr::Expr,
+    };
+
+    #[test]
+    fn we_can_create_a_qualified_column_expr() {
+        assert_eq!(
+            df_column("namespace.table", "amount"),
+            Expr::Column(Column::new(
+                Some(TableReference::from("namespace.table")),
+                "amount"
+            ))
+        );
+    }
+
+    #[test]
+    fn we_can_create_a_non_nullable_qualified_schema() {
+        let schema = df_schema(
+            "namespace.table",
+            vec![("id", DataType::Int64), ("name", DataType::Utf8)],
+        );
+
+        let fields = schema.fields();
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].qualified_name(), "namespace.table.id");
+        assert_eq!(fields[0].field().data_type(), &DataType::Int64);
+        assert!(!fields[0].field().is_nullable());
+        assert_eq!(fields[1].qualified_name(), "namespace.table.name");
+        assert_eq!(fields[1].field().data_type(), &DataType::Utf8);
+        assert!(!fields[1].field().is_nullable());
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Contributes a small coverage-focused change toward #560 by adding direct tests for the planner DataFusion utility helpers.

# What changes are included in this PR?

- Add a unit test for `df_column` to verify it builds a qualified DataFusion column expression.
- Add a unit test for `df_schema` to verify it builds a qualified, non-nullable schema with the expected field types.

# Are these changes tested?

I added focused unit tests for the changed coverage target and ran `git diff --check` locally.

I could not run `cargo test`, `source scripts/run_ci_checks.sh`, or `source scripts/check_commits.sh` in this environment because Rust/Cargo is not installed on this machine. The patch is intentionally small and limited to test code.
