### PR TITLE
test: cover SortMergeJoinExec constructor guards and multi-join-column verifier error

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -60,6 +60,8 @@ mod error;
 pub use error::ParseError;
 
 mod table_ref;
+#[cfg(test)]
+mod table_ref_test;
 #[cfg(feature = "arrow")]
 pub use crate::base::arrow::{
     arrow_array_to_column_conversion::{ArrayRefExt, ArrowArrayToColumnConversionError},

--- a/crates/proof-of-sql/src/base/database/table_ref_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref_test.rs
@@ -1,0 +1,173 @@
+use crate::base::database::{error::ParseError, TableRef};
+use core::str::FromStr;
+use sqlparser::ast::Ident;
+
+// --- new() ---
+
+#[test]
+fn we_can_create_table_ref_with_schema() {
+    let t = TableRef::new("myschema", "mytable");
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("myschema"));
+    assert_eq!(t.table_id().value, "mytable");
+}
+
+#[test]
+fn we_can_create_table_ref_without_schema_via_empty_string() {
+    let t = TableRef::new("", "mytable");
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "mytable");
+}
+
+// --- from_names() ---
+
+#[test]
+fn we_can_create_table_ref_from_names_with_schema() {
+    let t = TableRef::from_names(Some("sxt"), "blocks");
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_can_create_table_ref_from_names_without_schema() {
+    let t = TableRef::from_names(None, "blocks");
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+// --- from_idents() ---
+
+#[test]
+fn we_can_create_table_ref_from_idents_with_schema() {
+    let t = TableRef::from_idents(Some(Ident::new("sxt")), Ident::new("blocks"));
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_can_create_table_ref_from_idents_without_schema() {
+    let t = TableRef::from_idents(None, Ident::new("blocks"));
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+// --- from_strs() ---
+
+#[test]
+fn we_can_create_table_ref_from_strs_with_one_component() {
+    let t = TableRef::from_strs(&["blocks"]).unwrap();
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_can_create_table_ref_from_strs_with_two_components() {
+    let t = TableRef::from_strs(&["sxt", "blocks"]).unwrap();
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_get_error_from_strs_with_zero_components() {
+    let result = TableRef::from_strs::<&str>(&[]);
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { .. })
+    ));
+}
+
+#[test]
+fn we_get_error_from_strs_with_three_or_more_components() {
+    let result = TableRef::from_strs(&["a", "b", "c"]);
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { .. })
+    ));
+}
+
+// --- TryFrom<&str> ---
+
+#[test]
+fn we_can_parse_table_only_from_str() {
+    let t = TableRef::try_from("blocks").unwrap();
+    assert!(t.schema_id().is_none());
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_can_parse_schema_dot_table_from_str() {
+    let t = TableRef::try_from("sxt.blocks").unwrap();
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn we_get_error_parsing_three_part_dotted_str() {
+    let result = TableRef::try_from("a.b.c");
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { table_reference }) if table_reference == "a.b.c"
+    ));
+}
+
+// --- FromStr ---
+
+#[test]
+fn we_can_parse_via_from_str() {
+    let t: TableRef = "sxt.blocks".parse().unwrap();
+    assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("sxt"));
+    assert_eq!(t.table_id().value, "blocks");
+}
+
+#[test]
+fn from_str_error_matches_try_from_error() {
+    let result: Result<TableRef, _> = "a.b.c".parse();
+    assert!(matches!(
+        result,
+        Err(ParseError::InvalidTableReference { .. })
+    ));
+}
+
+// --- Display ---
+
+#[test]
+fn display_with_schema_uses_dot_notation() {
+    let t = TableRef::new("sxt", "blocks");
+    assert_eq!(t.to_string(), "sxt.blocks");
+}
+
+#[test]
+fn display_without_schema_uses_table_name_only() {
+    let t = TableRef::new("", "blocks");
+    assert_eq!(t.to_string(), "blocks");
+}
+
+// --- Serde round-trip ---
+
+#[test]
+fn serde_round_trip_with_schema() {
+    let original = TableRef::new("sxt", "blocks");
+    let json = serde_json::to_string(&original).unwrap();
+    let decoded: TableRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn serde_round_trip_without_schema() {
+    let original = TableRef::new("", "blocks");
+    let json = serde_json::to_string(&original).unwrap();
+    let decoded: TableRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn serde_serializes_as_display_string() {
+    let t = TableRef::new("sxt", "blocks");
+    let json = serde_json::to_string(&t).unwrap();
+    assert_eq!(json, "\"sxt.blocks\"");
+}
+
+#[test]
+fn serde_deserialize_invalid_string_returns_error() {
+    let result: Result<TableRef, _> = serde_json::from_str("\"a.b.c\"");
+    assert!(result.is_err());
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/filter_base_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/filter_base_test.rs
@@ -1,0 +1,121 @@
+#[cfg(test)]
+mod tests {
+    use super::super::verify_evaluate_filter;
+    use crate::base::{
+        proof::{ProofError, ProofSizeMismatch},
+        scalar::test_scalar::TestScalar,
+    };
+    use crate::sql::proof::mock_verification_builder::MockVerificationBuilder;
+
+    // --- verify_evaluate_filter happy path ---
+
+    #[test]
+    fn we_can_verify_evaluate_filter_with_zero_evaluations() {
+        // When final_round_mles has no rows, try_consume_final_round_mle_evaluation
+        // defaults to S::ZERO. With max_multiplicands = 3, all four subpolynomial
+        // evaluations (three Identity degree-2 and one ZeroSum degree-2) succeed.
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            3,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let result = verify_evaluate_filter(
+            &mut builder,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn we_can_verify_evaluate_filter_with_explicit_mle_values() {
+        // Provide two final-round MLE evaluations for c_star and d_star.
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            3,
+            vec![],
+            vec![vec![TestScalar::from(5u64), TestScalar::from(7u64)]],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let result = verify_evaluate_filter(
+            &mut builder,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            TestScalar::ONE,
+            TestScalar::ONE,
+        );
+        assert!(result.is_ok());
+    }
+
+    // --- verify_evaluate_filter error paths ---
+
+    #[test]
+    fn we_get_error_when_second_final_round_mle_evaluation_is_missing() {
+        // Row 0 has only one MLE value. The second try_consume_final_round_mle_evaluation
+        // (for d_star_eval) runs out of entries → TooFewMLEEvaluations.
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            3,
+            vec![],
+            vec![vec![TestScalar::ONE]], // only c_star available, d_star missing
+            vec![],
+            vec![],
+            vec![],
+        );
+        let err = verify_evaluate_filter(
+            &mut builder,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewMLEEvaluations
+            }
+        ));
+    }
+
+    #[test]
+    fn we_get_error_when_identity_subpolynomial_degree_exceeds_max_multiplicands() {
+        // subpolynomial_max_multiplicands = 2, but Identity subpolynomials have degree 2
+        // which requires degree + 1 = 3 <= max_multiplicands. With max = 2 → error.
+        let mut builder = MockVerificationBuilder::<TestScalar>::new(
+            vec![],
+            2,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let err = verify_evaluate_filter(
+            &mut builder,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+            TestScalar::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::SumcheckProofTooSmall
+            }
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -3,6 +3,8 @@
 mod divide_and_modulo_expr;
 mod filter_base;
 pub(crate) use filter_base::{final_round_evaluate_filter, verify_evaluate_filter};
+#[cfg(test)]
+mod filter_base_test;
 pub(crate) mod fold_log_expr;
 mod membership_check;
 mod monotonic;

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -1,11 +1,19 @@
 use super::test_utility::*;
 use crate::{
-    base::database::{
-        owned_table_utility::*, table_utility::*, ColumnType, TableRef, TableTestAccessor,
-        TestAccessor,
+    base::{
+        database::{
+            owned_table_utility::*, table_utility::*, ColumnType, TableRef, TableTestAccessor,
+            TestAccessor,
+        },
+        map::IndexMap,
+        proof::ProofError,
+        scalar::test_scalar::TestScalar,
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::{
+            exercise_verification, mock_verification_builder::MockVerificationBuilder, ProofPlan,
+            VerifiableQueryResult,
+        },
         proof_exprs::test_utility::*,
     },
 };
@@ -495,4 +503,131 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         varchar("human", [""; 0]),
     ]);
     assert_eq!(res, expected_res);
+}
+
+#[test]
+#[should_panic(expected = "Join column index out of bounds")]
+fn we_cannot_create_sort_merge_join_exec_with_out_of_bounds_join_column_index() {
+    sort_merge_join(
+        table_exec(
+            "sxt.left".parse().unwrap(),
+            vec![column_field("a", ColumnType::BigInt)],
+        ),
+        table_exec(
+            "sxt.right".parse().unwrap(),
+            vec![column_field("b", ColumnType::BigInt)],
+        ),
+        vec![1], // index 1 is out of bounds for a 1-column table
+        vec![0],
+        vec![Ident::new("b")],
+    );
+}
+
+#[test]
+#[should_panic(expected = "Join columns should have the same number of columns")]
+fn we_cannot_create_sort_merge_join_exec_with_mismatched_join_column_counts() {
+    sort_merge_join(
+        table_exec(
+            "sxt.left".parse().unwrap(),
+            vec![
+                column_field("a", ColumnType::BigInt),
+                column_field("b", ColumnType::BigInt),
+            ],
+        ),
+        table_exec(
+            "sxt.right".parse().unwrap(),
+            vec![
+                column_field("c", ColumnType::BigInt),
+                column_field("d", ColumnType::BigInt),
+            ],
+        ),
+        vec![0],     // 1 join column on left
+        vec![0, 1],  // 2 join columns on right — mismatch
+        vec![Ident::new("a"), Ident::new("c"), Ident::new("d")],
+    );
+}
+
+#[test]
+#[should_panic(
+    expected = "The amount of result idents should be the same as the expected number of columns"
+)]
+fn we_cannot_create_sort_merge_join_exec_with_wrong_result_ident_count() {
+    sort_merge_join(
+        table_exec(
+            "sxt.left".parse().unwrap(),
+            vec![
+                column_field("a", ColumnType::BigInt),
+                column_field("b", ColumnType::BigInt),
+            ],
+        ),
+        table_exec(
+            "sxt.right".parse().unwrap(),
+            vec![
+                column_field("c", ColumnType::BigInt),
+                column_field("d", ColumnType::BigInt),
+            ],
+        ),
+        vec![0],
+        vec![0],
+        vec![], // expected 2+2-1=3 idents, providing 0
+    );
+}
+
+#[test]
+fn we_get_error_when_verifying_sort_merge_join_with_multiple_join_columns() {
+    let table_left: TableRef = "sxt.left".parse().unwrap();
+    let table_right: TableRef = "sxt.right".parse().unwrap();
+    let plan = sort_merge_join(
+        table_exec(
+            table_left.clone(),
+            vec![
+                column_field("a", ColumnType::BigInt),
+                column_field("b", ColumnType::BigInt),
+            ],
+        ),
+        table_exec(
+            table_right.clone(),
+            vec![
+                column_field("c", ColumnType::BigInt),
+                column_field("d", ColumnType::BigInt),
+            ],
+        ),
+        vec![0, 1], // 2 join columns triggers "not supported yet" guard
+        vec![0, 1],
+        vec![Ident::new("a"), Ident::new("b")],
+    );
+
+    let mut left_cols: IndexMap<Ident, TestScalar> = IndexMap::default();
+    left_cols.insert(Ident::new("a"), TestScalar::ONE);
+    left_cols.insert(Ident::new("b"), TestScalar::ONE);
+    let mut right_cols: IndexMap<Ident, TestScalar> = IndexMap::default();
+    right_cols.insert(Ident::new("c"), TestScalar::ONE);
+    right_cols.insert(Ident::new("d"), TestScalar::ONE);
+    let mut accessor: IndexMap<TableRef, IndexMap<Ident, TestScalar>> = IndexMap::default();
+    accessor.insert(table_left.clone(), left_cols);
+    accessor.insert(table_right.clone(), right_cols);
+
+    let mut chi_eval_map: IndexMap<TableRef, (TestScalar, usize)> = IndexMap::default();
+    chi_eval_map.insert(table_left, (TestScalar::ONE, 1));
+    chi_eval_map.insert(table_right, (TestScalar::ONE, 1));
+
+    let mut builder = MockVerificationBuilder::<TestScalar>::new(
+        vec![],
+        2,
+        vec![],
+        vec![],
+        vec![TestScalar::ONE, TestScalar::ONE], // alpha, beta post-result challenges
+        vec![1],                                 // result chi evaluation length
+        vec![1],                                 // left rho evaluation length
+    );
+
+    let err = plan
+        .verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[])
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ProofError::VerificationError {
+            error: "Join on multiple columns not supported yet"
+        }
+    ));
 }


### PR DESCRIPTION
## Summary

Adds 4 tests to `sort_merge_join_exec_test.rs` targeting 6 previously-uncovered branches in `sort_merge_join_exec.rs`:

- **Line 74** — \`panic!("Join column index out of bounds")\`: triggered by passing a join column index ≥ the table's column count
- **Line 79** — \`assert!\` for mismatched join column vector lengths: triggered by passing different lengths for \`left_join_column_indexes\` and \`right_join_column_indexes\`
- **Line 83** — \`assert!\` for wrong \`result_idents\` count: triggered when the ident count doesn't equal \`num_left + num_right - num_join\`
- **Lines 172–174** — verifier \`return Err(…)\` for unsupported multi-column joins: exercised via \`MockVerificationBuilder\` with a plan configured for 2 join columns

## Test plan

- [ ] \`we_cannot_create_sort_merge_join_exec_with_out_of_bounds_join_column_index\` — \`#[should_panic]\` with index 1 on a 1-column table
- [ ] \`we_cannot_create_sort_merge_join_exec_with_mismatched_join_column_counts\` — \`#[should_panic]\` with left=[0], right=[0,1]
- [ ] \`we_cannot_create_sort_merge_join_exec_with_wrong_result_ident_count\` — \`#[should_panic]\` with 0 idents when 3 expected
- [ ] \`we_get_error_when_verifying_sort_merge_join_with_multiple_join_columns\` — asserts \`ProofError::VerificationError { error: "Join on multiple columns not supported yet" }\`

/attempt #560