### PR TITLE
test: cover permutation edge constructors

### DIFF
--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -29,7 +29,7 @@ pub struct Permutation {
 
 impl Permutation {
     /// Create a new permutation from a comparison function with the given length
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn unchecked_new_from_cmp<F>(length: usize, cmp: F) -> Self
     where
         F: Fn(&usize, &usize) -> Ordering + Sync,
@@ -99,6 +99,28 @@ mod test {
         assert_eq!(
             permutation.try_apply(&["and", "Space", "Time"]).unwrap(),
             vec!["Space", "and", "Time"]
+        );
+    }
+
+    #[test]
+    fn test_empty_permutation() {
+        let permutation = Permutation::try_new(vec![]).unwrap();
+        assert_eq!(permutation.size(), 0);
+        assert_eq!(
+            permutation.try_apply::<usize>(&[]).unwrap(),
+            Vec::<usize>::new()
+        );
+    }
+
+    #[test]
+    fn test_unchecked_new_from_cmp_applies_sorted_indexes() {
+        let permutation = Permutation::unchecked_new_from_cmp(4, |lhs, rhs| rhs.cmp(lhs));
+        assert_eq!(permutation.size(), 4);
+        assert_eq!(
+            permutation
+                .try_apply(&["zero", "one", "two", "three"])
+                .unwrap(),
+            vec!["three", "two", "one", "zero"]
         );
     }
 


### PR DESCRIPTION
/claim #560

## Summary
- Adds coverage for valid empty permutations, including size and applying to an empty slice.
- Adds direct coverage for `Permutation::unchecked_new_from_cmp`, asserting the generated sorted indexes are applied correctly.
- Scopes the `dead_code` expectation to non-test builds so the new test coverage does not introduce an unfulfilled lint expectation.

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-empty-permutation-refresh118
- Commit: f29b8f3ae97a

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test permutation --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`