### PR TITLE
test: cover RefInto and map helper macros

### DIFF
--- a/crates/proof-of-sql/src/base/map.rs
+++ b/crates/proof-of-sql/src/base/map.rs
@@ -18,3 +18,45 @@ macro_rules! indexset {
 #[cfg(test)]
 pub(crate) use indexmap;
 pub(crate) use indexset;
+
+#[cfg(test)]
+mod tests {
+    use super::{indexmap, indexset, IndexMap, IndexSet};
+    use alloc::{vec, vec::Vec};
+
+    #[test]
+    fn indexmap_macro_preserves_insertion_order_and_overwrites_duplicates() {
+        let map = indexmap! {
+            "first" => 1,
+            "second" => 2,
+            "first" => 3,
+        };
+
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("first"), Some(&3));
+        assert_eq!(
+            map.keys().copied().collect::<Vec<_>>(),
+            vec!["first", "second"]
+        );
+    }
+
+    #[test]
+    fn indexset_macro_preserves_insertion_order_and_deduplicates_values() {
+        let set = indexset!["alpha", "beta", "alpha"];
+
+        assert_eq!(set.len(), 2);
+        assert_eq!(
+            set.iter().copied().collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
+        );
+    }
+
+    #[test]
+    fn map_aliases_use_the_same_default_hasher_as_the_macros() {
+        let map: IndexMap<&str, u8> = indexmap! {"one" => 1};
+        let set: IndexSet<&str> = indexset!["one"];
+
+        assert_eq!(map.get("one"), Some(&1));
+        assert!(set.contains("one"));
+    }
+}

--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,38 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+    use alloc::{vec, vec::Vec};
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct WrappedU32(u32);
+
+    impl From<&WrappedU32> for u32 {
+        fn from(value: &WrappedU32) -> Self {
+            value.0
+        }
+    }
+
+    #[test]
+    fn ref_into_uses_reference_conversion_without_consuming_source() {
+        let wrapped = WrappedU32(42);
+
+        let converted = RefInto::<u32>::ref_into(&wrapped);
+
+        assert_eq!(converted, 42);
+        assert_eq!(wrapped, WrappedU32(42));
+    }
+
+    #[test]
+    fn ref_into_can_be_used_with_iterator_adapters() {
+        let wrapped = [WrappedU32(1), WrappedU32(2), WrappedU32(3)];
+
+        let converted: Vec<_> = wrapped.iter().map(RefInto::<u32>::ref_into).collect();
+
+        assert_eq!(converted, vec![1, 2, 3]);
+        assert_eq!(wrapped[0], WrappedU32(1));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary

- add focused unit coverage for the `RefInto` blanket implementation
- add focused unit coverage for `indexmap!` / `indexset!` helper macros and the related map/set aliases
- keep production behavior unchanged

## Validation

- `cargo fmt --check`
- `git diff --check`
- Attempted `cargo test -p proof-of-sql base::ref_into --no-default-features`; local compile was blocked by disk space (`No space left on device`) before test execution

AI-assisted with OpenAI Codex; I reviewed the diff before submission.
