### PR TITLE
test: cover test scalar display formatting

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
@@ -86,3 +86,30 @@ fn we_can_convert_u256_to_test_scalar_with_wrapping_of_random_u256() {
     // ASSERT
     assert_eq!(test_scalar, expected_scalar);
 }
+
+#[test]
+fn we_can_display_test_scalar_as_full_width_hex() {
+    assert_eq!(
+        format!("{}", TestScalar::TWO),
+        "0000000000000000000000000000000000000000000000000000000000000002"
+    );
+}
+
+#[test]
+fn we_can_display_test_scalar_with_explicit_sign() {
+    assert_eq!(
+        format!("{:+}", TestScalar::TWO),
+        "+0000000000000000000000000000000000000000000000000000000000000002"
+    );
+    assert_eq!(
+        format!("{:+}", -TestScalar::TWO),
+        "-0000000000000000000000000000000000000000000000000000000000000002"
+    );
+}
+
+#[test]
+fn we_can_display_test_scalar_as_compact_alternate_hex() {
+    assert_eq!(format!("{:#}", TestScalar::TWO), "0x0000...0002");
+    assert_eq!(format!("{:+#}", TestScalar::TWO), "+0x0000...0002");
+    assert_eq!(format!("{:+#}", -TestScalar::TWO), "-0x0000...0002");
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for `TestScalar`/`MontScalar` display formatting in `crates/proof-of-sql/src/base/scalar/test_scalar_test.rs`.
- Covers full-width hexadecimal display output.
- Covers explicit plus/minus sign formatting.
- Covers compact alternate hexadecimal formatting.

## Deconfliction
I checked the current open #560 PR list before implementing. These terms had 0 hits across the 300 open PRs inspected: `test_scalar_test.rs`, `MontScalar Display`, `Display for MontScalar`, `format plus sign`, `format alternate hex`, `we_can_display_test_scalar`.

## Validation
Passed locally on Windows with MSVC environment:

```text
cargo fmt --check
git diff --check
cargo test -p proof-of-sql --lib --no-default-features --features test we_can_display_test_scalar_as_full_width_hex -- --nocapture
cargo test -p proof-of-sql --lib --no-default-features --features test we_can_display_test_scalar_with_explicit_sign -- --nocapture
cargo test -p proof-of-sql --lib --no-default-features --features test we_can_display_test_scalar_as_compact_alternate_hex -- --nocapture
cargo test -p proof-of-sql --lib --no-default-features --features test test_scalar -- --nocapture
```

Result: 3 focused tests passed; 13 tests matched by the `test_scalar` filter passed.

## Evidence
MP4 evidence and supporting files: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-test-scalar-display-refresh78

## Payout wallet
EVM/USDC wallet: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`