### PR TITLE
test: cover PoSQL time unit helpers

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -81,4 +81,42 @@ mod time_unit_tests {
             ));
         }
     }
+
+    #[test]
+    fn we_can_convert_time_units_to_precision_values() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn we_can_display_time_units_with_precision_context() {
+        assert_eq!(
+            PoSQLTimeUnit::Second.to_string(),
+            "seconds (precision: 0)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
+
+    #[test]
+    fn invalid_precision_error_preserves_the_input_value() {
+        let result = PoSQLTimeUnit::try_from("12");
+
+        assert!(matches!(
+            result,
+            Err(PoSQLTimestampError::UnsupportedPrecision { error }) if error == "12"
+        ));
+    }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

/claim #560

Adds a small, non-overlapping test-only coverage slice for `PoSQLTimeUnit` helper behavior as part of the broader coverage bounty in #560.

I checked the current open coverage PR queue before choosing this slice. The nearby open PR #2191 covers `timezone.rs`; this PR covers `unit.rs` and does not overlap with the active timezone/parser coverage.

# What changes are included in this PR?

- Adds coverage for converting each `PoSQLTimeUnit` variant into its precision value via `u64::from`.
- Adds coverage for `Display` output for each supported precision.
- Adds coverage that unsupported precision errors preserve the original invalid input string.
- No production behavior changes.

# Are these changes tested?

Added focused unit tests in `crates/proof-of-sql/src/base/posql_time/unit.rs`.

Local validation run:

```text
git diff --check
# passed

static patch assertions
# passed
```

I attempted the Rust gates, but this worker image does not have Cargo/Rust installed:

```text
cargo fmt --check
# /usr/bin/bash: line 1: cargo: command not found

cargo test -p proof-of-sql time_unit_tests
# /usr/bin/bash: line 1: cargo: command not found
```

Because the patch is test-only and limited to one existing test module, I am submitting with that environment limitation disclosed for CI/reviewer validation.
