### PR TITLE
test: cover bit matrix multi-row orientation

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
@@ -87,3 +87,21 @@ fn we_can_compute_the_bit_matrix_for_data_entries_bigger_than_64_bit_integers() 
     assert_eq!(matrix[0], slice1);
     assert_eq!(matrix[1], slice2);
 }
+
+#[test]
+fn we_can_compute_bit_matrix_columns_for_multiple_varying_rows() {
+    let data: Vec<TestScalar> = vec![
+        TestScalar::from(0),
+        TestScalar::from(1),
+        TestScalar::from(2),
+        TestScalar::from(-3),
+    ];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
+    let alloc = Bump::new();
+    let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
+
+    assert_eq!(matrix.len(), 3);
+    assert_eq!(matrix[0], vec![false, true, false, true]);
+    assert_eq!(matrix[1], vec![false, false, true, false]);
+    assert_eq!(matrix[2], vec![true, true, true, false]);
+}


### PR DESCRIPTION
/claim #560

## Summary

Adds a focused test-only coverage slice for `crates/proof-of-sql/src/base/bit/bit_matrix_test.rs`.

Covered path:
- multi-row bit matrix orientation when bits 0/1 and the sign bit all vary across four rows

This verifies that `compute_varying_bit_matrix` returns one column per varying bit and preserves row ordering for positive, zero, and negative scalar values.

No production logic changes.

## Validation

- `git diff --check` passed locally
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_compute_bit_matrix_columns_for_multiple_varying_rows -- --nocapture` passed locally on Windows/MSVC
- I checked visible #560 comments for `bit_matrix`, `BitMatrix`, `bit_matrix_test`, and `compute_varying_bit_matrix` and found no existing claim for this slice

## Evidence

MP4 evidence for this bounty submission:
https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-bit-matrix-refresh72

AI-assisted with OpenAI Codex; I reviewed the diff and deconflicted against visible #560 comments before submitting.
