### PR TITLE
test: invoke uncovered TranscriptCore test helpers for Keccak256

### DIFF
--- a/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
@@ -1,4 +1,4 @@
-use super::{transcript_core::TranscriptCore, Keccak256Transcript as T, Transcript};
+use super::{transcript_core::{test_util, TranscriptCore}, Keccak256Transcript as T, Transcript};
 use crate::base::scalar::{test_scalar::TestScalar as S, Scalar, ScalarExt};
 use bnum::types::U256;
 #[test]
@@ -81,4 +81,14 @@ fn we_can_get_challenge_as_little_endian() {
     let mut transcript2: T = TranscriptCore::new();
 
     assert_eq!(transcript1.raw_challenge(), transcript2.challenge_as_le());
+}
+
+#[test]
+fn we_get_different_challenges_with_different_transcripts() {
+    test_util::we_get_different_challenges_with_different_transcripts::<T>();
+}
+
+#[test]
+fn we_get_different_nontrivial_consecutive_challenges_from_transcript() {
+    test_util::we_get_different_nontrivial_consecutive_challenges_from_transcript::<T>();
 }


### PR DESCRIPTION
## Summary

Calls two \`pub(super)\` test helper functions in \`transcript_core.rs\` that existed but were never invoked, leaving 5 lines uncovered (85, 98, 108, 112, 116):

- \`test_util::we_get_different_challenges_with_different_transcripts::<Keccak256Transcript>()\` — asserts two transcripts fed different messages produce different challenges
- \`test_util::we_get_different_nontrivial_consecutive_challenges_from_transcript::<Keccak256Transcript>()\` — asserts consecutive challenges from the same transcript are non-zero and distinct

## Test plan

- [ ] \`we_get_different_challenges_with_different_transcripts\` — delegates to existing helper, asserts divergent challenge outputs
- [ ] \`we_get_different_nontrivial_consecutive_challenges_from_transcript\` — delegates to existing helper, asserts non-trivial consecutive outputs

/attempt #560