### PR TITLE
test: cover TimestampTZ column index and repetition ops

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -120,7 +120,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::ColumnOperationError, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        database::ColumnOperationError,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn test_apply_index_op() {
@@ -188,5 +192,22 @@ mod tests {
         let expected = Column::VarBinary((expected_bytes.as_slice(), expected_scalars.as_slice()));
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_apply_index_op_timestamptz_preserves_metadata() {
+        let bump = Bump::new();
+        let time_unit = PoSQLTimeUnit::Microsecond;
+        let timezone = PoSQLTimeZone::new(5400);
+        let column: Column<TestScalar> =
+            Column::TimestampTZ(time_unit, timezone, &[100, 200, 300, 400]);
+        let indexes = [3, 0, 3, 2];
+
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+
+        assert_eq!(
+            result,
+            Column::TimestampTZ(time_unit, timezone, &[400, 100, 400, 300])
+        );
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -153,7 +153,10 @@ impl RepetitionOp for ElementwiseRepeatOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::{
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn test_column_repetition_op() {
@@ -267,5 +270,25 @@ mod tests {
             .collect();
         let expected = Column::VarBinary((expected_bytes.as_slice(), expected_scalars.as_slice()));
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_repetition_op_timestamptz_preserves_metadata() {
+        let bump = Bump::new();
+        let time_unit = PoSQLTimeUnit::Nanosecond;
+        let timezone = PoSQLTimeZone::new(-18_000);
+        let column: Column<TestScalar> = Column::TimestampTZ(time_unit, timezone, &[10, 20, 30]);
+
+        let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(
+            result,
+            Column::TimestampTZ(time_unit, timezone, &[10, 20, 30, 10, 20, 30])
+        );
+
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(
+            result,
+            Column::TimestampTZ(time_unit, timezone, &[10, 10, 20, 20, 30, 30])
+        );
     }
 }


### PR DESCRIPTION
This PR adds focused coverage for TimestampTZ handling in base database column operations as a small slice of #560.

Scope:
- Added a test showing `apply_column_to_indexes` reorders TimestampTZ values while preserving `PoSQLTimeUnit` and `PoSQLTimeZone`.
- Added a test showing both column-wise and element-wise repetition preserve TimestampTZ metadata.
- Kept the patch test-only with no production logic changes.

Verification:
- `git diff --check`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test -p proof-of-sql --no-default-features --features arrow test_apply_index_op_timestamptz_preserves_metadata`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test -p proof-of-sql --no-default-features --features arrow test_repetition_op_timestamptz_preserves_metadata`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test -p proof-of-sql --no-default-features --features arrow base::database::column_index_operation::tests`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test -p proof-of-sql --no-default-features --features arrow base::database::column_repetition_operation::tests`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo check -p proof-of-sql --no-default-features --features arrow`