### PR TITLE
test: cover missing verifier setup load

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
@@ -1,5 +1,6 @@
 use super::{test_rng, ProverSetup, PublicParameters, VerifierSetup};
 use ark_ec::pairing::Pairing;
+use std::io::ErrorKind;
 use std::{fs, path::Path};
 
 #[test]
@@ -90,6 +91,16 @@ fn we_can_create_save_load_and_manually_check_a_small_verifier_setup() {
     assert_eq!(setup.Gamma_2_fin, pp.Gamma_2_fin);
 
     fs::remove_file(Path::new("setup.bin")).unwrap();
+}
+
+#[test]
+fn we_get_an_error_when_loading_a_missing_verifier_setup_file() {
+    let path = Path::new("missing_verifier_setup_for_test.bin");
+    let _ = fs::remove_file(path);
+
+    let error = VerifierSetup::load_from_file(path).unwrap_err();
+
+    assert_eq!(error.kind(), ErrorKind::NotFound);
 }
 
 #[test]


### PR DESCRIPTION
/claim #560

## Summary

- Adds focused test-only coverage for `proof_primitive::dory::setup_test`.
- Covers the `VerifierSetup::load_from_file` missing-file error path.
- Asserts the returned `std::io::ErrorKind` is `NotFound`.

No production behavior changes.

## Deconfliction

I checked the current open #560 PR list before implementing. These terms had 0 hits across the open PR metadata inspected: `load_from_file`, `VerifierSetup::load_from_file`, `missing file`, `setup.bin`, `we_can_create_save_load_and_manually_check_a_small_verifier_setup`.

`/attempt #560` comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4644607771

## Validation

Passed locally on Windows with MSVC environment:

```text
cargo fmt --check
git diff --check
cargo test -p proof-of-sql --lib --no-default-features --features test setup_test -- --nocapture
```

Result: 6 `setup_test` tests passed; 0 failed.

## Evidence

MP4 evidence and validation log: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-verifier-setup-load-error-refresh83

## Payout wallet

EVM/USDC wallet: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`
