### PR TITLE
test: cover VerificationError conditions in membership_check and SumcheckProof

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -117,6 +117,7 @@ impl<S: Scalar> SumcheckProof<S> {
 #[cfg(test)]
 mod tests {
     use super::SumcheckProof;
+    use crate::base::proof::ProofError;
     use crate::base::scalar::test_scalar::TestScalar;
     use merlin::Transcript;
 
@@ -126,19 +127,31 @@ mod tests {
             coefficients: vec![TestScalar::from(1u64), TestScalar::from(2u64)],
         };
         let mut transcript = Transcript::new(b"test");
-        // 2 coefficients is not a multiple of 3 → "invalid proof size"
-        let result = proof.verify_without_evaluation(&mut transcript, 3, &TestScalar::ZERO);
-        assert!(result.is_err());
+        let err = proof
+            .verify_without_evaluation(&mut transcript, 3, &TestScalar::ZERO)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ProofError::VerificationError {
+                error: "invalid proof size"
+            }
+        ));
     }
 
     #[test]
     fn we_get_error_when_round_evaluation_does_not_match_claimed_sum() {
-        // 2 coefficients, 1 variable: round sum = 0+0 = 0, claimed_sum = 1 → mismatch
         let proof = SumcheckProof::<TestScalar> {
             coefficients: vec![TestScalar::ZERO, TestScalar::ZERO],
         };
         let mut transcript = Transcript::new(b"test");
-        let result = proof.verify_without_evaluation(&mut transcript, 1, &TestScalar::ONE);
-        assert!(result.is_err());
+        let err = proof
+            .verify_without_evaluation(&mut transcript, 1, &TestScalar::ONE)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ProofError::VerificationError {
+                error: "round evaluation does not match claimed sum"
+            }
+        ));
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -113,3 +113,32 @@ impl<S: Scalar> SumcheckProof<S> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SumcheckProof;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use merlin::Transcript;
+
+    #[test]
+    fn we_get_error_when_coefficients_not_multiple_of_num_variables() {
+        let proof = SumcheckProof::<TestScalar> {
+            coefficients: vec![TestScalar::from(1u64), TestScalar::from(2u64)],
+        };
+        let mut transcript = Transcript::new(b"test");
+        // 2 coefficients is not a multiple of 3 → "invalid proof size"
+        let result = proof.verify_without_evaluation(&mut transcript, 3, &TestScalar::ZERO);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn we_get_error_when_round_evaluation_does_not_match_claimed_sum() {
+        // 2 coefficients, 1 variable: round sum = 0+0 = 0, claimed_sum = 1 → mismatch
+        let proof = SumcheckProof::<TestScalar> {
+            coefficients: vec![TestScalar::ZERO, TestScalar::ZERO],
+        };
+        let mut transcript = Transcript::new(b"test");
+        let result = proof.verify_without_evaluation(&mut transcript, 1, &TestScalar::ONE);
+        assert!(result.is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
@@ -136,6 +136,7 @@ pub(crate) fn verify_membership_check<S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::verify_membership_check;
+    use crate::base::proof::ProofError;
     use crate::base::scalar::test_scalar::TestScalar;
     use crate::sql::proof::mock_verification_builder::MockVerificationBuilder;
 
@@ -144,8 +145,7 @@ mod tests {
         let mut builder = MockVerificationBuilder::<TestScalar>::new(
             vec![], 0, vec![], vec![], vec![], vec![], vec![],
         );
-        // 1 source column, 0 candidate columns → length mismatch → VerificationError
-        let result = verify_membership_check(
+        let err = verify_membership_check(
             &mut builder,
             TestScalar::ONE,
             TestScalar::ONE,
@@ -153,7 +153,13 @@ mod tests {
             TestScalar::ONE,
             &[TestScalar::ONE],
             &[],
-        );
-        assert!(result.is_err());
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ProofError::VerificationError {
+                error: "The number of source and candidate columns should be equal"
+            }
+        ));
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
@@ -132,3 +132,28 @@ pub(crate) fn verify_membership_check<S: Scalar>(
 
     Ok(multiplicity_eval)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::verify_membership_check;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::sql::proof::mock_verification_builder::MockVerificationBuilder;
+
+    #[test]
+    fn we_get_error_when_column_and_candidate_counts_differ() {
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![], 0, vec![], vec![], vec![], vec![], vec![],
+        );
+        // 1 source column, 0 candidate columns → length mismatch → VerificationError
+        let result = verify_membership_check(
+            &mut builder,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            &[TestScalar::ONE],
+            &[],
+        );
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

**`membership_check.rs`** (was 6 missed, 92.3%): Adds `we_get_error_when_column_and_candidate_counts_differ` — calls `verify_membership_check` directly with 1 source column and 0 candidate columns, triggering `Err(ProofError::VerificationError { error: "The number of source and candidate columns should be equal" })` before any builder interactions.

**`sumcheck/proof.rs`** (was 3 missed, 95.6%): Adds two tests for `SumcheckProof::verify_without_evaluation`:
- `we_get_error_when_coefficients_not_multiple_of_num_variables`: 2 coefficients with 3 variables → `2 % 3 ≠ 0` → `"invalid proof size"`
- `we_get_error_when_round_evaluation_does_not_match_claimed_sum`: coefficients `[0, 0]` with 1 variable gives round sum 0, but `claimed_sum = 1` → `"round evaluation does not match claimed sum"`

/claim #560

## Test plan

- [ ] Rust CI passes
- [ ] Codecov shows coverage increase in both files