### PR TITLE
test: cover utils helpers

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -67,7 +67,8 @@ merlin = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["std"] }
 rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -30,3 +30,19 @@ pub fn log_memory_usage(name: &str) {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::dispatcher::{with_default, Dispatch};
+
+    #[test]
+    fn we_can_log_memory_usage_when_trace_is_enabled() {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(Level::TRACE)
+            .finish();
+        let dispatch = Dispatch::new(subscriber);
+
+        with_default(&dispatch, || log_memory_usage("test"));
+    }
+}

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -34,15 +34,76 @@ pub fn log_memory_usage(name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tracing::dispatcher::{with_default, Dispatch};
+    use core::fmt;
+    use std::sync::{Arc, Mutex};
+    use tracing::{
+        dispatcher::{with_default, Dispatch},
+        field::{Field, Visit},
+        Event, Subscriber,
+    };
+    use tracing_subscriber::{
+        filter::LevelFilter,
+        layer::{Context, SubscriberExt},
+        registry::{LookupSpan, Registry},
+        Layer,
+    };
+
+    #[derive(Clone)]
+    struct CapturedEvent {
+        level: Level,
+        target: String,
+        message: String,
+    }
+
+    #[derive(Clone)]
+    struct CaptureLayer {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = MessageVisitor::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(CapturedEvent {
+                level: *event.metadata().level(),
+                target: event.metadata().target().to_string(),
+                message: visitor.message.unwrap_or_default(),
+            });
+        }
+    }
+
+    #[derive(Default)]
+    struct MessageVisitor {
+        message: Option<String>,
+    }
+
+    impl Visit for MessageVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            if field.name() == "message" {
+                self.message = Some(format!("{value:?}"));
+            }
+        }
+    }
 
     #[test]
     fn we_can_log_memory_usage_when_trace_is_enabled() {
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(Level::TRACE)
-            .finish();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = Registry::default()
+            .with(LevelFilter::TRACE)
+            .with(CaptureLayer {
+                events: Arc::clone(&events),
+            });
         let dispatch = Dispatch::new(subscriber);
 
         with_default(&dispatch, || log_memory_usage("test"));
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].level, Level::TRACE);
+        assert!(events[0].target.ends_with("utils::log"));
+        assert!(events[0].message.contains("test Available memory"));
     }
 }

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -104,14 +104,25 @@ mod tests {
                 BASE_FEE_PER_GAS DECIMAL(38, 0),
                 PRIMARY KEY(BLOCK_NUMBER)
             );
+
+            CREATE TABLE IF NOT EXISTS ETHEREUM.RECEIPTS(
+                TRANSACTION_HASH VARCHAR NOT NULL,
+                EFFECTIVE_GAS_PRICE DECIMAL(39, 2),
+                GAS_USED DECIMAL(38, 0),
+                PRIMARY KEY(TRANSACTION_HASH)
+            );
         ";
 
         let bigdecimals = find_bigdecimals(sql);
 
-        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(bigdecimals.len(), 2);
         assert_eq!(
             bigdecimals.get("ETHEREUM.BLOCKS").unwrap(),
             &[("REWARD".to_string(), 78, 0)]
+        );
+        assert_eq!(
+            bigdecimals.get("ETHEREUM.RECEIPTS").unwrap(),
+            &[("EFFECTIVE_GAS_PRICE".to_string(), 39, 2)]
         );
     }
 }

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,26 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn we_ignore_non_create_table_statements_when_finding_bigdecimals() {
+        let sql = "
+            SELECT CAST(1 AS DECIMAL(78, 0));
+
+            CREATE TABLE IF NOT EXISTS ETHEREUM.BLOCKS(
+                BLOCK_NUMBER BIGINT NOT NULL,
+                REWARD DECIMAL(78, 0),
+                BASE_FEE_PER_GAS DECIMAL(38, 0),
+                PRIMARY KEY(BLOCK_NUMBER)
+            );
+        ";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("ETHEREUM.BLOCKS").unwrap(),
+            &[("REWARD".to_string(), 78, 0)]
+        );
+    }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`. Not run on this Windows workspace; focused local checks are listed below.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md. Not run because this machine's `bash` resolves to WSL and no Linux distribution is installed; this PR is a single commit and `git diff --check HEAD^ HEAD` passed.
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

/claim #560

This is a focused test-only coverage slice for the remaining uncovered utility code paths in #560.

# What changes are included in this PR?

- Add a `find_bigdecimals` test that proves non-`CREATE TABLE` statements are ignored while a table with `DECIMAL(78, 0)` is still reported.
- Add a TRACE-enabled `log_memory_usage` test that exercises the std memory logging branch.
- Enable `tracing/std` for dev tests and add the workspace `tracing-subscriber` dev dependency used by the logging test.

# Are these changes tested?

Yes.

- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test utils:: -- --nocapture` - 34 passed
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target\sxt-utils-coverage.lcov -- utils::` - 34 passed and LCOV generated
- `git diff --check HEAD^ HEAD`

Focused LCOV evidence:

- `crates/proof-of-sql/src/utils/parse.rs`: 81/81 covered in the focused report.
- `crates/proof-of-sql/src/utils/log.rs`: 18/19 covered in the focused report; the std TRACE branch and memory calculations are exercised, with the remaining uncovered line corresponding to the `trace!` macro format string line in the LCOV output.
