### PR TITLE
test: cover column metadata helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,29 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_field_accessors_return_expected_owned_metadata() {
+        let column_field = ColumnField::new(Ident::new("customer_id"), ColumnType::Int);
+
+        let mut returned_name = column_field.name();
+        returned_name.value = "mutated".into();
+
+        assert_eq!(column_field.name(), Ident::new("customer_id"));
+        assert_eq!(column_field.data_type(), ColumnType::Int);
+    }
+
+    #[test]
+    fn column_field_round_trips_through_json() {
+        let column_field = ColumnField::new(Ident::new("region"), ColumnType::VarChar);
+
+        let serialized = serde_json::to_string(&column_field).unwrap();
+        let deserialized: ColumnField = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, column_field);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,36 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_ref_accessors_return_expected_owned_metadata() {
+        let table_ref = TableRef::new("analytics", "orders");
+        let column_id = Ident::new("order_total");
+        let column_ref = ColumnRef::new(table_ref.clone(), column_id.clone(), ColumnType::BigInt);
+
+        let mut returned_column_id = column_ref.column_id();
+        returned_column_id.value = "mutated".into();
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), column_id);
+        assert_eq!(column_ref.column_type(), &ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_ref_round_trips_through_json() {
+        let column_ref = ColumnRef::new(
+            TableRef::new("warehouse", "inventory"),
+            Ident::new("sku"),
+            ColumnType::VarChar,
+        );
+
+        let serialized = serde_json::to_string(&column_ref).unwrap();
+        let deserialized: ColumnRef = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, column_ref);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add `ColumnField` unit coverage for accessor ownership and JSON serde round trips.
- Add `ColumnRef` unit coverage for accessor ownership, table/column/type metadata, and JSON serde round trips.
- Keep the slice test-only; no production behavior changes.

## Validation
- `cargo test -p proof-of-sql base::database::column_ref --no-default-features --features test`
- `cargo test -p proof-of-sql base::database::column_field --no-default-features --features test`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p proof-of-sql base::database::column_ --no-default-features --features test`
- `PATH="$HOME/.cargo/bin:$PATH" cargo llvm-cov --no-report -p proof-of-sql --no-default-features --features test -- base::database::column_`
- `rustfmt --edition 2021 --check crates/proof-of-sql/src/base/database/column_ref.rs crates/proof-of-sql/src/base/database/column_field.rs`
- `git diff --check`

Note: repo-wide `cargo fmt --check` currently fails locally on an unrelated pre-existing import ordering change in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`; this PR does not touch that file.

AI-assisted with OpenAI Codex; I reviewed the diff and ran the validation above before submission.