### PR TITLE
test: cover ark serde macro helpers

### DIFF
--- a/crates/proof-of-sql/src/base/serialize.rs
+++ b/crates/proof-of-sql/src/base/serialize.rs
@@ -51,3 +51,134 @@ macro_rules! impl_serde_for_ark_serde_unchecked {
 
 pub(crate) use impl_serde_for_ark_serde_checked;
 pub(crate) use impl_serde_for_ark_serde_unchecked;
+
+#[cfg(test)]
+mod tests {
+    use super::{impl_serde_for_ark_serde_checked, impl_serde_for_ark_serde_unchecked};
+    use ark_serialize::{
+        CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid,
+        Validate, Write,
+    };
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct CheckedByte(u8);
+
+    impl Valid for CheckedByte {
+        fn check(&self) -> Result<(), SerializationError> {
+            if self.0 <= 7 {
+                Ok(())
+            } else {
+                Err(SerializationError::InvalidData)
+            }
+        }
+    }
+
+    impl CanonicalSerialize for CheckedByte {
+        fn serialize_with_mode<W: Write>(
+            &self,
+            mut writer: W,
+            compress: Compress,
+        ) -> Result<(), SerializationError> {
+            assert!(matches!(compress, Compress::Yes));
+            writer.write_all(&[self.0])?;
+            Ok(())
+        }
+
+        fn serialized_size(&self, compress: Compress) -> usize {
+            assert!(matches!(compress, Compress::Yes));
+            1
+        }
+    }
+
+    impl CanonicalDeserialize for CheckedByte {
+        fn deserialize_with_mode<R: Read>(
+            mut reader: R,
+            compress: Compress,
+            validate: Validate,
+        ) -> Result<Self, SerializationError> {
+            assert!(matches!(compress, Compress::Yes));
+            let mut bytes = [0_u8; 1];
+            reader.read_exact(&mut bytes)?;
+            let value = Self(bytes[0]);
+            if validate == Validate::Yes {
+                value.check()?;
+            }
+            Ok(value)
+        }
+    }
+
+    impl_serde_for_ark_serde_checked!(CheckedByte);
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct UncheckedByte(u8);
+
+    impl Valid for UncheckedByte {
+        fn check(&self) -> Result<(), SerializationError> {
+            if self.0 <= 7 {
+                Ok(())
+            } else {
+                Err(SerializationError::InvalidData)
+            }
+        }
+    }
+
+    impl CanonicalSerialize for UncheckedByte {
+        fn serialize_with_mode<W: Write>(
+            &self,
+            mut writer: W,
+            compress: Compress,
+        ) -> Result<(), SerializationError> {
+            assert!(matches!(compress, Compress::Yes));
+            writer.write_all(&[self.0])?;
+            Ok(())
+        }
+
+        fn serialized_size(&self, compress: Compress) -> usize {
+            assert!(matches!(compress, Compress::Yes));
+            1
+        }
+    }
+
+    impl CanonicalDeserialize for UncheckedByte {
+        fn deserialize_with_mode<R: Read>(
+            mut reader: R,
+            compress: Compress,
+            validate: Validate,
+        ) -> Result<Self, SerializationError> {
+            assert!(matches!(compress, Compress::Yes));
+            let mut bytes = [0_u8; 1];
+            reader.read_exact(&mut bytes)?;
+            let value = Self(bytes[0]);
+            if validate == Validate::Yes {
+                value.check()?;
+            }
+            Ok(value)
+        }
+    }
+
+    impl_serde_for_ark_serde_unchecked!(UncheckedByte);
+
+    #[test]
+    fn checked_serde_round_trips_valid_canonical_bytes() {
+        let encoded = serde_json::to_vec(&CheckedByte(7)).unwrap();
+        assert_eq!(encoded, b"[7]");
+
+        let decoded: CheckedByte = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, CheckedByte(7));
+    }
+
+    #[test]
+    fn checked_deserialization_rejects_invalid_canonical_data() {
+        let encoded_invalid_bytes = serde_json::to_vec(&[8_u8]).unwrap();
+
+        assert!(serde_json::from_slice::<CheckedByte>(&encoded_invalid_bytes).is_err());
+    }
+
+    #[test]
+    fn unchecked_deserialization_skips_canonical_validation() {
+        let encoded_invalid_bytes = serde_json::to_vec(&[8_u8]).unwrap();
+
+        let decoded: UncheckedByte = serde_json::from_slice(&encoded_invalid_bytes).unwrap();
+        assert_eq!(decoded, UncheckedByte(8));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused test-only coverage for the `base::serialize` ark serde helper macros
- verify checked deserialization rejects invalid canonical data while the unchecked helper skips validation
- verify valid checked serde output round-trips through the macro-generated `Serialize` / `Deserialize` impls

## Non-overlap
This slice is limited to `crates/proof-of-sql/src/base/serialize.rs`. I searched existing #560 coverage PRs for `impl_serde_for_ark_serde_checked`, `impl_serde_for_ark_serde_unchecked`, `serialize.rs`, and the Dory serde consumers before choosing this target.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test serialize::tests -- --nocapture`
- `git diff --check`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --summary-only --json --output-path target\sxt-serialize-coverage.json -- serialize::tests --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target\sxt-serialize-coverage.lcov -- serialize::tests --nocapture`

Focused coverage summary for `crates/proof-of-sql/src/base/serialize.rs`: 76 / 103 lines, 11 / 15 functions, 109 / 158 regions.

Note: the focused Windows `--no-default-features --features test` runs emit existing unused warnings in unrelated modules, but the tests pass.