### PR TITLE
test: cover Dory pairing wrappers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/pairings.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pairings.rs
@@ -138,3 +138,86 @@ fn multi_pairing_4_impl<P: Pairing>(
     );
     (c0, c1, c2, c3)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{multi_pairing, multi_pairing_2, multi_pairing_4, pairing};
+    use ark_bls12_381::{Bls12_381, G1Affine, G2Affine};
+    use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
+
+    fn scaled_g1(multiplier: u64) -> G1Affine {
+        G1Affine::generator().mul_bigint([multiplier]).into_affine()
+    }
+
+    fn scaled_g2(multiplier: u64) -> G2Affine {
+        G2Affine::generator().mul_bigint([multiplier]).into_affine()
+    }
+
+    #[test]
+    fn pairing_wrapper_matches_ark_pairing() {
+        let g1 = scaled_g1(2);
+        let g2 = scaled_g2(3);
+
+        assert_eq!(pairing::<Bls12_381>(g1, g2), Bls12_381::pairing(g1, g2));
+    }
+
+    #[test]
+    fn multi_pairing_wrapper_matches_ark_multi_pairing() {
+        let g1 = scaled_g1(2);
+        let g2 = scaled_g2(3);
+        let other_g1 = scaled_g1(5);
+        let other_g2 = scaled_g2(7);
+        let identity_g1 = G1Affine::identity();
+
+        assert_eq!(
+            multi_pairing::<Bls12_381>([g1, identity_g1, other_g1], [g2, other_g2, other_g2]),
+            Bls12_381::multi_pairing([g1, identity_g1, other_g1], [g2, other_g2, other_g2])
+        );
+    }
+
+    #[test]
+    fn multi_pairing_2_wrapper_returns_each_expected_pairing() {
+        let g1 = scaled_g1(2);
+        let g2 = scaled_g2(3);
+        let other_g1 = scaled_g1(5);
+        let other_g2 = scaled_g2(7);
+        let identity_g1 = G1Affine::identity();
+        let identity_g2 = G2Affine::identity();
+
+        let expected_0 = Bls12_381::multi_pairing([g1, identity_g1], [g2, other_g2]);
+        let expected_1 = Bls12_381::multi_pairing([other_g1], [identity_g2]);
+
+        assert_eq!(
+            multi_pairing_2::<Bls12_381>(
+                ([g1, identity_g1], [g2, other_g2]),
+                ([other_g1], [identity_g2])
+            ),
+            (expected_0, expected_1)
+        );
+    }
+
+    #[test]
+    fn multi_pairing_4_wrapper_returns_each_expected_pairing() {
+        let g1 = scaled_g1(2);
+        let g2 = scaled_g2(3);
+        let other_g1 = scaled_g1(5);
+        let other_g2 = scaled_g2(7);
+        let identity_g1 = G1Affine::identity();
+        let identity_g2 = G2Affine::identity();
+
+        let expected_0 = Bls12_381::multi_pairing([g1], [g2]);
+        let expected_1 = Bls12_381::multi_pairing([identity_g1], [other_g2]);
+        let expected_2 = Bls12_381::multi_pairing([g1, other_g1], [g2, identity_g2]);
+        let expected_3 = Bls12_381::multi_pairing([identity_g1, other_g1], [identity_g2, other_g2]);
+
+        assert_eq!(
+            multi_pairing_4::<Bls12_381>(
+                ([g1], [g2]),
+                ([identity_g1], [other_g2]),
+                ([g1, other_g1], [g2, identity_g2]),
+                ([identity_g1, other_g1], [identity_g2, other_g2]),
+            ),
+            (expected_0, expected_1, expected_2, expected_3)
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused test-only coverage for Dory pairing wrapper helpers
- verify `pairing` and `multi_pairing` match the corresponding `ark_ec::Pairing` APIs
- verify `multi_pairing_2` and `multi_pairing_4` return each grouped result in order
- use deterministic non-generator BLS12-381 multiples plus identity inputs for stronger wrapper regression coverage

## Non-overlap
This slice is limited to `crates/proof-of-sql/src/proof_primitive/dory/pairings.rs`. I searched existing #560 coverage PRs for `pairings`, `multi_pairing`, `multi_pairing_2`, `multi_pairing_4`, Dory scalar product, and transpose/offset helpers before choosing this target. I avoided repeated areas such as U256, offset_to_bytes, standard serialization, RefInto, Arrow conversions, planner/proof, database errors, join/group-by, time units, math log/permutation, and prior Dory bundle claims.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test pairings::tests -- --nocapture`
- `git diff --check`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --summary-only --json --output-path target\sxt-pairings-coverage.json -- pairings::tests --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path target\sxt-pairings-coverage.lcov -- pairings::tests --nocapture`

Focused coverage summary for `crates/proof-of-sql/src/proof_primitive/dory/pairings.rs`: 155 / 155 lines, 13 / 13 functions, 173 / 173 regions.