### PR TITLE
test: cover Dory scalar product messages

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -51,6 +51,9 @@ mod dory_reduce_helper;
 mod scalar_product;
 
 #[cfg(test)]
+mod scalar_product_test;
+
+#[cfg(test)]
 use dory_reduce::{dory_reduce_prove, dory_reduce_verify};
 use scalar_product::{scalar_product_prove, scalar_product_verify};
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/scalar_product_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/scalar_product_test.rs
@@ -1,8 +1,9 @@
 use super::{
-    rand_G_vecs, scalar_product_prove, scalar_product_verify, test_rng, DoryMessages,
-    ProverState, PublicParameters, VerifierSetup, VerifierState,
+    rand_G_vecs, scalar_product_prove, scalar_product_verify, test_rng, DoryMessages, ProverState,
+    PublicParameters, VerifierSetup, VerifierState,
 };
 use merlin::Transcript;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 fn scalar_product_fixture() -> (DoryMessages, VerifierState, VerifierSetup) {
     let mut rng = test_rng();
@@ -77,4 +78,34 @@ fn scalar_product_verify_rejects_unexpected_message_counts() {
         let (_, _, extra_setup) = scalar_product_fixture();
         messages.GT_messages.push(extra_setup.H_T);
     });
+}
+
+#[test]
+fn scalar_product_rejects_non_terminal_nu_state() {
+    let mut rng = test_rng();
+    let nu = 1;
+    let pp = PublicParameters::test_rand(nu, &mut rng);
+    let prover_setup = (&pp).into();
+    let verifier_setup = (&pp).into();
+    let (v1, v2) = rand_G_vecs(nu, &mut rng);
+    let prover_state = ProverState::new(v1, v2, nu);
+    let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+
+    let mut messages = DoryMessages::default();
+    let mut transcript = Transcript::new(b"scalar_product_test");
+    let prove_result = catch_unwind(AssertUnwindSafe(|| {
+        scalar_product_prove(&mut messages, &mut transcript, &prover_state);
+    }));
+    assert!(prove_result.is_err());
+
+    let mut verify_transcript = Transcript::new(b"scalar_product_test");
+    let verify_result = catch_unwind(AssertUnwindSafe(|| {
+        scalar_product_verify(
+            &mut messages,
+            &mut verify_transcript,
+            verifier_state,
+            &verifier_setup,
+        );
+    }));
+    assert!(verify_result.is_err());
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/scalar_product_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/scalar_product_test.rs
@@ -1,0 +1,80 @@
+use super::{
+    rand_G_vecs, scalar_product_prove, scalar_product_verify, test_rng, DoryMessages,
+    ProverState, PublicParameters, VerifierSetup, VerifierState,
+};
+use merlin::Transcript;
+
+fn scalar_product_fixture() -> (DoryMessages, VerifierState, VerifierSetup) {
+    let mut rng = test_rng();
+    let nu = 0;
+    let pp = PublicParameters::test_rand(nu, &mut rng);
+    let prover_setup = (&pp).into();
+    let verifier_setup = (&pp).into();
+    let (v1, v2) = rand_G_vecs(nu, &mut rng);
+    let prover_state = ProverState::new(v1, v2, nu);
+    let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+
+    let mut messages = DoryMessages::default();
+    let mut transcript = Transcript::new(b"scalar_product_test");
+    scalar_product_prove(&mut messages, &mut transcript, &prover_state);
+
+    (messages, verifier_state, verifier_setup)
+}
+
+#[test]
+fn scalar_product_prove_sends_one_group_message_each() {
+    let (messages, _, _) = scalar_product_fixture();
+
+    assert_eq!(messages.G1_messages.len(), 1);
+    assert_eq!(messages.G2_messages.len(), 1);
+    assert!(messages.F_messages.is_empty());
+    assert!(messages.GT_messages.is_empty());
+}
+
+#[test]
+fn scalar_product_verify_accepts_valid_messages() {
+    let (mut messages, verifier_state, verifier_setup) = scalar_product_fixture();
+    let mut transcript = Transcript::new(b"scalar_product_test");
+
+    assert!(scalar_product_verify(
+        &mut messages,
+        &mut transcript,
+        verifier_state,
+        &verifier_setup
+    ));
+}
+
+#[test]
+fn scalar_product_verify_rejects_unexpected_message_counts() {
+    fn assert_rejected_by(mutate: impl FnOnce(&mut DoryMessages, &VerifierSetup)) {
+        let (mut messages, verifier_state, verifier_setup) = scalar_product_fixture();
+        mutate(&mut messages, &verifier_setup);
+        let mut transcript = Transcript::new(b"scalar_product_test");
+
+        assert!(!scalar_product_verify(
+            &mut messages,
+            &mut transcript,
+            verifier_state,
+            &verifier_setup
+        ));
+    }
+
+    assert_rejected_by(|messages, _| {
+        messages.G1_messages.clear();
+    });
+    assert_rejected_by(|messages, _| {
+        let (extra_messages, _, _) = scalar_product_fixture();
+        messages.G1_messages.extend(extra_messages.G1_messages);
+    });
+    assert_rejected_by(|messages, _| {
+        messages.G2_messages.clear();
+    });
+    assert_rejected_by(|messages, _| {
+        let (extra_messages, _, _) = scalar_product_fixture();
+        messages.G2_messages.extend(extra_messages.G2_messages);
+    });
+    assert_rejected_by(|messages, _| {
+        let (_, _, extra_setup) = scalar_product_fixture();
+        messages.GT_messages.push(extra_setup.H_T);
+    });
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused test-only coverage for the Dory scalar-product protocol step
- assert the prover emits exactly one G1 and one G2 message, with no F or GT prover messages
- directly cover scalar-product verification acceptance plus rejection of unexpected G1, G2, and GT message counts
- add a non-terminal `nu = 1` guard regression documenting that scalar-product helpers are terminal-stage helpers and panic before message validation when called too early
- no production behavior changes

## Non-overlap check
I checked current #560 issue comments plus open/all PR titles and bodies for `scalar_product`, `scalar product`, and `Scalar-Product`; I did not find an active exact claim for `crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs`.

## Validation
- `cargo fmt --all -- --check` - passed on 2026-06-11
- `git diff --check upstream/main...HEAD` - passed on 2026-06-11
- `cargo +1.91.1-x86_64-pc-windows-gnu test -p proof-of-sql --no-default-features --features test scalar_product_ -- --quiet` - passed on 2026-06-11: 4 passed, 0 failed

AI-assisted with OpenAI Codex; I reviewed the patch and validation state before submitting.