### PR TITLE
test: cover u256 conversion contracts

### DIFF
--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -35,3 +35,43 @@ impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
         MontScalar::<T>::from_le_bytes_mod_order(&bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn from_words_preserves_low_and_high_halves() {
+        let value = U256::from_words(0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210);
+
+        assert_eq!(value.low, 0x0123_4567_89ab_cdef);
+        assert_eq!(value.high, 0xfedc_ba98_7654_3210);
+    }
+
+    #[test]
+    fn mont_scalar_to_u256_combines_little_endian_limbs() {
+        let scalar = TestScalar::from([0x0123_4567_89ab_cdef, 0x1111_2222_3333_4444, 0, 0]);
+
+        let value = U256::from(&scalar);
+
+        assert_eq!(
+            value.low,
+            0x0123_4567_89ab_cdef | (0x1111_2222_3333_4444_u128 << 64)
+        );
+        assert_eq!(value.high, 0);
+    }
+
+    #[test]
+    fn u256_to_mont_scalar_uses_low_then_high_little_endian_bytes() {
+        let value = U256::from_words(
+            0x0123_4567_89ab_cdef_1111_2222_3333_4444,
+            0x5555_6666_7777_8888_9999_aaaa_bbbb_cccc,
+        );
+        let bytes = [value.low.to_le_bytes(), value.high.to_le_bytes()].concat();
+
+        let scalar = TestScalar::from(&value);
+
+        assert_eq!(scalar, TestScalar::from_le_bytes_mod_order(&bytes));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary

- Adds focused coverage for the local `U256` conversion helper.
- Verifies `U256::from_words` preserves the low and high 128-bit halves.
- Verifies `MontScalar -> U256` combines the four scalar limbs into low/high halves in the intended little-endian limb order.
- Verifies `U256 -> MontScalar` feeds `low` bytes before `high` bytes into `from_le_bytes_mod_order`.

## Non-overlap check

Before opening this PR, I refreshed the open #560 PR list and checked for active focused claims around:

- `U256`
- `from_words`
- `from_le_bytes_mod_order`
- `base/encode/u256.rs`

I found related scalar varint, ZigZag, bit distribution, and serialization coverage, but did not find an open #560 PR focused on the `base::encode::u256` conversion contract itself.

## Validation

```bash
cargo test -p proof-of-sql --lib --no-default-features --features test base::encode::u256::tests -- --nocapture
rustfmt --check crates/proof-of-sql/src/base/encode/u256.rs
git diff --check
bash scripts/check_commits.sh
```
