### PR TITLE
test: cover verifier_evaluate error branches in PlaceholderExpr, FilterExec, and LegacyFilterExec

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
@@ -205,4 +205,20 @@ mod tests {
         let res = placeholder_expr.interpolate(&params);
         assert_eq!(res.unwrap(), &LiteralValue::Boolean(true));
     }
+
+    #[test]
+    fn we_propagate_interpolation_error_through_verifier_evaluate() {
+        use crate::{
+            base::{map::indexmap, scalar::test_scalar::TestScalar},
+            sql::proof::mock_verification_builder::MockVerificationBuilder,
+        };
+        let expr = PlaceholderExpr::try_new(1, ColumnType::Boolean).unwrap();
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 0, vec![], vec![], vec![], vec![], vec![],
+        );
+        let accessor = indexmap! {};
+        // No params supplied → interpolate fails → ? propagates into ProofError
+        let result = expr.verifier_evaluate(&mut builder, &accessor, TestScalar::ONE, &[]);
+        assert!(result.is_err());
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -269,3 +269,33 @@ impl ProverEvaluate for FilterExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FilterExec;
+    use crate::{
+        base::{database::LiteralValue, map::IndexMap, scalar::test_scalar::TestScalar},
+        sql::{
+            proof::mock_verification_builder::MockVerificationBuilder,
+            proof_exprs::DynProofExpr,
+            proof_plans::DynProofPlan,
+        },
+    };
+
+    #[test]
+    fn we_get_error_when_post_result_challenges_are_exhausted() {
+        let exec = FilterExec::new(
+            vec![],
+            Box::new(DynProofPlan::new_empty()),
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+        // No post_result_challenges → first try_consume_post_result_challenge returns Err
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 0, vec![], vec![], vec![], vec![], vec![],
+        );
+        let accessor = IndexMap::default();
+        let chi_eval_map = IndexMap::default();
+        let result = exec.verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/legacy_filter_exec.rs
@@ -287,3 +287,32 @@ impl ProverEvaluate for LegacyFilterExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::LegacyFilterExec;
+    use crate::{
+        base::{database::LiteralValue, map::IndexMap, scalar::test_scalar::TestScalar},
+        sql::{
+            proof::mock_verification_builder::MockVerificationBuilder,
+            proof_exprs::{DynProofExpr, TableExpr},
+        },
+    };
+
+    #[test]
+    fn we_get_error_when_post_result_challenges_are_exhausted() {
+        let exec = LegacyFilterExec::new(
+            vec![],
+            TableExpr { table_ref: "sxt.t".parse().unwrap() },
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+        // No post_result_challenges → first try_consume_post_result_challenge returns Err
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 0, vec![], vec![], vec![], vec![], vec![],
+        );
+        let accessor = IndexMap::default();
+        let chi_eval_map = IndexMap::default();
+        let result = exec.verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[]);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Three files each had 1 missed line — the error-propagation branch inside `verifier_evaluate`. The existing tests only exercise the happy path (no errors).

**`placeholder_expr.rs`** (1 miss, 99.1%): Adds `we_propagate_interpolation_error_through_verifier_evaluate` — calls `verifier_evaluate` with empty `params`, causing `interpolate()` → `Err(InvalidPlaceholderIndex)` → `?` propagates as `ProofError`.

**`filter_exec.rs`** (1 miss, 99.4%): Adds `we_get_error_when_post_result_challenges_are_exhausted` — creates a minimal `FilterExec` and calls `verifier_evaluate` with a `MockVerificationBuilder` that has no `post_result_challenges`. The first `builder.try_consume_post_result_challenge()?` returns `Err`, covering that branch.

**`legacy_filter_exec.rs`** (1 miss, 99.4%): Same pattern as `FilterExec` — empty `post_result_challenges` causes the first `?` in `verifier_evaluate` to fail.

Relates to coverage issue #560.

## Test plan

- [ ] Rust CI passes
- [ ] Codecov shows coverage increase in all three files