### PR TITLE
test: cover column expression metadata

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
@@ -2,15 +2,23 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, ColumnField, ColumnType, OwnedTableTestAccessor, TableRef,
+            owned_table_utility::*, ColumnField, ColumnRef, ColumnType, OwnedTableTestAccessor,
+            TableRef,
         },
+        map::{indexmap, IndexSet},
+        proof::ProofError,
+        scalar::test_scalar::TestScalar,
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::test_utility::*,
+        proof::{
+            exercise_verification, mock_verification_builder::MockVerificationBuilder,
+            VerifiableQueryResult,
+        },
+        proof_exprs::{test_utility::*, ColumnExpr, ProofExpr},
         proof_plans::test_utility::*,
     },
 };
+use sqlparser::ast::Ident;
 
 #[test]
 fn we_can_prove_a_query_with_a_single_selected_row() {
@@ -33,4 +41,44 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
         .table;
     let expected_res = owned_table([boolean("a", [true, false])]);
     assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_inspect_column_expr_metadata_and_missing_verifier_column_error() {
+    let t = TableRef::new("sxt", "t");
+    let column_ref = ColumnRef::new(t, Ident::from("a"), ColumnType::Boolean);
+    let expr = ColumnExpr::new(column_ref.clone());
+
+    assert_eq!(expr.get_column_reference(), column_ref);
+    assert_eq!(expr.column_ref(), &column_ref);
+    assert_eq!(expr.column_id(), Ident::from("a"));
+    assert_eq!(
+        expr.get_column_field(),
+        ColumnField::new("a".into(), ColumnType::Boolean)
+    );
+
+    let mut columns = IndexSet::default();
+    expr.get_column_references(&mut columns);
+    assert_eq!(columns.len(), 1);
+    assert!(columns.contains(&column_ref));
+
+    let mut verifier = MockVerificationBuilder::<TestScalar>::new(
+        Vec::new(),
+        1,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let accessor = indexmap! {};
+    let err = expr
+        .verifier_evaluate(&mut verifier, &accessor, TestScalar::ONE, &[])
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ProofError::VerificationError {
+            error: "Column Not Found"
+        }
+    ));
 }


### PR DESCRIPTION
/claim #560

Summary:
- Adds focused unit coverage for `ColumnExpr` metadata/reference helpers.
- Checks `get_column_reference`, `column_ref`, `column_id`, `get_column_field`, and `get_column_references`.
- Covers the verifier missing-column error path (`Column Not Found`).
- Keeps the change test-only; production code is unchanged.

Evidence:
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-column-expr-metadata-refresh94

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test column_expr -- --quiet`

Deconfliction:
- Current open PR metadata refresh94 showed zero open PR file hits for `crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs`.
- The local ledger has no previous claim against this file.
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4644840850