### PR TITLE
[codex] test: reduce Dory setup work

### DIFF
--- a/crates/proof-of-sql-benches/src/main.rs
+++ b/crates/proof-of-sql-benches/src/main.rs
@@ -85,6 +85,22 @@ enum CommitmentScheme {
     HyperKZG,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DoryBenchmarkSet {
+    Dory,
+    DynamicDory,
+    Both,
+}
+
+fn dory_benchmark_set(scheme: &CommitmentScheme) -> Option<DoryBenchmarkSet> {
+    match scheme {
+        CommitmentScheme::All => Some(DoryBenchmarkSet::Both),
+        CommitmentScheme::Dory => Some(DoryBenchmarkSet::Dory),
+        CommitmentScheme::DynamicDory => Some(DoryBenchmarkSet::DynamicDory),
+        CommitmentScheme::InnerProductProof | CommitmentScheme::HyperKZG => None,
+    }
+}
+
 #[derive(ValueEnum, Clone, Debug, PartialEq)]
 /// Supported queries.
 enum Query {
@@ -140,6 +156,18 @@ impl Query {
             Query::LimitOffset => "Limit Offset",
             Query::Not => "Not",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_scheme_uses_one_dory_setup_for_static_and_dynamic() {
+        let set = dory_benchmark_set(&CommitmentScheme::All).unwrap();
+
+        assert_eq!(set, DoryBenchmarkSet::Both);
     }
 }
 
@@ -375,14 +403,14 @@ fn load_dory_setup<'a>(
 /// * `cli` - A reference to the command line interface arguments.
 /// * `queries` - A slice of query entries to benchmark.
 #[tracing::instrument(name = "Dory", level = "debug", skip_all)]
-fn bench_dory(cli: &Cli, queries: &[QueryEntry]) {
-    let span = span!(Level::DEBUG, "setup", sigma = cli.nu_sigma).entered();
-    let public_parameters = load_dory_public_parameters(cli);
-    let (prover_setup, verifier_setup) = load_dory_setup(&public_parameters, cli);
-
-    let prover_public_setup = DoryProverPublicSetup::new(&prover_setup, cli.nu_sigma);
-    let verifier_public_setup = DoryVerifierPublicSetup::new(&verifier_setup, cli.nu_sigma);
-    span.exit();
+fn bench_dory_with_setup<'a>(
+    cli: &Cli,
+    queries: &[QueryEntry],
+    prover_setup: &'a ProverSetup<'a>,
+    verifier_setup: &'a VerifierSetup,
+) {
+    let prover_public_setup = DoryProverPublicSetup::new(prover_setup, cli.nu_sigma);
+    let verifier_public_setup = DoryVerifierPublicSetup::new(verifier_setup, cli.nu_sigma);
 
     bench_by_schema::<DoryEvaluationProof>(
         "Dory",
@@ -399,19 +427,40 @@ fn bench_dory(cli: &Cli, queries: &[QueryEntry]) {
 /// * `cli` - A reference to the command line interface arguments.
 /// * `queries` - A slice of query entries to benchmark.
 #[tracing::instrument(name = "Dynamic Dory", level = "debug", skip_all)]
-fn bench_dynamic_dory(cli: &Cli, queries: &[QueryEntry]) {
-    let span = span!(Level::DEBUG, "setup", nu = cli.nu_sigma).entered();
-    let public_parameters = load_dory_public_parameters(cli);
-    let (prover_setup, verifier_setup) = load_dory_setup(&public_parameters, cli);
-    span.exit();
-
+fn bench_dynamic_dory_with_setup<'a>(
+    cli: &Cli,
+    queries: &[QueryEntry],
+    prover_setup: &'a ProverSetup<'a>,
+    verifier_setup: &'a VerifierSetup,
+) {
     bench_by_schema::<DynamicDoryEvaluationProof>(
         "Dynamic Dory",
         cli,
         queries,
-        &prover_setup,
-        &verifier_setup,
+        prover_setup,
+        verifier_setup,
     );
+}
+
+#[tracing::instrument(name = "Dory Schemes", level = "debug", skip_all)]
+fn bench_dory_schemes(cli: &Cli, queries: &[QueryEntry], set: DoryBenchmarkSet) {
+    let span = span!(Level::DEBUG, "setup", nu_sigma = cli.nu_sigma).entered();
+    let public_parameters = load_dory_public_parameters(cli);
+    let (prover_setup, verifier_setup) = load_dory_setup(&public_parameters, cli);
+    span.exit();
+
+    match set {
+        DoryBenchmarkSet::Dory => {
+            bench_dory_with_setup(cli, queries, &prover_setup, &verifier_setup);
+        }
+        DoryBenchmarkSet::DynamicDory => {
+            bench_dynamic_dory_with_setup(cli, queries, &prover_setup, &verifier_setup);
+        }
+        DoryBenchmarkSet::Both => {
+            bench_dory_with_setup(cli, queries, &prover_setup, &verifier_setup);
+            bench_dynamic_dory_with_setup(cli, queries, &prover_setup, &verifier_setup);
+        }
+    }
 }
 
 /// Benchmarks the `HyperKZG` scheme.
@@ -494,18 +543,29 @@ fn main() {
     match cli.scheme {
         CommitmentScheme::All => {
             bench_inner_product_proof(&cli, &queries);
-            bench_dory(&cli, &queries);
-            bench_dynamic_dory(&cli, &queries);
+            bench_dory_schemes(
+                &cli,
+                &queries,
+                dory_benchmark_set(&cli.scheme).expect("all includes Dory schemes"),
+            );
             bench_hyperkzg(&cli, &queries);
         }
         CommitmentScheme::InnerProductProof => {
             bench_inner_product_proof(&cli, &queries);
         }
         CommitmentScheme::Dory => {
-            bench_dory(&cli, &queries);
+            bench_dory_schemes(
+                &cli,
+                &queries,
+                dory_benchmark_set(&cli.scheme).expect("Dory includes Dory scheme"),
+            );
         }
         CommitmentScheme::DynamicDory => {
-            bench_dynamic_dory(&cli, &queries);
+            bench_dory_schemes(
+                &cli,
+                &queries,
+                dory_benchmark_set(&cli.scheme).expect("Dynamic Dory includes Dory scheme"),
+            );
         }
         CommitmentScheme::HyperKZG => {
             bench_hyperkzg(&cli, &queries);

--- a/crates/proof-of-sql-planner/examples/hello_world/main.rs
+++ b/crates/proof-of-sql-planner/examples/hello_world/main.rs
@@ -20,6 +20,11 @@ use std::{
     io::{stdout, Write},
     time::Instant,
 };
+
+// The example table has four fixed rows. max_nu = 2 supports up to 8 rows under
+// the Dory setup capacity formula 2^(2 * max_nu - 1).
+const DORY_SETUP_MAX_NU: usize = 2;
+
 /// # Panics
 ///
 /// Will panic if flushing the output fails, which can happen due to issues with the underlying output stream.
@@ -45,7 +50,7 @@ fn main() {
     let timer = start_timer("Loading data");
     // Use a fixed seed for deterministic results
     let mut rng = StdRng::from_seed([0u8; 32]);
-    let public_parameters = PublicParameters::rand(5, &mut rng);
+    let public_parameters = PublicParameters::rand(DORY_SETUP_MAX_NU, &mut rng);
     let prover_setup = ProverSetup::from(&public_parameters);
     let verifier_setup = VerifierSetup::from(&public_parameters);
     let mut accessor =

--- a/crates/proof-of-sql-planner/examples/posql_db/main.rs
+++ b/crates/proof-of-sql-planner/examples/posql_db/main.rs
@@ -27,6 +27,7 @@ use proof_of_sql::{
     sql::proof::VerifiableQueryResult,
 };
 use proof_of_sql_planner::{get_table_refs_from_statement, sql_to_proof_plans};
+use rand::{rngs::StdRng, SeedableRng};
 use sqlparser::{ast::Ident, dialect::GenericDialect, parser::Parser as SqlParser};
 use std::{
     fs,
@@ -35,6 +36,8 @@ use std::{
     sync::Arc,
     time::Instant,
 };
+
+const DORY_SETUP_MAX_NU: usize = 5;
 
 /// Command line interface demonstrating an implementation of a simple csv-backed database with Proof of SQL capabilities.
 #[derive(Parser, Debug)]
@@ -134,6 +137,11 @@ fn end_timer(instant: Instant) {
     println!(" {:?}", instant.elapsed());
 }
 
+fn dory_public_parameters() -> PublicParameters {
+    let mut rng = StdRng::from_seed([0u8; 32]);
+    PublicParameters::rand(DORY_SETUP_MAX_NU, &mut rng)
+}
+
 /// # Panics
 ///
 /// This function can panic under the following circumstances:
@@ -153,16 +161,14 @@ fn end_timer(instant: Instant) {
 fn main() {
     let args = CliArgs::parse();
 
-    let mut rng = <ark_std::rand::rngs::StdRng as ark_std::rand::SeedableRng>::from_seed([0u8; 32]);
-    let public_parameters = PublicParameters::rand(5, &mut rng);
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let verifier_setup = VerifierSetup::from(&public_parameters);
     match args.command {
         Commands::Create {
             table,
             columns,
             data_types,
         } => {
+            let public_parameters = dory_public_parameters();
+            let prover_setup = ProverSetup::from(&public_parameters);
             let commit_accessor =
                 CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let csv_accessor = CsvDataAccessor::new(PathBuf::from(args.path));
@@ -189,6 +195,8 @@ fn main() {
             table: table_name,
             file: file_path,
         } => {
+            let public_parameters = dory_public_parameters();
+            let prover_setup = ProverSetup::from(&public_parameters);
             let mut commit_accessor =
                 CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let csv_accessor = CsvDataAccessor::new(PathBuf::from(args.path));
@@ -218,6 +226,8 @@ fn main() {
                 .expect("Failed to write commit");
         }
         Commands::Prove { query, file } => {
+            let public_parameters = dory_public_parameters();
+            let prover_setup = ProverSetup::from(&public_parameters);
             let mut commit_accessor =
                 CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let mut csv_accessor = CsvDataAccessor::new(PathBuf::from(args.path.clone()));
@@ -263,6 +273,8 @@ fn main() {
             .expect("Failed to write proof");
         }
         Commands::Verify { query, file } => {
+            let public_parameters = dory_public_parameters();
+            let verifier_setup = VerifierSetup::from(&public_parameters);
             let mut commit_accessor =
                 CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
 


### PR DESCRIPTION
Contributes to #557
/claim #557

## Summary

This PR reduces redundant Dory setup work in three narrow paths:

- `proof-of-sql-benches` tracing binary: when running with `--scheme all`, static Dory and Dynamic Dory now share the same loaded/generated public parameters and prover/verifier setup instead of loading/building them separately.
- `proof-of-sql-planner` `hello_world` example: the fixed four-row example now uses `max_nu = 2`, which still covers the table under the Dory setup capacity formula `2^(2 * max_nu - 1)` while avoiding the previous over-provisioned `max_nu = 5` setup generation.
- `proof-of-sql-planner` `posql_db` example: the general CLI keeps the same `max_nu = 5` capacity, but only builds the setup required by the selected subcommand. `create`, `append`, and `prove` skip verifier setup; `verify` skips prover setup.

Single-scheme benchmark runs stay scoped: `--scheme dory` still runs only Dory and `--scheme dynamic-dory` still runs only Dynamic Dory. The benchmark prove/verify loops, example queries, example data, setup capacity for the general `posql_db` CLI, and proof verification behavior are unchanged.

## Validation

Fresh validation on June 8, 2026 in WSL/Ubuntu:

- `cargo fmt --check --all`
- `git diff --check -- crates/proof-of-sql-benches/src/main.rs crates/proof-of-sql-planner/examples/hello_world/main.rs`
- `git diff --check -- crates/proof-of-sql-planner/examples/posql_db/main.rs`
- `CARGO_TARGET_DIR=/tmp/sxt-target cargo check -j1 -p proof-of-sql-benches --bin proof-of-sql-benches`
- `CARGO_TARGET_DIR=/tmp/sxt-target cargo test -j1 -p proof-of-sql-benches --bin proof-of-sql-benches all_scheme_uses_one_dory_setup_for_static_and_dynamic`
- `CARGO_TARGET_DIR=/tmp/sxt-target cargo run -j1 -p proof-of-sql-planner --example hello_world --no-default-features --features 'proof-of-sql/test,cpu-perf'`
- `CARGO_TARGET_DIR=/tmp/sxt-target cargo check -j1 -p proof-of-sql-planner --example posql_db --features 'proof-of-sql/utils'`
- CPU-only `posql_db` quick start: create, append, prove, verify.

Latest focused bench harness rerun result on commit `1c8878e`: `1 passed; 0 failed`; cached test build finished in 34.90s locally.

The `hello_world` example still prints `Valid proof!` and returns the expected `hello` / `world` rows. Local sample `Loading data` timing for that example was about 2.32s before the setup-size change and 0.89s after it, using the same CPU-only command above.

The `posql_db` quick start generated and verified a proof successfully after commit `4d5d9b3`; `verify` returned the expected `hello` / `world` rows. The `cargo check` output still includes existing unused warnings in `proof-of-sql`, with no new compile errors from this change.