### PR TITLE
test: cover empty slice casting

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
@@ -8,6 +8,15 @@ fn test_slice_map_to_vec() {
     assert_eq!(a, b);
 }
 
+#[test]
+fn test_slice_cast_empty_slice() {
+    let a: Vec<u32> = vec![];
+    let b: Vec<u64> = slice_cast_with(&a, |&x| u64::from(x));
+    let c: Vec<TestScalar> = slice_cast(&a);
+    assert!(b.is_empty());
+    assert!(c.is_empty());
+}
+
 /// random test for [`slice_cast_with`]
 #[test]
 fn test_slice_cast_with_random() {
@@ -48,6 +57,17 @@ fn test_slice_cast_mut() {
     let mut b: Vec<u64> = vec![0, 0, 0, 0];
     slice_cast_mut_with(&a, &mut b, |&x| u64::from(x));
     assert_eq!(b, slice_cast_with(&a, |&x| u64::from(x)));
+}
+
+#[test]
+fn test_slice_cast_mut_empty_slice() {
+    let a: Vec<u32> = vec![];
+    let mut b: Vec<u64> = vec![];
+    let mut c: Vec<TestScalar> = vec![];
+    slice_cast_mut_with(&a, &mut b, |&x| u64::from(x));
+    slice_cast_mut(&a, &mut c);
+    assert!(b.is_empty());
+    assert!(c.is_empty());
 }
 
 /// random test for [`slice_cast_mut_with`]


### PR DESCRIPTION
/claim #560

## Summary
- Adds empty-input coverage for slice casting helpers.
- Covers `slice_cast_with`, `slice_cast`, `slice_cast_mut_with`, and `slice_cast_mut` on empty slices.
- Keeps the change test-only; no production behavior changes.

## Scope / Deconfliction
- File: `crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs`
- Refresh102 open PR metadata showed zero open PR file hits for this test file.
- Local claim ledger has no previous claim against this file.
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4645017493

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-slice-cast-empty-refresh102

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test slice_cast_test -- --quiet` -> 9 passed, 0 failed