### PR TITLE
test: cover generate-parameters verifier setup

### DIFF
--- a/crates/proof-of-sql/utils/generate-parameters/round_trip_test.rs
+++ b/crates/proof-of-sql/utils/generate-parameters/round_trip_test.rs
@@ -120,3 +120,39 @@ fn read_digests_from_file(digests_path: &str) -> std::collections::HashMap<Strin
     }
     digests
 }
+
+#[test]
+fn we_can_generate_save_load_and_digest_verifier_setup() {
+    let temp_dir = tempdir().expect("Failed to create a temporary directory");
+    let target = temp_dir.path().to_str().unwrap();
+    let mut rng = ark_std::test_rng();
+    let public_parameters = PublicParameters::test_rand(2, &mut rng);
+
+    super::generate_verifier_setup(&public_parameters, 2, target);
+
+    let verifier_setup_path = format!("{target}/verifier_setup_nu_2.bin");
+    let digests_path = format!("{target}/digests_nu_2.txt");
+    assert!(
+        Path::new(&verifier_setup_path).exists(),
+        "Verifier setup file is missing"
+    );
+    assert!(
+        File::open(&verifier_setup_path)
+            .unwrap()
+            .metadata()
+            .unwrap()
+            .len()
+            > 0,
+        "Verifier setup file is empty"
+    );
+    VerifierSetup::load_from_file(Path::new(&verifier_setup_path))
+        .expect("Failed to reload verifier setup");
+
+    let expected_digest = super::compute_sha256(&verifier_setup_path).unwrap();
+    let actual_digests = read_digests_from_file(&digests_path);
+    assert_eq!(
+        actual_digests.get(&verifier_setup_path),
+        Some(&expected_digest),
+        "Digest mismatch for {verifier_setup_path}"
+    );
+}


### PR DESCRIPTION
## Summary
- add focused coverage for the `generate-parameters` verifier setup path
- verify a small generated verifier setup is written, non-empty, reloadable, and recorded in `digests_nu_*.txt`
- keep the change test-only and scoped to the utility test module

## Coverage
This targets the previously uncovered generate-parameters utility path around `generate_verifier_setup` and `write_verifier_setup` without overlapping the open CLI parsing/digest helper PR. A focused local `cargo llvm-cov` run hit `utils/generate-parameters/main.rs` lines 186-213, 311-313, and the digest/spinner helper path exercised by verifier generation.

## Verification
- WSL: `cargo test --quiet -p proof-of-sql --no-default-features --features 'std blitzar utils' --bin generate-parameters round_trip_test::we_can_generate_save_load_and_digest_verifier_setup -- --exact --nocapture`
- WSL: `cargo fmt --all -- --check`
- Windows: installed user-scoped Rustup and tried the same focused test, but `blitzar-sys` exits during build with `Unsupported OS. Only Linux is supported`; this bin requires the `blitzar` feature.
- `git diff --check`

Part of #560.

/claim #560