### PR TITLE
test: cover verifier_evaluate VerificationError conditions in SliceExec and UnionExec

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -247,3 +247,65 @@ impl ProverEvaluate for SliceExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SliceExec;
+    use crate::{
+        base::{database::TableRef, map::indexmap, scalar::test_scalar::TestScalar},
+        sql::{
+            proof::{mock_verification_builder::MockVerificationBuilder, ProofPlan},
+            proof_plans::DynProofPlan,
+        },
+    };
+
+    fn table_ref() -> TableRef {
+        "sxt.t".parse().unwrap()
+    }
+
+    fn make_slice(skip: usize, fetch: Option<usize>) -> SliceExec {
+        SliceExec::new(
+            Box::new(DynProofPlan::new_table(table_ref(), vec![])),
+            skip,
+            fetch,
+        )
+    }
+
+    fn make_builder(chi_lengths: Vec<usize>) -> MockVerificationBuilder<TestScalar> {
+        MockVerificationBuilder::new(vec![], 0, vec![], vec![], vec![], chi_lengths, vec![])
+    }
+
+    #[test]
+    fn we_get_error_when_output_length_mismatches_max_minus_offset() {
+        // chi queue: output_length=0, offset=0, max=2 → 0 != 2-0 → error
+        let exec = make_slice(1, None);
+        let mut builder = make_builder(vec![0, 0, 2]);
+        let chi_eval_map = indexmap! { table_ref() => (TestScalar::ONE, 1_usize) };
+        let accessor = indexmap! { table_ref() => indexmap!{} };
+        let result = exec.verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn we_get_error_when_offset_mismatches_skip_min_input_length() {
+        // chi queue: output_length=1, offset=0, max=1 → skip=2, 2.min(1)=1 != 0 → error
+        let exec = make_slice(2, None);
+        let mut builder = make_builder(vec![1, 0, 1]);
+        let chi_eval_map = indexmap! { table_ref() => (TestScalar::ONE, 1_usize) };
+        let accessor = indexmap! { table_ref() => indexmap!{} };
+        let result = exec.verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn we_get_error_when_max_mismatches_expected_fetch_value() {
+        // chi queue: output_length=2, offset=0, max=2 → fetch=Some(2), skip=0
+        // expected_max = (2+0).min(1) = 1, but max = 2 → 2 != 1 → error
+        let exec = make_slice(0, Some(2));
+        let mut builder = make_builder(vec![2, 0, 2]);
+        let chi_eval_map = indexmap! { table_ref() => (TestScalar::ONE, 1_usize) };
+        let accessor = indexmap! { table_ref() => indexmap!{} };
+        let result = exec.verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -204,3 +204,44 @@ impl ProverEvaluate for UnionExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::UnionExec;
+    use crate::{
+        base::{map::IndexMap, scalar::test_scalar::TestScalar},
+        sql::{
+            proof::{mock_verification_builder::MockVerificationBuilder, ProofPlan},
+            proof_plans::DynProofPlan,
+        },
+    };
+
+    fn make_exec() -> UnionExec {
+        let p1 = DynProofPlan::new_table("sxt.t1".parse().unwrap(), vec![]);
+        let p2 = DynProofPlan::new_table("sxt.t2".parse().unwrap(), vec![]);
+        UnionExec::try_new(vec![p1, p2]).unwrap()
+    }
+
+    #[test]
+    fn we_get_error_on_first_missing_post_result_challenge() {
+        let exec = make_exec();
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 0, vec![], vec![], vec![], vec![], vec![],
+        );
+        let result =
+            exec.verifier_evaluate(&mut builder, &IndexMap::default(), &IndexMap::default(), &[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn we_get_error_on_second_missing_post_result_challenge() {
+        let exec = make_exec();
+        // Provide only one challenge so first succeeds but second fails
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 0, vec![], vec![], vec![TestScalar::ONE], vec![], vec![],
+        );
+        let result =
+            exec.verifier_evaluate(&mut builder, &IndexMap::default(), &IndexMap::default(), &[]);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

**`slice_exec.rs`** (was 10 missed, 93.6%): `verifier_evaluate` has three `return Err(ProofError::VerificationError { ... })` blocks guarding correctness of the slice selection parameters. None were ever triggered by existing tests (honest prover always produces valid chi lengths). Adds three tests using `MockVerificationBuilder` with deliberately wrong `chi_evaluation_length_queue` values:

1. **output_length mismatch**: queue `[0, 0, 2]` → output=0, max=2, offset=0 → `0 ≠ 2−0`
2. **offset mismatch**: queue `[1, 0, 1]`, `skip=2` → `2.min(1)=1 ≠ offset=0`
3. **max mismatch**: queue `[2, 0, 2]`, `skip=0`, `fetch=Some(2)` → `max=2 ≠ (2+0).min(1)=1`

All three use an empty-schema `TableExec` as input (reads only from `chi_eval_map`, no builder calls).

**`union_exec.rs`** (was 2 missed, 98.5%): `verifier_evaluate` has two consecutive `builder.try_consume_post_result_challenge()?` calls. Each is a potential error branch never triggered by existing tests. Adds two tests: one with zero post-result challenges (first `?` fires), one with exactly one (second `?` fires).

Relates to coverage issue #560.

## Test plan

- [ ] Rust CI passes  
- [ ] Codecov shows significant coverage improvement in `slice_exec.rs` and `union_exec.rs`