### PR TITLE
test: cover standard binary integer encoding

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,16 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn integer_encoding_is_fixed_width_big_endian() {
+        assert_eq!(
+            try_standard_binary_serialization(0x0102_0304_u32).unwrap(),
+            [1, 2, 3, 4]
+        );
+        assert_eq!(
+            try_standard_binary_serialization(-0x0102_i16).unwrap(),
+            (-0x0102_i16).to_be_bytes()
+        );
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage that standard binary serialization uses fixed-width big-endian integer encoding.
- Checks both unsigned and signed integer cases so the test locks the configured bincode contract, not just round-trip behavior.

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-standard-binary-config-refresh119
- Commit: 7e61ddfcc196

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test integer_encoding_is_fixed_width_big_endian --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`