### PR TITLE
test: cover non-CREATE TABLE SQL branch and union verifier error path

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -5,19 +5,22 @@ use crate::{
             owned_table_utility::*, table_utility::*, ColumnType, OwnedTable,
             OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
-        map::indexmap,
+        map::{indexmap, IndexMap},
+        proof::ProofError,
+        scalar::test_scalar::TestScalar,
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
         proof::{
-            exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
-            VerifiableQueryResult,
+            exercise_verification, mock_verification_builder::MockVerificationBuilder, ProofPlan,
+            FirstRoundBuilder, ProvableQueryResult, ProverEvaluate, VerifiableQueryResult,
         },
         proof_exprs::test_utility::*,
     },
 };
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
+use sqlparser::ast::Ident;
 
 #[test]
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: NotEnoughInputPlans")]
@@ -339,4 +342,44 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
     ]);
 
     assert_eq!(res, expected);
+}
+
+#[test]
+fn we_get_error_when_verifier_runs_out_of_mle_evaluations_in_union_exec() {
+    let table_a: TableRef = "sxt.a".parse().unwrap();
+    let table_b: TableRef = "sxt.b".parse().unwrap();
+    let plan = union_exec(vec![
+        table_exec(table_a.clone(), vec![column_field("x", ColumnType::BigInt)]),
+        table_exec(table_b.clone(), vec![column_field("x", ColumnType::BigInt)]),
+    ]);
+
+    let mut cols_a: IndexMap<Ident, TestScalar> = IndexMap::default();
+    cols_a.insert(Ident::new("x"), TestScalar::ONE);
+    let mut cols_b: IndexMap<Ident, TestScalar> = IndexMap::default();
+    cols_b.insert(Ident::new("x"), TestScalar::ONE);
+    let mut accessor: IndexMap<TableRef, IndexMap<Ident, TestScalar>> = IndexMap::default();
+    accessor.insert(table_a.clone(), cols_a);
+    accessor.insert(table_b.clone(), cols_b);
+
+    let mut chi_eval_map: IndexMap<TableRef, (TestScalar, usize)> = IndexMap::default();
+    chi_eval_map.insert(table_a, (TestScalar::ONE, 1));
+    chi_eval_map.insert(table_b, (TestScalar::ONE, 1));
+
+    // Provide no first_round_mles so try_consume_first_round_mle_evaluations fails at line 85.
+    // final_round_mles has 2 entries (one per input's fold_log gadget evaluation).
+    // max_multiplicands=3 allows Identity subpolynomials with degree=2 to pass.
+    let mut builder = MockVerificationBuilder::<TestScalar>::new(
+        vec![],
+        3,
+        vec![],
+        vec![vec![TestScalar::ONE], vec![TestScalar::ONE]],
+        vec![TestScalar::ONE, TestScalar::ONE],
+        vec![],
+        vec![],
+    );
+
+    let err = plan
+        .verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[])
+        .unwrap_err();
+    assert!(matches!(err, ProofError::ProofSizeMismatch { .. }));
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -365,14 +365,15 @@ fn we_get_error_when_verifier_runs_out_of_mle_evaluations_in_union_exec() {
     chi_eval_map.insert(table_a, (TestScalar::ONE, 1));
     chi_eval_map.insert(table_b, (TestScalar::ONE, 1));
 
-    // Provide no first_round_mles so try_consume_first_round_mle_evaluations fails at line 85.
-    // final_round_mles has 2 entries (one per input's fold_log gadget evaluation).
-    // max_multiplicands=3 allows Identity subpolynomials with degree=2 to pass.
+    // Each input's fold_log gadget consumes one final_round_mle at indices [0][0] and [0][1]
+    // (evaluation_row_index stays 0 throughout). first_round_mles has an empty inner vec so
+    // try_consume_first_round_mle_evaluations finds the row but no element → ProofSizeMismatch.
+    // max_multiplicands=3 allows Identity subpolynomials (degree=2) from fold_log to pass.
     let mut builder = MockVerificationBuilder::<TestScalar>::new(
         vec![],
         3,
-        vec![],
-        vec![vec![TestScalar::ONE], vec![TestScalar::ONE]],
+        vec![vec![]],
+        vec![vec![TestScalar::ONE, TestScalar::ONE]],
         vec![TestScalar::ONE, TestScalar::ONE],
         vec![],
         vec![],

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,13 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn test_find_bigdecimals_skips_non_create_table_statements() {
+        // SELECT and other non-CREATE TABLE statements hit the `_ => None` arm
+        let sql = "SELECT 1; CREATE TABLE sxt.test (val DECIMAL(78, 0));";
+        let result = find_bigdecimals(sql);
+        assert_eq!(result.get("sxt.test").unwrap(), &[("val".to_string(), 78, 0)]);
+        assert_eq!(result.len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary

Two uncovered branches in separate files:

**`crates/proof-of-sql/src/utils/parse.rs` — line 42**

The `_ => None` wildcard arm in `find_bigdecimals` handles non-`CREATE TABLE` SQL statements (SELECT, INSERT, etc.). The existing test only passed `CREATE TABLE` statements so this arm was never reached. New test passes `SELECT 1;` alongside a `CREATE TABLE` to confirm the non-DDL statement is silently skipped.

**`crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs` — line 85**

The `?` operator error branch of `try_consume_first_round_mle_evaluations` in `UnionExec::verifier_evaluate` was never triggered. New test uses `MockVerificationBuilder` with two `TableExec` inputs (covering the fold-log `final_round_mle` slots) but no `first_round_mle` slots, causing `ProofError::ProofSizeMismatch` to propagate through line 85.

## Test plan

- [ ] `test_find_bigdecimals_skips_non_create_table_statements` — verifies SELECT is ignored, CREATE TABLE is processed
- [ ] `we_get_error_when_verifier_runs_out_of_mle_evaluations_in_union_exec` — verifies `ProofSizeMismatch` error from depleted first-round MLE queue

/attempt #560