### PR TITLE
test: cover composite polynomial padding

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder_test.rs
@@ -1,5 +1,8 @@
 use super::CompositePolynomialBuilder;
-use crate::proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar;
+use crate::{
+    base::{polynomial::compute_evaluation_vector, scalar::Scalar},
+    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+};
 use num_traits::One;
 
 #[test]
@@ -115,5 +118,51 @@ fn we_can_handle_empty_terms_with_other_terms() {
     let eval4 = Curve25519Scalar::from(mle4[0]) * m0 + Curve25519Scalar::from(mle4[1]) * m1;
     let eval_fr = fr[0] * m0 + fr[1] * m1;
     let expected = eval_fr * (eval1 * eval2 + Curve25519Scalar::from(17)) - eval3 * eval4;
+    assert_eq!(p.evaluate(&pt), expected);
+}
+
+#[test]
+fn we_can_handle_padded_terms_and_single_term_zerosum_products() {
+    let fr = [
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(2u64),
+        Curve25519Scalar::from(3u64),
+    ];
+    let mle1 = [4, 5, 6];
+    let mle2 = [7, 8, 9];
+    let fr_multiplier = Curve25519Scalar::from(2u64);
+    let zerosum_multiplier = Curve25519Scalar::from(3u64);
+    let mut builder = CompositePolynomialBuilder::new(2, &fr);
+    builder.produce_fr_multiplicand(&fr_multiplier, &[Box::new(&mle1)]);
+    builder.produce_zerosum_multiplicand(&zerosum_multiplier, &[Box::new(&mle2)]);
+
+    let p = builder.make_composite_polynomial();
+
+    assert_eq!(p.products.len(), 2);
+    assert_eq!(p.flattened_ml_extensions.len(), 3);
+    let pt = [
+        Curve25519Scalar::from(9_268_764_u64),
+        Curve25519Scalar::from(21_533_u64),
+    ];
+    let mut evaluation_vec = vec![Curve25519Scalar::ZERO; 1 << pt.len()];
+    compute_evaluation_vector(&mut evaluation_vec, &pt);
+
+    let eval_fr = fr
+        .iter()
+        .zip(evaluation_vec.iter())
+        .map(|(x, eval)| *x * *eval)
+        .sum::<Curve25519Scalar>();
+    let eval1 = mle1
+        .iter()
+        .zip(evaluation_vec.iter())
+        .map(|(x, eval)| Curve25519Scalar::from(*x) * *eval)
+        .sum::<Curve25519Scalar>();
+    let eval2 = mle2
+        .iter()
+        .zip(evaluation_vec.iter())
+        .map(|(x, eval)| Curve25519Scalar::from(*x) * *eval)
+        .sum::<Curve25519Scalar>();
+    let expected = eval_fr * fr_multiplier * eval1 + zerosum_multiplier * eval2;
+
     assert_eq!(p.evaluate(&pt), expected);
 }


### PR DESCRIPTION
## Summary

- add coverage for `CompositePolynomialBuilder` with two sumcheck variables and non-power-of-two term lengths
- cover a single-term zerosum product alongside a first-round multiplicand
- assert the resulting composite polynomial shape and evaluation against an independently computed expected value

## Deconfliction

- Checked current open #560 PR metadata for `CompositePolynomialBuilder`, `produce_fr_multiplicand`, `produce_zerosum_multiplicand`, and `make_composite_polynomial`; found 0 direct hits before working on this slice.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test composite_polynomial_builder --no-run`

Note: local execution of the compiled test binary was blocked by Windows App Control (`os error 4551`) after successful compilation. I kept this explicit rather than claiming a local run that did not happen.

## Evidence

- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-composite-polynomial-padding-refresh86

/claim #560

Payout wallet (EVM/Base USDC): `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`