### PR TITLE
test: cover TimestampTZ scale-cast branch and non-CREATE TABLE filter in parse

### DIFF
--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -235,4 +235,19 @@ mod tests {
         let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
         assert_eq!(proof_exprs, (left, right));
     }
+
+    #[test]
+    fn we_can_scale_cast_timestamp_tz_upcast_to_match_decimal_scale() {
+        use crate::base::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+        // TimestampTZ has scale = None (→ 0); Decimal75 with scale 5 → Ordering::Less,
+        // which triggers the `if matches!(left_type, ColumnType::TimestampTZ(_, _))` branch.
+        let ts = DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "ts".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ));
+        let decimal = COLUMN1_DECIMAL_10_5();
+        let result = scale_cast_binary_op(ts, decimal);
+        assert!(result.is_ok());
+    }
 }

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,13 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn we_skip_non_create_table_statements() {
+        // A SELECT statement mixed in with CREATE TABLE exercises the `_ => None` arm.
+        let sql = "SELECT 1; CREATE TABLE T (A DECIMAL(78, 0));";
+        let bigdecimals = find_bigdecimals(sql);
+        assert_eq!(bigdecimals.len(), 1);
+        assert!(bigdecimals.contains_key("T"));
+    }
 }


### PR DESCRIPTION
## Summary

Two small coverage gaps closed:

**`scale.rs`** (was 99.4%, 1 missed line): `scale_cast_binary_op` has two `if matches!(_, ColumnType::TimestampTZ(_, _))` branches — one for `Ordering::Less`, one for `Ordering::Greater`. All existing tests used `SmallInt`/`Decimal75` operands, leaving the `TimestampTZ` path in the `Ordering::Less` arm uncovered. Adds `we_can_scale_cast_timestamp_tz_upcast_to_match_decimal_scale` which pairs a `TimestampTZ` (scale 0) left operand with a `Decimal75(10, 5)` right operand to exercise that branch.

**`parse.rs`** (was 98.4%, 1 missed line): `find_bigdecimals` uses `filter_map` with a match that has a `_ => None` arm for non-`CREATE TABLE` SQL statements. The only existing test contained nothing but `CREATE TABLE`, leaving the `_ => None` arm uncovered. Adds `we_skip_non_create_table_statements` which prepends a `SELECT 1;` to a `CREATE TABLE`, forcing the `_ => None` path.

Relates to coverage issue #560.

## Test plan

- [ ] Rust CI passes
- [ ] Codecov shows coverage increase in `scale.rs` and `parse.rs`