### PR TITLE
test: cover malformed sumcheck proof size

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
@@ -86,6 +86,27 @@ fn test_create_verify_proof() {
     assert!(subclaim.is_err());
 }
 
+#[test]
+fn malformed_sumcheck_proof_size_is_rejected() {
+    let proof = SumcheckProof {
+        coefficients: vec![
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+        ],
+    };
+    let mut transcript = Transcript::new(b"sumchecktest");
+
+    let result = proof.verify_without_evaluation(&mut transcript, 2, &TestScalar::from(10));
+
+    assert!(matches!(
+        result,
+        Err(crate::base::proof::ProofError::VerificationError {
+            error: "invalid proof size"
+        })
+    ));
+}
+
 fn random_product(
     nv: usize,
     num_multiplicands: usize,


### PR DESCRIPTION
/claim #560

## Summary

- add focused coverage for malformed `SumcheckProof` coefficient sizes
- verify `verify_without_evaluation` rejects coefficient lengths that are not divisible by the expected variable count
- assert the exact `ProofError::VerificationError` message for the invalid proof-size path

## Non-overlap check

Before opening this PR, I checked the open #560 PR list for:

- `sumcheck_proof`
- `SumcheckProof`
- `verify_without_evaluation`
- `invalid proof size`

I found open coverage around sumcheck prover rounds, prover state, and other proof helpers, but did not find an open #560 PR focused on the malformed `SumcheckProof::verify_without_evaluation` proof-size branch.

## Validation

```bash
cargo test -p proof-of-sql --lib --no-default-features --features test proof_primitive::sumcheck::proof_test -- --nocapture
rustfmt --check crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
git diff --check
bash scripts/check_commits.sh
```
