### PR TITLE
test: cover owned table metadata accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -101,6 +101,39 @@ fn we_can_create_an_owned_table_with_data() {
     );
     assert_eq!(owned_table.into_inner(), table);
 }
+
+#[test]
+fn we_can_inspect_owned_table_metadata_and_columns_by_index() {
+    let owned_table = owned_table::<TestScalar>([
+        bigint("bigint", [10, 20]),
+        varchar("varchar", ["left", "right"]),
+        boolean("boolean", [true, false]),
+    ]);
+
+    assert_eq!(owned_table.num_columns(), 3);
+    assert_eq!(owned_table.num_rows(), 2);
+    assert!(!owned_table.is_empty());
+    assert_eq!(
+        owned_table
+            .column_names()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+        ["bigint", "varchar", "boolean"]
+    );
+    assert_eq!(
+        owned_table.column_by_index(0),
+        Some(&OwnedColumn::BigInt(vec![10, 20]))
+    );
+    assert_eq!(
+        owned_table.column_by_index(1),
+        Some(&OwnedColumn::VarChar(vec![
+            "left".to_string(),
+            "right".to_string()
+        ]))
+    );
+    assert_eq!(owned_table.column_by_index(3), None);
+}
+
 #[test]
 fn we_get_inequality_between_tables_with_differing_column_order() {
     let owned_table_a: OwnedTable<TestScalar> = owned_table([


### PR DESCRIPTION
/claim #560

Scope: focused test-only coverage for `OwnedTable` metadata/accessor helpers.

This PR adds `we_can_inspect_owned_table_metadata_and_columns_by_index` in `crates/proof-of-sql/src/base/database/owned_table_test.rs`, covering `num_rows`, `is_empty`, `column_names`, `column_by_index`, and the out-of-range `None` case. Production code is unchanged.

Evidence MP4:
- https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-owned-table-accessors-refresh105

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test owned_table_test -- --quiet` -> 7 passed, 0 failed

Deconfliction: refresh105 open PR metadata showed zero open PR file hits for this test file, and the local ledger has no previous claim against it. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4645077702