### PR TITLE
test: cover group-by and HyperKZG commitment edges

### DIFF
--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
         database::{group_by_util::*, Column},
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
@@ -45,6 +47,28 @@ fn we_cannot_apply_min_to_varchar() {
     let counts = &[];
     let alloc = bumpalo::Bump::new();
     let _ = min_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+#[should_panic(expected = "SUM can not be applied to non-numeric types")]
+fn we_cannot_apply_sum_to_boolean() {
+    let col: Column<'_, TestScalar> = Column::Boolean(&[]);
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = sum_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+fn we_cannot_aggregate_columns_with_mismatched_lengths() {
+    let group_by = &[Column::BigInt::<TestScalar>(&[1, 2])];
+    let selection = &[true];
+    let alloc = Bump::new();
+    let result = aggregate_columns(&alloc, group_by, &[], &[], &[], selection);
+    assert!(matches!(
+        result,
+        Err(AggregateColumnsError::ColumnLengthMismatch)
+    ));
 }
 
 #[test]
@@ -375,6 +399,38 @@ fn we_can_sum_aggregate_columns_by_counts() {
     assert_eq!(result, expected);
 }
 
+#[test]
+fn we_can_sum_aggregate_remaining_numeric_column_variants_by_counts() {
+    let indexes = &[2, 0, 1, 3];
+    let counts = &[2, 2];
+    let expected = &[TestScalar::from(4), TestScalar::from(6)];
+    let alloc = Bump::new();
+
+    let uint8_col = Column::Uint8::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        sum_aggregate_column_by_index_counts(&alloc, &uint8_col, counts, indexes),
+        expected
+    );
+
+    let tinyint_col = Column::TinyInt::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        sum_aggregate_column_by_index_counts(&alloc, &tinyint_col, counts, indexes),
+        expected
+    );
+
+    let smallint_col = Column::SmallInt::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        sum_aggregate_column_by_index_counts(&alloc, &smallint_col, counts, indexes),
+        expected
+    );
+
+    let int_col = Column::Int::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        sum_aggregate_column_by_index_counts(&alloc, &int_col, counts, indexes),
+        expected
+    );
+}
+
 // MAX slices
 #[test]
 fn we_can_max_aggregate_slice_by_counts_for_empty_slice() {
@@ -495,6 +551,63 @@ fn we_can_max_aggregate_columns_by_counts() {
     assert_eq!(result, expected);
 }
 
+#[test]
+fn we_can_max_aggregate_remaining_column_variants_by_counts() {
+    let indexes = &[2, 0, 1, 3];
+    let counts = &[2, 2];
+    let expected = &[Some(TestScalar::from(3)), Some(TestScalar::from(4))];
+    let alloc = Bump::new();
+
+    let bool_col = Column::Boolean::<TestScalar>(&[true, false, true, false]);
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &bool_col, counts, indexes),
+        &[Some(TestScalar::from(true)), Some(TestScalar::from(false))]
+    );
+
+    let uint8_col = Column::Uint8::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &uint8_col, counts, indexes),
+        expected
+    );
+
+    let tinyint_col = Column::TinyInt::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &tinyint_col, counts, indexes),
+        expected
+    );
+
+    let smallint_col = Column::SmallInt::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &smallint_col, counts, indexes),
+        expected
+    );
+
+    let int_col = Column::Int::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &int_col, counts, indexes),
+        expected
+    );
+
+    let decimals = [
+        TestScalar::from(1),
+        TestScalar::from(2),
+        TestScalar::from(3),
+        TestScalar::from(4),
+    ];
+    let decimal_col = Column::Decimal75(Precision::new(10).unwrap(), 0, &decimals);
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &decimal_col, counts, indexes),
+        expected
+    );
+
+    let timestamp_col =
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1, 2, 3, 4]);
+    assert_eq!(
+        max_aggregate_column_by_index_counts(&alloc, &timestamp_col, counts, indexes),
+        expected
+    );
+}
+
 // MIN slices
 #[test]
 fn we_can_min_aggregate_slice_by_counts_for_empty_slice() {
@@ -568,6 +681,63 @@ fn we_can_min_aggregate_slice_by_counts_without_empty_groups() {
     let result: &[Option<TestScalar>] =
         min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_min_aggregate_remaining_column_variants_by_counts() {
+    let indexes = &[2, 0, 1, 3];
+    let counts = &[2, 2];
+    let expected = &[Some(TestScalar::from(1)), Some(TestScalar::from(2))];
+    let alloc = Bump::new();
+
+    let bool_col = Column::Boolean::<TestScalar>(&[true, false, true, false]);
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &bool_col, counts, indexes),
+        &[Some(TestScalar::from(true)), Some(TestScalar::from(false))]
+    );
+
+    let uint8_col = Column::Uint8::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &uint8_col, counts, indexes),
+        expected
+    );
+
+    let tinyint_col = Column::TinyInt::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &tinyint_col, counts, indexes),
+        expected
+    );
+
+    let smallint_col = Column::SmallInt::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &smallint_col, counts, indexes),
+        expected
+    );
+
+    let int_col = Column::Int::<TestScalar>(&[1, 2, 3, 4]);
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &int_col, counts, indexes),
+        expected
+    );
+
+    let decimals = [
+        TestScalar::from(1),
+        TestScalar::from(2),
+        TestScalar::from(3),
+        TestScalar::from(4),
+    ];
+    let decimal_col = Column::Decimal75(Precision::new(10).unwrap(), 0, &decimals);
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &decimal_col, counts, indexes),
+        expected
+    );
+
+    let timestamp_col =
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1, 2, 3, 4]);
+    assert_eq!(
+        min_aggregate_column_by_index_counts(&alloc, &timestamp_col, counts, indexes),
+        expected
+    );
 }
 
 #[test]

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -218,6 +218,10 @@ mod tests {
     use super::*;
     #[cfg(feature = "hyperkzg_proof")]
     use crate::base::database::OwnedColumn;
+    #[cfg(feature = "hyperkzg_proof")]
+    use crate::base::math::decimal::Precision;
+    #[cfg(feature = "hyperkzg_proof")]
+    use crate::base::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
     use crate::base::{try_standard_binary_deserialization, try_standard_binary_serialization};
     #[cfg(feature = "hyperkzg_proof")]
     use crate::proof_primitive::hyperkzg::nova_commitment_key_to_hyperkzg_public_setup;
@@ -244,6 +248,39 @@ mod tests {
         assert_eq!(commitment.commitment, expected.commitment);
     }
 
+    #[test]
+    fn we_can_apply_hyperkzg_commitment_arithmetic() {
+        let generator: HyperKZGCommitment = (&G1Affine::generator()).into();
+        let doubled_by_ref = BNScalar::from(2_u64) * &generator;
+        let doubled_by_value = BNScalar::from(2_u64) * generator;
+        assert_eq!(doubled_by_ref, doubled_by_value);
+
+        let mut sum = generator;
+        sum += generator;
+        assert_eq!(sum, doubled_by_ref);
+
+        let mut difference = doubled_by_value;
+        difference -= generator;
+        assert_eq!(difference, generator);
+
+        assert_eq!(doubled_by_value - generator, generator);
+
+        let zero = generator - generator;
+        assert_eq!(zero.commitment, G1Affine::identity());
+    }
+
+    #[test]
+    fn we_can_write_hyperkzg_commitments_to_transcript_bytes() {
+        let commitment: HyperKZGCommitment = (&G1Affine::generator()).into();
+        let mut expected = Vec::with_capacity(commitment.commitment.compressed_size());
+        commitment
+            .commitment
+            .serialize_compressed(&mut expected)
+            .unwrap();
+
+        assert_eq!(commitment.to_transcript_bytes(), expected);
+    }
+
     #[cfg(feature = "hyperkzg_proof")]
     proptest! {
         #[test]
@@ -259,6 +296,48 @@ mod tests {
 
             prop_assert_eq!(non_blitzar_commitments, blitzar_commitments);
         }
+    }
+
+    #[test]
+    #[cfg(feature = "hyperkzg_proof")]
+    fn we_can_compute_non_blitzar_commitments_for_scalar_backed_columns() {
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 4);
+        let setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
+        let scalar_values = vec![
+            BNScalar::from(1_u64),
+            BNScalar::from(2_u64),
+            BNScalar::from(3_u64),
+        ];
+        let committable_columns = [
+            CommittableColumn::Decimal75(Precision::new(10).unwrap(), 0, scalar_values.clone()),
+            CommittableColumn::Scalar(scalar_values.clone()),
+            CommittableColumn::VarChar(scalar_values.clone()),
+            CommittableColumn::VarBinary(scalar_values),
+        ];
+
+        let commitments = compute_commitments_impl(&committable_columns, 1, &&setup[..]);
+
+        assert_eq!(commitments.len(), committable_columns.len());
+        assert!(commitments
+            .iter()
+            .all(|commitment| commitment.commitment != G1Affine::identity()));
+    }
+
+    #[test]
+    #[cfg(feature = "hyperkzg_proof")]
+    fn we_can_compute_non_blitzar_commitments_for_timestamps() {
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 4);
+        let setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
+        let committable_columns = [CommittableColumn::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            &[1, 2, 3],
+        )];
+
+        let commitments = compute_commitments_impl(&committable_columns, 1, &&setup[..]);
+
+        assert_eq!(commitments.len(), 1);
+        assert_ne!(commitments[0].commitment, G1Affine::identity());
     }
 
     #[test]


### PR DESCRIPTION
/claim #560

## Summary
- Add group-by utility coverage for mismatched input lengths, the SUM non-numeric guard, and remaining numeric/min/max column variants.
- Add HyperKZG commitment coverage for arithmetic operators, transcript byte serialization, and non-Blitzar scalar-backed/timestamp commitment paths.

## Coverage target
- Codecov on current `main` reports missed lines in `crates/proof-of-sql/src/base/database/group_by_util.rs`: 70, 159-162, 174, 191-192, 194-196, 199-200, 202-203, 228-229, 231-233, 236-237, 239-240.
- Codecov on current `main` reports missed lines in `crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs`: 19, 64-66, 78-82, 88-90, 94-96, 99-101, 105-108, 156-157, 188, 209-213.
- Conservative potential: 54 newly targeted lines, or about $5.40 at the issue's $0.10/line rate, subject to maintainer/Codecov baseline.

## Non-overlap check
I checked open/all PRs for `group_by_util`, `AggregateColumnsError`, `ColumnLengthMismatch`, `HyperKZGCommitment`, `to_transcript_bytes`, and `compute_commitments_impl`. I avoided the already busy `table_ref`, `owned_arrow`, `column_type_operation`, and `provable_query_result` coverage slices.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `wsl ... cargo test -p proof-of-sql --lib --no-default-features --features test group_by_util -- --nocapture` (35 passed)
- `wsl ... cargo test -p proof-of-sql --lib --no-default-features --features "test hyperkzg_proof" we_can_apply_hyperkzg_commitment_arithmetic -- --nocapture` (the local filter ran broadly under this feature set; 967 passed)
- `scripts/check_commits.sh` passed after streaming CRLF-stripped script contents to Bash on Windows

AI-assisted with OpenAI Codex; I reviewed the diff and ran the checks above.