### PR TITLE
test: cache repeated Dory test setups

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup,
-    ProverSetup, PublicParameters, VerifierSetup,
+    cached_dory_test_setup, test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryScalar,
+    DoryVerifierPublicSetup,
 };
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
@@ -8,45 +8,37 @@ use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_test_setup(4);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 4),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 4),
     );
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 3),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_test_setup(6);
     test_simple_commitment_evaluation_proof::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 2),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 2),
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_test_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 4),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 4),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 4),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 4),
     );
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 3),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 3),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 3),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 3),
     );
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_test_setup(6);
     test_commitment_evaluation_proof_with_length_1::<DoryEvaluationProof>(
-        &DoryProverPublicSetup::new(&prover_setup, 2),
-        &DoryVerifierPublicSetup::new(&verifier_setup, 2),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 2),
+        &DoryVerifierPublicSetup::new(&setup.verifier_setup, 2),
     );
 }
 
@@ -55,15 +47,13 @@ fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
     let setup_setup = [(4, 4), (4, 3), (6, 2)];
     for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let setup = cached_dory_test_setup(setup_p.0);
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
-                &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &DoryProverPublicSetup::new(&setup.prover_setup, setup_p.1),
+                &DoryVerifierPublicSetup::new(&setup.verifier_setup, setup_p.1),
             );
         }
     }
@@ -72,8 +62,7 @@ fn test_random_ipa_with_various_lengths() {
 #[test]
 fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
     let mut rng = test_rng();
-    let public_parameters = PublicParameters::test_rand(4, &mut rng);
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = cached_dory_test_setup(4);
     let a = core::iter::repeat_with(|| DoryScalar::rand(&mut rng))
         .take(30)
         .collect::<Vec<_>>();
@@ -86,7 +75,7 @@ fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
         &a,
         &b_point,
         0,
-        &DoryProverPublicSetup::new(&prover_setup, 3),
+        &DoryProverPublicSetup::new(&setup.prover_setup, 3),
     );
     let encoded = postcard::to_allocvec(&proof).unwrap();
     let decoded: DoryEvaluationProof = postcard::from_bytes(&encoded).unwrap();

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -5,17 +5,17 @@ use crate::{
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
     proof_primitive::dory::{
-        compute_dory_commitments, DoryProverPublicSetup, ProverSetup, PublicParameters, F, GT,
+        cached_dory_test_setup, compute_dory_commitments, DoryProverPublicSetup, F, GT,
     },
 };
 use ark_ec::pairing::Pairing;
-use ark_std::test_rng;
 use num_traits::Zero;
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_varbinary_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
 
     let data = [[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]];
@@ -23,8 +23,8 @@ fn we_can_compute_a_dory_commitment_with_varbinary_values() {
 
     let res = compute_dory_commitments(&[col], 0, &setup);
 
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(1u64)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(2u64)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(3u64);
@@ -34,12 +34,13 @@ fn we_can_compute_a_dory_commitment_with_varbinary_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_int128_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::Int128(&[0, -1, 2])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0_i128)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(-1_i128)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2_i128);
@@ -48,16 +49,17 @@ fn we_can_compute_a_dory_commitment_with_int128_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_boolean_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::Boolean(&[true, false, true])],
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(true)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(false)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(true);
@@ -66,12 +68,13 @@ fn we_can_compute_a_dory_commitment_with_boolean_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2);
@@ -80,12 +83,13 @@ fn we_can_compute_a_dory_commitment_with_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -95,12 +99,13 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[2, 3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(3);
     assert_eq!(res[0].0, expected);
@@ -108,12 +113,13 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with_signed_data() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(-3);
     assert_eq!(res[0].0, expected);
@@ -121,16 +127,17 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -146,8 +153,9 @@ fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
@@ -156,8 +164,8 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -182,12 +190,13 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1])], 5, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -195,16 +204,17 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -220,8 +230,9 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns()
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
@@ -230,8 +241,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -256,8 +267,9 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
 
 #[test]
 fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[
@@ -274,8 +286,8 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -342,8 +354,8 @@ fn we_can_compute_three_dory_commitments_with_an_offset_and_more_rows_than_colum
 
 #[test]
 fn we_can_compute_an_empty_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
     assert_eq!(res[0].0, GT::zero());
@@ -385,12 +397,13 @@ fn we_can_compute_an_empty_dory_commitment() {
 
 #[test]
 fn test_compute_dory_commitment_when_sigma_is_zero() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 0, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(2)
@@ -401,12 +414,13 @@ fn test_compute_dory_commitment_when_sigma_is_zero() {
 
 #[test]
 fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 5, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[5]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[6]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[7]) * F::from(2)
@@ -417,8 +431,9 @@ fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_rows_than_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[
@@ -444,8 +459,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -494,8 +509,9 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_fewer_rows_than_columns(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[
@@ -521,8 +537,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
         2,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -570,8 +586,9 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[
@@ -597,8 +614,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(0)
@@ -659,8 +676,9 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
 #[test]
 fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let prover_setup = &cached_setup.prover_setup;
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[
@@ -686,8 +704,8 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
         4,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[1]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(0)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof_test.rs
@@ -1,39 +1,31 @@
-use super::{
-    test_rng, DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
-};
+use super::{cached_dory_test_setup, test_rng, DoryScalar, DynamicDoryEvaluationProof};
 use crate::base::commitment::{commitment_evaluation_proof_test::*, CommitmentEvaluationProof};
 use ark_std::UniformRand;
 use merlin::Transcript;
 
 #[test]
 fn test_simple_ipa() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_test_setup(4);
     test_simple_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &&setup.prover_setup,
+        &&setup.verifier_setup,
     );
 }
 
 #[test]
 fn test_random_ipa_with_length_1() {
-    let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_test_setup(4);
     test_commitment_evaluation_proof_with_length_1::<DynamicDoryEvaluationProof>(
-        &&prover_setup,
-        &&verifier_setup,
+        &&setup.prover_setup,
+        &&setup.verifier_setup,
     );
 }
 
 #[test]
 #[should_panic = "verification improperly failed"]
 fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let prover_setup = &cached_dory_test_setup(6).prover_setup;
+    let verifier_setup = &cached_dory_test_setup(2).verifier_setup;
     test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
         128,
         0,
@@ -45,15 +37,13 @@ fn test_random_ipa_fails_with_too_small_of_verifier_setup() {
 #[test]
 fn test_random_ipa_with_various_lengths() {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let public_parameters = PublicParameters::test_rand(6, &mut test_rng());
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let setup = cached_dory_test_setup(6);
     for length in lengths {
         test_random_commitment_evaluation_proof::<DynamicDoryEvaluationProof>(
             length,
             0,
-            &&prover_setup,
-            &&verifier_setup,
+            &&setup.prover_setup,
+            &&setup.verifier_setup,
         );
     }
 }
@@ -61,8 +51,7 @@ fn test_random_ipa_with_various_lengths() {
 #[test]
 fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
     let mut rng = test_rng();
-    let public_parameters = PublicParameters::test_rand(4, &mut rng);
-    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = cached_dory_test_setup(4);
     let a = core::iter::repeat_with(|| DoryScalar::rand(&mut rng))
         .take(30)
         .collect::<Vec<_>>();
@@ -70,7 +59,8 @@ fn we_can_serialize_and_deserialize_dory_evaluation_proofs() {
         .take(5)
         .collect::<Vec<_>>();
     let mut transcript = Transcript::new(b"evaluation_proof");
-    let proof = DynamicDoryEvaluationProof::new(&mut transcript, &a, &b_point, 0, &&prover_setup);
+    let proof =
+        DynamicDoryEvaluationProof::new(&mut transcript, &a, &b_point, 0, &&setup.prover_setup);
     let encoded = postcard::to_allocvec(&proof).unwrap();
     let decoded: DynamicDoryEvaluationProof = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(decoded, proof);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
@@ -4,17 +4,15 @@ use crate::{
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     },
-    proof_primitive::dory::{
-        compute_dynamic_dory_commitments, test_rng, ProverSetup, PublicParameters, F, GT,
-    },
+    proof_primitive::dory::{cached_dory_test_setup, compute_dynamic_dory_commitments, F, GT},
 };
 use ark_ec::pairing::Pairing;
 use num_traits::Zero;
 
 #[test]
 fn we_can_handle_calling_with_an_empty_committable_column() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(&[], 0, &setup);
 
     assert!(res.is_empty());
@@ -22,8 +20,9 @@ fn we_can_handle_calling_with_an_empty_committable_column() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -31,8 +30,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(2)
@@ -57,8 +56,9 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -66,8 +66,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_o
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[3]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[3]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[3]) * F::from(2)
@@ -92,11 +92,12 @@ fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values_and_an_o
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_signed_bigint_values_and_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[2]) * F::from(-3);
     assert_eq!(res[0].0, expected);
@@ -104,8 +105,9 @@ fn we_can_compute_a_dynamic_dory_commitment_with_signed_bigint_values_and_an_off
 
 #[test]
 fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::BigInt(&[
@@ -121,8 +123,8 @@ fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset
         5,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[3]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[3]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[3]) * F::from(2)
@@ -189,8 +191,8 @@ fn we_can_compute_three_dynamic_dory_commitments_with_unsigned_bigint_and_offset
 
 #[test]
 fn we_can_compute_an_empty_dynamic_dory_commitment() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
     assert_eq!(res[0].0, GT::zero());
     let res = compute_dynamic_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 5, &setup);
@@ -231,8 +233,9 @@ fn we_can_compute_an_empty_dynamic_dory_commitment() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[0, 1]),
@@ -257,8 +260,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -306,8 +309,9 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_an_offset() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[0, 1]),
@@ -332,8 +336,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
         2,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[2]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -381,8 +385,9 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
 
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_signed_values() {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[-2, -1, 0, 1, 2]),
@@ -407,8 +412,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
         0,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(-1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(0)
@@ -469,8 +474,9 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
 #[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_an_offset_and_signed_values(
 ) {
-    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
-    let setup = ProverSetup::from(&public_parameters);
+    let cached_setup = cached_dory_test_setup(5);
+    let public_parameters = cached_setup.public_parameters;
+    let setup = &cached_setup.prover_setup;
     let res = compute_dynamic_dory_commitments(
         &[
             CommittableColumn::TinyInt(&[-2, -1, 0, 1, 2]),
@@ -495,8 +501,8 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
         4,
         &setup,
     );
-    let Gamma_1 = public_parameters.Gamma_1;
-    let Gamma_2 = public_parameters.Gamma_2;
+    let Gamma_1 = &public_parameters.Gamma_1;
+    let Gamma_2 = &public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[3]) * F::from(-2)
         + Pairing::pairing(Gamma_1[1], Gamma_2[3]) * F::from(-1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[3]) * F::from(0)

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -35,6 +35,11 @@ pub(crate) use dory_messages::DoryMessages;
 #[cfg(test)]
 mod dory_messages_test;
 
+#[cfg(test)]
+mod test_setup_cache;
+#[cfg(test)]
+pub(crate) use test_setup_cache::cached_dory_test_setup;
+
 mod setup;
 pub use setup::{ProverSetup, VerifierSetup};
 #[cfg(test)]

--- a/crates/proof-of-sql/src/proof_primitive/dory/test_setup_cache.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/test_setup_cache.rs
@@ -1,0 +1,34 @@
+use super::{test_rng, ProverSetup, PublicParameters, VerifierSetup};
+use std::{
+    collections::BTreeMap,
+    sync::{Mutex, OnceLock},
+};
+
+pub(crate) struct CachedDoryTestSetup {
+    pub public_parameters: &'static PublicParameters,
+    pub prover_setup: ProverSetup<'static>,
+    pub verifier_setup: VerifierSetup,
+}
+
+pub(crate) fn cached_dory_test_setup(max_nu: usize) -> &'static CachedDoryTestSetup {
+    static CACHE: OnceLock<Mutex<BTreeMap<usize, &'static CachedDoryTestSetup>>> = OnceLock::new();
+
+    let cache = CACHE.get_or_init(|| Mutex::new(BTreeMap::new()));
+    let mut cache = cache.lock().expect("cached dory test setup mutex poisoned");
+    if let Some(setup) = cache.get(&max_nu).copied() {
+        return setup;
+    }
+
+    // Dory tests only need one valid setup per `max_nu`; recomputing the same random setup
+    // dominates runtime without increasing coverage.
+    let public_parameters: &'static PublicParameters = Box::leak(Box::new(
+        PublicParameters::test_rand(max_nu, &mut test_rng()),
+    ));
+    let setup = Box::leak(Box::new(CachedDoryTestSetup {
+        public_parameters,
+        prover_setup: ProverSetup::from(public_parameters),
+        verifier_setup: VerifierSetup::from(public_parameters),
+    }));
+    cache.insert(max_nu, setup);
+    setup
+}


### PR DESCRIPTION
/claim #557

## Summary

This PR improves test performance by caching repeated Dory test setups keyed by `max_nu` and reusing them across the heaviest Dory test suites.

## What changed

- added a test-only `cached_dory_test_setup(max_nu)` helper
- reused cached `PublicParameters`, `ProverSetup`, and `VerifierSetup` in:
  - `dory_commitment_evaluation_proof_test`
  - `dynamic_dory_commitment_evaluation_proof_test`
  - `dory_compute_commitments_test`
  - `dynamic_dory_compute_commitments_test`

## Why this is safe

- no production code paths were changed
- no assertions were removed
- the tests still execute the same proof and commitment logic
- this only removes repeated construction of identical-size Dory setups within the same test process

## Local verification

I verified the targeted suites with the repo's documented no-blitzar workaround on Windows:

```bash
cargo test -p proof-of-sql dory_commitment_evaluation_proof_test --no-default-features --features="test std rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"
cargo test -p proof-of-sql dynamic_dory_commitment_evaluation_proof_test --no-default-features --features="test std rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"
cargo test -p proof-of-sql dory_compute_commitments_test --no-default-features --features="test std rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"
cargo test -p proof-of-sql dynamic_dory_compute_commitments_test --no-default-features --features="test std rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"
```

Note: I could not run `--all-features` locally on Windows because `blitzar-sys` is Linux-only, but the targeted Dory suites pass locally and CI can validate the full Linux matrix.
