### PR TITLE
test: cover empty mul add assignment

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
@@ -54,3 +54,23 @@ fn test_mul_add_assign_testscalar_uneven() {
     let c = [1 + 10 * 2, 2 + 10 * 3, 3].map(TestScalar::from).to_vec();
     assert_eq!(a, c);
 }
+
+#[test]
+fn test_mul_add_assign_with_empty_values_to_add_leaves_result_unchanged() {
+    let mut a = [1, 2, 3].map(TestScalar::from).to_vec();
+    let b: Vec<TestScalar> = Vec::new();
+
+    mul_add_assign(&mut a, TestScalar::from(10u64), &b);
+
+    assert_eq!(a, [1, 2, 3].map(TestScalar::from).to_vec());
+}
+
+#[test]
+fn test_mul_add_assign_with_empty_result_and_empty_values_to_add() {
+    let mut a: Vec<TestScalar> = Vec::new();
+    let b: Vec<TestScalar> = Vec::new();
+
+    mul_add_assign(&mut a, TestScalar::from(10u64), &b);
+
+    assert!(a.is_empty());
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for `mul_add_assign` empty-input behavior in `crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs`.
- Verifies an empty `to_mul_add` slice leaves an existing result slice unchanged.
- Verifies an empty result slice with an empty `to_mul_add` slice is accepted as a no-op.

## Deconfliction
I checked the current open #560 PR list before implementing. These terms had 0 hits across the 300 open PRs inspected: `mul_add_assign.rs`, `mul_add_assign_test.rs`, `mul_add_assign`, `test_mul_add_assign`. The broader `slice_ops` term had generic hits, but none for this function/file.

## Validation
Passed locally on Windows with MSVC environment:

```text
cargo fmt --check
git diff --check
cargo test -p proof-of-sql --lib --no-default-features --features test test_mul_add_assign_with_empty_values_to_add_leaves_result_unchanged -- --nocapture
cargo test -p proof-of-sql --lib --no-default-features --features test test_mul_add_assign_with_empty_result_and_empty_values_to_add -- --nocapture
cargo test -p proof-of-sql --lib --no-default-features --features test mul_add_assign -- --nocapture
```

Result: 2 focused tests passed; 7 `mul_add_assign` module tests passed.

## Evidence
MP4 evidence and supporting files: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-mul-add-assign-empty-refresh77

## Payout wallet
EVM/USDC wallet: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`