### PR TITLE
test: cover varying sign bit iteration

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -347,6 +347,14 @@ fn we_can_compute_the_bit_distribution_of_values_with_different_signs() {
 }
 
 #[test]
+fn varying_signs_include_the_leading_bit_in_vary_mask_iter() {
+    let data: Vec<i64> = vec![-1, 1];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
+
+    assert_eq!(dist.vary_mask_iter().collect::<Vec<_>>(), vec![0, 255]);
+}
+
+#[test]
 fn we_can_compute_the_bit_distribution_of_values_with_different_signs_and_values() {
     let data: Vec<i64> = vec![4, -1, 1];
     let dist = BitDistribution::new::<TestScalar, _>(&data);


### PR DESCRIPTION
/claim #560

## Summary
- Adds targeted coverage for `BitDistribution::vary_mask_iter()` when the source values have different signs.
- Verifies that the iterator reports both the varying value bit and the leading sign bit: `[0, 255]` for `[-1, 1]`.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-bit-distribution-sign-iter-refresh113
- Deconfliction comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4645282122

## Local validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test varying_signs_include_the_leading_bit_in_vary_mask_iter --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-113 -- --quiet` => 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.