### PR TITLE
test: cover transcript byte slice refs

### DIFF
--- a/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
@@ -41,6 +41,20 @@ fn we_can_add_values_to_the_transcript_in_little_endian_form_from_refs() {
 }
 
 #[test]
+fn we_can_add_byte_slices_to_the_transcript_from_refs() {
+    let mut transcript1: T = TranscriptCore::new();
+    transcript1.extend_as_le_from_refs([&[1u8, 2, 3][..], &[4][..], &[][..], &[5, 6][..]]);
+
+    let mut transcript2: T = TranscriptCore::new();
+    transcript2.raw_append(&[1, 2, 3]);
+    transcript2.raw_append(&[4]);
+    transcript2.raw_append(&[]);
+    transcript2.raw_append(&[5, 6]);
+
+    assert_eq!(transcript1.raw_challenge(), transcript2.raw_challenge());
+}
+
+#[test]
 fn we_can_add_scalars_to_the_transcript_in_big_endian_form() {
     let mut transcript1: T = TranscriptCore::new();
     transcript1.extend_scalars_as_be(&[S::from(1), S::from(1000), S::from(2)]);


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage for `Transcript::extend_as_le_from_refs` when the referenced messages are byte slices.
- Verifies variable-length byte slices, including an empty slice, are appended in order and unchanged by comparing the resulting transcript challenge against manual `raw_append` calls.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_add_byte_slices_to_the_transcript_from_refs --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-transcript-ref-slices-refresh121
- Commit: 1e3be3b8a068
- Payout wallet EVM/Base USDC/FNDRY: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`