### PR TITLE
test: cover database error displays

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,97 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn column_operation_errors_display_context() {
+        assert_eq!(
+            ColumnOperationError::DifferentColumnLength { len_a: 2, len_b: 3 }.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+        assert_eq!(
+            ColumnOperationError::BinaryOperationInvalidColumnType {
+                operator: "add".to_string(),
+                left_type: ColumnType::Int,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "\"add\"(lhs: Int, rhs: VarChar) is not supported"
+        );
+        assert_eq!(
+            ColumnOperationError::UnaryOperationInvalidColumnType {
+                operator: "not".to_string(),
+                operand_type: ColumnType::Int,
+            }
+            .to_string(),
+            "\"not\"(operand: Int) is not supported"
+        );
+        assert_eq!(
+            ColumnOperationError::IntegerOverflow {
+                error: "too large".to_string(),
+            }
+            .to_string(),
+            "Overflow in integer operation: too large"
+        );
+        assert_eq!(
+            ColumnOperationError::DivisionByZero.to_string(),
+            "Division by zero"
+        );
+        assert_eq!(
+            ColumnOperationError::DecimalConversionError {
+                source: DecimalError::InvalidScale {
+                    scale: "bad".to_string(),
+                },
+            }
+            .to_string(),
+            "Decimal scale is not valid: bad"
+        );
+        assert_eq!(
+            ColumnOperationError::UnionDifferentTypes {
+                correct_type: ColumnType::Boolean,
+                actual_type: ColumnType::Int,
+            }
+            .to_string(),
+            "Cannot union columns of different types: Boolean and Int"
+        );
+        assert_eq!(
+            ColumnOperationError::IndexOutOfBounds { index: 4, len: 4 }.to_string(),
+            "Index out of bounds: 4 >= 4"
+        );
+    }
+
+    #[test]
+    fn casting_errors_display_column_types() {
+        assert_eq!(
+            ColumnOperationError::SignedCastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            "Cannot fit TINYINT into UINT8 without losing data"
+        );
+        assert_eq!(
+            ColumnOperationError::CastingError {
+                left_type: ColumnType::VarChar,
+                right_type: ColumnType::Int,
+            }
+            .to_string(),
+            "Cannot fit VARCHAR into INT without losing data"
+        );
+        assert_eq!(
+            ColumnOperationError::ScaleCastingError {
+                left_type: ColumnType::Int128,
+                right_type: ColumnType::Decimal75(
+                    crate::base::math::decimal::Precision::new(10).unwrap(),
+                    2,
+                ),
+            }
+            .to_string(),
+            "Cannot fit DECIMAL into DECIMAL75(PRECISION: 10, SCALE: 2) without losing data"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -189,6 +189,7 @@ mod tests {
             .to_string(),
             "Cannot fit VARCHAR into INT without losing data"
         );
+        assert_eq!(ColumnType::Int128.to_string(), "DECIMAL");
         assert_eq!(
             ColumnOperationError::ScaleCastingError {
                 left_type: ColumnType::Int128,

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -301,6 +301,7 @@ impl Display for ColumnType {
 mod tests {
     use super::*;
     use crate::base::scalar::test_scalar::TestScalar;
+    use core::mem::size_of;
 
     #[test]
     fn column_type_serializes_to_string() {
@@ -671,6 +672,118 @@ mod tests {
             ColumnType::VarChar,
         ] {
             assert_eq!(column_type.sqrt_negative_min(), None);
+        }
+    }
+
+    #[test]
+    fn numeric_integer_and_signed_classification_is_reported() {
+        for column_type in [
+            ColumnType::Uint8,
+            ColumnType::TinyInt,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::BigInt,
+            ColumnType::Int128,
+        ] {
+            assert!(column_type.is_numeric());
+            assert!(column_type.is_integer());
+        }
+
+        assert!(ColumnType::Scalar.is_numeric());
+        assert!(!ColumnType::Scalar.is_integer());
+        assert!(ColumnType::Decimal75(Precision::new(12).unwrap(), 2).is_numeric());
+        assert!(!ColumnType::Decimal75(Precision::new(12).unwrap(), 2).is_integer());
+
+        for column_type in [
+            ColumnType::Boolean,
+            ColumnType::VarChar,
+            ColumnType::VarBinary,
+        ] {
+            assert!(!column_type.is_numeric());
+            assert!(!column_type.is_integer());
+            assert!(!column_type.is_signed());
+        }
+
+        assert!(ColumnType::TinyInt.is_signed());
+        assert!(ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).is_signed());
+        assert!(!ColumnType::Uint8.is_signed());
+    }
+
+    #[test]
+    fn integer_type_join_helpers_return_expected_bounds() {
+        assert_eq!(
+            ColumnType::TinyInt.max_integer_type(&ColumnType::BigInt),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::Uint8.max_integer_type(&ColumnType::TinyInt),
+            Some(ColumnType::TinyInt)
+        );
+        assert_eq!(ColumnType::VarChar.max_integer_type(&ColumnType::Int), None);
+
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::TinyInt),
+            Some(ColumnType::Uint8)
+        );
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::SmallInt),
+            None
+        );
+        assert_eq!(
+            ColumnType::Boolean.max_unsigned_integer_type(&ColumnType::Uint8),
+            None
+        );
+    }
+
+    #[test]
+    fn precision_scale_and_size_are_reported_for_column_types() {
+        assert_eq!(ColumnType::Uint8.precision_value(), Some(3));
+        assert_eq!(ColumnType::Int.precision_value(), Some(10));
+        assert_eq!(ColumnType::BigInt.precision_value(), Some(19));
+        assert_eq!(ColumnType::Int128.precision_value(), Some(39));
+        assert_eq!(ColumnType::Scalar.precision_value(), Some(0));
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(42).unwrap(), -7).precision_value(),
+            Some(42)
+        );
+        assert_eq!(ColumnType::VarBinary.precision_value(), None);
+
+        assert_eq!(
+            ColumnType::Decimal75(Precision::new(42).unwrap(), -7).scale(),
+            Some(-7)
+        );
+        assert_eq!(ColumnType::Int128.scale(), Some(0));
+        assert_eq!(ColumnType::VarChar.scale(), None);
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).scale(),
+            Some(0)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()).scale(),
+            Some(3)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc()).scale(),
+            Some(6)
+        );
+        assert_eq!(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc()).scale(),
+            Some(9)
+        );
+
+        let sized_types = [
+            (ColumnType::Boolean, size_of::<bool>()),
+            (ColumnType::Uint8, size_of::<u8>()),
+            (ColumnType::TinyInt, size_of::<i8>()),
+            (ColumnType::SmallInt, size_of::<i16>()),
+            (ColumnType::Int, size_of::<i32>()),
+            (ColumnType::BigInt, size_of::<i64>()),
+            (ColumnType::Int128, size_of::<i128>()),
+            (ColumnType::VarChar, size_of::<[u64; 4]>()),
+        ];
+        for (column_type, byte_size) in sized_types {
+            assert_eq!(column_type.byte_size(), byte_size);
+            assert_eq!(column_type.bit_size(), (byte_size as u32) * 8);
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -705,7 +705,15 @@ mod tests {
         }
 
         assert!(ColumnType::TinyInt.is_signed());
-        assert!(ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()).is_signed());
+        for time_unit in [
+            PoSQLTimeUnit::Second,
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeUnit::Microsecond,
+            PoSQLTimeUnit::Nanosecond,
+        ] {
+            assert!(ColumnType::TimestampTZ(time_unit, PoSQLTimeZone::utc()).is_signed());
+            assert!(ColumnType::TimestampTZ(time_unit, PoSQLTimeZone::new(1)).is_signed());
+        }
         assert!(!ColumnType::Uint8.is_signed());
     }
 

--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,20 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn parse_error_displays_invalid_table_reference() {
+        assert_eq!(
+            ParseError::InvalidTableReference {
+                table_reference: "space.table.extra".to_string(),
+            }
+            .to_string(),
+            "Invalid table reference: space.table.extra"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,47 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn owned_column_errors_display_context() {
+        assert_eq!(
+            OwnedColumnError::TypeCastError {
+                from_type: ColumnType::VarChar,
+                to_type: ColumnType::Int,
+            }
+            .to_string(),
+            "Can not perform type casting from VarChar to Int"
+        );
+        assert_eq!(
+            OwnedColumnError::ScalarConversionError {
+                error: "bad scalar".to_string(),
+            }
+            .to_string(),
+            "Error in converting scalars to a given column type: bad scalar"
+        );
+        assert_eq!(
+            OwnedColumnError::Unsupported {
+                error: "operation".to_string(),
+            }
+            .to_string(),
+            "Unsupported operation: operation"
+        );
+    }
+
+    #[test]
+    fn column_coercion_errors_display_reason() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add display coverage for database column operation errors
- add display coverage for owned column and column coercion errors
- add parse error display coverage for invalid table references
- add `ColumnType` coverage for numeric/integer/signed classification, integer type joins, precision/scale, and size helpers

## Verification
- cargo fmt
- wsl cargo test -p proof-of-sql database::
- scripts/check_commits.sh