### PR TITLE
test: cover sumcheck mle evaluation metadata

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
@@ -1,5 +1,6 @@
 use super::SumcheckMleEvaluations;
 use crate::{
+    base::polynomial::{compute_rho_eval, compute_truncated_lagrange_basis_sum},
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::SumcheckRandomScalars,
 };
@@ -46,5 +47,69 @@ fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
     assert_eq!(
         *evals.chi_evaluations.values().next().unwrap(),
         expected_eval
+    );
+}
+
+#[test]
+fn we_can_track_rho_singleton_rho_256_and_pcs_evaluations() {
+    let evaluation_point = [
+        Curve25519Scalar::from(1u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+        Curve25519Scalar::from(0u64),
+    ];
+    let random_scalars = [
+        Curve25519Scalar::from(11u64),
+        Curve25519Scalar::from(12u64),
+        Curve25519Scalar::from(13u64),
+        Curve25519Scalar::from(14u64),
+        Curve25519Scalar::from(15u64),
+        Curve25519Scalar::from(16u64),
+        Curve25519Scalar::from(17u64),
+        Curve25519Scalar::from(18u64),
+        Curve25519Scalar::from(19u64),
+    ];
+    let sumcheck_random_scalars = SumcheckRandomScalars::new(&random_scalars, 5, 9);
+    let first_round_pcs_proof_evaluations =
+        [Curve25519Scalar::from(21u64), Curve25519Scalar::from(22u64)];
+    let final_round_pcs_proof_evaluations = [Curve25519Scalar::from(31u64)];
+
+    let evals = SumcheckMleEvaluations::new(
+        5,
+        [5, 1, 5],
+        [5, 3],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &first_round_pcs_proof_evaluations,
+        &final_round_pcs_proof_evaluations,
+    );
+
+    assert_eq!(evals.chi_evaluations.len(), 2);
+    assert_eq!(
+        evals.chi_evaluations[&5],
+        compute_truncated_lagrange_basis_sum(5, &evaluation_point)
+    );
+    assert_eq!(evals.rho_evaluations.len(), 2);
+    assert_eq!(
+        evals.rho_evaluations[&5],
+        compute_rho_eval(5, &evaluation_point)
+    );
+    assert_eq!(
+        evals.singleton_chi_evaluation,
+        compute_truncated_lagrange_basis_sum(1, &evaluation_point)
+    );
+    assert_eq!(evals.rho_256_evaluation, Some(Curve25519Scalar::from(1u64)));
+    assert_eq!(
+        evals.first_round_pcs_proof_evaluations,
+        first_round_pcs_proof_evaluations
+    );
+    assert_eq!(
+        evals.final_round_pcs_proof_evaluations,
+        final_round_pcs_proof_evaluations
     );
 }


### PR DESCRIPTION
## Summary
- add coverage for SumcheckMleEvaluations metadata fields
- assert chi length deduplication, rho evaluations, singleton chi, and rho_256 evaluation
- assert first/final round PCS evaluation slices are preserved

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-sumcheck-mle-metadata-refresh107
- Local test: `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_track_rho_singleton_rho_256_and_pcs_evaluations -- --quiet` -> 1 passed

## Bounty
- /claim #560