### PR TITLE
test: cover annotate_trace, term_product None branch, and add_product dedup in CompositePolynomial

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -149,3 +149,37 @@ impl<S: Scalar> CompositePolynomial<S> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CompositePolynomial;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::rc::Rc;
+
+    #[test]
+    fn we_can_annotate_trace_on_a_nonempty_polynomial() {
+        let ext = Rc::new(vec![TestScalar::from(1u64), TestScalar::from(2u64)]);
+        let mut poly = CompositePolynomial::<TestScalar>::new(1);
+        poly.add_product([ext], TestScalar::from(1u64));
+        poly.annotate_trace();
+    }
+
+    #[test]
+    fn we_can_sum_hypercube_beyond_extension_length() {
+        let ext = Rc::new(vec![TestScalar::from(3u64), TestScalar::from(5u64)]);
+        let mut poly = CompositePolynomial::<TestScalar>::new(2);
+        poly.add_product([ext], TestScalar::from(1u64));
+        // Requests indices 0..4; indices 2 and 3 exceed the extension length of 2,
+        // exercising the unwrap_or(&S::ZERO) None branch in term_product.
+        let _ = poly.hypercube_sum(4);
+    }
+
+    #[test]
+    fn we_deduplicate_shared_extensions_in_add_product() {
+        let ext = Rc::new(vec![TestScalar::from(1u64)]);
+        let mut poly = CompositePolynomial::<TestScalar>::new(0);
+        // Using the same Rc twice triggers the cached-lookup branch in add_product.
+        poly.add_product([ext.clone(), ext.clone()], TestScalar::from(1u64));
+        assert_eq!(poly.flattened_ml_extensions.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

`composite_polynomial.rs` had 3 missed lines at 96.4% coverage. All three were in code paths never exercised by existing tests.

Adds an inline `#[cfg(test)]` module with three focused tests:

- **`we_can_annotate_trace_on_a_nonempty_polynomial`**: calls `annotate_trace()` on a polynomial with one product, covering the loop body (the `tracing::info!` call) that was entirely missed
- **`we_can_sum_hypercube_beyond_extension_length`**: calls `hypercube_sum(4)` on a polynomial whose extension has only 2 elements, forcing `term_product` to call `get(i).unwrap_or(&S::ZERO)` with `None` for indices 2 and 3
- **`we_deduplicate_shared_extensions_in_add_product`**: passes the same `Rc` twice to `add_product`, triggering the `if let Some(index)` cached-lookup branch that returns the pre-existing index instead of inserting a new one

Relates to coverage issue #560.

## Test plan

- [ ] Rust CI passes
- [ ] Codecov shows `composite_polynomial.rs` coverage increase