### PR TITLE
Make opaque Scalar conversions explicit rather than using From/Into trait

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
@@ -14,7 +14,7 @@ const MAX_SUPPORTED_I256: i256 = i256::from_parts(
 pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
     let is_negative = val > &S::MAX_SIGNED;
     let abs_scalar = if is_negative { -*val } else { *val };
-    let limbs: [u64; 4] = abs_scalar.into();
+    let limbs = abs_scalar.to_limbs();
 
     let low = u128::from(limbs[0]) | (u128::from(limbs[1]) << 64);
     let high = i128::from(limbs[2]) | (i128::from(limbs[3]) << 64);
@@ -47,7 +47,7 @@ pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
         ];
 
         // Convert limbs to Scalar and adjust for sign
-        let scalar: S = limbs.into();
+        let scalar = S::from_limbs(limbs);
         Some(if value.is_negative() { -scalar } else { scalar })
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -3,7 +3,6 @@ use crate::base::{
     if_rayon,
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    ref_into::RefInto,
     scalar::{Scalar, ScalarExt},
 };
 use alloc::vec::Vec;
@@ -116,16 +115,16 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::BigInt(ints) => CommittableColumn::BigInt(ints),
             Column::Int128(ints) => CommittableColumn::Int128(ints),
             Column::Decimal75(precision, scale, decimals) => {
-                let as_limbs: Vec<_> = decimals.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = decimals.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::Decimal75(*precision, *scale, as_limbs)
             }
             Column::Scalar(scalars) => (scalars as &[_]).into(),
             Column::VarChar((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarChar(as_limbs)
             }
             Column::VarBinary((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarBinary(as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
@@ -155,7 +154,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 decimals
                     .iter()
                     .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             OwnedColumn::Scalar(scalars) => (scalars as &[_]).into(),
@@ -163,14 +162,13 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 strings
                     .iter()
                     .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             OwnedColumn::VarBinary(bytes) => CommittableColumn::VarBinary(
                 bytes
                     .iter()
-                    .map(|b| S::from_byte_slice_via_hash(b))
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|b| S::from_byte_slice_via_hash(b).to_limbs())
                     .collect(),
             ),
             OwnedColumn::TimestampTZ(tu, tz, times) => {
@@ -216,7 +214,7 @@ impl<'a, S: Scalar> From<&'a [S]> for CommittableColumn<'a> {
     fn from(value: &'a [S]) -> Self {
         CommittableColumn::Scalar(
             if_rayon!(value.par_iter(), value.iter())
-                .map(RefInto::<[u64; 4]>::ref_into)
+                .map(Scalar::to_limbs)
                 .collect(),
         )
     }
@@ -331,7 +329,7 @@ mod tests {
             -1,
             [-1, 1, 2]
                 .map(<TestScalar>::from)
-                .map(<[u64; 4]>::from)
+                .map(|scalar| scalar.to_limbs())
                 .into(),
         );
 
@@ -481,7 +479,7 @@ mod tests {
             ["12", "34", "56"]
                 .map(Into::<String>::into)
                 .map(Into::<TestScalar>::into)
-                .map(Into::<[u64; 4]>::into)
+                .map(|scalar| scalar.to_limbs())
                 .into(),
         );
         assert_eq!(bigint_committable_column.len(), 3);
@@ -500,7 +498,7 @@ mod tests {
         let bigint_committable_column = CommittableColumn::Scalar(
             [12, 34, 56]
                 .map(<TestScalar>::from)
-                .map(<[u64; 4]>::from)
+                .map(|scalar| scalar.to_limbs())
                 .into(),
         );
         assert_eq!(bigint_committable_column.len(), 3);
@@ -668,7 +666,7 @@ mod tests {
             CommittableColumn::from(&Column::VarChar((&varchar_data, &scalars)));
         assert_eq!(
             from_borrowed_column,
-            CommittableColumn::VarChar(scalars.map(<[u64; 4]>::from).into())
+            CommittableColumn::VarChar(scalars.map(|scalar| scalar.to_limbs()).into())
         );
     }
 
@@ -682,7 +680,7 @@ mod tests {
         let from_borrowed_column = CommittableColumn::from(&Column::Scalar(&scalars));
         assert_eq!(
             from_borrowed_column,
-            CommittableColumn::Scalar(scalars.map(<[u64; 4]>::from).into())
+            CommittableColumn::Scalar(scalars.map(|scalar| scalar.to_limbs()).into())
         );
     }
 
@@ -807,7 +805,12 @@ mod tests {
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
-            CommittableColumn::VarChar(strings.map(TestScalar::from).map(<[u64; 4]>::from).into())
+            CommittableColumn::VarChar(
+                strings
+                    .map(TestScalar::from)
+                    .map(|scalar| scalar.to_limbs())
+                    .into(),
+            )
         );
     }
 
@@ -823,7 +826,7 @@ mod tests {
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
-            CommittableColumn::Scalar(scalars.map(<[u64; 4]>::from).into())
+            CommittableColumn::Scalar(scalars.map(|scalar| scalar.to_limbs()).into())
         );
     }
 
@@ -976,7 +979,7 @@ mod tests {
             TestScalar::from(34),
             TestScalar::from(56),
         ]
-        .map(<[u64; 4]>::from);
+        .map(|scalar| scalar.to_limbs());
         let committable_column =
             CommittableColumn::Decimal75(Precision::new(1).unwrap(), 0, (values).to_vec());
 
@@ -1032,7 +1035,7 @@ mod tests {
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);
-        let scalars = values.map(TestScalar::from).map(<[u64; 4]>::from);
+        let scalars = values.map(TestScalar::from).map(|scalar| scalar.to_limbs());
         let sequence_expected = Sequence::from(scalars.as_slice());
         let mut commitment_buffer = [CompressedRistretto::default(); 2];
         compute_curve25519_commitments(
@@ -1058,7 +1061,7 @@ mod tests {
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);
-        let scalars = values.map(TestScalar::from).map(<[u64; 4]>::from);
+        let scalars = values.map(TestScalar::from).map(|scalar| scalar.to_limbs());
         let sequence_expected = Sequence::from(scalars.as_slice());
         let mut commitment_buffer = [CompressedRistretto::default(); 2];
         compute_curve25519_commitments(

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -177,7 +177,7 @@ mod tests {
     use crate::base::{
         commitment::naive_commitment::NaiveCommitment,
         database::{Column, OwnedColumn},
-        scalar::test_scalar::TestScalar,
+        scalar::{test_scalar::TestScalar, Scalar},
     };
     #[test]
     fn we_can_convert_from_columns() {
@@ -207,7 +207,7 @@ mod tests {
                 column_b
                     .iter()
                     .map(TestScalar::from)
-                    .map(<[u64; 4]>::from)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
         ];
@@ -243,7 +243,7 @@ mod tests {
                 column_b
                     .iter()
                     .map(TestScalar::from)
-                    .map(<[u64; 4]>::from)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
         ];
@@ -313,28 +313,28 @@ mod tests {
                 column_a
                     .iter()
                     .map(Into::<TestScalar>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             CommittableColumn::VarChar(
                 column_b
                     .iter()
                     .map(Into::<TestScalar>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             CommittableColumn::VarChar(
                 column_c
                     .iter()
                     .map(Into::<TestScalar>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             CommittableColumn::VarChar(
                 column_d
                     .iter()
                     .map(Into::<TestScalar>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
         ];
@@ -371,7 +371,7 @@ mod tests {
                 column_b
                     .iter()
                     .map(Into::<TestScalar>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
         ];
@@ -450,7 +450,7 @@ mod tests {
                 column_b[3..]
                     .iter()
                     .map(Into::<TestScalar>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
         ];

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -1,4 +1,4 @@
-use crate::base::scalar::MontScalar;
+use crate::base::scalar::{MontScalar, Scalar};
 use ark_ff::MontConfig;
 
 /// U256 represents an unsigned 256-bits integer number
@@ -21,7 +21,7 @@ impl U256 {
 /// This trait converts a dalek scalar into a U256 integer
 impl<T: MontConfig<4>> From<&MontScalar<T>> for U256 {
     fn from(val: &MontScalar<T>) -> Self {
-        let buf: [u64; 4] = val.into();
+        let buf = val.to_limbs();
         let low: u128 = u128::from(buf[0]) | (u128::from(buf[1]) << 64);
         let high: u128 = u128::from(buf[2]) | (u128::from(buf[3]) << 64);
         U256::from_words(low, high)

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -10,16 +10,12 @@
 // There were significant code changes to simplify the code
 // ---------------------------------------------------------------------------------------------------------------
 use super::{
-    scalar_varint::{
-        read_scalar_varint, read_u256_varint, scalar_varint_size, u256_varint_size,
-        write_scalar_varint, write_u256_varint,
-    },
+    scalar_varint::{read_u256_varint, u256_varint_size, write_u256_varint},
     U256,
 };
-use crate::base::scalar::MontScalar;
+use crate::base::scalar::Scalar;
 #[cfg(test)]
 use alloc::{vec, vec::Vec};
-use ark_ff::MontConfig;
 
 /// Most-significant byte, == 0x80
 pub const MSB: u8 = 0b1000_0000;
@@ -282,14 +278,69 @@ impl VarInt for i128 {
     }
 }
 
-impl<T: MontConfig<4>> VarInt for MontScalar<T> {
+fn limbs_to_u256(limbs: [u64; 4]) -> U256 {
+    U256 {
+        low: u128::from(limbs[0]) | (u128::from(limbs[1]) << 64),
+        high: u128::from(limbs[2]) | (u128::from(limbs[3]) << 64),
+    }
+}
+
+#[expect(clippy::cast_possible_truncation)]
+fn u256_to_limbs(value: U256) -> [u64; 4] {
+    [
+        value.low as u64,
+        (value.low >> 64) as u64,
+        value.high as u64,
+        (value.high >> 64) as u64,
+    ]
+}
+
+fn scalar_to_zigzag<S: Scalar>(scalar: &S) -> U256 {
+    let mut x = limbs_to_u256(scalar.to_limbs());
+    let mut y = limbs_to_u256((-*scalar).to_limbs());
+
+    if x.high > y.high || (x.high == y.high && x.low > y.low) {
+        y.high = (y.high << 1) | (y.low >> 127);
+        y.low <<= 1;
+
+        let (low_val, carry_low) = y.low.overflowing_sub(1_u128);
+        y.low = low_val;
+        y.high -= u128::from(carry_low);
+
+        y
+    } else {
+        x.high = (x.high << 1) | (x.low >> 127);
+        x.low <<= 1;
+
+        x
+    }
+}
+
+fn zigzag_to_scalar<S: Scalar>(value: U256) -> S {
+    let mut zig_val = U256 {
+        low: (value.low >> 1) | ((value.high & 1) << 127),
+        high: value.high >> 1,
+    };
+
+    if value.low & 1 == 1 {
+        let (low_val, carry_low) = zig_val.low.overflowing_add(1_u128);
+        zig_val.low = low_val;
+        zig_val.high += u128::from(carry_low);
+
+        -S::from_limbs(u256_to_limbs(zig_val))
+    } else {
+        S::from_limbs(u256_to_limbs(zig_val))
+    }
+}
+
+impl<S: Scalar> VarInt for S {
     fn required_space(self) -> usize {
-        scalar_varint_size(&self)
+        u256_varint_size(scalar_to_zigzag(&self))
     }
     fn decode_var(src: &[u8]) -> Option<(Self, usize)> {
-        read_scalar_varint(src)
+        read_u256_varint(src).map(|(val, size)| (zigzag_to_scalar(val), size))
     }
     fn encode_var(self, dst: &mut [u8]) -> usize {
-        write_scalar_varint(dst, &self)
+        write_u256_varint(dst, scalar_to_zigzag(&self))
     }
 }

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -10,12 +10,16 @@
 // There were significant code changes to simplify the code
 // ---------------------------------------------------------------------------------------------------------------
 use super::{
-    scalar_varint::{read_u256_varint, u256_varint_size, write_u256_varint},
+    scalar_varint::{
+        read_scalar_varint, read_u256_varint, scalar_varint_size, u256_varint_size,
+        write_scalar_varint, write_u256_varint,
+    },
     U256,
 };
-use crate::base::scalar::Scalar;
+use crate::base::scalar::MontScalar;
 #[cfg(test)]
 use alloc::{vec, vec::Vec};
+use ark_ff::MontConfig;
 
 /// Most-significant byte, == 0x80
 pub const MSB: u8 = 0b1000_0000;
@@ -278,69 +282,14 @@ impl VarInt for i128 {
     }
 }
 
-fn limbs_to_u256(limbs: [u64; 4]) -> U256 {
-    U256 {
-        low: u128::from(limbs[0]) | (u128::from(limbs[1]) << 64),
-        high: u128::from(limbs[2]) | (u128::from(limbs[3]) << 64),
-    }
-}
-
-#[expect(clippy::cast_possible_truncation)]
-fn u256_to_limbs(value: U256) -> [u64; 4] {
-    [
-        value.low as u64,
-        (value.low >> 64) as u64,
-        value.high as u64,
-        (value.high >> 64) as u64,
-    ]
-}
-
-fn scalar_to_zigzag<S: Scalar>(scalar: &S) -> U256 {
-    let mut x = limbs_to_u256(scalar.to_limbs());
-    let mut y = limbs_to_u256((-*scalar).to_limbs());
-
-    if x.high > y.high || (x.high == y.high && x.low > y.low) {
-        y.high = (y.high << 1) | (y.low >> 127);
-        y.low <<= 1;
-
-        let (low_val, carry_low) = y.low.overflowing_sub(1_u128);
-        y.low = low_val;
-        y.high -= u128::from(carry_low);
-
-        y
-    } else {
-        x.high = (x.high << 1) | (x.low >> 127);
-        x.low <<= 1;
-
-        x
-    }
-}
-
-fn zigzag_to_scalar<S: Scalar>(value: U256) -> S {
-    let mut zig_val = U256 {
-        low: (value.low >> 1) | ((value.high & 1) << 127),
-        high: value.high >> 1,
-    };
-
-    if value.low & 1 == 1 {
-        let (low_val, carry_low) = zig_val.low.overflowing_add(1_u128);
-        zig_val.low = low_val;
-        zig_val.high += u128::from(carry_low);
-
-        -S::from_limbs(u256_to_limbs(zig_val))
-    } else {
-        S::from_limbs(u256_to_limbs(zig_val))
-    }
-}
-
-impl<S: Scalar> VarInt for S {
+impl<T: MontConfig<4>> VarInt for MontScalar<T> {
     fn required_space(self) -> usize {
-        u256_varint_size(scalar_to_zigzag(&self))
+        scalar_varint_size(&self)
     }
     fn decode_var(src: &[u8]) -> Option<(Self, usize)> {
-        read_u256_varint(src).map(|(val, size)| (zigzag_to_scalar(val), size))
+        read_scalar_varint(src)
     }
     fn encode_var(self, dst: &mut [u8]) -> usize {
-        write_u256_varint(dst, scalar_to_zigzag(&self))
+        write_scalar_varint(dst, &self)
     }
 }

--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -1,8 +1,5 @@
 use super::Transcript;
-use crate::base::{
-    ref_into::RefInto,
-    scalar::{Scalar, ScalarExt},
-};
+use crate::base::scalar::{Scalar, ScalarExt};
 use bnum::types::U256;
 use zerocopy::{AsBytes, FromBytes};
 
@@ -57,7 +54,7 @@ impl<T: TranscriptCore> Transcript for T {
         &mut self,
         messages: impl IntoIterator<Item = &'a S>,
     ) {
-        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(RefInto::ref_into));
+        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(Scalar::to_limbs));
     }
     fn scalar_challenge_as_be<S: Scalar>(&mut self) -> S {
         ScalarExt::from_wrapping(

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -230,19 +230,13 @@ where
         assert!(digits.len() <= 4); // This should not happen if the above check is correct
         let mut limbs = [0u64; 4];
         limbs[..digits.len()].copy_from_slice(&digits);
-        let result = Self::from(limbs);
+        let result = Self::from_limbs(limbs);
         Ok(match sign {
             num_bigint::Sign::Minus => -result,
             num_bigint::Sign::Plus | num_bigint::Sign::NoSign => result,
         })
     }
 }
-impl<T: MontConfig<4>> From<[u64; 4]> for MontScalar<T> {
-    fn from(value: [u64; 4]) -> Self {
-        Self(Fp::new(ark_ff::BigInt(value)))
-    }
-}
-
 impl<T: MontConfig<4>> ark_std::UniformRand for MontScalar<T> {
     fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
         Self(ark_ff::UniformRand::rand(rng))
@@ -275,7 +269,7 @@ impl<T: MontConfig<4>> num_traits::Inv for MontScalar<T> {
 }
 impl<T: MontConfig<4>> Serialize for MontScalar<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut limbs: [u64; 4] = self.into();
+        let mut limbs = self.to_limbs();
         limbs.reverse();
         limbs.serialize(serializer)
     }
@@ -284,7 +278,7 @@ impl<'de, T: MontConfig<4>> Deserialize<'de> for MontScalar<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let mut limbs: [u64; 4] = Deserialize::deserialize(deserializer)?;
         limbs.reverse();
-        Ok(limbs.into())
+        Ok(Self::from_limbs(limbs))
     }
 }
 
@@ -292,18 +286,6 @@ impl<T: MontConfig<4>> core::ops::Neg for &MontScalar<T> {
     type Output = MontScalar<T>;
     fn neg(self) -> Self::Output {
         MontScalar(-self.0)
-    }
-}
-
-impl<T: MontConfig<4>> From<MontScalar<T>> for [u64; 4] {
-    fn from(value: MontScalar<T>) -> Self {
-        (&value).into()
-    }
-}
-
-impl<T: MontConfig<4>> From<&MontScalar<T>> for [u64; 4] {
-    fn from(value: &MontScalar<T>) -> Self {
-        value.0.into_bigint().0
     }
 }
 
@@ -376,6 +358,14 @@ impl<T> Scalar for MontScalar<T>
 where
     T: MontConfig<4>,
 {
+    fn from_limbs(val: [u64; 4]) -> Self {
+        Self(Fp::new(ark_ff::BigInt(val)))
+    }
+
+    fn to_limbs(&self) -> [u64; 4] {
+        self.0.into_bigint().0
+    }
+
     const MAX_SIGNED: Self = Self(Fp::new(T::MODULUS.divide_by_2_round_down()));
     const ZERO: Self = Self(Fp::ZERO);
     const ONE: Self = Self(Fp::ONE);
@@ -413,9 +403,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -447,7 +437,7 @@ where
             });
         }
 
-        let abs: [u64; 4] = value.into();
+        let abs = value.to_limbs();
 
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -471,9 +461,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -495,9 +485,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -519,9 +509,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -543,9 +533,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -569,9 +559,9 @@ where
     #[expect(clippy::cast_possible_wrap)]
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -603,7 +593,7 @@ where
         } else {
             num_bigint::Sign::Plus
         };
-        let value_abs: [u64; 4] = (if is_negative { -value } else { value }).into();
+        let value_abs = (if is_negative { -value } else { value }).to_limbs();
         let bits: &[u8] = bytemuck::cast_slice(&value_abs);
         BigInt::from_bytes_le(sign, bits)
     }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
+use crate::base::scalar::ScalarConversionError;
 use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
@@ -40,8 +40,6 @@ pub trait Scalar:
     + core::convert::TryInto <i32>
     + core::convert::TryInto <i64>
     + core::convert::TryInto <i128>
-    + core::convert::Into<[u64; 4]>
-    + core::convert::From<[u64; 4]>
     + core::convert::From<u8>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
@@ -51,9 +49,7 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + RefInto<[u64; 4]>
     + for<'a> core::convert::From<&'a String>
-    + VarInt
     + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
@@ -65,6 +61,11 @@ pub trait Scalar:
     + core::convert::Into<BigInt>
     + TryFrom<BigInt, Error = ScalarConversionError>
 {
+    /// Creates a scalar from its canonical non-Montgomery 256-bit limb representation.
+    fn from_limbs(val: [u64; 4]) -> Self;
+    /// Converts this scalar to its canonical non-Montgomery 256-bit limb representation.
+    fn to_limbs(&self) -> [u64; 4];
+
     /// The value (p - 1) / 2. This is "mid-point" of the field - the "six" on the clock.
     /// It is the largest signed value that can be represented in the field with the natural embedding.
     const MAX_SIGNED: Self;

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::scalar::ScalarConversionError;
+use crate::base::{encode::VarInt, scalar::ScalarConversionError};
 use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
@@ -49,6 +49,7 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
+    + VarInt
     + for<'a> core::convert::From<&'a String>
     + core::convert::From<String>
     + core::convert::From<i128>

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -24,12 +24,12 @@ pub trait ScalarExt: Scalar {
     /// Converts a U256 to Scalar, wrapping as needed
     fn from_wrapping(value: U256) -> Self {
         let value_as_limbs: [u64; 4] = value.into();
-        Self::from(value_as_limbs)
+        Self::from_limbs(value_as_limbs)
     }
 
     /// Converts a Scalar to U256. Note that any values above `MAX_SIGNED` shall remain positive, even if they are representative of negative values.
     fn into_u256_wrapping(self) -> U256 {
-        U256::from(Into::<[u64; 4]>::into(self))
+        U256::from(self.to_limbs())
     }
 
     /// Converts a byte slice to a Scalar using a hash function, preventing collisions.

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -82,7 +82,7 @@ pub(crate) fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
     // get rho for the first 256 rows
     let rho_256 = alloc.alloc_slice_fill_iter(0u8..=255);
 
-    // get (rho_256 + α)⁻¹
+    // get (rho_256 + Î±)â»Â¹
     let rho_256_logarithmic_derivative: &mut [S] =
         alloc.alloc_slice_fill_iter((0..256).map(S::from));
     slice_ops::add_const::<S, S>(rho_256_logarithmic_derivative, alpha);
@@ -95,14 +95,14 @@ pub(crate) fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
     let row_sums = alloc.alloc_slice_fill_copy(num_rows, S::ZERO);
 
     for byte_column in word_columns {
-        // (wᵢ + α)⁻¹
+        // (wáµ¢ + Î±)â»Â¹
         let words_inv = get_logarithmic_derivative_from_rho_256_logarithmic_derivative(
             alloc,
             byte_column,
             rho_256_logarithmic_derivative,
         );
         builder.produce_intermediate_mle(words_inv);
-        // (wᵢ + α)⁻¹ * (wᵢ + α) - chi_n = 0
+        // (wáµ¢ + Î±)â»Â¹ * (wáµ¢ + Î±) - chi_n = 0
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
             vec![
@@ -126,7 +126,7 @@ pub(crate) fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
     let chi_256 = alloc.alloc_slice_fill_copy(256, true);
 
     // Argument:
-    // (rho_256 + α)⁻¹ * (rho_256 + α) - chi_256 = 0
+    // (rho_256 + Î±)â»Â¹ * (rho_256 + Î±) - chi_256 = 0
     builder.produce_sumcheck_subpolynomial(
         SumcheckSubpolynomialType::Identity,
         vec![
@@ -147,7 +147,7 @@ pub(crate) fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
 
     builder.produce_intermediate_mle(word_counts as &[_]);
 
-    // ∑ⱼ ((∑ᵢ (wᵢⱼ + α)⁻¹) - countⱼ * (ρ₂₅₆,ⱼ + α)⁻¹) = 0 where 0 <= i < 32, and 0 <= j < max(n, 256)
+    // âˆ‘â±¼ ((âˆ‘áµ¢ (wáµ¢â±¼ + Î±)â»Â¹) - countâ±¼ * (Ïâ‚‚â‚…â‚†,â±¼ + Î±)â»Â¹) = 0 where 0 <= i < 32, and 0 <= j < max(n, 256)
     builder.produce_sumcheck_subpolynomial(
         SumcheckSubpolynomialType::ZeroSum,
         vec![
@@ -169,9 +169,9 @@ pub(crate) fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
 /// ```text
 /// | Column 0   | Column 1   | Column 2   | ... | Column 31   |
 /// |------------|------------|------------|-----|-------------|
-/// |  w₀,₀      |  w₀,₁      |  w₀,₂      | ... |  w₀,₃₁      |
-/// |  w₁,₀      |  w₁,₁      |  w₁,₂      | ... |  w₁,₃₁      |
-/// |  w₂,₀      |  w₂,₁      |  w₂,₂      | ... |  w₂,₃₁      |
+/// |  wâ‚€,â‚€      |  wâ‚€,â‚      |  wâ‚€,â‚‚      | ... |  wâ‚€,â‚ƒâ‚      |
+/// |  wâ‚,â‚€      |  wâ‚,â‚      |  wâ‚,â‚‚      | ... |  wâ‚,â‚ƒâ‚      |
+/// |  wâ‚‚,â‚€      |  wâ‚‚,â‚      |  wâ‚‚,â‚‚      | ... |  wâ‚‚,â‚ƒâ‚      |
 /// ------------------------------------------------------------
 /// ```
 #[tracing::instrument(
@@ -191,7 +191,7 @@ where
             .take(31)
             .collect();
     for (i, scalar) in column_data.iter().enumerate() {
-        let scalar_array: [u64; 4] = (*scalar).into().into();
+        let scalar_array = Into::<S>::into(*scalar).to_limbs();
         // Convert the [u64; 4] into a slice of bytes
         let scalar_bytes = &cast_slice::<u64, u8>(&scalar_array)[..31];
 
@@ -237,43 +237,43 @@ pub(crate) fn verifier_evaluate_range_check<S: Scalar>(
     input_column_eval: S,
     chi_n_eval: S,
 ) -> Result<(), ProofSizeMismatch> {
-    // Retrieve the post-result challenge α
+    // Retrieve the post-result challenge Î±
     let alpha = builder.try_consume_post_result_challenge()?;
     let chi_256_eval = builder.try_consume_chi_evaluation()?.0;
 
-    // We will accumulate ∑(wᵢ * 256ⁱ) in `sum`.
-    // Additionally, we'll collect all (wᵢ + α)⁻¹ evaluations in `w_plus_alpha_inv_evals`
+    // We will accumulate âˆ‘(wáµ¢ * 256â±) in `sum`.
+    // Additionally, we'll collect all (wáµ¢ + Î±)â»Â¹ evaluations in `w_plus_alpha_inv_evals`
     // to use later for the ZeroSum argument.
     let mut word_eval_weighted_sum = S::ZERO;
     let mut word_logarithmic_derivative_eval_sum = S::ZERO;
 
     // Process 31 columns (one per byte in a 248-bit decomposition).
     // Each iteration handles:
-    //  - Consuming MLE evaluations for wᵢ and (wᵢ + α)⁻¹
-    //  - Verifying that (wᵢ + α)⁻¹ * (wᵢ + α) - 1 = 0
-    //  - Accumulating wᵢ * 256ⁱ into `sum`
+    //  - Consuming MLE evaluations for wáµ¢ and (wáµ¢ + Î±)â»Â¹
+    //  - Verifying that (wáµ¢ + Î±)â»Â¹ * (wáµ¢ + Î±) - 1 = 0
+    //  - Accumulating wáµ¢ * 256â± into `sum`
     for i in 0..31 {
-        // Consume the next MLE evaluations: one for wᵢ, one for (wᵢ + α)⁻¹
+        // Consume the next MLE evaluations: one for wáµ¢, one for (wáµ¢ + Î±)â»Â¹
         let word_eval = builder.try_consume_first_round_mle_evaluation()?;
         let word_logarithmic_derivative_eval = builder.try_consume_final_round_mle_evaluation()?;
 
-        // Compute 256ⁱ via a small loop (instead of a fold or pow)
+        // Compute 256â± via a small loop (instead of a fold or pow)
         let mut power = S::from(1);
         for _ in 0..i {
             power *= S::from(256);
         }
 
-        // Argue that ( (wᵢ + α)⁻¹ * (wᵢ + α) ) - 1 = 0
+        // Argue that ( (wáµ¢ + Î±)â»Â¹ * (wáµ¢ + Î±) ) - 1 = 0
         builder.try_produce_sumcheck_subpolynomial_evaluation(
             SumcheckSubpolynomialType::Identity,
             word_logarithmic_derivative_eval * (word_eval + alpha) - chi_n_eval,
             2,
         )?;
 
-        // Add wᵢ * 256ⁱ to our running sum to ensure the entire column is in range
+        // Add wáµ¢ * 256â± to our running sum to ensure the entire column is in range
         word_eval_weighted_sum += word_eval * power;
 
-        // Sum over all (wᵢ + α)⁻¹ evaluations to get row_sum_eval
+        // Sum over all (wáµ¢ + Î±)â»Â¹ evaluations to get row_sum_eval
         word_logarithmic_derivative_eval_sum += word_logarithmic_derivative_eval;
     }
 
@@ -289,10 +289,10 @@ pub(crate) fn verifier_evaluate_range_check<S: Scalar>(
         .rho_256_evaluation()
         .ok_or(ProofSizeMismatch::TooFewSumcheckVariables)?;
 
-    // Retrieve the final-round MLE evaluation for (rho_256 + α)⁻¹
+    // Retrieve the final-round MLE evaluation for (rho_256 + Î±)â»Â¹
     let rho_256_logarithmic_derivative_eval = builder.try_consume_final_round_mle_evaluation()?;
 
-    // Argue that (rho_256 + α)⁻¹ * (rho_256 + α) - 1 = 0
+    // Argue that (rho_256 + Î±)â»Â¹ * (rho_256 + Î±) - 1 = 0
     builder.try_produce_sumcheck_subpolynomial_evaluation(
         SumcheckSubpolynomialType::Identity,
         rho_256_logarithmic_derivative_eval * (rho_256_eval + alpha) - chi_256_eval,
@@ -302,10 +302,10 @@ pub(crate) fn verifier_evaluate_range_check<S: Scalar>(
     // The final-round MLE evaluation for word count
     let count_eval = builder.try_consume_final_round_mle_evaluation()?;
 
-    // Compute count_eval * (word_vals + α)⁻¹
+    // Compute count_eval * (word_vals + Î±)â»Â¹
     let count_value_product_eval = count_eval * rho_256_logarithmic_derivative_eval;
 
-    // Argue that row_sum_eval - (count_eval * (word_vals + α)⁻¹) = 0
+    // Argue that row_sum_eval - (count_eval * (word_vals + Î±)â»Â¹) = 0
     // This ensures consistency of counts vs. actual row sums.
     builder.try_produce_sumcheck_subpolynomial_evaluation(
         SumcheckSubpolynomialType::ZeroSum,


### PR DESCRIPTION
## Summary

- add explicit `Scalar::from_limbs` and `Scalar::to_limbs` methods
- remove opaque limb conversion bounds from `Scalar`
- remove concrete limb `From` conversions for `MontScalar`
- update production call sites and tests to use the explicit limb methods

## Notes

This now addresses only the limb-conversion checkbox from #228. I split the blanket `VarInt` refactor back out so this PR lines up with the issue's request for separate PRs.

## Testing

Not run locally: this workspace does not currently have `cargo` / `rustc` installed.

/claim #228