### PR TITLE
test: cover multilinear extension array methods

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -114,3 +114,41 @@ fn we_can_use_multilinear_extension_methods_for_i64_vec() {
         MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
 }
+
+#[test]
+fn we_can_use_multilinear_extension_methods_for_i64_arrays() {
+    let array = [7, 11, 13];
+    let evaluation_vec: Vec<TestScalar> = vec![2.into(), 3.into(), 5.into()];
+
+    assert_eq!(
+        (&array).inner_product(&evaluation_vec),
+        (7 * 2 + 11 * 3 + 13 * 5).into()
+    );
+
+    let mut res = evaluation_vec.clone();
+    (&array).mul_add(&mut res, &4.into());
+    assert_eq!(res, vec![30.into(), 47.into(), 57.into()]);
+
+    assert_eq!(
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&&array, 2),
+        vec![7.into(), 11.into(), 13.into(), 0.into()]
+    );
+
+    assert_eq!(
+        (&array).evaluate_at_point(&[TestScalar::from(3u64), TestScalar::from(5u64)]),
+        TestScalar::from(7)
+            * (TestScalar::from(1) - TestScalar::from(3))
+            * (TestScalar::from(1) - TestScalar::from(5))
+            + TestScalar::from(11)
+                * TestScalar::from(3)
+                * (TestScalar::from(1) - TestScalar::from(5))
+            + TestScalar::from(13)
+                * (TestScalar::from(1) - TestScalar::from(3))
+                * TestScalar::from(5)
+    );
+
+    assert_ne!(
+        MultilinearExtension::<TestScalar>::id(&&array),
+        MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
+    );
+}


### PR DESCRIPTION
## Summary
- add coverage for the array-backed MultilinearExtension implementation
- assert inner_product, mul_add, to_sumcheck_term padding, evaluate_at_point, and id behavior for `&[T; N]`

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-mle-array-evaluate-refresh108
- Local test: `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_use_multilinear_extension_methods_for_i64_arrays -- --quiet` -> 1 passed

## Bounty
- /claim #560