### PR TITLE
test: cover divide modulo verifier return values

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -146,12 +146,12 @@ mod tests {
             database::{Column, ColumnRef, ColumnType, Table, TableRef},
             map::indexmap,
             polynomial::MultilinearExtension,
-            scalar::test_scalar::TestScalar,
+            scalar::{test_scalar::TestScalar, Scalar},
         },
         sql::{
             proof::{
-                mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
-                FirstRoundBuilder,
+                mock_verification_builder::{run_verify_for_each_row, MockVerificationBuilder},
+                FinalRoundBuilder, FirstRoundBuilder,
             },
             proof_exprs::{ColumnExpr, DynProofExpr},
         },
@@ -202,5 +202,42 @@ mod tests {
         );
         let matrix = mock_verification_builder.get_identity_results();
         assert!(matrix.into_iter().all(|v| v.into_iter().all(|b| b)));
+    }
+
+    #[test]
+    fn we_can_return_quotient_and_remainder_from_verifier_evaluate() {
+        let table_ref: TableRef = "sxt.t".parse().unwrap();
+        let lhs_ident = Ident::from("lhs");
+        let rhs_ident = Ident::from("rhs");
+        let lhs_ref = ColumnRef::new(table_ref.clone(), lhs_ident.clone(), ColumnType::Int128);
+        let rhs_ref = ColumnRef::new(table_ref, rhs_ident.clone(), ColumnType::Int128);
+        let divide_and_modulo_expr = DivideAndModuloExpr::new(
+            Box::new(DynProofExpr::Column(ColumnExpr::new(lhs_ref.clone()))),
+            Box::new(DynProofExpr::Column(ColumnExpr::new(rhs_ref.clone()))),
+        );
+        let quotient_eval = TestScalar::from(7);
+        let remainder_eval = TestScalar::from(2);
+        let lhs_eval = TestScalar::from(23);
+        let rhs_eval = TestScalar::from(3);
+        let mut verification_builder = MockVerificationBuilder::new(
+            Vec::new(),
+            4,
+            Vec::new(),
+            vec![vec![quotient_eval, remainder_eval]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let accessor = indexmap! {
+            lhs_ref.column_id() => lhs_eval,
+            rhs_ref.column_id() => rhs_eval
+        };
+
+        let (quotient, remainder) = divide_and_modulo_expr
+            .verifier_evaluate(&mut verification_builder, &accessor, TestScalar::ONE, &[])
+            .unwrap();
+
+        assert_eq!(quotient, quotient_eval);
+        assert_eq!(remainder, remainder_eval);
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- Adds verifier-side coverage for `DivideAndModuloExpr::verifier_evaluate` returning the quotient and remainder final-round MLE evaluations.
- Builds a minimal mock verifier context with column accessors for the operands and asserts the returned `(quotient, remainder)` tuple exactly matches the supplied evaluations.

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-divide-modulo-verifier-return-refresh117
- Commit: a4104b52580a

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_return_quotient_and_remainder_from_verifier_evaluate --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`