### PR TITLE
test: cover record batch errors

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -29,3 +29,45 @@ pub enum AppendRecordBatchTableCommitmentError {
         source: RecordBatchToColumnsError,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::arrow::arrow_array_to_column_conversion::ArrowArrayToColumnConversionError;
+    use crate::base::commitment::ColumnCommitmentsMismatch;
+
+    #[test]
+    fn we_can_display_record_batch_to_columns_source_errors() {
+        let error = RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+            source: ArrowArrayToColumnConversionError::ArrayContainsNulls,
+        };
+
+        assert_eq!(error.to_string(), "arrow array must not contain nulls");
+    }
+
+    #[test]
+    fn we_can_display_append_record_batch_commitment_mismatch_errors() {
+        let error = AppendRecordBatchTableCommitmentError::ColumnCommitmentsMismatch {
+            source: ColumnCommitmentsMismatch::NumColumns,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "commitments with different column counts cannot operate with each other"
+        );
+    }
+
+    #[test]
+    fn we_can_display_append_record_batch_column_conversion_errors() {
+        let error = AppendRecordBatchTableCommitmentError::ArrowBatchToColumnError {
+            source: RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                source: ArrowArrayToColumnConversionError::IndexOutOfBounds { len: 2, index: 5 },
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "index out of bounds: the len is 2 but the index is 5"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add direct coverage for `RecordBatchToColumnsError` transparent Arrow conversion errors
- cover append-record-batch commitment mismatch display forwarding
- cover nested append-record-batch column conversion error display forwarding

/claim #560

## Non-overlap
Checked current open PRs for `record_batch_errors`, `RecordBatchToColumnsError`, `AppendRecordBatchTableCommitmentError`, `RecordBatchError`, and Arrow record-batch error coverage before taking this slice; no active overlapping claim was found.

## Verification
- `cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features 'arrow test' record_batch_errors -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.