### PR TITLE
test: cover lhs verifier_evaluate error branch in AndExpr, OrExpr, and MultiplyExpr

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -147,3 +147,41 @@ impl ProofExpr for AndExpr {
         self.rhs.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AndExpr;
+    use crate::{
+        base::{
+            database::{ColumnRef, ColumnType, TableRef},
+            map::indexmap,
+            scalar::test_scalar::TestScalar,
+        },
+        sql::{
+            proof::mock_verification_builder::MockVerificationBuilder,
+            proof_exprs::{ColumnExpr, DynProofExpr, PlaceholderExpr, ProofExpr},
+        },
+    };
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn we_propagate_lhs_error_in_verifier_evaluate() {
+        let t: TableRef = "sxt.t".parse().unwrap();
+        let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+        // lhs is a Boolean placeholder; rhs is a Boolean column
+        let lhs = DynProofExpr::Placeholder(
+            PlaceholderExpr::try_new(1, ColumnType::Boolean).unwrap(),
+        );
+        let rhs = DynProofExpr::Column(ColumnExpr::new(b.clone()));
+        let and_expr = AndExpr::try_new(Box::new(lhs), Box::new(rhs)).unwrap();
+
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 2, vec![], vec![], vec![], vec![], vec![],
+        );
+        let accessor = indexmap! { b.column_id() => TestScalar::ONE };
+        // Calling without params forces PlaceholderExpr::verifier_evaluate to return Err,
+        // exercising the `?` error branch on the lhs verifier_evaluate call.
+        let result = and_expr.verifier_evaluate(&mut builder, &accessor, TestScalar::ONE, &[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -138,3 +138,41 @@ impl ProofExpr for MultiplyExpr {
 }
 
 impl DecimalProofExpr for MultiplyExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::MultiplyExpr;
+    use crate::{
+        base::{
+            database::{ColumnRef, ColumnType, TableRef},
+            map::indexmap,
+            scalar::test_scalar::TestScalar,
+        },
+        sql::{
+            proof::mock_verification_builder::MockVerificationBuilder,
+            proof_exprs::{ColumnExpr, DynProofExpr, PlaceholderExpr, ProofExpr},
+        },
+    };
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn we_propagate_lhs_error_in_verifier_evaluate() {
+        let t: TableRef = "sxt.t".parse().unwrap();
+        let b = ColumnRef::new(t, Ident::from("b"), ColumnType::BigInt);
+        // lhs is a BigInt placeholder; rhs is a BigInt column
+        let lhs = DynProofExpr::Placeholder(
+            PlaceholderExpr::try_new(1, ColumnType::BigInt).unwrap(),
+        );
+        let rhs = DynProofExpr::Column(ColumnExpr::new(b.clone()));
+        let mul_expr = MultiplyExpr::try_new(Box::new(lhs), Box::new(rhs)).unwrap();
+
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 2, vec![], vec![], vec![], vec![], vec![],
+        );
+        let accessor = indexmap! { b.column_id() => TestScalar::ONE };
+        // Calling without params forces PlaceholderExpr::verifier_evaluate to return Err,
+        // exercising the `?` error branch on the lhs verifier_evaluate call.
+        let result = mul_expr.verifier_evaluate(&mut builder, &accessor, TestScalar::ONE, &[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -184,3 +184,41 @@ pub fn verifier_evaluate_or<S: Scalar>(
     // selection
     Ok(*lhs + *rhs - lhs_and_rhs)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OrExpr;
+    use crate::{
+        base::{
+            database::{ColumnRef, ColumnType, TableRef},
+            map::indexmap,
+            scalar::test_scalar::TestScalar,
+        },
+        sql::{
+            proof::mock_verification_builder::MockVerificationBuilder,
+            proof_exprs::{ColumnExpr, DynProofExpr, PlaceholderExpr, ProofExpr},
+        },
+    };
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn we_propagate_lhs_error_in_verifier_evaluate() {
+        let t: TableRef = "sxt.t".parse().unwrap();
+        let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+        // lhs is a Boolean placeholder; rhs is a Boolean column
+        let lhs = DynProofExpr::Placeholder(
+            PlaceholderExpr::try_new(1, ColumnType::Boolean).unwrap(),
+        );
+        let rhs = DynProofExpr::Column(ColumnExpr::new(b.clone()));
+        let or_expr = OrExpr::try_new(Box::new(lhs), Box::new(rhs)).unwrap();
+
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 2, vec![], vec![], vec![], vec![], vec![],
+        );
+        let accessor = indexmap! { b.column_id() => TestScalar::ONE };
+        // Calling without params forces PlaceholderExpr::verifier_evaluate to return Err,
+        // exercising the `?` error branch on the lhs verifier_evaluate call.
+        let result = or_expr.verifier_evaluate(&mut builder, &accessor, TestScalar::ONE, &[]);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Three proof expression files each had 1 missed line — the error-propagation branch of the lhs `?` operator inside `verifier_evaluate`. All existing tests use column expressions as operands, which always succeed in the accessor lookup. The `?` error path was therefore never triggered.

Pattern applied to each file: create the expression with a `PlaceholderExpr` (of a compatible type) as lhs and a column expression as rhs, then call `verifier_evaluate` with an empty params slice. The placeholder's `verifier_evaluate` returns `Err(InvalidPlaceholderIndex)` which propagates through the `?`, exercising the missed branch.

Files covered:
- **`and_expr.rs`** (was 1 missed, 98.9%) — `AndExpr` with `Boolean` lhs placeholder
- **`or_expr.rs`** (was 1 missed, 99.1%) — `OrExpr` with `Boolean` lhs placeholder
- **`multiply_expr.rs`** (was 1 missed, 98.8%) — `MultiplyExpr` with `BigInt` lhs placeholder

Relates to coverage issue #560.

## Test plan

- [ ] Rust CI passes
- [ ] Codecov shows coverage increase in all three files