### PR TITLE
test: cover record batch errors

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -29,3 +29,46 @@ pub enum AppendRecordBatchTableCommitmentError {
         source: RecordBatchToColumnsError,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::DataType;
+
+    #[test]
+    fn we_can_display_record_batch_to_columns_source_errors() {
+        let error = RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+            source: ArrowArrayToColumnConversionError::UnsupportedType {
+                datatype: DataType::Float64,
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "unsupported type: attempted conversion from ArrayRef of type Float64 to OwnedColumn"
+        );
+    }
+
+    #[test]
+    fn we_can_display_append_record_batch_commitment_mismatch_errors() {
+        let error = AppendRecordBatchTableCommitmentError::ColumnCommitmentsMismatch {
+            source: ColumnCommitmentsMismatch::NumColumns,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "commitments with different column counts cannot operate with each other"
+        );
+    }
+
+    #[test]
+    fn we_can_display_append_record_batch_column_conversion_errors() {
+        let error = AppendRecordBatchTableCommitmentError::ArrowBatchToColumnError {
+            source: RecordBatchToColumnsError::ArrowArrayToColumnConversionError {
+                source: ArrowArrayToColumnConversionError::ArrayContainsNulls,
+            },
+        };
+
+        assert_eq!(error.to_string(), "arrow array must not contain nulls");
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused unit coverage for `RecordBatchToColumnsError` transparent source display forwarding.
- Add focused unit coverage for both `AppendRecordBatchTableCommitmentError` transparent source variants.
- Keep the change test-only with no production behavior changes.

## Non-overlap
I refreshed the current open #560 PR list and checked for `RecordBatchToColumnsError`, `AppendRecordBatchTableCommitmentError`, `record_batch_errors`, `ArrowArrayToColumnConversionError`, and `ColumnCommitmentsMismatch` before taking this slice. I found an existing PR for record batch conversion behavior, but not for the dedicated `record_batch_errors.rs` transparent wrapper display paths.

I also skipped nearby exact-overlap candidates such as `base/proof/error.rs` and `owned_column_error.rs` because current open PRs already cover those slices.

The repository coverage workflow remains authoritative for final payout accounting.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features 'test arrow' base::arrow::record_batch_errors -- --nocapture`
- `rustfmt --check crates/proof-of-sql/src/base/arrow/record_batch_errors.rs`
- `git diff --check`
- `bash scripts/check_commits.sh`
