### PR TITLE
test: cover TimestampTZ column union

### DIFF
--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -245,7 +245,11 @@ pub fn table_union<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{map::IndexMap, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        map::IndexMap,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
 
     #[test]
     fn we_can_union_no_columns() {
@@ -427,6 +431,28 @@ mod tests {
     }
 
     #[test]
+    fn we_can_union_timestamptz_columns() {
+        let alloc = Bump::new();
+        let time_unit = PoSQLTimeUnit::Microsecond;
+        let timezone = PoSQLTimeZone::new(7200);
+        let col0: Column<TestScalar> = Column::TimestampTZ(time_unit, timezone, &[]);
+        let col1: Column<TestScalar> = Column::TimestampTZ(time_unit, timezone, &[10, 20]);
+        let col2: Column<TestScalar> = Column::TimestampTZ(time_unit, timezone, &[30]);
+
+        let result = column_union(
+            &[&col0, &col1, &col2],
+            &alloc,
+            ColumnType::TimestampTZ(time_unit, timezone),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            Column::TimestampTZ(time_unit, timezone, &[10, 20, 30])
+        );
+    }
+
+    #[test]
     fn we_can_union_tables_with_varbinary_columns() {
         let alloc = Bump::new();
         let binary_binding = [b"foo".as_ref(), b"bar".as_ref()];
@@ -476,6 +502,42 @@ mod tests {
                 Column::VarBinary((expected_raw.as_slice(), expected_scalars.as_slice())),
             )]),
             TableOptions::new(Some(4)),
+        )
+        .unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_union_tables_with_timestamptz_columns() {
+        let alloc = Bump::new();
+        let time_unit = PoSQLTimeUnit::Nanosecond;
+        let timezone = PoSQLTimeZone::new(-18_000);
+        let table0 = Table::<'_, TestScalar>::try_new_with_options(
+            IndexMap::from_iter(vec![(
+                "event_time".into(),
+                Column::TimestampTZ(time_unit, timezone, &[100, 200]),
+            )]),
+            TableOptions::new(Some(2)),
+        )
+        .unwrap();
+        let table1 = Table::<'_, TestScalar>::try_new_with_options(
+            IndexMap::from_iter(vec![(
+                "renamed_event_time".into(),
+                Column::TimestampTZ(time_unit, timezone, &[300, 400, 500]),
+            )]),
+            TableOptions::new(Some(3)),
+        )
+        .unwrap();
+
+        let result = table_union(&[table0, table1], &alloc).unwrap();
+
+        let expected = Table::try_new_with_options(
+            IndexMap::from_iter(vec![(
+                "event_time".into(),
+                Column::TimestampTZ(time_unit, timezone, &[100, 200, 300, 400, 500]),
+            )]),
+            TableOptions::new(Some(5)),
         )
         .unwrap();
 


### PR DESCRIPTION
This PR adds focused TimestampTZ coverage for column and table union operations as another test-only slice of #560.

Scope:
- Added a test showing TimestampTZ columns can be unioned while preserving `PoSQLTimeUnit` and `PoSQLTimeZone` metadata.
- Added a test showing tables with TimestampTZ columns can be unioned while preserving the TimestampTZ column metadata.
- Kept the patch test-only with no production logic changes.

Verification:
- `git diff --check`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test -p proof-of-sql --no-default-features --features arrow we_can_union_timestamptz_columns`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test -p proof-of-sql --no-default-features --features arrow we_can_union_tables_with_timestamptz_columns`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test -p proof-of-sql --no-default-features --features arrow base::database::union_util::tests`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo check -p proof-of-sql --no-default-features --features arrow`