### PR TITLE
test: cover add const slice op

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::base::scalar::test_scalar::TestScalar;
 
 #[test]
 fn test_add_const() {
@@ -6,4 +7,19 @@ fn test_add_const() {
     add_const(&mut a, 10);
     let b = vec![1 + 10, 2 + 10, 3 + 10, 4 + 10];
     assert_eq!(a, b);
+}
+
+#[test]
+fn test_add_const_empty_slice() {
+    let mut values: Vec<i32> = Vec::new();
+    add_const(&mut values, 10);
+    assert!(values.is_empty());
+}
+
+#[test]
+fn test_add_const_converts_to_result_type() {
+    let mut values = [1, 2, 3].map(TestScalar::from);
+    add_const(&mut values, 7u64);
+
+    assert_eq!(values, [8, 9, 10].map(TestScalar::from));
 }


### PR DESCRIPTION
## Rationale
This adds focused coverage for the dd_const slice operation, including the empty-slice no-op path and generic conversion into the result type.

Refs #560
/claim #560

## Testing
- cargo fmt --check`n- cargo test -p proof-of-sql --lib base::slice_ops::add_const_test --no-default-features --features=`"std`"`