### PR TITLE
test: cover slice ops edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::base::scalar::test_scalar::TestScalar;
 
 #[test]
 fn test_add_const() {
@@ -6,4 +7,19 @@ fn test_add_const() {
     add_const(&mut a, 10);
     let b = vec![1 + 10, 2 + 10, 3 + 10, 4 + 10];
     assert_eq!(a, b);
+}
+
+#[test]
+fn we_can_add_const_to_empty_slices() {
+    let mut a: Vec<TestScalar> = Vec::new();
+    add_const(&mut a, TestScalar::from(10u64));
+    assert!(a.is_empty());
+}
+
+#[test]
+fn we_can_add_convertible_const_to_scalar_slices() {
+    let mut a = [1, 2, 3, 4].map(TestScalar::from).to_vec();
+    add_const(&mut a, 10u64);
+    let expected = [11, 12, 13, 14].map(TestScalar::from).to_vec();
+    assert_eq!(a, expected);
 }

--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
@@ -116,3 +116,47 @@ fn we_can_pseudo_invert_arrays_with_nonzero_count_smaller_than_min_chunking_size
         }
     }
 }
+
+#[test]
+fn we_can_batch_invert_and_scale_nonzero_values() {
+    let input = [
+        TestScalar::from(2_u32),
+        (-3_i32).into(),
+        TestScalar::from(5_u32),
+    ];
+    let coeff = TestScalar::from(7_u32);
+    let mut res = input.to_vec();
+    slice_ops::batch_inversion_and_mul(&mut res[..], coeff);
+
+    for (input_val, res_val) in input.iter().zip(res) {
+        assert_eq!(input_val.inv().unwrap() * coeff, res_val);
+    }
+}
+
+#[test]
+fn we_can_batch_invert_and_scale_while_preserving_zeros() {
+    let input = [
+        TestScalar::from(0_u32),
+        TestScalar::from(2_u32),
+        TestScalar::from(0_u32),
+        (-5_i32).into(),
+    ];
+    let coeff = TestScalar::from(11_u32);
+    let mut res = input.to_vec();
+    slice_ops::batch_inversion_and_mul(&mut res[..], coeff);
+
+    for (input_val, res_val) in input.iter().zip(res) {
+        if *input_val == TestScalar::zero() {
+            assert_eq!(TestScalar::zero(), res_val);
+        } else {
+            assert_eq!(input_val.inv().unwrap() * coeff, res_val);
+        }
+    }
+}
+
+#[test]
+fn we_can_batch_invert_and_scale_all_zero_values() {
+    let mut res = vec![TestScalar::zero(); 4];
+    slice_ops::batch_inversion_and_mul(&mut res[..], TestScalar::from(13_u32));
+    assert_eq!(res, vec![TestScalar::zero(); 4]);
+}

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -162,3 +162,17 @@ fn test_inner_product_testscalar_uneven() {
     ];
     assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
+
+#[test]
+fn test_inner_product_ref_cast() {
+    let a = [1, 2, 3, 4].map(TestScalar::from).to_vec();
+    let b = [2, 3, 4, 5].map(TestScalar::from).to_vec();
+    assert_eq!(TestScalar::from(40), inner_product_ref_cast(&a, &b));
+}
+
+#[test]
+fn test_inner_product_ref_cast_different_lengths() {
+    let a = [1, 2, 3, 4].map(TestScalar::from).to_vec();
+    let b = [2, 3].map(TestScalar::from).to_vec();
+    assert_eq!(TestScalar::from(8), inner_product_ref_cast(&a, &b));
+}

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
@@ -71,3 +71,19 @@ fn test_slice_cast_mut_random() {
     slice_cast_mut(&a, &mut b);
     assert_eq!(b, slice_cast(&a));
 }
+
+#[test]
+fn test_slice_cast_mut_with_leaves_extra_result_entries_unchanged() {
+    let a: Vec<u32> = vec![1, 2];
+    let mut b: Vec<u64> = vec![10, 20, 30, 40];
+    slice_cast_mut_with(&a, &mut b, |&x| u64::from(x));
+    assert_eq!(b, vec![1, 2, 30, 40]);
+}
+
+#[test]
+fn test_slice_cast_mut_with_empty_input_leaves_result_unchanged() {
+    let a: Vec<u32> = Vec::new();
+    let mut b: Vec<u64> = vec![10, 20];
+    slice_cast_mut_with(&a, &mut b, |&x| u64::from(x));
+    assert_eq!(b, vec![10, 20]);
+}


### PR DESCRIPTION
## Summary
- add edge coverage for `add_const` on empty and convertible scalar slices
- cover `batch_inversion_and_mul` coefficient scaling for nonzero, mixed-zero, and all-zero inputs
- add direct `inner_product_ref_cast` coverage and mutable slice-cast truncation/empty-input behavior

/claim #560

## Non-overlap
Checked current open #560 PRs for `slice_ops`, `add_const`, `batch_inversion_and_mul`, `inner_product_ref_cast`, `slice_cast_mut_with`, and related slice-op helper coverage before taking this slice; no active overlapping claim was found.

## Verification
- `cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features test slice_ops -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.
