### PR TITLE
test: cover lagrange inner product assertions

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
@@ -192,6 +192,24 @@ fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_0_va
         TestScalar::from(0u32)
     );
 }
+
+#[test]
+#[should_panic(expected = "assertion `left == right` failed")]
+fn compute_truncated_lagrange_basis_inner_product_panics_when_points_have_different_lengths() {
+    let a = vec![TestScalar::from(2u8)];
+    let b = vec![TestScalar::from(3u8), TestScalar::from(5u8)];
+    compute_truncated_lagrange_basis_inner_product(1, &a, &b);
+}
+
+#[test]
+#[should_panic(expected = "assertion failed: part_length <= 1")]
+fn compute_truncated_lagrange_basis_inner_product_panics_when_length_exceeds_zero_variable_domain()
+{
+    let a: Vec<TestScalar> = vec![];
+    let b: Vec<TestScalar> = vec![];
+    compute_truncated_lagrange_basis_inner_product(2, &a, &b);
+}
+
 #[test]
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_1_variables() {
     let a = vec![TestScalar::from(2u8)];


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

/claim #560

This adds a small test-only coverage slice for the documented assertion paths in `compute_truncated_lagrange_basis_inner_product`:

- point slices must have the same length
- the zero-variable domain rejects requested lengths greater than `1`

This is intended to be non-overlapping with the open rho-eval/evaluation-vector coverage PR in the same test file; this PR only covers the inner-product assertion paths near the existing zero-variable inner-product tests.

# What changes are included in this PR?

- Add `#[should_panic]` regression coverage for mismatched point lengths.
- Add `#[should_panic]` regression coverage for zero-variable `part_length > 1`.
- No production behavior changes.

# Are these changes tested?
Yes, targeted locally:

- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --no-default-features --features test base::polynomial::lagrange_basis_evaluation_test -- --nocapture`
- `cargo llvm-cov --no-report -p proof-of-sql --no-default-features --features test --lib -- base::polynomial::lagrange_basis_evaluation_test --nocapture`
- `git diff --check`
- `source scripts/check_commits.sh`

I did not run the full `source scripts/run_ci_checks.sh` locally; this PR is a one-file test-only slice and the focused checks above passed.
