### PR TITLE
test: cover Arrow schema compatibility utility

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,86 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_field(field: &Field, name: &str, data_type: &DataType, nullable: bool) {
+        assert_eq!(field.name(), name);
+        assert_eq!(field.data_type(), data_type);
+        assert_eq!(field.is_nullable(), nullable);
+    }
+
+    #[test]
+    fn float_fields_are_converted_to_posql_decimal_fields_without_changing_metadata() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("half", DataType::Float16, false),
+            Field::new("single", DataType::Float32, true),
+            Field::new("double", DataType::Float64, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_field(
+            &converted.fields()[0],
+            "half",
+            &DataType::Decimal256(20, 10),
+            false,
+        );
+        assert_field(
+            &converted.fields()[1],
+            "single",
+            &DataType::Decimal256(20, 10),
+            true,
+        );
+        assert_field(
+            &converted.fields()[2],
+            "double",
+            &DataType::Decimal256(20, 10),
+            false,
+        );
+    }
+
+    #[test]
+    fn non_float_fields_keep_their_type_name_and_nullability() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("label", DataType::Utf8, true),
+            Field::new("active", DataType::Boolean, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_field(&converted.fields()[0], "id", &DataType::UInt64, false);
+        assert_field(&converted.fields()[1], "label", &DataType::Utf8, true);
+        assert_field(&converted.fields()[2], "active", &DataType::Boolean, false);
+    }
+
+    #[test]
+    fn mixed_schema_preserves_field_order_while_converting_only_float_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("score", DataType::Float64, true),
+            Field::new("label", DataType::Utf8, true),
+            Field::new("ratio", DataType::Float32, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_field(&converted.fields()[0], "id", &DataType::UInt64, false);
+        assert_field(
+            &converted.fields()[1],
+            "score",
+            &DataType::Decimal256(20, 10),
+            true,
+        );
+        assert_field(&converted.fields()[2], "label", &DataType::Utf8, true);
+        assert_field(
+            &converted.fields()[3],
+            "ratio",
+            &DataType::Decimal256(20, 10),
+            false,
+        );
+    }
+}


### PR DESCRIPTION
Adds focused test-only coverage for ase::database::arrow_schema_utility::get_posql_compatible_schema.

Scope:
- covers Float16, Float32, and Float64 conversion to Decimal256(20, 10)
- verifies non-float fields preserve name, data type, and nullability
- no production behavior changes

Validation:
- git diff --check
- Rust test execution will rely on CI because this Windows environment does not have cargo installed

AI-assisted with OpenAI Codex; patch reviewed before submission.

/claim #560