### PR TITLE
test: fix SubtractExpr type-mismatch test and add try_difference error coverage

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -311,7 +311,15 @@ mod tests {
             Err(ColumnCommitmentsMismatch::NumColumns)
         ));
         assert!(matches!(
-            metadata_b.try_union(metadata_a.clone()),
+            metadata_b.clone().try_union(metadata_a.clone()),
+            Err(ColumnCommitmentsMismatch::NumColumns)
+        ));
+        assert!(matches!(
+            metadata_a.clone().try_difference(metadata_b.clone()),
+            Err(ColumnCommitmentsMismatch::NumColumns)
+        ));
+        assert!(matches!(
+            metadata_b.try_difference(metadata_a.clone()),
             Err(ColumnCommitmentsMismatch::NumColumns)
         ));
 
@@ -322,7 +330,15 @@ mod tests {
             Err(ColumnCommitmentsMismatch::NumColumns)
         ));
         assert!(matches!(
-            empty_metadata.try_union(metadata_a),
+            empty_metadata.clone().try_union(metadata_a.clone()),
+            Err(ColumnCommitmentsMismatch::NumColumns)
+        ));
+        assert!(matches!(
+            metadata_a.clone().try_difference(empty_metadata.clone()),
+            Err(ColumnCommitmentsMismatch::NumColumns)
+        ));
+        assert!(matches!(
+            empty_metadata.try_difference(metadata_a),
             Err(ColumnCommitmentsMismatch::NumColumns)
         ));
     }

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -379,4 +379,13 @@ mod tests {
             })
         ));
     }
+
+    #[test]
+    fn test_try_new_with_mismatched_column_lengths() {
+        let result = OwnedTable::<TestScalar>::try_from_iter([
+            bigint("a", [1i64, 2, 3]),
+            bigint("b", [1i64, 2]),
+        ]);
+        assert!(result.is_err());
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -1,4 +1,4 @@
-use super::AddExpr;
+use super::{AddExpr, SubtractExpr};
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -287,7 +287,7 @@ fn we_cannot_add_subtract_mismatching_types() {
             right_type: _
         }
     ));
-    let sub_err = AddExpr::try_new(lhs, rhs).unwrap_err();
+    let sub_err = SubtractExpr::try_new(lhs, rhs).unwrap_err();
     assert!(matches!(
         sub_err,
         AnalyzeError::DataTypeMismatch {


### PR DESCRIPTION
## Summary

- **Bug fix** (`add_subtract_expr_test.rs`): `we_cannot_add_subtract_mismatching_types` had a copy-paste error — the second assertion tested `AddExpr::try_new` again instead of `SubtractExpr::try_new`. This left the error path in `subtract_expr.rs` (the `DataTypeMismatch` closure in `SubtractExpr::try_new`) completely uncovered. Fixed by changing `AddExpr::try_new` → `SubtractExpr::try_new` and importing `SubtractExpr`.

- **Missing coverage** (`column_commitment_metadata_map.rs`): `we_cannot_perform_arithmetic_on_metadata_maps_with_different_column_counts` only asserted that `try_union` returns `Err(NumColumns)` for maps with different column counts, but never tested `try_difference` with the same error condition. Added the symmetric `try_difference` assertions to cover the `return Err(ColumnCommitmentsMismatch::NumColumns)` branch in `try_difference`.

Relates to coverage issue #560.

## Test plan

- [ ] Rust CI passes
- [ ] Codecov shows coverage increase in `subtract_expr.rs` and `column_commitment_metadata_map.rs`