### PR TITLE
test: cover deferred msm batch construction

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/deferred_msm.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/deferred_msm.rs
@@ -140,4 +140,36 @@ mod test {
 
         assert_eq!(result, expected_result);
     }
+
+    #[test]
+    fn we_can_compute_deferred_group_elements_from_zipped_inputs() {
+        let rng = &mut ark_std::test_rng();
+        let bases = [
+            G1Affine::rand(rng),
+            G1Affine::rand(rng),
+            G1Affine::rand(rng),
+        ];
+        let scalars = [Fr::rand(rng), Fr::rand(rng), Fr::rand(rng)];
+
+        let result = DeferredMSM::<G1Affine, Fr>::new(bases, scalars);
+        let expected_result = bases[0] * scalars[0] + bases[1] * scalars[1] + bases[2] * scalars[2];
+
+        assert_eq!(result, expected_result);
+    }
+
+    #[test]
+    fn we_can_add_two_deferred_group_element_batches() {
+        let rng = &mut ark_std::test_rng();
+        let left_base = G1Affine::rand(rng);
+        let left_scalar = Fr::rand(rng);
+        let right_base = G1Affine::rand(rng);
+        let right_scalar = Fr::rand(rng);
+
+        let left = DeferredMSM::<G1Affine, Fr>::new([left_base], [left_scalar]);
+        let right = DeferredMSM::<G1Affine, Fr>::new([right_base], [right_scalar]);
+        let result = left + right;
+        let expected_result = left_base * left_scalar + right_base * right_scalar;
+
+        assert_eq!(result, expected_result);
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary

- Adds focused test-only coverage for `proof_primitive::dory::deferred_msm`.
- Covers `DeferredMSM::new` with zipped base/scalar inputs.
- Covers adding two independently constructed deferred MSM batches.

No production behavior changes.

## Deconfliction

I checked the current open #560 PR list before implementing. These terms had 0 hits across the open PR metadata inspected: `deferred_msm`, `deferred_msm.rs`, `DeferredMSM`.

`/attempt #560` comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4644571065

## Validation

Passed locally on Windows with MSVC environment:

```text
cargo fmt --check
git diff --check
cargo test -p proof-of-sql --lib --no-default-features --features test deferred_msm -- --nocapture
```

Result: 3 `deferred_msm` tests passed; 0 failed.

## Evidence

MP4 evidence and validation log: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-deferred-msm-new-add-refresh81

## Payout wallet

EVM/USDC wallet: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`
