### PR TITLE
test: cover query commitments without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -122,6 +122,66 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
     }
 }
 
+#[cfg(test)]
+mod no_blitzar_tests {
+    use super::*;
+    use crate::base::{
+        commitment::{
+            naive_commitment::NaiveCommitment, naive_evaluation_proof::NaiveEvaluationProof,
+        },
+        database::{owned_table_utility::*, OwnedTableTestAccessor, SchemaAccessor, TestAccessor},
+    };
+
+    #[test]
+    fn we_can_build_query_commitments_from_selected_columns_without_blitzar() {
+        let table_ref = TableRef::new("sxt", "query_commitments");
+        let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+        accessor.add_table(
+            table_ref.clone(),
+            owned_table([
+                bigint("a", [1, 2, 3]),
+                varchar("b", ["x", "y", "z"]),
+                int("c", [4, 5, 6]),
+            ]),
+            7,
+        );
+
+        let column_a_id: Ident = "a".into();
+        let column_b_id: Ident = "b".into();
+        let column_c_id: Ident = "c".into();
+        let query_commitments = QueryCommitments::<NaiveCommitment>::from_accessor_with_max_bounds(
+            [
+                ColumnRef::new(table_ref.clone(), column_c_id.clone(), ColumnType::Int),
+                ColumnRef::new(table_ref.clone(), column_a_id.clone(), ColumnType::BigInt),
+            ],
+            &accessor,
+        );
+
+        assert_eq!(query_commitments.len(), 1);
+        assert_eq!(query_commitments.get_offset(&table_ref), 7);
+        assert_eq!(query_commitments.get_length(&table_ref), 3);
+        assert_eq!(
+            query_commitments.lookup_schema(&table_ref),
+            vec![
+                (column_a_id.clone(), ColumnType::BigInt),
+                (column_c_id.clone(), ColumnType::Int),
+            ]
+        );
+        assert_eq!(
+            query_commitments.lookup_column(&table_ref, &column_b_id),
+            None
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_ref, &column_a_id),
+            accessor.get_commitment(&table_ref, &column_a_id)
+        );
+        assert_eq!(
+            query_commitments.get_commitment(&table_ref, &column_c_id),
+            accessor.get_commitment(&table_ref, &column_c_id)
+        );
+    }
+}
+
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;


### PR DESCRIPTION
/claim #560

## Summary
- Add no-Blitzar unit coverage for `QueryCommitments::from_accessor_with_max_bounds`.
- Verify selected columns are grouped by table, restored to accessor schema order, and do not include unrequested columns.
- Verify generated query commitments preserve table offset, row count, schema lookup, and commitment lookup for selected columns.
- Keep the change test-only with no production behavior changes.

## Non-overlap
I refreshed the current open #560 PR list and checked for `QueryCommitments`, `query_commitments`, and `QueryCommitmentsExt` before taking this slice. I did not find an active focused claim for this module.

The existing tests in `query_commitments.rs` are gated behind `feature = "blitzar"`. This PR intentionally adds a focused `--no-default-features --features test` path using `NaiveCommitment`, so the coverage lane can exercise the query-commitment construction/accessor logic without Dory/Blitzar setup.

The repository coverage workflow remains authoritative for final payout accounting.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test base::commitment::query_commitments::no_blitzar_tests -- --nocapture`
- `rustfmt --check crates/proof-of-sql/src/base/commitment/query_commitments.rs`
- `git diff --check`
- `bash scripts/check_commits.sh`
