### PR TITLE
test: cover byte log floor and powers

### DIFF
--- a/crates/proof-of-sql/src/base/math/log.rs
+++ b/crates/proof-of-sql/src/base/math/log.rs
@@ -71,6 +71,25 @@ mod tests {
         assert_eq!(log2_up(4u32), 2);
     }
 
+    #[test]
+    fn test_is_pow2_bytes() {
+        assert!(is_pow2_bytes(&[0, 0, 0, 0]));
+        assert!(is_pow2_bytes(&[0, 0, 1, 0]));
+        assert!(is_pow2_bytes(&[128, 0, 0, 0]));
+        assert!(!is_pow2_bytes(&[1, 1, 0, 0]));
+        assert!(!is_pow2_bytes(&[3, 0, 0, 0]));
+    }
+
+    #[test]
+    fn test_log2_down_bytes_floor() {
+        assert_eq!(log2_down_bytes(&[0, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[1, 0, 0, 0]), 0);
+        assert_eq!(log2_down_bytes(&[255, 0, 0, 0]), 7);
+        assert_eq!(log2_down_bytes(&[0, 1, 0, 0]), 8);
+        assert_eq!(log2_down_bytes(&[0, 0, 128, 0]), 23);
+        assert_eq!(log2_down_bytes(&[255, 255, 255, 255]), 31);
+    }
+
     #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     #[test]
     fn test_log2_bytes_ceil() {


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage for `is_pow2_bytes`, including zero-as-power, true powers, and multi-bit non-powers.
- Adds direct floor coverage for `log2_down_bytes` across zero, single-byte, multibyte, and all-ones byte arrays.

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-log-byte-floor-pow2-refresh120
- Commit: 685cd86ef647

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test log --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`