### PR TITLE
test: cover provable result guards

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -167,6 +167,22 @@ fn evaluation_fails_if_extra_data_is_included() {
 }
 
 #[test]
+fn evaluation_fails_if_the_column_field_count_is_invalid() {
+    let cols: [Column<TestScalar>; 1] = [Column::BigInt(&[10, 12])];
+    let res = ProvableQueryResult::new(2, &cols);
+    let evaluation_point = [TestScalar::from(10u64), TestScalar::from(100u64)];
+    let column_fields = [
+        ColumnField::new("a".into(), ColumnType::BigInt),
+        ColumnField::new("b".into(), ColumnType::BigInt),
+    ];
+
+    assert!(matches!(
+        res.evaluate(&evaluation_point, 2, &column_fields),
+        Err(QueryError::InvalidColumnCount)
+    ));
+}
+
+#[test]
 fn evaluation_fails_if_the_result_cant_be_decoded() {
     let mut res = ProvableQueryResult::new_from_raw_data(1, 1, vec![0b1111_1111_u8; 38]);
     res.data_mut()[37] = 0b0000_0001_u8;
@@ -207,6 +223,21 @@ fn evaluation_fails_if_data_is_missing() {
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::Overflow)
+    ));
+}
+
+#[test]
+fn conversion_fails_if_the_column_field_count_is_invalid() {
+    let cols: [Column<TestScalar>; 1] = [Column::BigInt(&[10, 12])];
+    let res = ProvableQueryResult::new(2, &cols);
+    let column_fields = [
+        ColumnField::new("a".into(), ColumnType::BigInt),
+        ColumnField::new("b".into(), ColumnType::BigInt),
+    ];
+
+    assert!(matches!(
+        res.to_owned_table::<TestScalar>(&column_fields),
+        Err(QueryError::InvalidColumnCount)
     ));
 }
 


### PR DESCRIPTION
## Summary
- add `ProvableQueryResult::evaluate` coverage for mismatched result-field counts
- add `ProvableQueryResult::to_owned_table` coverage for mismatched result-field counts
- keep the change test-only in the existing provable query-result test module

/claim #560

## Non-overlap
Checked current open PRs for `ProvableQueryResult`, `provable_query_result`, `InvalidColumnCount`, and result-field count guards before taking this slice; no active overlapping claim was found.

## Verification
- `cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features 'arrow test' provable_query_result_test -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.