### PR TITLE
test: cover big decimal conversions

### DIFF
--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -89,4 +89,43 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, IntermediateDecimalError::ConversionFailure));
     }
+
+    #[test]
+    fn we_can_convert_decimal_with_exact_precision_and_scale() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap();
+        let result = big_decimal
+            .try_into_bigint_with_precision_and_scale(5, 2)
+            .unwrap();
+        let expected: BigInt = "12345".parse().unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_convert_decimal_by_padding_target_scale() {
+        let big_decimal: BigDecimal = "123.4".parse::<BigDecimal>().unwrap();
+        let result = big_decimal
+            .try_into_bigint_with_precision_and_scale(5, 2)
+            .unwrap();
+        let expected: BigInt = "12340".parse().unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_convert_integer_with_negative_target_scale() {
+        let big_decimal: BigDecimal = "1200".parse::<BigDecimal>().unwrap();
+        let result = big_decimal
+            .try_into_bigint_with_precision_and_scale(2, -2)
+            .unwrap();
+        let expected: BigInt = "12".parse().unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_reject_scaled_decimal_when_precision_is_too_small() {
+        let big_decimal: BigDecimal = "123.4".parse::<BigDecimal>().unwrap();
+        let err = big_decimal
+            .try_into_bigint_with_precision_and_scale(4, 2)
+            .unwrap_err();
+        assert!(matches!(err, IntermediateDecimalError::LossyCast));
+    }
 }


### PR DESCRIPTION
## Summary
- add `BigDecimalExt` coverage for exact precision/scale conversion
- cover target-scale padding and negative target-scale conversion
- cover the `LossyCast` branch when scaled digits exceed target precision

/claim #560

## Non-overlap
Checked current open #560 PRs for `BigDecimalExt`, `try_into_bigint_with_precision_and_scale`, decimal precision/scale conversion, `LossyCast`, and `ConversionFailure` coverage before taking this slice; no active overlapping claim was found.

## Verification
- `cargo --config 'target.x86_64-unknown-linux-gnu.linker="cc"' --config 'target.x86_64-unknown-linux-gnu.rustflags=[]' test -p proof-of-sql --lib --no-default-features --features test big_decimal_ext -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_commits.sh`

AI-assisted with OpenAI Codex; I reviewed the diff and verification before submitting.
