### PR TITLE
test: cover negative sign verifier path

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -71,6 +71,40 @@ fn we_can_verify_a_constant_decomposition() {
 }
 
 #[test]
+fn we_can_verify_a_negative_constant_decomposition() {
+    let data = [-123_i64, -123, -123];
+
+    let dists = [BitDistribution::new::<TestScalar, _>(&data)];
+    let scalars = [TestScalar::from(97), TestScalar::from(3432)];
+    let sumcheck_random_scalars = SumcheckRandomScalars::new(&scalars, data.len(), 2);
+    let evaluation_point = [TestScalar::from(324), TestScalar::from(97)];
+    let sumcheck_evaluations = SumcheckMleEvaluations::new(
+        data.len(),
+        [data.len()],
+        [],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &[],
+        &[],
+    );
+    let chi_evals = sumcheck_evaluations.chi_evaluations.clone();
+    let chi_eval = chi_evals.values().next().unwrap();
+
+    let mut builder = VerificationBuilderImpl::new(
+        sumcheck_evaluations,
+        &dists,
+        &[],
+        VecDeque::new(),
+        Vec::new(),
+        Vec::new(),
+        3,
+    );
+    let data_eval = (&data).evaluate_at_point(&evaluation_point);
+    let eval = verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, Some(8)).unwrap();
+    assert_eq!(eval, *chi_eval);
+}
+
+#[test]
 fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_distribution() {
     let data = [123_i64, 123, 123];
 


### PR DESCRIPTION
﻿/claim #560

## Summary
- Add focused test coverage for `verifier_evaluate_sign` with a constant negative column.
- Exercise the external `VerificationBuilderImpl` path with `BitDistribution`, `SumcheckMleEvaluations`, and `Some(8)` bit bounds.
- Assert the verifier returns `chi_eval` for the negative sign-bit path, complementing the existing positive constant and mismatch tests.
- Production code is unchanged.

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-sign-expr-negative-verifier-refresh89

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test sign_expr -- --quiet` -> 4 passed, 0 failed

## Deconfliction
- Before implementation, current open #560 PR metadata had 0 hits for `sign_expr` and this change is limited to `crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs`.
