### PR TITLE
fix: detect numeric and dec bigdecimal columns

### DIFF
--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -10,6 +10,20 @@ use sqlparser::{
 };
 
 #[expect(clippy::cast_possible_truncation)]
+fn bigdecimal_spec(data_type: &DataType) -> Option<(u8, i8)> {
+    match data_type {
+        DataType::Decimal(exact_number_info)
+        | DataType::Numeric(exact_number_info)
+        | DataType::Dec(exact_number_info) => match exact_number_info {
+            ExactNumberInfo::PrecisionAndScale(precision, scale) if *precision > 38 => {
+                Some((*precision as u8, *scale as i8))
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Parse a DDL file and return a map of table names to bigdecimal columns
 ///
 /// # Panics
@@ -28,13 +42,10 @@ pub fn find_bigdecimals(queries: &str) -> IndexMap<String, Vec<(String, u8, i8)>
                 let str_name = name.to_string();
                 let big_decimal_specs: Vec<(String, u8, i8)> = columns
                     .iter()
-                    .filter_map(|column_def| match column_def.data_type {
-                        DataType::Decimal(ExactNumberInfo::PrecisionAndScale(precision, scale))
-                            if precision > 38 =>
-                        {
-                            Some((column_def.name.to_string(), precision as u8, scale as i8))
-                        }
-                        _ => None,
+                    .filter_map(|column_def| {
+                        bigdecimal_spec(&column_def.data_type).map(|(precision, scale)| {
+                            (column_def.name.to_string(), precision, scale)
+                        })
                     })
                     .collect();
                 Some((str_name, big_decimal_specs))
@@ -56,6 +67,9 @@ mod tests {
             BLOCK_HASH VARCHAR,
             MINER VARCHAR,
             REWARD DECIMAL(78, 0),
+            TOTAL_DIFFICULTY NUMERIC(39, 0),
+            BASE_BURN DEC(40, 2),
+            EXACT_LIMIT DECIMAL(38, 0),
             SIZE_ INT,
             GAS_USED INT,
             GAS_LIMIT INT,
@@ -83,6 +97,8 @@ mod tests {
             bigdecimals.get("ETHEREUM.BLOCKS").unwrap(),
             &[
                 ("REWARD".to_string(), 78, 0),
+                ("TOTAL_DIFFICULTY".to_string(), 39, 0),
+                ("BASE_BURN".to_string(), 40, 2),
                 ("BASE_FEE_PER_GAS".to_string(), 78, 0)
             ]
         );


### PR DESCRIPTION
/claim #560

> Disclosure: This PR was authored with assistance from Codex.

## Summary
- Detect `NUMERIC(p, s)` and `DEC(p, s)` columns as bigdecimal columns alongside `DECIMAL(p, s)`.
- Keep the existing `precision > 38` threshold, including excluding `DECIMAL(38, 0)`.
- Cover SQL exact numeric aliases in `test_find_bigdecimals`.

## Non-overlap check
Before opening this PR, I checked the open #560 PRs touching `parse.rs`. Those cover non-`CREATE TABLE` handling and `DECIMAL` threshold/boundary cases. This PR intentionally does not change the current `DECIMAL(p)` precision-only behavior and focuses on SQL aliases (`NUMERIC` and `DEC`) instead.

## Validation
- `cargo f --check`
- `cargo test --manifest-path crates/proof-of-sql/Cargo.toml --no-default-features --features std test_find_bigdecimals --lib`
- `cargo clippy --manifest-path crates/proof-of-sql/Cargo.toml --no-default-features --features std --lib -- -A warnings -D clippy::cast_possible_truncation`
- `cargo test --manifest-path crates/proof-of-sql/Cargo.toml --no-default-features --features std --lib`