### PR TITLE
test: reduce dory commitment setup size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn we_can_convert_from_columns() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
         let Gamma_1 = &public_parameters.Gamma_1;
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn we_can_append_rows() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
         let Gamma_1 = &public_parameters.Gamma_1;
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn we_cannot_append_rows_with_different_column_count() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
 
@@ -250,7 +250,7 @@ mod tests {
 
     #[test]
     fn we_can_extend_columns() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
         let Gamma_1 = &public_parameters.Gamma_1;
@@ -307,7 +307,7 @@ mod tests {
 
     #[test]
     fn we_can_add_commitment_collections() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
         let Gamma_1 = &public_parameters.Gamma_1;
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn we_cannot_add_commitment_collections_of_mixed_column_counts() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
 
@@ -403,7 +403,7 @@ mod tests {
 
     #[test]
     fn we_can_sub_commitment_collections() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
         let Gamma_1 = &public_parameters.Gamma_1;
@@ -446,7 +446,7 @@ mod tests {
 
     #[test]
     fn we_cannot_sub_commitment_collections_of_mixed_column_counts() {
-        let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+        let public_parameters = PublicParameters::test_rand(3, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
 


### PR DESCRIPTION
/claim #557

## Summary
- reduce unused Dory public parameter generation in `dory_commitment.rs` tests
- keep the existing `DoryProverPublicSetup::new(..., 2)` setup surface and all test assertions/data unchanged
- use `max_nu = 2` for 3-row/no-offset cases and `max_nu = 3` for cases that touch position 4 through offset/full-length data

## Why this helps
`PublicParameters::test_rand(max_nu)` generates `1 << max_nu` G1/G2 parameter pairs. These tests were all using `max_nu = 5` (32 pairs), while their local setups only need either 4 or 8 pairs. This removes unused randomized setup work from eight tests without weakening their assertions.

## Testing
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql dory_commitment --no-default-features --features='test std rayon ark-ec/parallel ark-poly/parallel ark-ff/asm'`