### PR TITLE
test: cover analyze error conversions

### DIFF
--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -81,6 +81,15 @@ mod tests {
         let message: String = AnalyzeError::NotEnoughInputPlans.into();
 
         assert_eq!(message, "Not enough input plans");
+
+        let nested_message: String = AnalyzeError::DecimalConversionError {
+            source: DecimalError::IntermediateDecimalConversionError {
+                source: IntermediateDecimalError::LossyCast,
+            },
+        }
+        .into();
+
+        assert_eq!(nested_message, "Fractional part of decimal is non-zero");
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,29 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_convert_analyze_error_to_string() {
+        let message: String = AnalyzeError::NotEnoughInputPlans.into();
+
+        assert_eq!(message, "Not enough input plans");
+    }
+
+    #[test]
+    fn we_can_convert_intermediate_decimal_error_to_analyze_error() {
+        let error: AnalyzeError = IntermediateDecimalError::OutOfRange.into();
+
+        assert_eq!(
+            error,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::OutOfRange
+                }
+            }
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused tests for the two conversion helpers in `sql::error`:
  - `From<AnalyzeError> for String`
  - `From<IntermediateDecimalError> for AnalyzeError`
- Keep the change test-only and scoped to `crates/proof-of-sql/src/sql/error.rs`.

## Coverage target
Codecov on current `main` reports `crates/proof-of-sql/src/sql/error.rs` at 0/8 covered lines, with the missed executable lines exactly in these two conversion impls: 59-61 and 65-69.

Conservative potential: 8 newly targeted lines, or about $0.80 at the issue's $0.10/line rate, subject to maintainer/Codecov baseline.

## Non-overlap check
I checked current #560 issue comments and PR search for `sql/error.rs`, `AnalyzeError`, `IntermediateDecimalError`, and `DecimalConversionError`; I did not find an active overlapping claim for this slice.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `wsl ... cargo test -p proof-of-sql --lib --no-default-features --features test sql::error::tests -- --nocapture` (2 passed)
- `scripts/check_commits.sh` passed after streaming CRLF-stripped script contents to Bash on Windows

AI-assisted with OpenAI Codex; I reviewed the diff and ran the checks above.