### PR TITLE
Add FixedSizeBinary column support

### DIFF
--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -71,6 +71,9 @@ pub(crate) fn scalar_value_to_literal_value(value: ScalarValue) -> PlannerResult
         ScalarValue::Binary(Some(v)) | ScalarValue::LargeBinary(Some(v)) => {
             Ok(LiteralValue::VarBinary(v))
         }
+        ScalarValue::FixedSizeBinary(size, Some(v)) if (0..=32).contains(&size) => {
+            Ok(LiteralValue::FixedSizeBinary(size, v))
+        }
         ScalarValue::TimestampSecond(Some(v), None) => Ok(LiteralValue::TimeStampTZ(
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::utc(),
@@ -320,6 +323,13 @@ mod tests {
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::VarBinary(vec![72, 97, 108, 108, 101, 108, 117, 106, 97, 104])
+        );
+
+        // FixedSizeBinary
+        let value = ScalarValue::FixedSizeBinary(2, Some(vec![1, 2]));
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::FixedSizeBinary(2, vec![1, 2])
         );
 
         // TimestampSecond

--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -7,9 +7,10 @@ use crate::base::{
 };
 use arrow::{
     array::{
-        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, FixedSizeBinaryArray,
+        Int16Array, Int32Array, Int64Array, Int8Array, LargeBinaryArray, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, TimeUnit as ArrowTimeUnit},
 };
@@ -305,6 +306,33 @@ impl ArrayRefExt for ArrayRef {
                     };
 
                     Ok(Column::VarBinary((vals, scals)))
+                } else {
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
+                }
+            }
+            DataType::FixedSizeBinary(size) => {
+                if !(0..=32).contains(size) {
+                    return Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    });
+                }
+                if let Some(array) = self.as_any().downcast_ref::<FixedSizeBinaryArray>() {
+                    let vals = alloc
+                        .alloc_slice_fill_with(range.end - range.start, |i| -> &'a [u8] {
+                            array.value(range.start + i)
+                        });
+
+                    let scals = if let Some(scals) = precomputed_scals {
+                        &scals[range.start..range.end]
+                    } else {
+                        alloc.alloc_slice_fill_with(vals.len(), |i| {
+                            S::from_fixed_size_binary(vals[i])
+                        })
+                    };
+
+                    Ok(Column::FixedSizeBinary(*size, (vals, scals)))
                 } else {
                     Err(ArrowArrayToColumnConversionError::UnsupportedType {
                         datatype: self.data_type().clone(),
@@ -1036,6 +1064,30 @@ mod tests {
     }
 
     #[test]
+    fn we_can_convert_valid_fixed_size_binary_array_refs_into_valid_columns() {
+        let alloc = Bump::new();
+        let data = [b"cd".as_slice(), b"ef".as_slice()];
+        let scals: Vec<_> = data
+            .iter()
+            .copied()
+            .map(DoryScalar::from_fixed_size_binary)
+            .collect();
+        let array: ArrayRef = Arc::new(
+            FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                data.iter().map(|bytes| Some(*bytes)),
+                2,
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(0..2), None)
+                .unwrap(),
+            Column::FixedSizeBinary(2, (&data[..], &scals[..]))
+        );
+    }
+
+    #[test]
     fn we_can_convert_valid_boolean_array_refs_into_valid_columns() {
         let alloc = Bump::new();
         let data = vec![true, false];
@@ -1173,6 +1225,32 @@ mod tests {
     }
 
     #[test]
+    fn we_can_convert_valid_fixed_size_binary_array_refs_into_valid_columns_using_ranges_smaller_than_arrays(
+    ) {
+        let alloc = Bump::new();
+        let data = [b"ab".as_slice(), b"cd".as_slice(), b"ef".as_slice()];
+        let scals: Vec<_> = data
+            .iter()
+            .copied()
+            .map(DoryScalar::from_fixed_size_binary)
+            .collect();
+
+        let array: ArrayRef = Arc::new(
+            FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                data.iter().map(|bytes| Some(*bytes)),
+                2,
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            array
+                .to_column::<DoryScalar>(&alloc, &(1..3), None)
+                .unwrap(),
+            Column::FixedSizeBinary(2, (&data[1..3], &scals[1..3]))
+        );
+    }
+
+    #[test]
     fn we_can_convert_valid_string_array_refs_into_valid_columns_using_precomputed_scalars() {
         let alloc = Bump::new();
         let data = vec!["ab", "-f34"];
@@ -1201,6 +1279,31 @@ mod tests {
                 .to_column::<TestScalar>(&alloc, &(0..2), Some(&scals))
                 .unwrap(),
             Column::VarBinary((&data[..], &scals[..]))
+        );
+    }
+
+    #[test]
+    fn we_can_convert_valid_fixed_size_binary_array_refs_into_valid_columns_using_precomputed_scalars(
+    ) {
+        let alloc = Bump::new();
+        let data = [b"ab".as_slice(), b"cd".as_slice()];
+        let scals: Vec<_> = data
+            .iter()
+            .copied()
+            .map(TestScalar::from_fixed_size_binary)
+            .collect();
+        let array: ArrayRef = Arc::new(
+            FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                data.iter().map(|bytes| Some(*bytes)),
+                2,
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            array
+                .to_column::<TestScalar>(&alloc, &(0..2), Some(&scals))
+                .unwrap(),
+            Column::FixedSizeBinary(2, (&data[..], &scals[..]))
         );
     }
 

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -22,6 +22,7 @@ impl From<&ColumnType> for DataType {
             }
             ColumnType::VarChar => DataType::Utf8,
             ColumnType::VarBinary => DataType::LargeBinary,
+            ColumnType::FixedSizeBinary(size) => DataType::FixedSizeBinary(*size),
             ColumnType::Scalar => unimplemented!("Cannot convert Scalar type to arrow type"),
             ColumnType::TimestampTZ(timeunit, timezone) => {
                 let arrow_timezone = Some(Arc::from(timezone.to_string()));
@@ -67,6 +68,9 @@ impl TryFrom<DataType> for ColumnType {
             }
             DataType::Utf8 => Ok(ColumnType::VarChar),
             DataType::LargeBinary => Ok(ColumnType::VarBinary),
+            DataType::FixedSizeBinary(size) if (0..=32).contains(&size) => {
+                Ok(ColumnType::FixedSizeBinary(size))
+            }
             _ => Err(format!("Unsupported arrow data type {data_type:?}")),
         }
     }

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -23,9 +23,10 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, LargeBinaryArray, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Int16Array,
+        Int32Array, Int64Array, Int8Array, LargeBinaryArray, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
     error::ArrowError,
@@ -99,6 +100,13 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
             OwnedColumn::VarBinary(col) => Arc::new(LargeBinaryArray::from_iter_values(
                 col.iter().map(Vec::as_slice),
             )),
+            OwnedColumn::FixedSizeBinary(size, col) => Arc::new(
+                FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                    col.iter().map(|bytes| Some(bytes.as_slice())),
+                    size,
+                )
+                .expect("all values must match the fixed binary size"),
+            ),
             OwnedColumn::TimestampTZ(time_unit, _, col) => match time_unit {
                 PoSQLTimeUnit::Second => Arc::new(TimestampSecondArray::from(col)),
                 PoSQLTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(col)),
@@ -239,6 +247,18 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .map(|s| s.map(<[u8]>::to_vec).unwrap())
                     .collect(),
             )),
+            DataType::FixedSizeBinary(size) if (0..=32).contains(size) => {
+                Ok(Self::FixedSizeBinary(
+                    *size,
+                    value
+                        .as_any()
+                        .downcast_ref::<FixedSizeBinaryArray>()
+                        .unwrap()
+                        .iter()
+                        .map(|s| s.map(<[u8]>::to_vec).unwrap())
+                        .collect(),
+                ))
+            }
             DataType::Timestamp(time_unit, timezone) => match time_unit {
                 ArrowTimeUnit::Second => {
                     let array = value

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -7,8 +7,8 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
-        StringArray,
+        ArrayRef, BooleanArray, Decimal128Array, FixedSizeBinaryArray, Float32Array, Int64Array,
+        LargeBinaryArray, StringArray,
     },
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
@@ -33,6 +33,21 @@ fn we_can_convert_between_varbinary_owned_column_and_array_ref_impl(data: &[Vec<
             .map(std::vec::Vec::as_slice)
             .collect::<Vec<&[u8]>>(),
     ));
+    we_can_convert_between_owned_column_and_array_ref_impl(&owned_col, arrow_col);
+}
+
+fn we_can_convert_between_fixed_size_binary_owned_column_and_array_ref_impl(
+    size: i32,
+    data: &[Vec<u8>],
+) {
+    let owned_col = OwnedColumn::<TestScalar>::FixedSizeBinary(size, data.to_owned());
+    let arrow_col = Arc::new(
+        FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            data.iter().map(|bytes| Some(bytes.as_slice())),
+            size,
+        )
+        .unwrap(),
+    );
     we_can_convert_between_owned_column_and_array_ref_impl(&owned_col, arrow_col);
 }
 
@@ -89,6 +104,12 @@ fn we_can_convert_between_owned_column_and_array_ref() {
         b"some bytes".to_vec(),
     ];
     we_can_convert_between_varbinary_owned_column_and_array_ref_impl(&varbin_data);
+
+    let fixed_size_binary_data = vec![b"foo".to_vec(), b"bar".to_vec(), b"baz".to_vec()];
+    we_can_convert_between_fixed_size_binary_owned_column_and_array_ref_impl(
+        3,
+        &fixed_size_binary_data,
+    );
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -239,6 +239,7 @@ impl ColumnBounds {
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
             | CommittableColumn::VarBinary(_)
+            | CommittableColumn::FixedSizeBinary(_, _)
             | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
         }
     }

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -55,6 +55,7 @@ impl ColumnCommitmentMetadata {
                 ColumnType::Boolean
                 | ColumnType::VarChar
                 | ColumnType::VarBinary
+                | ColumnType::FixedSizeBinary(_)
                 | ColumnType::Scalar
                 | ColumnType::Decimal75(..),
                 ColumnBounds::NoOrder,

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -48,6 +48,8 @@ pub enum CommittableColumn<'a> {
     VarChar(Vec<[u64; 4]>),
     /// Column of limbs for committing to scalars, hashed from a `Binary` column.
     VarBinary(Vec<[u64; 4]>),
+    /// Column of limbs for committing to scalars, hashed from a fixed-size binary column.
+    FixedSizeBinary(i32, Vec<[u64; 4]>),
     /// Borrowed Timestamp column with Timezone, mapped to `i64`.
     TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, &'a [i64]),
 }
@@ -66,7 +68,8 @@ impl CommittableColumn<'_> {
             CommittableColumn::Decimal75(_, _, col)
             | CommittableColumn::Scalar(col)
             | CommittableColumn::VarChar(col)
-            | CommittableColumn::VarBinary(col) => col.len(),
+            | CommittableColumn::VarBinary(col)
+            | CommittableColumn::FixedSizeBinary(_, col) => col.len(),
             CommittableColumn::Boolean(col) => col.len(),
         }
     }
@@ -99,6 +102,7 @@ impl<'a> From<&CommittableColumn<'a>> for ColumnType {
             CommittableColumn::Scalar(_) => ColumnType::Scalar,
             CommittableColumn::VarChar(_) => ColumnType::VarChar,
             CommittableColumn::VarBinary(_) => ColumnType::VarBinary,
+            CommittableColumn::FixedSizeBinary(size, _) => ColumnType::FixedSizeBinary(*size),
             CommittableColumn::Boolean(_) => ColumnType::Boolean,
             CommittableColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
         }
@@ -127,6 +131,10 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::VarBinary((_, scalars)) => {
                 let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
                 CommittableColumn::VarBinary(as_limbs)
+            }
+            Column::FixedSizeBinary(size, (_, scalars)) => {
+                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                CommittableColumn::FixedSizeBinary(*size, as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
         }
@@ -170,6 +178,14 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 bytes
                     .iter()
                     .map(|b| S::from_byte_slice_via_hash(b))
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+            OwnedColumn::FixedSizeBinary(size, bytes) => CommittableColumn::FixedSizeBinary(
+                *size,
+                bytes
+                    .iter()
+                    .map(|b| S::from_fixed_size_binary(b))
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),
@@ -240,7 +256,8 @@ impl<'a, 'b> From<&'a CommittableColumn<'b>> for Sequence<'a> {
             CommittableColumn::Decimal75(_, _, limbs)
             | CommittableColumn::Scalar(limbs)
             | CommittableColumn::VarChar(limbs)
-            | CommittableColumn::VarBinary(limbs) => Sequence::from(limbs),
+            | CommittableColumn::VarBinary(limbs)
+            | CommittableColumn::FixedSizeBinary(_, limbs) => Sequence::from(limbs),
             CommittableColumn::Boolean(bools) => Sequence::from(*bools),
             CommittableColumn::TimestampTZ(_, _, times) => Sequence::from(*times),
         }

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -148,7 +148,8 @@ impl Commitment for NaiveCommitment {
                         scalar_vec.iter().map(core::convert::Into::into).collect()
                     }
                     CommittableColumn::VarChar(varchar_vec)
-                    | CommittableColumn::VarBinary(varchar_vec) => {
+                    | CommittableColumn::VarBinary(varchar_vec)
+                    | CommittableColumn::FixedSizeBinary(_, varchar_vec) => {
                         varchar_vec.iter().map(core::convert::Into::into).collect()
                     }
                     CommittableColumn::TimestampTZ(_, _, i64_vec) => {

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -47,6 +47,8 @@ pub enum Column<'a, S: Scalar> {
     Scalar(&'a [S]),
     /// Variable length binary columns
     VarBinary((&'a [&'a [u8]], &'a [S])),
+    /// Fixed length binary columns
+    FixedSizeBinary(i32, (&'a [&'a [u8]], &'a [S])),
 }
 
 impl<'a, S: Scalar> Column<'a, S> {
@@ -68,6 +70,7 @@ impl<'a, S: Scalar> Column<'a, S> {
                 ColumnType::TimestampTZ(*time_unit, *timezone)
             }
             Self::VarBinary(..) => ColumnType::VarBinary,
+            Self::FixedSizeBinary(size, ..) => ColumnType::FixedSizeBinary(*size),
         }
     }
     /// Returns the length of the column.
@@ -87,6 +90,10 @@ impl<'a, S: Scalar> Column<'a, S> {
                 col.len()
             }
             Self::VarBinary((col, scals)) => {
+                assert_eq!(col.len(), scals.len());
+                col.len()
+            }
+            Self::FixedSizeBinary(_, (col, scals)) => {
                 assert_eq!(col.len(), scals.len());
                 col.len()
             }
@@ -152,6 +159,24 @@ impl<'a, S: Scalar> Column<'a, S> {
 
                 Column::VarBinary((bytes_slice, scalars))
             }
+            LiteralValue::FixedSizeBinary(size, bytes) => {
+                let fixed_size =
+                    usize::try_from(*size).expect("fixed-size binary size must be nonnegative");
+                assert!(
+                    fixed_size <= 32,
+                    "fixed-size binary size must be at most 32"
+                );
+                assert_eq!(
+                    fixed_size,
+                    bytes.len(),
+                    "literal byte length must match the fixed-size binary size"
+                );
+                let bytes_slice = alloc
+                    .alloc_slice_fill_with(length, |_| alloc.alloc_slice_copy(bytes) as &[_]);
+                let scalars = alloc.alloc_slice_fill_copy(length, S::from_fixed_size_binary(bytes));
+
+                Column::FixedSizeBinary(*size, (bytes_slice, scalars))
+            }
         }
     }
 
@@ -197,6 +222,20 @@ impl<'a, S: Scalar> Column<'a, S> {
                     alloc.alloc_slice_clone(&bytes),
                     alloc.alloc_slice_copy(scalars.as_slice()),
                 ))
+            }
+            OwnedColumn::FixedSizeBinary(size, col) => {
+                let scalars = col
+                    .iter()
+                    .map(|b| S::from_fixed_size_binary(b))
+                    .collect::<Vec<_>>();
+                let bytes = col.iter().map(|s| s as &'a [u8]).collect::<Vec<_>>();
+                Column::FixedSizeBinary(
+                    *size,
+                    (
+                        alloc.alloc_slice_clone(&bytes),
+                        alloc.alloc_slice_copy(scalars.as_slice()),
+                    ),
+                )
             }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col.as_slice()),
         }
@@ -285,7 +324,9 @@ impl<'a, S: Scalar> Column<'a, S> {
     /// Returns the column as a slice of strings and a slice of scalars if it is a varchar column. Otherwise, returns None.
     pub(crate) fn as_varbinary(&self) -> Option<(&'a [&'a [u8]], &'a [S])> {
         match self {
-            Self::VarBinary((col, scals)) => Some((col, scals)),
+            Self::VarBinary((col, scals)) | Self::FixedSizeBinary(_, (col, scals)) => {
+                Some((col, scals))
+            }
             _ => None,
         }
     }
@@ -311,7 +352,9 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::BigInt(col) | Self::TimestampTZ(_, _, col) => S::from(col[index]),
             Self::Int128(col) => S::from(col[index]),
             Self::Scalar(col) | Self::Decimal75(_, _, col) => col[index],
-            Self::VarChar((_, scals)) | Self::VarBinary((_, scals)) => scals[index],
+            Self::VarChar((_, scals))
+            | Self::VarBinary((_, scals))
+            | Self::FixedSizeBinary(_, (_, scals)) => scals[index],
         })
     }
 
@@ -322,7 +365,9 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::Boolean(col) => slice_cast_with(col, |b| S::from(b)),
             Self::Decimal75(_, _, col) => slice_cast_with(col, |s| *s),
             Self::VarChar((_, values)) => slice_cast_with(values, |s| *s),
-            Self::VarBinary((_, values)) => slice_cast_with(values, |s| *s),
+            Self::VarBinary((_, values)) | Self::FixedSizeBinary(_, (_, values)) => {
+                slice_cast_with(values, |s| *s)
+            }
             Self::Uint8(col) => slice_cast_with(col, |i| S::from(i)),
             Self::TinyInt(col) => slice_cast_with(col, |i| S::from(i)),
             Self::SmallInt(col) => slice_cast_with(col, |i| S::from(i)),
@@ -555,6 +600,22 @@ mod tests {
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
         assert_eq!(column.column_type(), ColumnType::VarBinary);
+    }
+
+    #[test]
+    fn we_can_convert_fixed_size_binary_literal_to_column() {
+        use bumpalo::Bump;
+
+        let alloc = Bump::new();
+        let literal = LiteralValue::FixedSizeBinary(2, b"\x34\x12".to_vec());
+        let expected_bytes = [b"\x34\x12".as_slice(); 3];
+        let expected_scalar = TestScalar::from_fixed_size_binary(b"\x34\x12");
+        let expected_scalars = [expected_scalar; 3];
+
+        assert_eq!(
+            Column::from_literal_with_length(&literal, 3, &alloc),
+            Column::FixedSizeBinary(2, (&expected_bytes, &expected_scalars))
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -103,6 +103,19 @@ where
                 alloc.alloc_slice_copy(&scalars) as &[_],
             )))
         }
+        ColumnType::FixedSizeBinary(size) => {
+            let (raw_values, raw_scalars) =
+                column.as_varbinary().expect("Column types should match");
+            let raw_values = apply_slice_to_indexes(raw_values, indexes)?;
+            let scalars = apply_slice_to_indexes(raw_scalars, indexes)?;
+            Ok(Column::FixedSizeBinary(
+                size,
+                (
+                    alloc.alloc_slice_clone(&raw_values) as &[_],
+                    alloc.alloc_slice_copy(&scalars) as &[_],
+                ),
+            ))
+        }
         ColumnType::TimestampTZ(tu, tz) => {
             let raw_values = apply_slice_to_indexes(
                 column.as_timestamptz().expect("Column types should match"),

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -119,6 +119,29 @@ pub trait RepetitionOp {
                     }) as &[_],
                 ))
             }
+            ColumnType::FixedSizeBinary(size) => {
+                let (raw_result, raw_scalars) =
+                    column.as_varbinary().expect("Column types should match");
+
+                let mut result_iter = Self::op(raw_result, n);
+                let mut scalar_iter = Self::op(raw_scalars, n);
+
+                Column::FixedSizeBinary(
+                    size,
+                    (
+                        alloc.alloc_slice_fill_with(len, |_| {
+                            result_iter
+                                .next()
+                                .expect("Iterator should have enough elements")
+                        }) as &[_],
+                        alloc.alloc_slice_fill_with(len, |_| {
+                            scalar_iter
+                                .next()
+                                .expect("Iterator should have enough elements")
+                        }) as &[_],
+                    ),
+                )
+            }
             ColumnType::TimestampTZ(tu, tz) => {
                 let mut iter = Self::op(
                     column.as_timestamptz().expect("Column types should match"),

--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -56,6 +56,10 @@ pub enum ColumnType {
     /// Mapped to [u8]
     #[serde(alias = "BINARY", alias = "BINARY")]
     VarBinary,
+    /// Mapped to fixed-length [u8]
+    #[serde(alias = "FIXED_SIZE_BINARY", alias = "fixed_size_binary")]
+    #[cfg_attr(test, proptest(skip))]
+    FixedSizeBinary(i32),
 }
 
 impl ColumnType {
@@ -187,7 +191,7 @@ impl ColumnType {
             // Scalars are not in database & are only used for typeless comparisons for testing so we return 0
             // so that they do not cause errors when used in comparisons.
             Self::Scalar => Some(0_u8),
-            Self::Boolean | Self::VarChar | Self::VarBinary => None,
+            Self::Boolean | Self::VarChar | Self::VarBinary | Self::FixedSizeBinary(_) => None,
         }
     }
     /// Returns scale of a [`ColumnType`] if it is convertible to a decimal wrapped in `Some()`. Otherwise return None.
@@ -202,7 +206,7 @@ impl ColumnType {
             | Self::BigInt
             | Self::Int128
             | Self::Scalar => Some(0),
-            Self::Boolean | Self::VarBinary | Self::VarChar => None,
+            Self::Boolean | Self::VarBinary | Self::FixedSizeBinary(_) | Self::VarChar => None,
             Self::TimestampTZ(tu, _) => match tu {
                 PoSQLTimeUnit::Second => Some(0),
                 PoSQLTimeUnit::Millisecond => Some(3),
@@ -223,9 +227,11 @@ impl ColumnType {
             Self::Int => size_of::<i32>(),
             Self::BigInt | Self::TimestampTZ(_, _) => size_of::<i64>(),
             Self::Int128 => size_of::<i128>(),
-            Self::Scalar | Self::Decimal75(_, _) | Self::VarBinary | Self::VarChar => {
-                size_of::<[u64; 4]>()
-            }
+            Self::Scalar
+            | Self::Decimal75(_, _)
+            | Self::VarBinary
+            | Self::FixedSizeBinary(_)
+            | Self::VarChar => size_of::<[u64; 4]>(),
         }
     }
 
@@ -249,6 +255,7 @@ impl ColumnType {
             Self::Decimal75(_, _)
             | Self::Scalar
             | Self::VarBinary
+            | Self::FixedSizeBinary(_)
             | Self::VarChar
             | Self::Boolean
             | Self::Uint8 => false,
@@ -289,6 +296,7 @@ impl Display for ColumnType {
             }
             ColumnType::VarChar => write!(f, "VARCHAR"),
             ColumnType::VarBinary => write!(f, "BINARY"),
+            ColumnType::FixedSizeBinary(size) => write!(f, "FIXED_SIZE_BINARY({size})"),
             ColumnType::Scalar => write!(f, "SCALAR"),
             ColumnType::TimestampTZ(timeunit, timezone) => {
                 write!(f, "TIMESTAMP(TIMEUNIT: {timeunit}, TIMEZONE: {timezone})")

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -278,6 +278,10 @@ pub fn try_equals_types(lhs: ColumnType, rhs: ColumnType) -> ColumnOperationResu
             | (ColumnType::Boolean, ColumnType::Boolean)
             | (_, ColumnType::Scalar)
             | (ColumnType::Scalar, _)
+    ) || matches!(
+        (lhs, rhs),
+        (ColumnType::FixedSizeBinary(left_size), ColumnType::FixedSizeBinary(right_size))
+            if left_size == right_size
     ) || (lhs.is_numeric() && rhs.is_numeric() && lhs.scale() == rhs.scale())
         || matches!(
             (lhs, rhs),
@@ -353,6 +357,10 @@ pub fn try_equals_types_with_scaling(
             | (ColumnType::Boolean, ColumnType::Boolean)
             | (_, ColumnType::Scalar)
             | (ColumnType::Scalar, _)
+    ) || matches!(
+        (lhs, rhs),
+        (ColumnType::FixedSizeBinary(left_size), ColumnType::FixedSizeBinary(right_size))
+            if left_size == right_size
     ) || (lhs.is_numeric() && rhs.is_numeric()))
     .then_some(())
     .ok_or(ColumnOperationError::BinaryOperationInvalidColumnType {
@@ -1107,6 +1115,28 @@ mod test {
             Err(ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidScale { .. }
             })
+        ));
+    }
+
+    #[test]
+    fn we_can_compare_matching_fixed_size_binary_types_for_equality() {
+        assert!(try_equals_types(
+            ColumnType::FixedSizeBinary(2),
+            ColumnType::FixedSizeBinary(2)
+        )
+        .is_ok());
+        assert!(try_equals_types_with_scaling(
+            ColumnType::FixedSizeBinary(2),
+            ColumnType::FixedSizeBinary(2)
+        )
+        .is_ok());
+
+        assert!(matches!(
+            try_equals_types(
+                ColumnType::FixedSizeBinary(2),
+                ColumnType::FixedSizeBinary(3)
+            ),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
     }
 

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -69,6 +69,13 @@ pub fn filter_column_by_index<'a, S: Scalar>(
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
         )),
+        Column::FixedSizeBinary(size, (col, scals)) => Column::FixedSizeBinary(
+            *size,
+            (
+                alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+                alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
+            ),
+        ),
         Column::Scalar(col) => {
             Column::Scalar(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -170,7 +170,8 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         Column::VarChar(_)
         | Column::TimestampTZ(_, _, _)
         | Column::Boolean(_)
-        | Column::VarBinary(_) => {
+        | Column::VarBinary(_)
+        | Column::FixedSizeBinary(_, _) => {
             unreachable!("SUM can not be applied to non-numeric types")
         }
     }
@@ -203,7 +204,7 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
             max_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarBinary(_) => {
+        Column::VarBinary(_) | Column::FixedSizeBinary(_, _) => {
             unreachable!("MAX can not be applied to varbinary")
         }
         // The following should never be reached because the `MAX` function can't be applied to varchar.
@@ -240,7 +241,9 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
             min_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarBinary(_) => unreachable!("MIN can not be applied to varbinary"),
+        Column::VarBinary(_) | Column::FixedSizeBinary(_, _) => {
+            unreachable!("MIN can not be applied to varbinary")
+        }
         // The following should never be reached because the `MIN` function can't be applied to varchar.
         Column::VarChar(_) => {
             unreachable!("MIN can not be applied to varchar")

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -50,6 +50,8 @@ pub enum LiteralValue {
     /// Binary data literals
     ///  - the backing store is a Vec<u8> for variable length binary data
     VarBinary(Vec<u8>),
+    /// Fixed-size binary data literals
+    FixedSizeBinary(i32, Vec<u8>),
 }
 
 impl LiteralValue {
@@ -65,6 +67,7 @@ impl LiteralValue {
             Self::BigInt(_) => ColumnType::BigInt,
             Self::VarChar(_) => ColumnType::VarChar,
             Self::VarBinary(_) => ColumnType::VarBinary,
+            Self::FixedSizeBinary(size, _) => ColumnType::FixedSizeBinary(*size),
             Self::Int128(_) => ColumnType::Int128,
             Self::Scalar(_) => ColumnType::Scalar,
             Self::Decimal75(precision, scale, _) => ColumnType::Decimal75(*precision, *scale),
@@ -83,6 +86,7 @@ impl LiteralValue {
             Self::BigInt(i) => i.into(),
             Self::VarChar(str) => str.into(),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
+            Self::FixedSizeBinary(_, bytes) => S::from_fixed_size_binary(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),
             Self::Scalar(limbs) => (*limbs).into(),
@@ -116,6 +120,7 @@ mod tests {
             LiteralValue::TimeStampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc(), 10),
             LiteralValue::Scalar([1; 4]),
             LiteralValue::VarBinary(vec![1]),
+            LiteralValue::FixedSizeBinary(1, vec![1]),
         ];
         for literal_value in literal_values {
             let column_type = literal_value.column_type();

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -26,6 +26,7 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
             Column::Scalar(col) => col[i].cmp(&col[j]),
             Column::VarChar((col, _)) => col[i].cmp(col[j]),
             Column::VarBinary((col, _)) => col[i].cmp(col[j]),
+            Column::FixedSizeBinary(_, (col, _)) => col[i].cmp(col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)
@@ -88,6 +89,11 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
             (Column::VarChar((left_col, _)), Column::VarChar((right_col, _))) => {
                 left_col[left_row_index].cmp(right_col[right_row_index])
             }
+            (Column::VarBinary((left_col, _)), Column::VarBinary((right_col, _)))
+            | (
+                Column::FixedSizeBinary(_, (left_col, _)),
+                Column::FixedSizeBinary(_, (right_col, _)),
+            ) => left_col[left_row_index].cmp(right_col[right_row_index]),
             // Should never happen since we checked the column types
             _ => unreachable!(),
         };

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -10,7 +10,9 @@ use crate::base::{
     },
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::Scalar,
-    slice_ops::{inner_product_ref_cast, inner_product_with_bytes},
+    slice_ops::{
+        inner_product_ref_cast, inner_product_with_bytes, inner_product_with_fixed_size_binary,
+    },
 };
 use alloc::{
     string::{String, ToString},
@@ -51,6 +53,9 @@ pub enum OwnedColumn<S: Scalar> {
     Scalar(Vec<S>),
     /// Variable length binary columns
     VarBinary(Vec<Vec<u8>>),
+    /// Fixed length binary columns
+    #[cfg_attr(test, proptest(skip))]
+    FixedSizeBinary(i32, Vec<Vec<u8>>),
 }
 
 impl<S: Scalar> OwnedColumn<S> {
@@ -67,6 +72,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             OwnedColumn::VarChar(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::VarBinary(col) => inner_product_with_bytes(col, vec),
+            OwnedColumn::FixedSizeBinary(_, col) => inner_product_with_fixed_size_binary(col, vec),
             OwnedColumn::Int128(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => {
                 inner_product_ref_cast(col, vec)
@@ -86,6 +92,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.len(),
             OwnedColumn::VarChar(col) => col.len(),
             OwnedColumn::VarBinary(col) => col.len(),
+            OwnedColumn::FixedSizeBinary(_, col) => col.len(),
             OwnedColumn::Int128(col) => col.len(),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col.len(),
         }
@@ -102,6 +109,9 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) => OwnedColumn::BigInt(permutation.try_apply(col)?),
             OwnedColumn::VarChar(col) => OwnedColumn::VarChar(permutation.try_apply(col)?),
             OwnedColumn::VarBinary(col) => OwnedColumn::VarBinary(permutation.try_apply(col)?),
+            OwnedColumn::FixedSizeBinary(size, col) => {
+                OwnedColumn::FixedSizeBinary(*size, permutation.try_apply(col)?)
+            }
             OwnedColumn::Int128(col) => OwnedColumn::Int128(permutation.try_apply(col)?),
             OwnedColumn::Decimal75(precision, scale, col) => {
                 OwnedColumn::Decimal75(*precision, *scale, permutation.try_apply(col)?)
@@ -125,6 +135,9 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) => OwnedColumn::BigInt(col[start..end].to_vec()),
             OwnedColumn::VarChar(col) => OwnedColumn::VarChar(col[start..end].to_vec()),
             OwnedColumn::VarBinary(col) => OwnedColumn::VarBinary(col[start..end].to_vec()),
+            OwnedColumn::FixedSizeBinary(size, col) => {
+                OwnedColumn::FixedSizeBinary(*size, col[start..end].to_vec())
+            }
             OwnedColumn::Int128(col) => OwnedColumn::Int128(col[start..end].to_vec()),
             OwnedColumn::Decimal75(precision, scale, col) => {
                 OwnedColumn::Decimal75(*precision, *scale, col[start..end].to_vec())
@@ -148,6 +161,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.is_empty(),
             OwnedColumn::VarChar(col) => col.is_empty(),
             OwnedColumn::VarBinary(col) => col.is_empty(),
+            OwnedColumn::FixedSizeBinary(_, col) => col.is_empty(),
             OwnedColumn::Int128(col) => col.is_empty(),
             OwnedColumn::Scalar(col) | OwnedColumn::Decimal75(_, _, col) => col.is_empty(),
         }
@@ -164,6 +178,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(_) => ColumnType::BigInt,
             OwnedColumn::VarChar(_) => ColumnType::VarChar,
             OwnedColumn::VarBinary(_) => ColumnType::VarBinary,
+            OwnedColumn::FixedSizeBinary(size, _) => ColumnType::FixedSizeBinary(*size),
             OwnedColumn::Int128(_) => ColumnType::Int128,
             OwnedColumn::Scalar(_) => ColumnType::Scalar,
             OwnedColumn::Decimal75(precision, scale, _) => {
@@ -254,10 +269,12 @@ impl<S: Scalar> OwnedColumn<S> {
                 Ok(OwnedColumn::TimestampTZ(tu, tz, raw_values))
             }
             // Can not convert scalars to VarChar
-            ColumnType::VarChar | ColumnType::VarBinary => Err(OwnedColumnError::TypeCastError {
-                from_type: ColumnType::Scalar,
-                to_type: ColumnType::VarChar,
-            }),
+            ColumnType::VarChar | ColumnType::VarBinary | ColumnType::FixedSizeBinary(_) => {
+                Err(OwnedColumnError::TypeCastError {
+                    from_type: ColumnType::Scalar,
+                    to_type: column_type,
+                })
+            }
         }
     }
 
@@ -373,6 +390,10 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for OwnedColumn<S> {
             Column::VarBinary((col, _)) => {
                 OwnedColumn::VarBinary(col.iter().map(|slice| slice.to_vec()).collect())
             }
+            Column::FixedSizeBinary(size, (col, _)) => OwnedColumn::FixedSizeBinary(
+                *size,
+                col.iter().map(|slice| slice.to_vec()).collect(),
+            ),
             Column::Int128(col) => OwnedColumn::Int128(col.to_vec()),
             Column::Decimal75(precision, scale, col) => {
                 OwnedColumn::Decimal75(*precision, *scale, col.to_vec())
@@ -904,6 +925,32 @@ mod test {
 
         let expected =
             lhs_hashes[0] * scalars[0] + lhs_hashes[1] * scalars[1] + lhs_hashes[2] * scalars[2];
+
+        assert_eq!(product, expected);
+    }
+
+    #[test]
+    fn we_can_compute_inner_product_with_fixed_size_binary_columns_using_direct_embedding() {
+        let lhs = OwnedColumn::<TestScalar>::FixedSizeBinary(
+            2,
+            vec![
+                b"\x01\x00".to_vec(),
+                b"\x02\x00".to_vec(),
+                b"\x03\x00".to_vec(),
+            ],
+        );
+
+        let scalars = vec![
+            TestScalar::from(10),
+            TestScalar::from(20),
+            TestScalar::from(30),
+        ];
+
+        let product = lhs.inner_product(&scalars);
+
+        let expected = TestScalar::from(10)
+            + TestScalar::from(2) * TestScalar::from(20)
+            + TestScalar::from(3) * TestScalar::from(30);
 
         assert_eq!(product, expected);
     }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -126,6 +126,17 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
 
                 Column::VarBinary((col_as_slices, scals))
             }
+            OwnedColumn::FixedSizeBinary(size, col) => {
+                let col_as_slices: &mut [&[u8]] = self
+                    .alloc
+                    .alloc_slice_fill_iter(col.iter().map(Vec::as_slice));
+                let scals: &mut [CP::Scalar] = self.alloc.alloc_slice_fill_iter(
+                    col.iter()
+                        .map(|b| CP::Scalar::from_fixed_size_binary(b.as_slice())),
+                );
+
+                Column::FixedSizeBinary(*size, (col_as_slices, scals))
+            }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col),
         }
     }

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -183,6 +183,32 @@ pub fn column_union<'a, S: Scalar>(
                 }) as &[_],
             ))
         }
+        ColumnType::FixedSizeBinary(size) => {
+            let (nested_results, nested_scalars): (Vec<_>, Vec<_>) = columns
+                .iter()
+                .map(|col| col.as_varbinary().expect("Column types should match"))
+                .unzip();
+
+            // Create iterators for both results and scalars
+            let mut result_iter = nested_results.into_iter().flatten().copied();
+            let mut scalar_iter = nested_scalars.into_iter().flatten().copied();
+
+            Column::FixedSizeBinary(
+                size,
+                (
+                    alloc.alloc_slice_fill_with(len, |_| {
+                        result_iter
+                            .next()
+                            .expect("Iterator should have enough elements")
+                    }) as &[_],
+                    alloc.alloc_slice_fill_with(len, |_| {
+                        scalar_iter
+                            .next()
+                            .expect("Iterator should have enough elements")
+                    }) as &[_],
+                ),
+            )
+        }
         ColumnType::TimestampTZ(tu, tz) => {
             let mut iter = columns
                 .iter()

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -102,6 +102,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
             Column::Uint8(c) => c.inner_product(evaluation_vec),
             Column::TinyInt(c) => c.inner_product(evaluation_vec),
@@ -118,6 +119,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => {
                 c.mul_add(res, multiplier);
             }
@@ -136,6 +138,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
             Column::Uint8(c) => c.to_sumcheck_term(num_vars),
             Column::TinyInt(c) => c.to_sumcheck_term(num_vars),
@@ -152,6 +155,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c)
             | Column::VarChar((_, c))
             | Column::VarBinary((_, c))
+            | Column::FixedSizeBinary(_, (_, c))
             | Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
             Column::Uint8(c) => MultilinearExtension::<S>::id(c),
             Column::TinyInt(c) => MultilinearExtension::<S>::id(c),

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -51,6 +51,23 @@ pub trait ScalarExt: Scalar {
         let masked_val = hashed_val & Self::CHALLENGE_MASK;
         Self::from_wrapping(masked_val)
     }
+
+    /// Converts fixed-size binary bytes to a Scalar.
+    ///
+    /// Values shorter than 32 bytes are embedded directly as little-endian integers.
+    /// Exactly 32-byte values are hashed to stay within the supported scalar range.
+    #[must_use]
+    fn from_fixed_size_binary(bytes: &[u8]) -> Self {
+        match bytes.len() {
+            0 => Self::zero(),
+            1..=31 => Self::from_wrapping(
+                U256::from_le_slice(bytes)
+                    .expect("at most 31 bytes => guaranteed to parse as U256"),
+            ),
+            32 => Self::from_byte_slice_via_hash(bytes),
+            _ => panic!("fixed-size binary values larger than 32 bytes are not supported"),
+        }
+    }
 }
 
 impl<S: Scalar> ScalarExt for S {}
@@ -107,6 +124,24 @@ mod tests {
         assert_eq!(
             scalar_from_bytes, scalar_from_ref,
             "The masked keccak v256 of 'abc' must match"
+        );
+    }
+
+    #[test]
+    fn we_can_embed_short_fixed_size_binary_directly() {
+        let bytes = [0x34, 0x12];
+        assert_eq!(
+            TestScalar::from_fixed_size_binary(&bytes),
+            TestScalar::from_wrapping(U256::from(0x1234_u16))
+        );
+    }
+
+    #[test]
+    fn we_hash_32_byte_fixed_size_binary() {
+        let bytes = [7_u8; 32];
+        assert_eq!(
+            TestScalar::from_fixed_size_binary(&bytes),
+            TestScalar::from_byte_slice_via_hash(&bytes)
         );
     }
 

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -40,3 +40,12 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
         .sum()
 }
+
+/// Cannot use blanket impls for `Vec<u8>` because fixed-size binary uses a
+/// direct scalar embedding for values shorter than 32 bytes.
+pub fn inner_product_with_fixed_size_binary<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
+    if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
+        .zip(b)
+        .map(|(lhs_bytes, &rhs)| S::from_fixed_size_binary(lhs_bytes) * rhs)
+        .sum()
+}

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -41,6 +41,7 @@ pub const fn min_as_f(column_type: ColumnType) -> F {
         | ColumnType::Scalar
         | ColumnType::VarChar
         | ColumnType::VarBinary
+        | ColumnType::FixedSizeBinary(_)
         | ColumnType::Boolean => MontFp!("0"),
     }
 }
@@ -133,7 +134,8 @@ fn copy_column_data_to_slice(
         CommittableColumn::Scalar(column)
         | CommittableColumn::Decimal75(_, _, column)
         | CommittableColumn::VarChar(column)
-        | CommittableColumn::VarBinary(column) => {
+        | CommittableColumn::VarBinary(column)
+        | CommittableColumn::FixedSizeBinary(_, column) => {
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -76,7 +76,9 @@ fn compute_dory_commitment(
             compute_dory_commitment_impl(column, offset, setup)
         }
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::VarBinary(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::VarBinary(column) | CommittableColumn::FixedSizeBinary(_, column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -83,6 +83,7 @@ fn compute_dory_commitment(
         CommittableColumn::Int128(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::VarChar(column)
         | CommittableColumn::VarBinary(column)
+        | CommittableColumn::FixedSizeBinary(_, column)
         | CommittableColumn::Decimal75(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -448,7 +448,8 @@ pub fn bit_table_and_scalars_for_packed_msm(
             CommittableColumn::Decimal75(_, _, column)
             | CommittableColumn::Scalar(column)
             | CommittableColumn::VarChar(column)
-            | CommittableColumn::VarBinary(column) => {
+            | CommittableColumn::VarBinary(column)
+            | CommittableColumn::FixedSizeBinary(_, column) => {
                 pack_bit(
                     column,
                     &mut packed_scalars,

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -156,7 +156,8 @@ fn compute_commitments_impl(
             CommittableColumn::Decimal75(_, _, vals)
             | CommittableColumn::Scalar(vals)
             | CommittableColumn::VarChar(vals)
-            | CommittableColumn::VarBinary(vals) => {
+            | CommittableColumn::VarBinary(vals)
+            | CommittableColumn::FixedSizeBinary(_, vals) => {
                 compute_commitment_generic_impl(setup, offset, vals)
             }
         })

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
@@ -94,7 +94,8 @@ mod tests {
                 CommittableColumn::Decimal75(_, _, vals)
                 | CommittableColumn::Scalar(vals)
                 | CommittableColumn::VarChar(vals)
-                | CommittableColumn::VarBinary(vals) => {
+                | CommittableColumn::VarBinary(vals)
+                | CommittableColumn::FixedSizeBinary(_, vals) => {
                     expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
                 }
             }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -124,6 +124,18 @@ impl ProvableQueryResult {
                         let x = S::from_byte_slice_via_hash(raw_bytes);
                         Ok((x, used))
                     }
+                    ColumnType::FixedSizeBinary(size) => {
+                        let (raw_bytes, used) =
+                            decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;
+                        let Ok(size) = usize::try_from(size) else {
+                            return Err(QueryError::MiscellaneousEvaluationError);
+                        };
+                        if size > 32 || raw_bytes.len() != size {
+                            return Err(QueryError::MiscellaneousEvaluationError);
+                        }
+                        let x = S::from_fixed_size_binary(raw_bytes);
+                        Ok((x, used))
+                    }
                     ColumnType::TimestampTZ(_, _) => {
                         decode_and_convert::<i64, S>(&self.data[offset..])
                     }
@@ -212,6 +224,17 @@ impl ProvableQueryResult {
                         let col_vec = decoded_slices.into_iter().map(<[u8]>::to_vec).collect();
 
                         Ok((field.name(), OwnedColumn::VarBinary(col_vec)))
+                    }
+                    ColumnType::FixedSizeBinary(size) => {
+                        // Manually specify the item type: `&[u8]`
+                        let (decoded_slices, num_read) =
+                            decode_multiple_elements::<&[u8]>(&self.data[offset..], n)?;
+                        offset += num_read;
+
+                        // Convert those slices to owned `Vec<u8>`
+                        let col_vec = decoded_slices.into_iter().map(<[u8]>::to_vec).collect();
+
+                        Ok((field.name(), OwnedColumn::FixedSizeBinary(size, col_vec)))
                     }
                     ColumnType::Scalar => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -5,13 +5,16 @@ use crate::{
         database::{Column, ColumnField, ColumnType},
         math::decimal::Precision,
         polynomial::compute_evaluation_vector,
-        scalar::Scalar,
+        scalar::{Scalar, ScalarExt},
     },
     // proof_primitive::inner_product::TestScalar,
 };
 use alloc::sync::Arc;
 use arrow::{
-    array::{Decimal128Array, Decimal256Array, Int64Array, LargeBinaryArray, StringArray},
+    array::{
+        Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Int64Array, LargeBinaryArray,
+        StringArray,
+    },
     datatypes::{i256, Field, Schema},
     record_batch::RecordBatch,
 };
@@ -49,6 +52,30 @@ fn we_can_evaluate_result_columns_as_mles() {
     let expected_evals = [
         TestScalar::from(10u64) * evaluation_vec[0] - TestScalar::from(12u64) * evaluation_vec[1]
     ];
+    assert_eq!(evals, expected_evals);
+}
+
+#[test]
+fn we_can_evaluate_fixed_size_binary_result_columns_as_mles() {
+    let raw_bytes = [b"ab".as_ref(), b"cd".as_ref()];
+    let scalars: Vec<TestScalar> = raw_bytes
+        .iter()
+        .map(|b| TestScalar::from_fixed_size_binary(b))
+        .collect();
+    let cols: [Column<TestScalar>; 1] = [Column::FixedSizeBinary(
+        2,
+        (raw_bytes.as_slice(), scalars.as_slice()),
+    )];
+    let res = ProvableQueryResult::new(2, &cols);
+    let evaluation_point = [TestScalar::from(10u64), TestScalar::from(100u64)];
+    let mut evaluation_vec = [TestScalar::ZERO; 2];
+    compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
+
+    let column_fields = vec![ColumnField::new("a".into(), ColumnType::FixedSizeBinary(2))];
+    let evals = res
+        .evaluate(&evaluation_point, 2, &column_fields[..])
+        .unwrap();
+    let expected_evals = [scalars[0] * evaluation_vec[0] + scalars[1] * evaluation_vec[1]];
     assert_eq!(evals, expected_evals);
 }
 
@@ -361,6 +388,43 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_varbinary() {
             b"foo".as_slice(),
             b"bar".as_slice(),
         ]))],
+    )
+    .unwrap();
+
+    assert_eq!(record_batch, expected);
+}
+
+#[test]
+fn we_can_convert_a_provable_result_to_a_final_result_with_fixed_size_binary() {
+    let raw_bytes = [b"foo".as_ref(), b"bar".as_ref()];
+    let scalars: Vec<TestScalar> = raw_bytes
+        .iter()
+        .map(|b| TestScalar::from_fixed_size_binary(b))
+        .collect();
+    let col = Column::FixedSizeBinary(3, (raw_bytes.as_slice(), scalars.as_slice()));
+    let res = ProvableQueryResult::new(2, &[col]);
+    let column_fields = vec![ColumnField::new(
+        "fsb_col".into(),
+        ColumnType::FixedSizeBinary(3),
+    )];
+
+    let record_batch =
+        RecordBatch::try_from(res.to_owned_table::<TestScalar>(&column_fields).unwrap()).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "fsb_col",
+        arrow::datatypes::DataType::FixedSizeBinary(3),
+        false,
+    )]));
+    let expected = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(
+            FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                raw_bytes.iter().map(|bytes| Some(*bytes)),
+                3,
+            )
+            .unwrap(),
+        )],
     )
     .unwrap();
 

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -40,7 +40,9 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Int128(col) => col.num_bytes(length),
             Column::Decimal75(_, _, col) | Column::Scalar(col) => col.num_bytes(length),
             Column::VarChar((col, _)) => col.num_bytes(length),
-            Column::VarBinary((col, _)) => col.num_bytes(length),
+            Column::VarBinary((col, _)) | Column::FixedSizeBinary(_, (col, _)) => {
+                col.num_bytes(length)
+            }
         }
     }
 
@@ -55,7 +57,9 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Int128(col) => col.write(out, length),
             Column::Decimal75(_, _, col) | Column::Scalar(col) => col.write(out, length),
             Column::VarChar((col, _)) => col.write(out, length),
-            Column::VarBinary((col, _)) => col.write(out, length),
+            Column::VarBinary((col, _)) | Column::FixedSizeBinary(_, (col, _)) => {
+                col.write(out, length)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #229.

## Summary

- add `ColumnType::FixedSizeBinary(i32)` and carry fixed-width binary values through `Column`, `OwnedColumn`, `CommittableColumn`, Arrow conversion, result decoding, filtering, indexing, repetition, union, ordering, commitments, and MLE/proof paths
- add explicit fixed-size binary scalar conversion semantics: values up to 31 bytes are naturally embedded, 32-byte values are hashed, and larger widths are rejected at Arrow/type boundaries
- add typed fixed-size binary literals and equality support for matching fixed-width binary types
- add coverage for Arrow conversion, owned/Arrow round-trips, fixed-size binary literal conversion, MLE evaluation, final result conversion, direct embedding, and 32-byte hashing

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql --no-default-features --features="arrow test" fixed_size_binary`
- `cargo test -p proof-of-sql --no-default-features --features="arrow test" we_can_convert_between_owned_column_and_array_ref`
- `cargo test -p proof-of-sql --no-default-features --features="arrow test" we_can_roundtrip_arbitrary_owned_column`
- `cargo test -p proof-of-sql --no-default-features --features="arrow test" we_can_roundtrip_arbitrary_column_type`
- `cargo test -p proof-of-sql --no-default-features --features="arrow test" we_can_roundtrip_arbitrary_column`
- `cargo test -p proof-of-sql-planner --lib scalar_value_to_literal_value`
- `cargo test -p proof-of-sql-planner --lib --tests`
- `cargo test -p proof-of-sql --no-default-features --features="arrow test"`

## Results

- `proof-of-sql`: 1063 unit tests passed; doctests 27 passed, 25 ignored
- `proof-of-sql-planner`: 107 unit tests passed; 13 e2e tests passed; 20 EVM tests ignored because `forge` is not present