### PR TITLE
test: cover complex boolean proof verification

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -1,9 +1,21 @@
 use super::{test_utility::*, DynProofExpr, ProofExpr};
 use crate::base::{
     commitment::InnerProductProof,
-    database::{table_utility::*, Column, TableRef, TableTestAccessor, TestAccessor},
+    database::{
+        table_utility::*, Column, ColumnRef, ColumnType, Table, TableRef, TableTestAccessor,
+        TestAccessor,
+    },
+    map::indexmap,
+    polynomial::MultilinearExtension,
+    scalar::test_scalar::TestScalar,
 };
+use crate::sql::proof::{
+    mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder, FirstRoundBuilder,
+};
+use crate::sql::proof_exprs::ColumnExpr;
 use bumpalo::Bump;
+use sqlparser::ast::Ident;
+use std::collections::VecDeque;
 
 #[test]
 fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_first_round_evaluate() {
@@ -47,4 +59,62 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_first_round_ev
         false, false, false,
     ]);
     assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_verify_the_correct_result_of_a_complex_bool_expr() {
+    let alloc = Bump::new();
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let lhs = &[true, true, false, false];
+    let rhs = &[true, false, true, false];
+    let excluded = &[false, true, false, true];
+    let expected = &[true, false, true, false];
+    let table = Table::try_new(indexmap! {
+        "lhs".into() => Column::Boolean::<TestScalar>(lhs),
+        "rhs".into() => Column::Boolean::<TestScalar>(rhs),
+        "excluded".into() => Column::Boolean::<TestScalar>(excluded),
+    })
+    .unwrap();
+    let lhs_ref = ColumnRef::new(t.clone(), Ident::from("lhs"), ColumnType::Boolean);
+    let rhs_ref = ColumnRef::new(t.clone(), Ident::from("rhs"), ColumnType::Boolean);
+    let excluded_ref = ColumnRef::new(t, Ident::from("excluded"), ColumnType::Boolean);
+    let bool_expr: DynProofExpr = and(
+        or(
+            DynProofExpr::Column(ColumnExpr::new(lhs_ref.clone())),
+            DynProofExpr::Column(ColumnExpr::new(rhs_ref.clone())),
+        ),
+        not(DynProofExpr::Column(ColumnExpr::new(excluded_ref.clone()))),
+    );
+
+    let first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(4);
+    let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
+        FinalRoundBuilder::new(4, VecDeque::new());
+
+    let res = bool_expr
+        .final_round_evaluate(&mut final_round_builder, &alloc, &table, &[])
+        .unwrap();
+    assert_eq!(res, Column::Boolean(expected));
+
+    let verification_builder = run_verify_for_each_row(
+        4,
+        &first_round_builder,
+        &final_round_builder,
+        Vec::new(),
+        3,
+        |verification_builder, chi_eval, evaluation_point| {
+            let accessor = indexmap! {
+                lhs_ref.clone().column_id() => lhs.inner_product(evaluation_point),
+                rhs_ref.clone().column_id() => rhs.inner_product(evaluation_point),
+                excluded_ref.clone().column_id() => excluded.inner_product(evaluation_point),
+            };
+            let res = bool_expr
+                .verifier_evaluate(verification_builder, &accessor, chi_eval, &[])
+                .unwrap();
+            assert_eq!(res, expected.inner_product(evaluation_point));
+        },
+    );
+    assert_eq!(
+        verification_builder.get_identity_results(),
+        vec![vec![true, true, true]; 4]
+    );
 }


### PR DESCRIPTION
/claim #560

## Summary
- Adds verifier-level coverage for a composed boolean proof expression: `and(or(lhs, rhs), not(excluded))`.
- Checks the final-round boolean result and row-wise verifier output.
- Asserts all identity subpolynomial evaluations from the composed expression succeed.

## Scope / Deconfliction
- File: `crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs`
- Refresh99 open PR metadata showed zero open PR file hits for this test file.
- Local claim ledger has no previous claim against this file.
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4644944016

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-complex-bool-verifier-refresh99

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_expr -- --quiet` -> 46 passed, 0 failed