### PR TITLE
test: cover vmv setup max nu boundary

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/vmv_state_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/vmv_state_test.rs
@@ -127,3 +127,24 @@ fn we_can_create_vmv_states_from_random_vmv_and_get_correct_sizes() {
         assert_eq!(verifier_state.r_tensor, vmv.r_tensor);
     }
 }
+
+#[test]
+fn we_can_create_vmv_states_at_the_setup_max_nu_boundary() {
+    let mut rng = test_rng();
+    let max_nu = 3;
+    let pp = PublicParameters::test_rand(max_nu, &mut rng);
+    let prover_setup = (&pp).into();
+    let vmv = VMV::rand(max_nu, &mut rng);
+
+    let prover_state = vmv.calculate_prover_state(&prover_setup);
+    let verifier_state = vmv.calculate_verifier_state(&prover_setup);
+
+    assert_eq!(prover_state.nu, max_nu);
+    assert_eq!(prover_state.L_vec.len(), 1 << max_nu);
+    assert_eq!(prover_state.R_vec.len(), 1 << max_nu);
+    assert_eq!(prover_state.T_vec_prime.len(), 1 << max_nu);
+    assert_eq!(prover_state.v_vec.len(), 1 << max_nu);
+    assert_eq!(verifier_state.nu, max_nu);
+    assert_eq!(verifier_state.l_tensor, vmv.l_tensor);
+    assert_eq!(verifier_state.r_tensor, vmv.r_tensor);
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds coverage for creating VMV prover/verifier states exactly at the setup `max_nu` boundary.
- Confirms prover state keeps `nu == max_nu` and all derived vectors have length `1 << max_nu`.
- Confirms verifier state keeps `nu == max_nu` and preserves the original VMV tensors.

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-vmv-max-nu-state-refresh114
- Commit: 70cdb7be1f0074a1b32ef4baba75b3fb9c4ab7b2

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_create_vmv_states_at_the_setup_max_nu_boundary --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-113 -- --quiet`
  - Result: 1 passed; 0 failed; 960 filtered out
- `cargo fmt --check`
- `git diff --check`

Note: a fresh temporary target compile was blocked by Windows Application Control, so I revalidated successfully with a warmed target directory and the default target.