### PR TITLE
test: cover dynamic dory uint8 varbinary offset

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
@@ -380,6 +380,31 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
 }
 
 #[test]
+fn we_can_compute_dynamic_dory_commitments_for_uint8_and_varbinary_with_an_offset() {
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let setup = ProverSetup::from(&public_parameters);
+    let res = compute_dynamic_dory_commitments(
+        &[
+            CommittableColumn::Uint8(&[0, u8::MAX]),
+            CommittableColumn::VarBinary(vec![[3, 0, 0, 0], [4, 0, 0, 0]]),
+        ],
+        1,
+        &setup,
+    );
+
+    assert_eq!(res.len(), 2);
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
+    let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
+        + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(u8::MAX);
+    assert_eq!(res[0].0, expected);
+
+    let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(3)
+        + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(4);
+    assert_eq!(res[1].0, expected);
+}
+
+#[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_signed_values() {
     let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);


### PR DESCRIPTION
/claim #560

## Summary
- Adds dynamic Dory commitment coverage for `CommittableColumn::Uint8` and `CommittableColumn::VarBinary`.
- Exercises a non-zero offset so both column variants are checked against the shifted Gamma index mapping.
- Asserts the returned commitment count and manually computed GT pairings for both columns.

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dynamic-dory-u8-varbinary-refresh115
- Commit: e74253af8e12f8778fb5fc552b6271e6eba4e775

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_compute_dynamic_dory_commitments_for_uint8_and_varbinary_with_an_offset --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-115 -- --quiet`
  - Result: 1 passed; 0 failed; 960 filtered out
- `cargo fmt --check`
- `git diff --check -- crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs`