### PR TITLE
test: cover EqualOp/GreaterThanOp/LessThanOp implementations in column_comparison_operation

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
@@ -414,3 +414,253 @@ impl ComparisonOp for LessThanOp {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{math::decimal::Precision, scalar::test_scalar::TestScalar};
+    use alloc::{string::ToString, vec};
+
+    // --- EqualOp::op ---
+
+    #[test]
+    fn we_can_compare_equal_integers_with_equal_op() {
+        assert!(EqualOp::op::<i64>(&7, &7));
+        assert!(!EqualOp::op::<i64>(&7, &8));
+        assert!(EqualOp::op::<bool>(&true, &true));
+        assert!(!EqualOp::op::<bool>(&false, &true));
+    }
+
+    // --- GreaterThanOp::op ---
+
+    #[test]
+    fn we_can_compare_integers_with_greater_than_op() {
+        assert!(GreaterThanOp::op::<i64>(&8, &7));
+        assert!(!GreaterThanOp::op::<i64>(&7, &8));
+        assert!(!GreaterThanOp::op::<i64>(&7, &7));
+    }
+
+    // --- LessThanOp::op ---
+
+    #[test]
+    fn we_can_compare_integers_with_less_than_op() {
+        assert!(LessThanOp::op::<i64>(&7, &8));
+        assert!(!LessThanOp::op::<i64>(&8, &7));
+        assert!(!LessThanOp::op::<i64>(&7, &7));
+    }
+
+    // --- string_op ---
+
+    #[test]
+    fn we_can_compare_equal_strings_with_equal_op() {
+        let lhs = vec!["alpha".to_string(), "beta".to_string()];
+        let rhs = vec!["alpha".to_string(), "gamma".to_string()];
+        let result = EqualOp::string_op(&lhs, &rhs).unwrap();
+        assert_eq!(result, vec![true, false]);
+    }
+
+    #[test]
+    fn we_cannot_compare_strings_with_greater_than_op() {
+        let lhs = vec!["a".to_string()];
+        let rhs = vec!["b".to_string()];
+        assert!(matches!(
+            GreaterThanOp::string_op(&lhs, &rhs),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_compare_strings_with_less_than_op() {
+        let lhs = vec!["a".to_string()];
+        let rhs = vec!["b".to_string()];
+        assert!(matches!(
+            LessThanOp::string_op(&lhs, &rhs),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    // --- owned_column_element_wise_comparison: error paths ---
+
+    #[test]
+    fn we_cannot_compare_columns_of_different_lengths() {
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false]);
+        let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true]);
+        assert!(matches!(
+            EqualOp::owned_column_element_wise_comparison(&lhs, &rhs),
+            Err(ColumnOperationError::DifferentColumnLength { .. })
+        ));
+        assert!(matches!(
+            GreaterThanOp::owned_column_element_wise_comparison(&lhs, &rhs),
+            Err(ColumnOperationError::DifferentColumnLength { .. })
+        ));
+        assert!(matches!(
+            LessThanOp::owned_column_element_wise_comparison(&lhs, &rhs),
+            Err(ColumnOperationError::DifferentColumnLength { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_compare_incompatible_column_types() {
+        let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![1]);
+        let rhs = OwnedColumn::<TestScalar>::VarChar(vec!["a".to_string()]);
+        assert!(matches!(
+            EqualOp::owned_column_element_wise_comparison(&lhs, &rhs),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_compare_uint8_with_tinyint() {
+        let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1]);
+        let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![1]);
+        assert!(matches!(
+            EqualOp::owned_column_element_wise_comparison(&lhs, &rhs),
+            Err(ColumnOperationError::SignedCastingError { .. })
+        ));
+    }
+
+    // --- Boolean × Boolean ---
+
+    #[test]
+    fn we_can_compare_boolean_columns_for_equality() {
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]);
+        let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, false]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(
+            result,
+            OwnedColumn::<TestScalar>::Boolean(vec![true, true, false])
+        );
+    }
+
+    // --- VarChar × VarChar ---
+
+    #[test]
+    fn we_can_compare_varchar_columns_for_equality() {
+        let lhs = OwnedColumn::<TestScalar>::VarChar(vec!["foo".to_string(), "bar".to_string()]);
+        let rhs = OwnedColumn::<TestScalar>::VarChar(vec!["foo".to_string(), "baz".to_string()]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(
+            result,
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false])
+        );
+    }
+
+    #[test]
+    fn we_cannot_compare_varchar_columns_with_ordering_ops() {
+        let lhs = OwnedColumn::<TestScalar>::VarChar(vec!["a".to_string()]);
+        let rhs = OwnedColumn::<TestScalar>::VarChar(vec!["b".to_string()]);
+        assert!(matches!(
+            GreaterThanOp::owned_column_element_wise_comparison(&lhs, &rhs),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+        assert!(matches!(
+            LessThanOp::owned_column_element_wise_comparison(&lhs, &rhs),
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+    }
+
+    // --- Decimal75 × integer: decimal_op_left_upcast and decimal_op_right_upcast ---
+
+    #[test]
+    fn we_can_compare_uint8_column_with_decimal75_column() {
+        let lhs = OwnedColumn::<TestScalar>::Uint8(vec![5, 10]);
+        let rhs_scalars: Vec<TestScalar> = vec![5i64.into(), 99i64.into()];
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(
+            Precision::new(5).unwrap(),
+            0,
+            rhs_scalars,
+        );
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(
+            result,
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false])
+        );
+    }
+
+    #[test]
+    fn we_can_compare_decimal75_column_with_bigint_column() {
+        let lhs_scalars: Vec<TestScalar> = vec![100i64.into(), 200i64.into()];
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(
+            Precision::new(5).unwrap(),
+            0,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![100, 300]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(
+            result,
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false])
+        );
+    }
+
+    #[test]
+    fn we_can_compare_decimal75_columns_with_each_other() {
+        // 100 at scale 2 == 10 at scale 1  (both represent 1.0)
+        // 200 at scale 2 != 10 at scale 1  (2.0 vs 1.0)
+        let lhs_scalars: Vec<TestScalar> = vec![100i64.into(), 200i64.into()];
+        let rhs_scalars: Vec<TestScalar> = vec![10i64.into(), 10i64.into()];
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(
+            Precision::new(5).unwrap(),
+            2,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<TestScalar>::Decimal75(
+            Precision::new(5).unwrap(),
+            1,
+            rhs_scalars,
+        );
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(
+            result,
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false])
+        );
+    }
+
+    #[test]
+    fn we_can_apply_greater_than_to_decimal75_and_bigint_columns() {
+        let lhs_scalars: Vec<TestScalar> = vec![50i64.into(), 5i64.into()];
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(
+            Precision::new(5).unwrap(),
+            0,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![10, 10]);
+        let result = GreaterThanOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(
+            result,
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false])
+        );
+    }
+
+    #[test]
+    fn we_can_apply_less_than_to_decimal75_and_bigint_columns() {
+        let lhs_scalars: Vec<TestScalar> = vec![5i64.into(), 50i64.into()];
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(
+            Precision::new(5).unwrap(),
+            0,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![10, 10]);
+        let result = LessThanOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(
+            result,
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false])
+        );
+    }
+
+    #[test]
+    fn we_can_compare_decimal75_column_with_tinyint_column() {
+        let lhs_scalars: Vec<TestScalar> = vec![3i64.into(), 7i64.into()];
+        let lhs = OwnedColumn::<TestScalar>::Decimal75(
+            Precision::new(3).unwrap(),
+            0,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![3i8, 8]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(
+            result,
+            OwnedColumn::<TestScalar>::Boolean(vec![true, false])
+        );
+    }
+}


### PR DESCRIPTION
## Summary

/claim #560

Adds a `#[cfg(test)] mod tests` block directly inside `column_comparison_operation.rs` to cover the operator method bodies (`EqualOp`, `GreaterThanOp`, `LessThanOp`) and the previously untested column-type combination arms (Decimal75 × integer, Boolean × Boolean, VarChar × VarChar, and error paths).

**Why these lines were uncovered:** The `op()` method bodies in each operator impl are short enough that LLVM inlines them into their call sites. Direct calls from a test in the same file create a non-inlined monomorphization whose source lines register as covered.

## Changes

- `crates/proof-of-sql/src/base/database/column_comparison_operation.rs` — add 17 focused tests

## Tests added

| Test | Covered path |
|------|-------------|
| `we_can_compare_equal_integers_with_equal_op` | `EqualOp::op` body |
| `we_can_compare_integers_with_greater_than_op` | `GreaterThanOp::op` body |
| `we_can_compare_integers_with_less_than_op` | `LessThanOp::op` body |
| `we_can_compare_equal_strings_with_equal_op` | `EqualOp::string_op` |
| `we_cannot_compare_strings_with_greater_than_op` | `GreaterThanOp::string_op` error |
| `we_cannot_compare_strings_with_less_than_op` | `LessThanOp::string_op` error |
| `we_cannot_compare_columns_of_different_lengths` | `DifferentColumnLength` (all 3 ops) |
| `we_cannot_compare_incompatible_column_types` | `BinaryOperationInvalidColumnType` |
| `we_cannot_compare_uint8_with_tinyint` | `SignedCastingError` |
| `we_can_compare_boolean_columns_for_equality` | `Boolean × Boolean` arm |
| `we_can_compare_varchar_columns_for_equality` | `VarChar × VarChar` arm (EqualOp) |
| `we_cannot_compare_varchar_columns_with_ordering_ops` | `VarChar × VarChar` error (GT/LT) |
| `we_can_compare_uint8_column_with_decimal75_column` | `Uint8 × Decimal75` left-upcast |
| `we_can_compare_decimal75_column_with_bigint_column` | `Decimal75 × BigInt` right-upcast |
| `we_can_compare_decimal75_columns_with_each_other` | `Decimal75 × Decimal75` left-upcast + scale normalisation |
| `we_can_apply_greater_than_to_decimal75_and_bigint_columns` | `GreaterThanOp` Decimal75 right-upcast |
| `we_can_apply_less_than_to_decimal75_and_bigint_columns` | `LessThanOp` Decimal75 right-upcast |
| `we_can_compare_decimal75_column_with_tinyint_column` | `Decimal75 × TinyInt` right-upcast |

## Test plan

- [ ] `cargo test -p proof-of-sql base::database::column_comparison_operation::tests` passes
- [ ] No existing tests are broken