### PR TITLE
test: add unit test coverage for models, planner, and proof plans

### DIFF
--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -25,3 +25,47 @@ pub(crate) fn df_schema(table_name: &str, pairs: Vec<(&str, DataType)>) -> DFSch
     );
     DFSchema::try_from_qualified_schema(table_name, &arrow_schema).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn df_column_qualifies_the_column_with_the_table_name() {
+        let expr = df_column("orders", "total");
+
+        match expr {
+            Expr::Column(column) => {
+                assert_eq!(column.relation, Some(TableReference::from("orders")));
+                assert_eq!(column.name, "total");
+            }
+            other => panic!("expected Expr::Column, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn df_schema_marks_fields_as_non_nullable_and_qualified() {
+        let schema = df_schema(
+            "orders",
+            vec![("id", DataType::Int64), ("total", DataType::Float64)],
+        );
+
+        let fields = schema.fields();
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].name(), "id");
+        assert_eq!(fields[0].data_type(), &DataType::Int64);
+        assert!(!fields[0].is_nullable());
+        assert_eq!(fields[1].name(), "total");
+        assert_eq!(fields[1].data_type(), &DataType::Float64);
+        assert!(!fields[1].is_nullable());
+
+        let qualifiers = schema.iter().map(|(q, _)| q.cloned()).collect::<Vec<_>>();
+        assert_eq!(
+            qualifiers,
+            vec![
+                Some(TableReference::from("orders")),
+                Some(TableReference::from("orders")),
+            ]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,30 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_float_fields_to_decimal_and_preserves_other_metadata() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("f16", DataType::Float16, true),
+            Field::new("f32", DataType::Float32, false),
+            Field::new("f64", DataType::Float64, true),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+        let fields = converted.fields();
+
+        assert_eq!(fields[0].data_type(), &DataType::Decimal256(20, 10));
+        assert!(fields[0].is_nullable());
+        assert_eq!(fields[1].data_type(), &DataType::Decimal256(20, 10));
+        assert!(!fields[1].is_nullable());
+        assert_eq!(fields[2].data_type(), &DataType::Decimal256(20, 10));
+        assert!(fields[2].is_nullable());
+        assert_eq!(fields[3].data_type(), &DataType::Utf8);
+        assert!(!fields[3].is_nullable());
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,26 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_column_field_getters() {
+        let ident = Ident::new("my_column");
+        let field = ColumnField::new(ident.clone(), ColumnType::BigInt);
+
+        assert_eq!(field.name(), ident);
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn test_column_field_serde_roundtrip() {
+        let field = ColumnField::new(Ident::new("my_column"), ColumnType::BigInt);
+        let serialized = serde_json::to_string(&field).unwrap();
+        let deserialized: ColumnField = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(field, deserialized);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,18 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_ref_accessors_return_the_original_values() {
+        let table_ref = TableRef::from_names(Some("analytics"), "orders");
+        let column_ref = ColumnRef::new(table_ref.clone(), "total".into(), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), Ident::new("total"));
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,21 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn test_table_evaluation_properties() {
+        let evals = vec![TestScalar::from(10), TestScalar::from(20)];
+        let chi_val = (TestScalar::from(30), 2);
+
+        let eval = TableEvaluation::new(evals.clone(), chi_val);
+
+        assert_eq!(eval.column_evals(), &evals);
+        assert_eq!(eval.chi_eval(), TestScalar::from(30));
+        assert_eq!(eval.chi(), chi_val);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,100 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_table_ref_new_with_and_without_schema() {
+        let with_schema = TableRef::new("schema_name", "table_name");
+        assert_eq!(with_schema.schema_id(), Some(&Ident::new("schema_name")));
+        assert_eq!(with_schema.table_id(), &Ident::new("table_name"));
+
+        let without_schema = TableRef::new("", "table_name");
+        assert_eq!(without_schema.schema_id(), None);
+        assert_eq!(without_schema.table_id(), &Ident::new("table_name"));
+    }
+
+    #[test]
+    fn test_table_ref_from_names() {
+        let ref_names = TableRef::from_names(Some("schema_name"), "table_name");
+        assert_eq!(ref_names.schema_id(), Some(&Ident::new("schema_name")));
+        assert_eq!(ref_names.table_id(), &Ident::new("table_name"));
+    }
+
+    #[test]
+    fn test_table_ref_from_idents() {
+        let schema = Ident::new("schema_name");
+        let table = Ident::new("table_name");
+        let ref_idents = TableRef::from_idents(Some(schema.clone()), table.clone());
+        assert_eq!(ref_idents.schema_id(), Some(&schema));
+        assert_eq!(ref_idents.table_id(), &table);
+    }
+
+    #[test]
+    fn test_table_ref_from_strs() {
+        let single_component = ["table_name"];
+        let ref_single = TableRef::from_strs(&single_component).unwrap();
+        assert_eq!(ref_single.schema_id(), None);
+        assert_eq!(ref_single.table_id(), &Ident::new("table_name"));
+
+        let double_component = ["schema_name", "table_name"];
+        let ref_double = TableRef::from_strs(&double_component).unwrap();
+        assert_eq!(ref_double.schema_id(), Some(&Ident::new("schema_name")));
+        assert_eq!(ref_double.table_id(), &Ident::new("table_name"));
+
+        let triple_component = ["db_name", "schema_name", "table_name"];
+        let result = TableRef::from_strs(&triple_component);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_table_ref_try_from_str() {
+        let single = TableRef::try_from("table_name").unwrap();
+        assert_eq!(single.schema_id(), None);
+        assert_eq!(single.table_id(), &Ident::new("table_name"));
+
+        let double = TableRef::try_from("schema_name.table_name").unwrap();
+        assert_eq!(double.schema_id(), Some(&Ident::new("schema_name")));
+        assert_eq!(double.table_id(), &Ident::new("table_name"));
+
+        let triple = TableRef::try_from("db_name.schema_name.table_name");
+        assert!(triple.is_err());
+    }
+
+    #[test]
+    fn test_table_ref_from_str_trait() {
+        let table_ref: TableRef = "schema_name.table_name".parse().unwrap();
+        assert_eq!(table_ref.schema_id(), Some(&Ident::new("schema_name")));
+        assert_eq!(table_ref.table_id(), &Ident::new("table_name"));
+    }
+
+    #[test]
+    fn test_table_ref_equivalent() {
+        let ref1 = TableRef::new("schema_name", "table_name");
+        let ref2 = TableRef::new("schema_name", "table_name");
+        let ref3 = TableRef::new("other_schema", "table_name");
+
+        assert!(ref1.equivalent(&ref2));
+        assert!(!ref1.equivalent(&ref3));
+    }
+
+    #[test]
+    fn test_table_ref_display() {
+        let with_schema = TableRef::new("schema_name", "table_name");
+        assert_eq!(with_schema.to_string(), "schema_name.table_name");
+
+        let without_schema = TableRef::new("", "table_name");
+        assert_eq!(without_schema.to_string(), "table_name");
+    }
+
+    #[test]
+    fn test_table_ref_serde_roundtrip() {
+        let table_ref = TableRef::new("schema_name", "table_name");
+        let serialized = serde_json::to_string(&table_ref).unwrap();
+        let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(table_ref, deserialized);
+    }
+}

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -35,3 +35,40 @@ impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
         MontScalar::<T>::from_le_bytes_mod_order(&bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn test_u256_from_words() {
+        let u256 = U256::from_words(12345, 67890);
+        assert_eq!(u256.low, 12345);
+        assert_eq!(u256.high, 67890);
+    }
+
+    #[test]
+    fn test_u256_scalar_conversions() {
+        let val = 42u64;
+        let scalar = TestScalar::from(val);
+        let u256 = U256::from(&scalar);
+        assert_eq!(u256.low, val as u128);
+        assert_eq!(u256.high, 0);
+
+        let roundtrip: TestScalar = (&u256).into();
+        assert_eq!(roundtrip, scalar);
+    }
+
+    #[test]
+    fn test_u256_scalar_large_value_roundtrip() {
+        let low = u128::MAX >> 2;
+        let high = 0u128;
+        let u256 = U256::from_words(low, high);
+
+        let scalar: TestScalar = (&u256).into();
+        let roundtrip = U256::from(&scalar);
+        assert_eq!(roundtrip.low, low);
+        assert_eq!(roundtrip.high, high);
+    }
+}

--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,24 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    struct Wrapper(i32);
+
+    impl From<&Wrapper> for i32 {
+        fn from(val: &Wrapper) -> Self {
+            val.0
+        }
+    }
+
+    #[test]
+    fn test_ref_into_blanket_implementation() {
+        let wrapper = Wrapper(123);
+        let val: i32 = wrapper.ref_into();
+        assert_eq!(val, 123);
+    }
+}

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,38 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_analyze_error_display_and_conversions() {
+        let err = AnalyzeError::DataTypeMismatch {
+            left_type: "Int".to_string(),
+            right_type: "VarChar".to_string(),
+        };
+
+        let display = err.to_string();
+        assert_eq!(
+            display,
+            "Left side has 'Int' type but right side has 'VarChar' type"
+        );
+
+        let string_converted: String = err.into();
+        assert_eq!(
+            string_converted,
+            "Left side has 'Int' type but right side has 'VarChar' type"
+        );
+    }
+
+    #[test]
+    fn test_analyze_error_from_intermediate_decimal_error() {
+        let intermediate_err = IntermediateDecimalError::PrecisionOverflow;
+        let analyze_err: AnalyzeError = intermediate_err.into();
+        assert!(matches!(
+            analyze_err,
+            AnalyzeError::DecimalConversionError { .. }
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -191,3 +191,33 @@ impl ProverEvaluate for EVMProofPlan {
             .final_round_evaluate(builder, alloc, table_map, params)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::proof_plans::EmptyExec;
+
+    #[test]
+    fn test_evm_proof_plan_getters_and_delegation() {
+        let dyn_plan = DynProofPlan::Empty(EmptyExec::new());
+        let evm_plan = EVMProofPlan::new(dyn_plan.clone());
+
+        assert_eq!(evm_plan.inner(), &dyn_plan);
+        assert_eq!(evm_plan.clone().into_inner(), dyn_plan);
+
+        assert_eq!(evm_plan.get_column_result_fields(), Vec::new());
+        assert!(evm_plan.get_column_references().is_empty());
+        assert!(evm_plan.get_table_references().is_empty());
+    }
+
+    #[test]
+    fn test_evm_proof_plan_serde_roundtrip() {
+        let dyn_plan = DynProofPlan::Empty(EmptyExec::new());
+        let evm_plan = EVMProofPlan::new(dyn_plan);
+
+        let serialized = serde_json::to_string(&evm_plan).unwrap();
+        let deserialized: EVMProofPlan = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(evm_plan.inner(), deserialized.inner());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -69,3 +69,51 @@ impl<'a, T: ProvableResultElement<'a>, const N: usize> ProvableResultColumn for 
         (&self[..]).write(out, length)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use bumpalo::Bump;
+
+    #[test]
+    fn test_provable_result_column_slice_i64() {
+        let data: &[i64] = &[1, 2, 3, 4];
+        let length = 4;
+
+        let num_bytes = data.num_bytes(length);
+        assert!(num_bytes > 0);
+
+        let mut buf = vec![0u8; num_bytes];
+        let written = data.write(&mut buf, length);
+        assert_eq!(written, num_bytes);
+    }
+
+    #[test]
+    fn test_provable_result_column_slice_string() {
+        let data: &[String] = &[String::from("hello"), String::from("world")];
+        let length = 2;
+
+        let num_bytes = data.num_bytes(length);
+        assert!(num_bytes > 0);
+
+        let mut buf = vec![0u8; num_bytes];
+        let written = data.write(&mut buf, length);
+        assert_eq!(written, num_bytes);
+    }
+
+    #[test]
+    fn test_provable_result_column_boolean_column() {
+        let alloc = Bump::new();
+        let bool_data = alloc.alloc_slice_copy(&[true, false, true]);
+        let col = Column::<TestScalar>::Boolean(bool_data);
+        let length = 3;
+
+        let num_bytes = col.num_bytes(length);
+        assert!(num_bytes > 0);
+
+        let mut buf = vec![0u8; num_bytes];
+        let written = col.write(&mut buf, length);
+        assert_eq!(written, num_bytes);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
@@ -27,3 +27,42 @@ impl<'a, S: Scalar> SumcheckRandomScalars<'a, S> {
         v
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn splits_scalars_into_subpolynomial_multipliers_and_entrywise_point() {
+        let scalars = [
+            TestScalar::from(2u64),
+            TestScalar::from(3u64),
+            TestScalar::from(5u64),
+            TestScalar::from(7u64),
+        ];
+
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 4, 2);
+
+        assert_eq!(
+            random_scalars.subpolynomial_multipliers,
+            &[TestScalar::from(2u64), TestScalar::from(3u64)]
+        );
+        assert_eq!(
+            random_scalars.entrywise_point,
+            &[TestScalar::from(5u64), TestScalar::from(7u64)]
+        );
+        assert_eq!(random_scalars.table_length, 4);
+    }
+
+    #[test]
+    fn computes_entrywise_multipliers_from_the_entrywise_point() {
+        let scalars = [TestScalar::from(11u64), TestScalar::from(3u64)];
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 2, 1);
+
+        assert_eq!(
+            random_scalars.compute_entrywise_multipliers(),
+            vec![TestScalar::ONE - TestScalar::from(3u64), TestScalar::from(3u64)]
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
@@ -62,7 +62,10 @@ mod tests {
 
         assert_eq!(
             random_scalars.compute_entrywise_multipliers(),
-            vec![TestScalar::ONE - TestScalar::from(3u64), TestScalar::from(3u64)]
+            vec![
+                TestScalar::ONE - TestScalar::from(3u64),
+                TestScalar::from(3u64)
+            ]
         );
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
@@ -141,3 +141,109 @@ impl<'a, S: Scalar + 'a> IntoIterator for &'a OptimizedSumcheckTerms<'a, S> {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn test_optimizer_empty_input() {
+        let optimizer = SumcheckTermOptimizer::<TestScalar>::new(core::iter::empty(), 4);
+        let optimized = optimizer.terms();
+        let list: Vec<_> = optimized.into_iter().collect();
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn test_optimizer_merges_constants() {
+        let all_terms = vec![
+            (
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::from(3),
+                vec![],
+            ),
+            (
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::from(5),
+                vec![],
+            ),
+        ];
+
+        let optimizer = SumcheckTermOptimizer::new(
+            all_terms
+                .iter()
+                .map(|(ty, coeff, mult)| (*ty, *coeff, mult)),
+            4,
+        );
+
+        let optimized = optimizer.terms();
+        let list: Vec<_> = optimized.into_iter().collect();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].0, SumcheckSubpolynomialType::Identity);
+        assert_eq!(list[0].1, TestScalar::from(8)); // 3 + 5
+        assert!(list[0].2.is_empty());
+    }
+
+    #[test]
+    fn test_optimizer_merges_linear_terms() {
+        let mle1: &[TestScalar] = &[TestScalar::from(2)];
+        let mle2: &[TestScalar] = &[TestScalar::from(3)];
+
+        let term1 = vec![Box::new(mle1) as Box<dyn MultilinearExtension<TestScalar>>];
+        let term2 = vec![Box::new(mle2) as Box<dyn MultilinearExtension<TestScalar>>];
+
+        let all_terms = vec![
+            (
+                SumcheckSubpolynomialType::ZeroSum,
+                TestScalar::from(10),
+                &term1,
+            ),
+            (
+                SumcheckSubpolynomialType::ZeroSum,
+                TestScalar::from(20),
+                &term2,
+            ),
+        ];
+
+        let optimizer = SumcheckTermOptimizer::new(all_terms.into_iter(), 1);
+
+        let optimized = optimizer.terms();
+        let list: Vec<_> = optimized.into_iter().collect();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].0, SumcheckSubpolynomialType::ZeroSum);
+        assert_eq!(list[0].1, TestScalar::ONE);
+
+        assert_eq!(list[0].2.len(), 1);
+
+        let evaluation_vector = vec![TestScalar::ONE];
+        let res = list[0].2[0].inner_product(&evaluation_vector);
+        assert_eq!(res, TestScalar::from(80)); // 10 * 2 + 20 * 3 = 80
+    }
+
+    #[test]
+    fn test_optimizer_does_not_merge_superlinear_terms() {
+        let mle1: &[TestScalar] = &[TestScalar::from(2)];
+        let mle2: &[TestScalar] = &[TestScalar::from(3)];
+
+        let superlinear_term = vec![
+            Box::new(mle1) as Box<dyn MultilinearExtension<TestScalar>>,
+            Box::new(mle2) as Box<dyn MultilinearExtension<TestScalar>>,
+        ];
+
+        let all_terms = vec![(
+            SumcheckSubpolynomialType::ZeroSum,
+            TestScalar::from(5),
+            &superlinear_term,
+        )];
+
+        let optimizer = SumcheckTermOptimizer::new(all_terms.into_iter(), 1);
+
+        let optimized = optimizer.terms();
+        let list: Vec<_> = optimized.into_iter().collect();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].0, SumcheckSubpolynomialType::ZeroSum);
+        assert_eq!(list[0].1, TestScalar::from(5));
+        assert_eq!(list[0].2.len(), 2);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -122,3 +122,45 @@ impl DynProofExpr {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::{ColumnRef, ColumnType, TableRef};
+    use crate::sql::proof_exprs::AliasedDynProofExpr;
+    use serde_json;
+
+    #[test]
+    fn test_dyn_proof_expr_builders() {
+        let table_ref = TableRef::new("ns", "tbl");
+        let column_ref = ColumnRef::new(table_ref, Ident::new("col"), ColumnType::BigInt);
+
+        let col_expr = DynProofExpr::new_column(column_ref.clone());
+        assert!(matches!(col_expr, DynProofExpr::Column(_)));
+
+        let lit_expr = DynProofExpr::new_literal(LiteralValue::BigInt(10));
+        assert!(matches!(lit_expr, DynProofExpr::Literal(_)));
+
+        let and_expr = DynProofExpr::try_new_and(col_expr.clone(), col_expr.clone());
+        assert!(and_expr.is_err());
+    }
+
+    #[test]
+    fn test_aliased_dyn_proof_expr_serde() {
+        let table_ref = TableRef::new("ns", "tbl");
+        let column_ref = ColumnRef::new(table_ref, Ident::new("col"), ColumnType::BigInt);
+        let col_expr = DynProofExpr::new_column(column_ref);
+
+        let aliased = AliasedDynProofExpr {
+            expr: col_expr,
+            alias: Ident::new("my_alias"),
+        };
+
+        let cloned = aliased.clone();
+        assert_eq!(aliased, cloned);
+
+        let serialized = serde_json::to_string(&aliased).unwrap();
+        let deserialized: AliasedDynProofExpr = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(aliased, deserialized);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -184,3 +184,36 @@ impl DynProofPlan {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::{ColumnField, ColumnType};
+
+    #[test]
+    fn test_dyn_proof_plan_builders() {
+        let empty = DynProofPlan::new_empty();
+        assert!(matches!(empty, DynProofPlan::Empty(_)));
+
+        let table_ref = TableRef::new("namespace", "table_name");
+        let fields = vec![ColumnField::new("col".into(), ColumnType::BigInt)];
+        let table_plan = DynProofPlan::new_table(table_ref.clone(), fields);
+        assert!(matches!(table_plan, DynProofPlan::Table(_)));
+
+        let slice = DynProofPlan::new_slice(table_plan, 10, Some(20));
+        assert!(matches!(slice, DynProofPlan::Slice(_)));
+    }
+
+    #[test]
+    fn test_get_column_result_fields_as_references() {
+        let table_ref = TableRef::new("namespace", "table_name");
+        let fields = vec![ColumnField::new("a".into(), ColumnType::BigInt)];
+        let table_plan = DynProofPlan::new_table(table_ref, fields);
+
+        let refs = table_plan.get_column_result_fields_as_references();
+        assert_eq!(refs.len(), 1);
+        let ref_col = refs.get_index(0).unwrap();
+        assert_eq!(ref_col.column_id(), Ident::new("a"));
+        assert_eq!(ref_col.column_type(), &ColumnType::BigInt);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec_test.rs
@@ -1,0 +1,34 @@
+use super::test_utility::*;
+use crate::{
+    base::database::{owned_table_utility::*, TableRef, TableTestAccessor},
+    sql::proof::{exercise_verification, VerifiableQueryResult},
+};
+use blitzar::proof::InnerProductProof;
+
+#[test]
+fn we_can_create_and_prove_an_empty_exec_plan() {
+    let plan = empty_exec();
+
+    // Verify metadata and references
+    assert_eq!(plan.get_column_result_fields(), Vec::new());
+    assert!(plan.get_column_references().is_empty());
+    assert!(plan.get_table_references().is_empty());
+
+    // We can use an empty table accessor for testing since EmptyExec doesn't reference any tables
+    let accessor = TableTestAccessor::<InnerProductProof>::new_empty();
+
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
+
+    exercise_verification(&verifiable_res, &plan, &accessor, &TableRef::new("", ""));
+
+    let res = verifiable_res
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    // EmptyExec first_round_evaluate and final_round_evaluate return a Table with 1 row and 0 columns
+    let expected = owned_table(std::iter::empty());
+    assert_eq!(res.num_rows(), 1);
+    assert_eq!(res, expected);
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -1,6 +1,8 @@
 //! This module proves provable execution plans.
 mod empty_exec;
 pub use empty_exec::EmptyExec;
+#[cfg(all(test, feature = "blitzar"))]
+mod empty_exec_test;
 
 mod table_exec;
 pub use table_exec::TableExec;


### PR DESCRIPTION
### Summary
This PR increases test coverage across core database components. Specifically, it introduces new test suites covering base database models, proof plans, term optimization, and planner helper utilities.

### Key Changes
- Adds comprehensive unit tests for base database models and term optimization.
- Adds validation coverage tests for proof utilities and the SQL planner.