### PR TITLE
test: cover fold util edge cases

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -122,3 +122,15 @@ fn we_can_fold_vals() {
         (12345).into()
     );
 }
+
+#[test]
+fn fold_vals_handles_single_value_and_zero_beta() {
+    let vals = [
+        Curve25519Scalar::from(4),
+        Curve25519Scalar::from(9),
+        Curve25519Scalar::from(16),
+    ];
+
+    assert_eq!(fold_vals(Curve25519Scalar::from(123), &[vals[0]]), vals[0]);
+    assert_eq!(fold_vals(Curve25519Scalar::zero(), &vals), vals[2]);
+}


### PR DESCRIPTION
﻿/claim #560

## Summary
- Add focused test coverage for `fold_vals` edge cases.
- Cover that a single-value fold returns the value regardless of beta.
- Cover that zero beta on a non-empty input returns the last value.
- Production code is unchanged.

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-fold-util-edge-cases-refresh90

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test fold_util -- --quiet` -> 5 passed, 0 failed

## Deconfliction
- Before implementation, current open #560 PR metadata had 0 hits for `fold_util`.
- Change is limited to `crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs`.
