### PR TITLE
Make scalar string hashing explicit

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -279,7 +279,9 @@ impl ArrayRefExt for ArrayRef {
                     let scals = if let Some(scals) = precomputed_scals {
                         &scals[range.start..range.end]
                     } else {
-                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S { vals[i].into() })
+                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S {
+                            S::from_str_via_hash(vals[i])
+                        })
                     };
 
                     Ok(Column::VarChar((vals, scals)))
@@ -430,7 +432,10 @@ mod tests {
         let array: ArrayRef = Arc::new(StringArray::from(vec!["hello", "world", "test"]));
         let result = array.to_column::<TestScalar>(&alloc, &(1..3), None);
         let expected_vals = vec!["world", "test"];
-        let expected_scals: Vec<TestScalar> = expected_vals.iter().map(|&v| v.into()).collect();
+        let expected_scals: Vec<TestScalar> = expected_vals
+            .iter()
+            .map(|&v| TestScalar::from_str_via_hash(v))
+            .collect();
 
         assert_eq!(
             result.unwrap(),
@@ -463,7 +468,7 @@ mod tests {
         let array: ArrayRef = Arc::new(StringArray::from(vec!["hello", "world", "test"]));
         let precomputed_scals: Vec<DoryScalar> = ["hello", "world", "test"]
             .iter()
-            .map(|&v| v.into())
+            .map(|&v| DoryScalar::from_str_via_hash(v))
             .collect();
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), Some(&precomputed_scals));
         let expected_vals = vec!["world", "test"];

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -3,7 +3,6 @@ use crate::base::{
     if_rayon,
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    ref_into::RefInto,
     scalar::{Scalar, ScalarExt},
 };
 use alloc::vec::Vec;
@@ -116,16 +115,16 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::BigInt(ints) => CommittableColumn::BigInt(ints),
             Column::Int128(ints) => CommittableColumn::Int128(ints),
             Column::Decimal75(precision, scale, decimals) => {
-                let as_limbs: Vec<_> = decimals.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = decimals.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::Decimal75(*precision, *scale, as_limbs)
             }
             Column::Scalar(scalars) => (scalars as &[_]).into(),
             Column::VarChar((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarChar(as_limbs)
             }
             Column::VarBinary((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarBinary(as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
@@ -154,23 +153,22 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 *scale,
                 decimals
                     .iter()
-                    .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|s| S::from_str_via_hash(s))
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             OwnedColumn::Scalar(scalars) => (scalars as &[_]).into(),
             OwnedColumn::VarChar(strings) => CommittableColumn::VarChar(
                 strings
                     .iter()
-                    .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|s| S::from_str_via_hash(s))
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             OwnedColumn::VarBinary(bytes) => CommittableColumn::VarBinary(
                 bytes
                     .iter()
-                    .map(|b| S::from_byte_slice_via_hash(b))
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|b| S::from_byte_slice_via_hash(b).to_limbs())
                     .collect(),
             ),
             OwnedColumn::TimestampTZ(tu, tz, times) => {
@@ -216,7 +214,7 @@ impl<'a, S: Scalar> From<&'a [S]> for CommittableColumn<'a> {
     fn from(value: &'a [S]) -> Self {
         CommittableColumn::Scalar(
             if_rayon!(value.par_iter(), value.iter())
-                .map(RefInto::<[u64; 4]>::ref_into)
+                .map(Scalar::to_limbs)
                 .collect(),
         )
     }
@@ -331,7 +329,7 @@ mod tests {
             -1,
             [-1, 1, 2]
                 .map(<TestScalar>::from)
-                .map(<[u64; 4]>::from)
+                .map(|scalar| scalar.to_limbs())
                 .into(),
         );
 
@@ -481,7 +479,7 @@ mod tests {
             ["12", "34", "56"]
                 .map(Into::<String>::into)
                 .map(Into::<TestScalar>::into)
-                .map(Into::<[u64; 4]>::into)
+                .map(|scalar| scalar.to_limbs())
                 .into(),
         );
         assert_eq!(bigint_committable_column.len(), 3);
@@ -500,7 +498,7 @@ mod tests {
         let bigint_committable_column = CommittableColumn::Scalar(
             [12, 34, 56]
                 .map(<TestScalar>::from)
-                .map(<[u64; 4]>::from)
+                .map(|scalar| scalar.to_limbs())
                 .into(),
         );
         assert_eq!(bigint_committable_column.len(), 3);
@@ -668,7 +666,7 @@ mod tests {
             CommittableColumn::from(&Column::VarChar((&varchar_data, &scalars)));
         assert_eq!(
             from_borrowed_column,
-            CommittableColumn::VarChar(scalars.map(<[u64; 4]>::from).into())
+            CommittableColumn::VarChar(scalars.map(|scalar| scalar.to_limbs()).into())
         );
     }
 
@@ -682,7 +680,7 @@ mod tests {
         let from_borrowed_column = CommittableColumn::from(&Column::Scalar(&scalars));
         assert_eq!(
             from_borrowed_column,
-            CommittableColumn::Scalar(scalars.map(<[u64; 4]>::from).into())
+            CommittableColumn::Scalar(scalars.map(|scalar| scalar.to_limbs()).into())
         );
     }
 
@@ -807,7 +805,12 @@ mod tests {
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
-            CommittableColumn::VarChar(strings.map(TestScalar::from).map(<[u64; 4]>::from).into())
+            CommittableColumn::VarChar(
+                strings
+                    .map(TestScalar::from)
+                    .map(|scalar| scalar.to_limbs())
+                    .into(),
+            )
         );
     }
 
@@ -823,7 +826,7 @@ mod tests {
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
-            CommittableColumn::Scalar(scalars.map(<[u64; 4]>::from).into())
+            CommittableColumn::Scalar(scalars.map(|scalar| scalar.to_limbs()).into())
         );
     }
 
@@ -976,7 +979,7 @@ mod tests {
             TestScalar::from(34),
             TestScalar::from(56),
         ]
-        .map(<[u64; 4]>::from);
+        .map(|scalar| scalar.to_limbs());
         let committable_column =
             CommittableColumn::Decimal75(Precision::new(1).unwrap(), 0, (values).to_vec());
 
@@ -1032,7 +1035,9 @@ mod tests {
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);
-        let scalars = values.map(TestScalar::from).map(<[u64; 4]>::from);
+        let scalars = values
+            .map(TestScalar::from_str_via_hash)
+            .map(|scalar| scalar.to_limbs());
         let sequence_expected = Sequence::from(scalars.as_slice());
         let mut commitment_buffer = [CompressedRistretto::default(); 2];
         compute_curve25519_commitments(
@@ -1058,7 +1063,9 @@ mod tests {
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);
-        let scalars = values.map(TestScalar::from).map(<[u64; 4]>::from);
+        let scalars = values
+            .map(TestScalar::from_str_via_hash)
+            .map(|scalar| scalar.to_limbs());
         let sequence_expected = Sequence::from(scalars.as_slice());
         let mut commitment_buffer = [CompressedRistretto::default(); 2];
         compute_curve25519_commitments(

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -139,7 +139,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, S::from(string)),
+                alloc.alloc_slice_fill_copy(length, S::from_str_via_hash(string)),
             )),
             LiteralValue::VarBinary(bytes) => {
                 // Convert the bytes to a slice of bytes references
@@ -177,7 +177,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
             OwnedColumn::VarChar(col) => {
-                let scalars = col.iter().map(S::from).collect::<Vec<_>>();
+                let scalars = col.iter().map(|s| S::from_str_via_hash(s)).collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -81,7 +81,7 @@ impl LiteralValue {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar(str) => str.into(),
+            Self::VarChar(str) => S::from_str_via_hash(str),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -108,7 +108,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
                 let scals: &mut [_] = self
                     .alloc
-                    .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
+                    .alloc_slice_fill_iter(col.iter().map(|s| <CP::Scalar as Scalar>::from_str_via_hash(s)));
                 Column::VarChar((col, scals))
             }
             OwnedColumn::VarBinary(col) => {

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -288,7 +288,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
         })
         .collect();
     let alloc_strings = alloc.alloc_slice_clone(&strings);
-    let scalars: Vec<S> = strings.iter().map(|s| (*s).into()).collect();
+    let scalars: Vec<S> = strings.iter().map(|s| S::from_str_via_hash(s)).collect();
     let alloc_scalars = alloc.alloc_slice_copy(&scalars);
     (name.into(), Column::VarChar((alloc_strings, alloc_scalars)))
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,7 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
-use alloc::string::String;
+use crate::base::scalar::ScalarConversionError;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
@@ -13,7 +12,6 @@ pub trait Scalar:
     + core::fmt::Display
     + PartialEq
     + Default
-    + for<'a> From<&'a str>
     + Sync
     + Send
     + num_traits::One
@@ -40,8 +38,6 @@ pub trait Scalar:
     + core::convert::TryInto <i32>
     + core::convert::TryInto <i64>
     + core::convert::TryInto <i128>
-    + core::convert::Into<[u64; 4]>
-    + core::convert::From<[u64; 4]>
     + core::convert::From<u8>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
@@ -51,10 +47,6 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + RefInto<[u64; 4]>
-    + for<'a> core::convert::From<&'a String>
-    + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>
@@ -65,6 +57,17 @@ pub trait Scalar:
     + core::convert::Into<BigInt>
     + TryFrom<BigInt, Error = ScalarConversionError>
 {
+    /// Creates a scalar from its canonical non-Montgomery 256-bit limb representation.
+    fn from_limbs(val: [u64; 4]) -> Self;
+    /// Converts this scalar to its canonical non-Montgomery 256-bit limb representation.
+    fn to_limbs(&self) -> [u64; 4];
+
+    /// Hashes a string into a scalar.
+    #[must_use]
+    fn from_str_via_hash(val: &str) -> Self {
+        <Self as crate::base::scalar::ScalarExt>::from_byte_slice_via_hash(val.as_bytes())
+    }
+
     /// The value (p - 1) / 2. This is "mid-point" of the field - the "six" on the clock.
     /// It is the largest signed value that can be represented in the field with the natural embedding.
     const MAX_SIGNED: Self;


### PR DESCRIPTION
# PR Body Draft for `#228` String-Hash Slice

## Summary

- add `Scalar::from_str_via_hash(&str)` with a default implementation
- remove opaque string-conversion bounds from `Scalar`
- update varchar conversion call sites to use the explicit string-hash helper

## Notes

This PR intentionally covers only the second checkbox from `#228`.
The limb-conversion PR is already split out separately, and the blanket `VarInt` refactor stays out of this slice.

## Testing

Not run locally in this workspace because `cargo` / `rustc` are unavailable here.

/claim #228
