### PR TITLE
test: cover dory scalar u8 conversion

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
@@ -26,6 +26,25 @@ fn test_dory_scalar_to_bool_overflow() {
 }
 
 #[test]
+fn test_dory_scalar_to_u8() {
+    assert_eq!(u8::try_from(DoryScalar::ZERO).unwrap(), 0);
+    assert_eq!(u8::try_from(DoryScalar::ONE).unwrap(), 1);
+    assert_eq!(u8::try_from(DoryScalar::from(u8::MAX)).unwrap(), u8::MAX);
+}
+
+#[test]
+fn test_dory_scalar_to_u8_overflow() {
+    matches!(
+        u8::try_from(DoryScalar::from(-1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+    matches!(
+        u8::try_from(DoryScalar::from(u16::from(u8::MAX) + 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+}
+
+#[test]
 fn test_dory_scalar_to_i8() {
     assert_eq!(i8::try_from(DoryScalar::from(0)).unwrap(), 0);
     assert_eq!(i8::try_from(DoryScalar::ONE).unwrap(), 1);


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct `DoryScalar` to `u8` conversion coverage.
- Verifies valid `ZERO`, `ONE`, and `u8::MAX` conversions, plus rejection of negative and above-`u8::MAX` values.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-u8-conversion-refresh112
- Deconfliction comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4645248030

## Local validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test test_dory_scalar_to_u8 --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-112 -- --quiet` => 2 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.