### PR TITLE
test: cover literal expr verifier paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -1,15 +1,20 @@
-use super::{DynProofExpr, ProofExpr};
+use super::{literal_expr::LiteralExpr, DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, table_utility::*, Column, ColumnType, OwnedTableTestAccessor,
-            Table, TableRef,
+            owned_table_utility::*, table_utility::*, Column, ColumnType, LiteralValue,
+            OwnedTableTestAccessor, Table, TableRef,
         },
+        map::IndexMap,
+        scalar::test_scalar::TestScalar,
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
+        proof::{
+            exercise_verification, mock_verification_builder::MockVerificationBuilder,
+            VerifiableQueryResult,
+        },
         proof_exprs::test_utility::*,
         proof_plans::test_utility::*,
     },
@@ -149,4 +154,43 @@ fn we_can_compute_the_correct_output_of_a_literal_expr_using_first_round_evaluat
         .unwrap();
     let expected_res = Column::Boolean(&[true, true, true, true]);
     assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_read_literal_expr_value_and_data_type() {
+    let literal_expr = LiteralExpr::new(LiteralValue::VarChar("hello".into()));
+
+    assert_eq!(literal_expr.value(), &LiteralValue::VarChar("hello".into()));
+    assert_eq!(literal_expr.data_type(), ColumnType::VarChar);
+}
+
+#[test]
+fn we_can_verify_boolean_literal_expr_values() {
+    let mut verification_builder = MockVerificationBuilder::new(
+        Vec::new(),
+        0,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let accessor = IndexMap::default();
+    let chi_eval = TestScalar::from(7_u64);
+
+    let true_expr = LiteralExpr::new(LiteralValue::Boolean(true));
+    assert_eq!(
+        true_expr
+            .verifier_evaluate(&mut verification_builder, &accessor, chi_eval, &[])
+            .unwrap(),
+        chi_eval
+    );
+
+    let false_expr = LiteralExpr::new(LiteralValue::Boolean(false));
+    assert_eq!(
+        false_expr
+            .verifier_evaluate(&mut verification_builder, &accessor, chi_eval, &[])
+            .unwrap(),
+        TestScalar::ZERO
+    );
 }


### PR DESCRIPTION
## Summary

- add direct coverage for `LiteralExpr::new`, `LiteralExpr::value`, and `LiteralExpr::data_type`
- cover verifier evaluation for boolean literal `true` and `false`, including the `chi_eval * literal_scalar` behavior

## Deconfliction

- Checked current open #560 PR metadata for `literal_expr`, `LiteralExpr`, and `literal_expr_test.rs`; found 0 hits before working on this slice.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test literal_expr -- --quiet` (8 passed; 0 failed)

## Evidence

- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-literal-expr-verifier-refresh85

/claim #560

Payout wallet (EVM/Base USDC): `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`