### PR TITLE
test: cover EmptyExec::default() implementation

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -104,3 +104,15 @@ impl ProverEvaluate for EmptyExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EmptyExec;
+
+    #[test]
+    fn we_can_create_empty_exec_via_default() {
+        let a = EmptyExec::default();
+        let b = EmptyExec::new();
+        assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary

`empty_exec.rs` had 3 missed lines at 94.5% coverage. One of them is the `Default::default()` implementation, which always delegates to `EmptyExec::new()` but was never called directly in any test.

Adds an inline `#[cfg(test)]` module with `we_can_create_empty_exec_via_default` that calls both `EmptyExec::default()` and `EmptyExec::new()` and asserts they produce equal values, covering the `Default` impl.

Relates to coverage issue #560.

## Test plan

- [ ] Rust CI passes
- [ ] Codecov shows `empty_exec.rs` coverage increase