### PR TITLE
test: cover verifier_evaluate error branch in InequalityExpr, SubtractExpr, and CastExpr

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -99,3 +99,36 @@ impl ProofExpr for CastExpr {
         self.from_expr.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CastExpr;
+    use crate::{
+        base::{
+            database::ColumnType,
+            map::indexmap,
+            scalar::test_scalar::TestScalar,
+        },
+        sql::{
+            proof::mock_verification_builder::MockVerificationBuilder,
+            proof_exprs::{DynProofExpr, PlaceholderExpr, ProofExpr},
+        },
+    };
+
+    #[test]
+    fn we_propagate_from_expr_error_in_verifier_evaluate() {
+        // Boolean → Int128 is a valid cast (confirmed by existing tests)
+        let from = DynProofExpr::Placeholder(
+            PlaceholderExpr::try_new(1, ColumnType::Boolean).unwrap(),
+        );
+        let expr = CastExpr::try_new(Box::new(from), ColumnType::Int128).unwrap();
+
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 2, vec![], vec![], vec![], vec![], vec![],
+        );
+        let accessor = indexmap! {};
+        // No params → PlaceholderExpr verifier_evaluate fails, propagated via tail call
+        let result = expr.verifier_evaluate(&mut builder, &accessor, TestScalar::ONE, &[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -158,3 +158,38 @@ impl ProofExpr for InequalityExpr {
         self.rhs.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::InequalityExpr;
+    use crate::{
+        base::{
+            database::{ColumnRef, ColumnType, TableRef},
+            map::indexmap,
+            scalar::test_scalar::TestScalar,
+        },
+        sql::{
+            proof::mock_verification_builder::MockVerificationBuilder,
+            proof_exprs::{ColumnExpr, DynProofExpr, PlaceholderExpr, ProofExpr},
+        },
+    };
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn we_propagate_lhs_error_in_verifier_evaluate() {
+        let t: TableRef = "sxt.t".parse().unwrap();
+        let b = ColumnRef::new(t, Ident::from("b"), ColumnType::BigInt);
+        let lhs = DynProofExpr::Placeholder(
+            PlaceholderExpr::try_new(1, ColumnType::BigInt).unwrap(),
+        );
+        let rhs = DynProofExpr::Column(ColumnExpr::new(b.clone()));
+        let expr = InequalityExpr::try_new(Box::new(lhs), Box::new(rhs), true).unwrap();
+
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 2, vec![], vec![], vec![], vec![], vec![],
+        );
+        let accessor = indexmap! { b.column_id() => TestScalar::ONE };
+        let result = expr.verifier_evaluate(&mut builder, &accessor, TestScalar::ONE, &[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
@@ -118,3 +118,38 @@ impl ProofExpr for SubtractExpr {
 }
 
 impl DecimalProofExpr for SubtractExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::SubtractExpr;
+    use crate::{
+        base::{
+            database::{ColumnRef, ColumnType, TableRef},
+            map::indexmap,
+            scalar::test_scalar::TestScalar,
+        },
+        sql::{
+            proof::mock_verification_builder::MockVerificationBuilder,
+            proof_exprs::{ColumnExpr, DynProofExpr, PlaceholderExpr, ProofExpr},
+        },
+    };
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn we_propagate_lhs_error_in_verifier_evaluate() {
+        let t: TableRef = "sxt.t".parse().unwrap();
+        let b = ColumnRef::new(t, Ident::from("b"), ColumnType::BigInt);
+        let lhs = DynProofExpr::Placeholder(
+            PlaceholderExpr::try_new(1, ColumnType::BigInt).unwrap(),
+        );
+        let rhs = DynProofExpr::Column(ColumnExpr::new(b.clone()));
+        let expr = SubtractExpr::try_new(Box::new(lhs), Box::new(rhs)).unwrap();
+
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 2, vec![], vec![], vec![], vec![], vec![],
+        );
+        let accessor = indexmap! { b.column_id() => TestScalar::ONE };
+        let result = expr.verifier_evaluate(&mut builder, &accessor, TestScalar::ONE, &[]);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Applies the same placeholder-based pattern from PR #2288 to three more proof expression types. Each had missed lines in the error-propagation branch of their `from_expr`/lhs `verifier_evaluate` call.

**Pattern**: construct the expression with a `PlaceholderExpr` as the lhs/from-expr operand (compatible type, so `try_new` succeeds), then call `verifier_evaluate` with an empty `params` slice. The placeholder's `interpolate()` returns `Err(InvalidPlaceholderIndex)`, which propagates through `?` into `ProofError`.

Files:
- **`inequality_expr.rs`** (was 4 missed, 95.3%) — `Placeholder(BigInt)` lhs, `BigInt` column rhs, `is_lt=true`
- **`subtract_expr.rs`** (was 7 missed, partially addressed in #2282) — `Placeholder(BigInt)` lhs, `BigInt` column rhs
- **`cast_expr.rs`** (was 3 missed, 95.2%) — `Placeholder(Boolean)` cast to `Int128` (confirmed valid from existing cast tests)

Relates to coverage issue #560.

## Test plan

- [ ] Rust CI passes
- [ ] Codecov shows coverage increase in all three files