### PR TITLE
test: cover empty evaluation vector output

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
@@ -66,6 +66,20 @@ fn we_compute_the_evaluation_vector_for_an_empty_point() {
 }
 
 #[test]
+fn we_compute_the_evaluation_vector_for_an_empty_output() {
+    let mut v = [];
+    compute_evaluation_vector(
+        &mut v,
+        &[
+            TestScalar::from(3u64),
+            TestScalar::from(5u64),
+            TestScalar::from(7u64),
+        ],
+    );
+    assert!(v.is_empty());
+}
+
+#[test]
 fn we_get_the_same_result_using_evaluation_vector_as_direct_evaluation() {
     let xs = [
         TestScalar::from(3u64),


### PR DESCRIPTION
/claim #560

Scope: focused test-only coverage for empty output handling in `compute_evaluation_vector`.

This PR adds `we_compute_the_evaluation_vector_for_an_empty_output` in `crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs`, covering the `v.is_empty()` early-return branch with a non-empty evaluation point. Production code is unchanged.

Evidence MP4:
- https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-evaluation-vector-empty-refresh103

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test evaluation_vector -- --quiet` -> 8 passed, 0 failed

Deconfliction: refresh103 open PR metadata showed zero open PR file hits for this test file, and the local ledger has no previous claim against it. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4645043458