### PR TITLE
test: cover i256 limb constructor

### DIFF
--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -284,6 +284,17 @@ mod tests {
         assert_eq!(I256::from(-2), NEG_TWO);
     }
     #[test]
+    fn we_can_construct_i256_from_limbs() {
+        let limbs = [
+            0x0123_4567_89AB_CDEF,
+            0xFEDC_BA98_7654_3210,
+            0x0F0F_F0F0_AAAA_5555,
+            0x8000_0000_0000_0001,
+        ];
+
+        assert_eq!(I256::new(limbs).limbs(), limbs);
+    }
+    #[test]
     fn we_can_convert_i256_between_type_compatibly() {
         let mut rng = thread_rng();
         for _ in 0..10 {


### PR DESCRIPTION
/claim #560

## Summary

- Adds focused test-only coverage for `base::math::i256`.
- Covers `I256::new` with explicit limb values.
- Verifies the test-only `limbs` accessor returns those limbs unchanged.

No production behavior changes.

## Deconfliction

I checked the current open #560 PR list before implementing. The term `i256.rs` had 0 hits across the open PR metadata inspected.

`/attempt #560` comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4644589179

## Validation

Passed locally on Windows with MSVC environment:

```text
cargo fmt --check
git diff --check
cargo test -p proof-of-sql --lib --no-default-features --features test i256 -- --nocapture
```

Result: 7 `i256` tests passed; 0 failed.

## Evidence

MP4 evidence and validation log: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-i256-new-limbs-refresh82

## Payout wallet

EVM/USDC wallet: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`
