### PR TITLE
test: cover standard binary encoding contract

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,16 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn integer_encoding_is_fixed_width_big_endian() {
+        let serialized = try_standard_binary_serialization((0x1234_u16, 0x5678_9abc_u32)).unwrap();
+
+        assert_eq!(serialized, [0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
+
+        let (deserialized, bytes_read): ((u16, u32), _) =
+            try_standard_binary_deserialization(&serialized).unwrap();
+        assert_eq!(deserialized, (0x1234, 0x5678_9abc));
+        assert_eq!(bytes_read, serialized.len());
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary

- Adds focused coverage for the standard binary serialization contract.
- Verifies integer encoding uses fixed-width, big-endian bytes.
- Verifies deserialization returns both the decoded value and the number of consumed bytes.

## Non-overlap check

Before opening this PR, I refreshed the open #560 PR list and checked for active focused claims around:

- `binary`
- `standard_serializations`
- `try_standard_binary_serialization`
- `try_standard_binary_deserialization`

I found related serialization coverage around limbs and varbinary behavior, but did not find an open #560 PR focused on the standard binary helper's fixed-width big-endian contract.

## Validation

```bash
cargo test -p proof-of-sql --lib --no-default-features --features test base::standard_serializations::binary::tests -- --nocapture
rustfmt --check crates/proof-of-sql/src/base/standard_serializations/binary.rs
git diff --check
bash scripts/check_commits.sh
```
