### PR TITLE
test: cover placeholder verifier evaluation

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
@@ -6,11 +6,15 @@ use crate::{
             owned_table_utility::*, table_utility::*, Column, ColumnType, LiteralValue,
             OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
         },
+        map::{indexmap, IndexSet},
         proof::{PlaceholderError, ProofError},
+        scalar::test_scalar::TestScalar,
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        proof::{QueryError, VerifiableQueryResult},
+        proof::{
+            mock_verification_builder::MockVerificationBuilder, QueryError, VerifiableQueryResult,
+        },
         proof_exprs::test_utility::*,
         proof_plans::test_utility::*,
     },
@@ -176,6 +180,35 @@ fn we_can_compute_the_correct_output_of_a_placeholder_expr_using_first_round_eva
         .unwrap();
     let expected_res = Column::BigInt(&[504, 504, 504, 504]);
     assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_verify_a_placeholder_expr_directly() {
+    let placeholder_expr = PlaceholderExpr::try_new(1, ColumnType::BigInt).unwrap();
+    let mut verifier = MockVerificationBuilder::<TestScalar>::new(
+        Vec::new(),
+        1,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let accessor = indexmap! {};
+    let chi_eval = TestScalar::from(7);
+    let res = placeholder_expr
+        .verifier_evaluate(
+            &mut verifier,
+            &accessor,
+            chi_eval,
+            &[LiteralValue::BigInt(6)],
+        )
+        .unwrap();
+    assert_eq!(res, TestScalar::from(42));
+
+    let mut columns = IndexSet::default();
+    placeholder_expr.get_column_references(&mut columns);
+    assert!(columns.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
/claim #560

Summary:
- Adds focused unit coverage for `PlaceholderExpr::verifier_evaluate`.
- Verifies `chi_eval * param_scalar` behavior directly.
- Asserts placeholders report no column references.
- Keeps the change test-only; production code is unchanged.

Evidence:
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-placeholder-verifier-refresh97

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test placeholder_expr -- --quiet`

Deconfliction:
- Current open PR metadata refresh97 showed zero open PR file hits for `crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs`.
- The local ledger has no previous claim against this file.
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4644889151