### PR TITLE
test: cover fold scalars nu guards

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars_test.rs
@@ -35,3 +35,43 @@ fn we_can_fold_scalars() {
         verifier_folded_state
     );
 }
+
+#[test]
+#[should_panic(expected = "assertion `left == right` failed")]
+fn we_cannot_fold_scalars_with_nonzero_nu_on_prover_side() {
+    let mut rng = test_rng();
+    let nu = 1;
+    let pp = PublicParameters::test_rand(nu, &mut rng);
+    let prover_setup = (&pp).into();
+    let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
+    let (v1, v2) = rand_G_vecs(nu, &mut rng);
+    let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
+    let mut transcript = Transcript::new(b"fold_scalars_nonzero_nu_prover_test");
+    let mut messages = DoryMessages::default();
+
+    fold_scalars_0_prove(&mut messages, &mut transcript, prover_state, &prover_setup);
+}
+
+#[test]
+#[should_panic(expected = "assertion `left == right` failed")]
+fn we_cannot_fold_scalars_with_nonzero_nu_on_verifier_side() {
+    let mut rng = test_rng();
+    let nu = 1;
+    let pp = PublicParameters::test_rand(nu, &mut rng);
+    let prover_setup = (&pp).into();
+    let verifier_setup = (&pp).into();
+    let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
+    let (v1, v2) = rand_G_vecs(nu, &mut rng);
+    let prover_state = ExtendedProverState::new_from_tensors(s1_tensor, s2_tensor, v1, v2, nu);
+    let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+    let mut transcript = Transcript::new(b"fold_scalars_nonzero_nu_verifier_test");
+    let mut messages = DoryMessages::default();
+
+    fold_scalars_0_verify(
+        &mut messages,
+        &mut transcript,
+        verifier_state,
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs,
+    );
+}


### PR DESCRIPTION
/claim #560

## Summary

- Adds focused test-only coverage for `proof_primitive::dory::fold_scalars`.
- Covers the prover-side `nu == 0` guard rejecting nonzero `nu`.
- Covers the verifier-side `nu == 0` guard rejecting nonzero `nu`.

No production behavior changes.

## Deconfliction

I checked the current open #560 PR list before implementing. These terms had 0 hits across the open PR metadata inspected: `fold_scalars`, `fold_scalars_test.rs`, `fold scalars`.

`/attempt #560` comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4644551007

## Validation

Passed locally on Windows with MSVC environment:

```text
cargo fmt --check
git diff --check
cargo test -p proof-of-sql --lib --no-default-features --features test fold_scalars -- --nocapture
```

Result: 3 `fold_scalars` tests passed; 0 failed.

## Evidence

MP4 evidence and validation log: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-fold-scalars-guards-refresh80

## Payout wallet

EVM/USDC wallet: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`
