### PR TITLE
test: cover batched inner product verification

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/inner_product/inner_product_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/inner_product_proof.rs
@@ -88,9 +88,15 @@ impl CommitmentEvaluationProof for InnerProductProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::commitment::commitment_evaluation_proof_test::{
-        test_commitment_evaluation_proof_with_length_1, test_random_commitment_evaluation_proof,
-        test_simple_commitment_evaluation_proof,
+    use crate::base::{
+        commitment::{
+            commitment_evaluation_proof_test::{
+                test_commitment_evaluation_proof_with_length_1,
+                test_random_commitment_evaluation_proof, test_simple_commitment_evaluation_proof,
+            },
+            VecCommitmentExt,
+        },
+        database::Column,
     };
 
     #[test]
@@ -101,6 +107,78 @@ mod tests {
     #[test]
     fn test_random_ipa_with_length_1() {
         test_commitment_evaluation_proof_with_length_1::<InnerProductProof>(&(), &());
+    }
+
+    #[test]
+    fn we_can_verify_a_batched_ipa_with_multiple_commitments() {
+        let b_point = [MontScalar::from(3u64), MontScalar::from(7u64)];
+        let column_1 = [
+            MontScalar::from(2u64),
+            MontScalar::from(5u64),
+            MontScalar::from(8u64),
+            MontScalar::from(11u64),
+        ];
+        let column_2 = [
+            MontScalar::from(13u64),
+            MontScalar::from(17u64),
+            MontScalar::from(19u64),
+            MontScalar::from(23u64),
+        ];
+        let batching_factors = [MontScalar::from(29u64), MontScalar::from(31u64)];
+
+        let mut folded_column = vec![MontScalar::default(); column_1.len()];
+        for ((folded, &left), &right) in folded_column.iter_mut().zip(&column_1).zip(&column_2) {
+            *folded = left * batching_factors[0] + right * batching_factors[1];
+        }
+
+        let mut transcript = merlin::Transcript::new(b"evaluation_proof");
+        let proof = InnerProductProof::new(&mut transcript, &folded_column, &b_point, 0, &());
+
+        let commits = Vec::from_columns_with_offset(
+            [Column::Scalar(&column_1), Column::Scalar(&column_2)],
+            0,
+            &(),
+        );
+
+        let mut evaluation_vector = vec![MontScalar::default(); column_1.len()];
+        crate::base::polynomial::compute_evaluation_vector(&mut evaluation_vector, &b_point);
+        let evaluations = [column_1, column_2].map(|column| {
+            column
+                .iter()
+                .zip(&evaluation_vector)
+                .map(|(&a, &b)| a * b)
+                .sum()
+        });
+
+        let mut transcript = merlin::Transcript::new(b"evaluation_proof");
+        assert!(proof
+            .verify_batched_proof(
+                &mut transcript,
+                &commits,
+                &batching_factors,
+                &evaluations,
+                &b_point,
+                0,
+                column_1.len(),
+                &(),
+            )
+            .is_ok());
+
+        let mut bad_evaluations = evaluations;
+        bad_evaluations[1] += MontScalar::ONE;
+        let mut transcript = merlin::Transcript::new(b"evaluation_proof");
+        assert!(proof
+            .verify_batched_proof(
+                &mut transcript,
+                &commits,
+                &batching_factors,
+                &bad_evaluations,
+                &b_point,
+                0,
+                column_1.len(),
+                &(),
+            )
+            .is_err());
     }
 
     #[test]


### PR DESCRIPTION
/claim #560

# Rationale for this change

This adds focused coverage for the `InnerProductProof::verify_batched_proof` path when verification folds multiple commitments and multiple evaluations with non-trivial batching factors. Existing helper tests exercise the single-commitment `verify_proof` wrapper; this test directly covers the batched verifier behavior used by query proof verification.

I checked the current open PR list and issue #560 comments for `inner_product_proof`, `verify_batched_proof`, and `batching_factors`; I did not find an overlapping open PR or claim for this file/path.

This PR was prepared with AI assistance.

# What changes are included in this PR?

- Add a batched IPA unit test with two scalar columns and two batching factors.
- Assert that the valid batched proof verifies.
- Assert that changing one batched evaluation makes verification fail.

# Are these changes tested?

Yes, locally on macOS where possible:

- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `cargo test -p proof-of-sql --lib base::math::permutation --no-default-features --features test --offline` (3 passed)

I also attempted the targeted blitzar test locally:

- `cargo test -p proof-of-sql --lib we_can_verify_a_batched_ipa_with_multiple_commitments --no-default-features --features blitzar`

That local targeted run could not complete because `blitzar-sys` exits during build on macOS with `Unsupported OS. Only Linux is supported.` I expect the repository's Linux CI to be the authoritative environment for the new blitzar-gated test.
