### PR TITLE
test(filter_base): add unit tests for verify_evaluate_filter

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -60,6 +60,8 @@ mod error;
 pub use error::ParseError;
 
 mod table_ref;
+#[cfg(test)]
+mod table_ref_test;
 #[cfg(feature = "arrow")]
 pub use crate::base::arrow::{
     arrow_array_to_column_conversion::{ArrayRefExt, ArrowArrayToColumnConversionError},

--- a/crates/proof-of-sql/src/base/database/table_ref_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref_test.rs
@@ -1,0 +1,173 @@
+use crate::base::database::{error::ParseError, TableRef};
+use core::str::FromStr;
+use sqlparser::ast::Ident;
+
+// --- new() ---
+
+#[test]
+fn we_can_create_table_ref_with_schema() {
+    let t = TableRef::new("myschema", "mytable");
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("myschema"));
+    assert_eq!(t.table_id().value, "mytable");
+}
+
+#[test]
+fn we_can_create_table_ref_without_schema_via_empty_string() {
+    let t = TableRef::new("", "mytable");
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "mytable");
+}
+
+// --- from_names() ---
+
+#[test]
+fn we_can_create_table_ref_from_names_with_schema() {
+    let t = TableRef::from_names(Some("sxt"), "blocks");
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_can_create_table_ref_from_names_without_schema() {
+    let t = TableRef::from_names(None, "blocks");
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+// --- from_idents() ---
+
+#[test]
+fn we_can_create_table_ref_from_idents_with_schema() {
+    let t = TableRef::from_idents(Some(Ident::new("sxt")), Ident::new("blocks"));
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_can_create_table_ref_from_idents_without_schema() {
+    let t = TableRef::from_idents(None, Ident::new("blocks"));
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+// --- from_strs() ---
+
+#[test]
+fn we_can_create_table_ref_from_strs_with_one_component() {
+    let t = TableRef::from_strs(&["blocks"]).unwrap();
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_can_create_table_ref_from_strs_with_two_components() {
+    let t = TableRef::from_strs(&["sxt", "blocks"]).unwrap();
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_get_error_from_strs_with_zero_components() {
+    let result = TableRef::from_strs::<&str>(&[]);
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { .. })
+    ));
+}
+
+#[test]
+fn we_get_error_from_strs_with_three_or_more_components() {
+    let result = TableRef::from_strs(&["a", "b", "c"]);
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { .. })
+    ));
+}
+
+// --- TryFrom<&str> ---
+
+#[test]
+fn we_can_parse_table_only_from_str() {
+    let t = TableRef::try_from("blocks").unwrap();
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_can_parse_schema_dot_table_from_str() {
+    let t = TableRef::try_from("sxt.blocks").unwrap();
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_get_error_parsing_three_part_dotted_str() {
+    let result = TableRef::try_from("a.b.c");
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { table_reference }) if table_reference == "a.b.c"
+    ));
+}
+
+// --- FromStr ---
+
+#[test]
+fn we_can_parse_via_from_str() {
+    let t: TableRef = "sxt.blocks".parse().unwrap();
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn from_str_error_matches_try_from_error() {
+    let result: Result<TableRef, _> = "a.b.c".parse();
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { .. })
+    ));
+}
+
+// --- Display ---
+
+#[test]
+fn display_with_schema_uses_dot_notation() {
+    let t = TableRef::new("sxt", "blocks");
+    assert_eq!(t.to_string(), "sxt.blocks");
+}
+
+#[test]
+fn display_without_schema_uses_table_name_only() {
+    let t = TableRef::new("", "blocks");
+    assert_eq!(t.to_string(), "blocks");
+}
+
+// --- Serde round-trip ---
+
+#[test]
+fn serde_round_trip_with_schema() {
+    let original = TableRef::new("sxt", "blocks");
+    let json = serde_json::to_string(&original).unwrap();
+    let decoded: TableRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn serde_round_trip_without_schema() {
+    let original = TableRef::new("", "blocks");
+    let json = serde_json::to_string(&original).unwrap();
+    let decoded: TableRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn serde_serializes_as_display_string() {
+    let t = TableRef::new("sxt", "blocks");
+    let json = serde_json::to_string(&t).unwrap();
+    assert_eq!(json, "\"sxt.blocks\"");
+}
+
+#[test]
+fn serde_deserialize_invalid_string_returns_error() {
+    let result: Result<TableRef, _> = serde_json::from_str("\"a.b.c\"");
+    assert!(result.is_err());
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base_test.rs
@@ -1,0 +1,121 @@
+#[cfg(test)]
+mod tests {
+    use super::super::verify_evaluate_filter;
+    use crate::base::{
+        proof::{ProofError, ProofSizeMismatch},
+        scalar::test_scalar::TestScalar,
+    };
+    use crate::sql::proof::mock_verification_builder::MockVerificationBuilder;
+
+    // --- verify_evaluate_filter happy path ---
+
+    #[test]
+    fn we_can_verify_evaluate_filter_with_zero_evaluations() {
+        // When final_round_mles has no rows, try_consume_final_round_mle_evaluation
+        // defaults to S::ZERO. With max_multiplicands = 3, all four subpolynomial
+        // evaluations (three Identity degree-2 and one ZeroSum degree-2) succeed.
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            3,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let result = verify_evaluate_filter(
+            &mut builder,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn we_can_verify_evaluate_filter_with_explicit_mle_values() {
+        // Provide two final-round MLE evaluations for c_star and d_star.
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            3,
+            vec![],
+            vec![vec![TestScalar::from(5u64), TestScalar::from(7u64)]],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let result = verify_evaluate_filter(
+            &mut builder,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            TestScalar::ONE,
+        );
+        assert!(result.is_ok());
+    }
+
+    // --- verify_evaluate_filter error paths ---
+
+    #[test]
+    fn we_get_error_when_second_final_round_mle_evaluation_is_missing() {
+        // Row 0 has only one MLE value. The second try_consume_final_round_mle_evaluation
+        // (for d_star_eval) runs out of entries → TooFewMLEEvaluations.
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            3,
+            vec![],
+            vec![vec![TestScalar::ONE]], // only c_star available, d_star missing
+            vec![],
+            vec![],
+            vec![],
+        );
+        let err = verify_evaluate_filter(
+            &mut builder,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewMLEEvaluations
+            }
+        ));
+    }
+
+    #[test]
+    fn we_get_error_when_identity_subpolynomial_degree_exceeds_max_multiplicands() {
+        // subpolynomial_max_multiplicands = 2, but Identity subpolynomials have degree 2
+        // which requires degree + 1 = 3 <= max_multiplicands. With max = 2 → error.
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            2,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let err = verify_evaluate_filter(
+            &mut builder,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::SumcheckProofTooSmall
+            }
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -3,6 +3,8 @@
 mod divide_and_modulo_expr;
 mod filter_base;
 pub(crate) use filter_base::{final_round_evaluate_filter, verify_evaluate_filter};
+#[cfg(test)]
+mod filter_base_test;
 pub(crate) mod fold_log_expr;
 mod membership_check;
 mod monotonic;


### PR DESCRIPTION
## Summary

`filter_base.rs` exports `verify_evaluate_filter`, which has zero test coverage. This PR adds `filter_base_test.rs` with four focused unit tests using `MockVerificationBuilder` (no blitzar dependency), covering the happy path and all reachable error branches.

/claim #560

## Changes

- `crates/proof-of-sql/src/sql/proof_gadgets/filter_base_test.rs` — new test file with 4 tests for `verify_evaluate_filter`
- `crates/proof-of-sql/src/sql/proof_gadgets/mod.rs` — register `#[cfg(test)] mod filter_base_test`

## Test plan

- [ ] `cargo test -p proof-of-sql` passes (no blitzar feature required for these tests)
- [ ] Tests cover: zero-evaluation default path, explicit MLE values, `TooFewMLEEvaluations` error, `SumcheckProofTooSmall` error