### PR TITLE
test: cover table exec verifier metadata

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
@@ -1,13 +1,21 @@
 use super::test_utility::*;
 use crate::{
     base::database::{
-        owned_table_utility::*, table_utility::*, ColumnField, ColumnType, TableRef,
-        TableTestAccessor,
+        owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
+        TableEvaluation, TableRef, TableTestAccessor,
     },
-    sql::proof::{exercise_verification, VerifiableQueryResult},
+    base::{
+        map::{indexmap, indexset},
+        scalar::test_scalar::TestScalar,
+    },
+    sql::proof::{
+        exercise_verification, mock_verification_builder::MockVerificationBuilder, ProofPlan,
+        VerifiableQueryResult,
+    },
 };
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
+use sqlparser::ast::Ident;
 
 #[test]
 fn we_can_create_and_prove_an_empty_table_exec() {
@@ -91,4 +99,54 @@ fn we_can_create_and_prove_a_table_exec() {
         ),
     ]);
     assert_eq!(res, expected);
+}
+
+#[test]
+fn we_can_verify_table_exec_metadata_and_evaluations_directly() {
+    let table_ref = TableRef::new("namespace", "table_name");
+    let schema = vec![
+        ColumnField::new("language_rank".into(), ColumnType::BigInt),
+        ColumnField::new("language_name".into(), ColumnType::VarChar),
+    ];
+    let plan = table_exec(table_ref.clone(), schema.clone());
+
+    assert_eq!(plan.get_column_result_fields(), schema);
+    assert_eq!(plan.get_table_references(), indexset! { table_ref.clone() });
+    assert_eq!(
+        plan.get_column_references(),
+        indexset! {
+            ColumnRef::new(table_ref.clone(), Ident::from("language_rank"), ColumnType::BigInt),
+            ColumnRef::new(table_ref.clone(), Ident::from("language_name"), ColumnType::VarChar),
+        }
+    );
+
+    let mut builder = MockVerificationBuilder::<TestScalar>::new(
+        Vec::new(),
+        0,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let accessor = indexmap! {
+        table_ref.clone() => indexmap! {
+            Ident::from("language_rank") => TestScalar::from(1),
+            Ident::from("language_name") => TestScalar::from(2),
+        },
+    };
+    let chi_eval_map = indexmap! {
+        table_ref => (TestScalar::from(3), 4),
+    };
+
+    let res = plan
+        .verifier_evaluate(&mut builder, &accessor, &chi_eval_map, &[])
+        .unwrap();
+    assert_eq!(
+        res,
+        TableEvaluation::new(
+            vec![TestScalar::from(1), TestScalar::from(2)],
+            (TestScalar::from(3), 4)
+        )
+    );
 }


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage for `TableExec` metadata and verifier evaluation.
- Checks result fields, table references, column references, and verifier output.
- Keeps the change test-only; no production behavior changes.

## Scope / Deconfliction
- File: `crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs`
- Refresh101 open PR metadata showed zero open PR file hits for this test file.
- Local claim ledger has no previous claim against this file.
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4644993543

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-table-exec-metadata-refresh101

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test table_exec -- --quiet` -> 3 passed, 0 failed