### PR TITLE
test: add coverage tests for planner and proof utilities

### DIFF
--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -25,3 +25,47 @@ pub(crate) fn df_schema(table_name: &str, pairs: Vec<(&str, DataType)>) -> DFSch
     );
     DFSchema::try_from_qualified_schema(table_name, &arrow_schema).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn df_column_qualifies_the_column_with_the_table_name() {
+        let expr = df_column("orders", "total");
+
+        match expr {
+            Expr::Column(column) => {
+                assert_eq!(column.relation, Some(TableReference::from("orders")));
+                assert_eq!(column.name, "total");
+            }
+            other => panic!("expected Expr::Column, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn df_schema_marks_fields_as_non_nullable_and_qualified() {
+        let schema = df_schema(
+            "orders",
+            vec![("id", DataType::Int64), ("total", DataType::Float64)],
+        );
+
+        let fields = schema.fields();
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].name(), "id");
+        assert_eq!(fields[0].data_type(), &DataType::Int64);
+        assert!(!fields[0].is_nullable());
+        assert_eq!(fields[1].name(), "total");
+        assert_eq!(fields[1].data_type(), &DataType::Float64);
+        assert!(!fields[1].is_nullable());
+
+        let qualifiers = schema.iter().map(|(q, _)| q.cloned()).collect::<Vec<_>>();
+        assert_eq!(
+            qualifiers,
+            vec![
+                Some(TableReference::from("orders")),
+                Some(TableReference::from("orders")),
+            ]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,30 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_float_fields_to_decimal_and_preserves_other_metadata() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("f16", DataType::Float16, true),
+            Field::new("f32", DataType::Float32, false),
+            Field::new("f64", DataType::Float64, true),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+        let fields = converted.fields();
+
+        assert_eq!(fields[0].data_type(), &DataType::Decimal256(20, 10));
+        assert!(fields[0].is_nullable());
+        assert_eq!(fields[1].data_type(), &DataType::Decimal256(20, 10));
+        assert!(!fields[1].is_nullable());
+        assert_eq!(fields[2].data_type(), &DataType::Decimal256(20, 10));
+        assert!(fields[2].is_nullable());
+        assert_eq!(fields[3].data_type(), &DataType::Utf8);
+        assert!(!fields[3].is_nullable());
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,18 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_ref_accessors_return_the_original_values() {
+        let table_ref = TableRef::from_names(Some("analytics"), "orders");
+        let column_ref = ColumnRef::new(table_ref.clone(), "total".into(), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), Ident::new("total"));
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
@@ -27,3 +27,42 @@ impl<'a, S: Scalar> SumcheckRandomScalars<'a, S> {
         v
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn splits_scalars_into_subpolynomial_multipliers_and_entrywise_point() {
+        let scalars = [
+            TestScalar::from(2u64),
+            TestScalar::from(3u64),
+            TestScalar::from(5u64),
+            TestScalar::from(7u64),
+        ];
+
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 4, 2);
+
+        assert_eq!(
+            random_scalars.subpolynomial_multipliers,
+            &[TestScalar::from(2u64), TestScalar::from(3u64)]
+        );
+        assert_eq!(
+            random_scalars.entrywise_point,
+            &[TestScalar::from(5u64), TestScalar::from(7u64)]
+        );
+        assert_eq!(random_scalars.table_length, 4);
+    }
+
+    #[test]
+    fn computes_entrywise_multipliers_from_the_entrywise_point() {
+        let scalars = [TestScalar::from(11u64), TestScalar::from(3u64)];
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 2, 1);
+
+        assert_eq!(
+            random_scalars.compute_entrywise_multipliers(),
+            vec![TestScalar::ONE - TestScalar::from(3u64), TestScalar::from(3u64)]
+        );
+    }
+}


### PR DESCRIPTION
Closes #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This PR contributes a small, test-only coverage slice toward the broader coverage work tracked in #560.

# What changes are included in this PR?

- add direct tests for `proof-of-sql-planner::df_util`
- add direct tests for `proof-of-sql::base::database::ColumnRef`
- add direct tests for PoSQL-compatible Arrow schema conversion
- add direct tests for `proof-of-sql::sql::proof::SumcheckRandomScalars`

# Are these changes tested?

Yes, test cases were added for the covered utility code paths.

I successfully ran `source scripts/check_commits.sh`.

I also ran `source scripts/run_ci_checks.sh`, but the checks could not complete in this local Windows environment because Rust linking is blocked by missing Windows SDK / MSVC linker libraries (`kernel32.lib`, `ntdll.lib`, `ws2_32.lib`, `dbghelp.lib`).