### PR TITLE
test: cover database operation errors

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,68 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_column_operation_errors() {
+        assert_eq!(
+            ColumnOperationError::DifferentColumnLength { len_a: 2, len_b: 3 }.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+        assert_eq!(
+            ColumnOperationError::BinaryOperationInvalidColumnType {
+                operator: "add".to_string(),
+                left_type: ColumnType::BigInt,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "\"add\"(lhs: BigInt, rhs: VarChar) is not supported"
+        );
+        assert_eq!(
+            ColumnOperationError::UnaryOperationInvalidColumnType {
+                operator: "negation".to_string(),
+                operand_type: ColumnType::Boolean,
+            }
+            .to_string(),
+            "\"negation\"(operand: Boolean) is not supported"
+        );
+        assert_eq!(
+            ColumnOperationError::IntegerOverflow {
+                error: "checked add failed".to_string()
+            }
+            .to_string(),
+            "Overflow in integer operation: checked add failed"
+        );
+        assert_eq!(
+            ColumnOperationError::DivisionByZero.to_string(),
+            "Division by zero"
+        );
+        assert_eq!(
+            ColumnOperationError::IndexOutOfBounds { index: 4, len: 4 }.to_string(),
+            "Index out of bounds: 4 >= 4"
+        );
+    }
+
+    #[test]
+    fn we_can_display_column_casting_errors() {
+        for error in [
+            ColumnOperationError::SignedCastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            },
+            ColumnOperationError::CastingError {
+                left_type: ColumnType::BigInt,
+                right_type: ColumnType::SmallInt,
+            },
+            ColumnOperationError::ScaleCastingError {
+                left_type: ColumnType::Int,
+                right_type: ColumnType::TinyInt,
+            },
+        ] {
+            assert!(error.to_string().contains("without losing data"));
+        }
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,46 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_owned_column_errors() {
+        assert_eq!(
+            OwnedColumnError::TypeCastError {
+                from_type: ColumnType::VarChar,
+                to_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Can not perform type casting from VarChar to BigInt"
+        );
+        assert_eq!(
+            OwnedColumnError::ScalarConversionError {
+                error: "out of range".to_string()
+            }
+            .to_string(),
+            "Error in converting scalars to a given column type: out of range"
+        );
+        assert_eq!(
+            OwnedColumnError::Unsupported {
+                error: "varbinary scalar conversion".to_string()
+            }
+            .to_string(),
+            "Unsupported operation: varbinary scalar conversion"
+        );
+    }
+
+    #[test]
+    fn we_can_display_column_coercion_errors() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,56 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_display_table_operation_errors() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+        assert_eq!(
+            TableOperationError::JoinWithDifferentNumberOfColumns {
+                left_num_columns: 1,
+                right_num_columns: 2,
+            }
+            .to_string(),
+            "Cannot join tables with different numbers of columns: 1 and 2"
+        );
+        assert_eq!(
+            TableOperationError::JoinIncompatibleTypes {
+                left_type: ColumnType::BigInt,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Cannot join tables on columns with incompatible types: BigInt and VarChar"
+        );
+        assert_eq!(
+            TableOperationError::ColumnDoesNotExist {
+                column_ident: Ident::new("missing")
+            }
+            .to_string(),
+            "Column Ident { value: \"missing\", quote_style: None } does not exist in table"
+        );
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+        assert_eq!(
+            TableOperationError::ColumnIndexOutOfBounds { column_index: 7 }.to_string(),
+            "Column index out of bounds: 7"
+        );
+    }
+
+    #[test]
+    fn we_can_display_transparent_column_operation_errors() {
+        let error = TableOperationError::ColumnOperationError {
+            source: ColumnOperationError::DivisionByZero,
+        };
+
+        assert_eq!(error.to_string(), "Division by zero");
+    }
+}


### PR DESCRIPTION
## Summary
- add direct display coverage for `ColumnOperationError` variants, including casting and arithmetic errors
- add direct display and transparent forwarding coverage for `TableOperationError`
- add direct display coverage for `OwnedColumnError` and `ColumnCoercionError`

/claim #560

## Non-overlap
Checked current open PRs for `table_operation_error`, `column_operation_error`, `owned_column_error`, `TableOperationError`, `ColumnOperationError`, and `OwnedColumnError` before taking this slice; no active overlapping claim was found.

## Verification
- `cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features test operation_error -- --nocapture`
- `cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features test owned_column_error -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.