### PR TITLE
test: cover composite polynomial trace annotation

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -67,7 +67,7 @@ merlin = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["std"] }
 rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -30,7 +30,9 @@ impl Subscriber for ProductTraceSubscriber {
         if event.metadata().level() == &tracing::Level::INFO {
             let mut visitor = MessageVisitor::default();
             event.record(&mut visitor);
-            self.events.lock().unwrap().push(visitor.message);
+            if visitor.message.starts_with("Product #") {
+                self.events.lock().unwrap().push(visitor.message);
+            }
         }
     }
 
@@ -135,6 +137,12 @@ fn test_composite_polynomial_annotate_trace_logs_each_product() {
 
     let events = events.lock().unwrap();
     assert_eq!(events.len(), 2);
-    assert!(events[0].contains("Product #0"));
-    assert!(events[1].contains("Product #1"));
+    assert_eq!(
+        events[0],
+        format!("Product #0: {:#} * [0, 1]", TestScalar::from(7u32))
+    );
+    assert_eq!(
+        events[1],
+        format!("Product #1: {:#} * [2]", TestScalar::from(11u32))
+    );
 }

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -1,6 +1,56 @@
 use super::CompositePolynomial;
 use crate::base::scalar::test_scalar::TestScalar;
 use alloc::rc::Rc;
+use std::sync::{Arc, Mutex};
+use tracing::{
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+    Event, Metadata, Subscriber,
+};
+
+#[derive(Default)]
+struct ProductTraceSubscriber {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl Subscriber for ProductTraceSubscriber {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.target() == "proof_of_sql::base::polynomial::composite_polynomial"
+    }
+
+    fn new_span(&self, _: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _: &Id, _: &Record<'_>) {}
+
+    fn record_follows_from(&self, _: &Id, _: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        if event.metadata().level() == &tracing::Level::INFO {
+            let mut visitor = MessageVisitor::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(visitor.message);
+        }
+    }
+
+    fn enter(&self, _: &Id) {}
+
+    fn exit(&self, _: &Id) {}
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn core::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{value:?}");
+        }
+    }
+}
 
 #[test]
 fn test_composite_polynomial_evaluation() {
@@ -68,4 +118,23 @@ fn test_composite_polynomial_hypercube_sum() {
         sum,
         TestScalar::from(3 * ((-7) * 2 + 2 * (-8) + (-6) * 4 + 17 * 1) + 2 * (1 + 3 + (-5) + (-9)))
     );
+}
+
+#[test]
+fn test_composite_polynomial_annotate_trace_logs_each_product() {
+    let a = Rc::new(vec![TestScalar::from(1u32), TestScalar::from(2u32)]);
+    let b = Rc::new(vec![TestScalar::from(3u32), TestScalar::from(4u32)]);
+    let c = Rc::new(vec![TestScalar::from(5u32), TestScalar::from(6u32)]);
+    let mut prod = CompositePolynomial::new(1);
+    prod.add_product([a, b], TestScalar::from(7u32));
+    prod.add_product([c], TestScalar::from(11u32));
+
+    let subscriber = ProductTraceSubscriber::default();
+    let events = Arc::clone(&subscriber.events);
+    tracing::subscriber::with_default(subscriber, || prod.annotate_trace());
+
+    let events = events.lock().unwrap();
+    assert_eq!(events.len(), 2);
+    assert!(events[0].contains("Product #0"));
+    assert!(events[1].contains("Product #1"));
 }


### PR DESCRIPTION
/claim #560

## Summary
- add focused coverage for `CompositePolynomial::annotate_trace`
- capture only `Product #...` tracing info events with a scoped test subscriber
- assert the exact trace payload for the coefficient and multiplicand indexes, not just the product numbering
- enable `tracing/std` for dev-dependencies only so tests can install a scoped default subscriber

AI-assisted with OpenAI Codex; I reviewed the diff and validation before submitting.

## Validation
- `cargo test -p proof-of-sql --lib base::polynomial::composite_polynomial_test --no-default-features --features test --offline -- --nocapture`
- `cargo check -p proof-of-sql --lib --no-default-features --offline`
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`
- `source scripts/check_commits.sh`

`cargo llvm-cov` was attempted locally, but this machine could not install `llvm-tools-preview` for toolchain `1.91.1-aarch64-apple-darwin` because rustup reported a missing manifest.
