### PR TITLE
test: cover verifier state constructor

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/state_test.rs
@@ -1,4 +1,4 @@
-use super::{rand_G_vecs, test_rng, ProverState, PublicParameters};
+use super::{rand_G_vecs, test_rng, ProverSetup, ProverState, PublicParameters, VerifierState};
 use ark_ec::pairing::Pairing;
 
 #[test]
@@ -21,4 +21,23 @@ pub fn we_can_create_a_verifier_state_from_a_prover_state() {
         assert_eq!(verifier_state.D_2, D_2);
         assert_eq!(verifier_state.nu, nu);
     }
+}
+
+#[test]
+pub fn we_can_create_a_verifier_state_from_commitments() {
+    let mut rng = test_rng();
+    let nu = 3;
+    let pp = PublicParameters::test_rand(nu, &mut rng);
+    let prover_setup: ProverSetup = (&pp).into();
+    let (v1, v2) = rand_G_vecs(nu, &mut rng);
+
+    let C = Pairing::multi_pairing(&v1, &v2);
+    let D_1 = Pairing::multi_pairing(&v1, prover_setup.Gamma_2[nu]);
+    let D_2 = Pairing::multi_pairing(prover_setup.Gamma_1[nu], &v2);
+    let verifier_state = VerifierState::new(C.into(), D_1.into(), D_2.into(), nu);
+
+    assert_eq!(verifier_state.C, C);
+    assert_eq!(verifier_state.D_1, D_1);
+    assert_eq!(verifier_state.D_2, D_2);
+    assert_eq!(verifier_state.nu, nu);
 }


### PR DESCRIPTION
/claim #560

Scope: focused test-only coverage for `VerifierState::new`.

This PR adds `we_can_create_a_verifier_state_from_commitments` in `crates/proof-of-sql/src/proof_primitive/dory/state_test.rs`, covering direct verifier state construction from commitment values. Production code is unchanged.

Evidence MP4:
- https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-verifier-state-new-refresh104

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test state_test -- --quiet` -> 5 passed, 0 failed

Deconfliction: refresh104 open PR metadata showed zero open PR file hits for this test file, and the local ledger has no previous claim against it. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4645061302