### PR TITLE
test: cover precision constructors

### DIFF
--- a/crates/proof-of-sql/src/base/math/decimal_tests.rs
+++ b/crates/proof-of-sql/src/base/math/decimal_tests.rs
@@ -1,7 +1,34 @@
 #[cfg(test)]
 mod precision_tests {
-    use crate::base::math::decimal::Precision;
+    use crate::base::math::decimal::{DecimalError, Precision};
     use serde_json;
+
+    #[test]
+    fn we_can_construct_valid_precision() {
+        let precision = Precision::new(1).unwrap();
+
+        assert_eq!(precision.value(), 1);
+    }
+
+    #[test]
+    fn we_cannot_construct_zero_precision() {
+        assert_eq!(
+            Precision::new(0),
+            Err(DecimalError::InvalidPrecision {
+                error: "0".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn we_cannot_construct_precision_from_oversized_u64() {
+        assert_eq!(
+            Precision::try_from(u64::MAX),
+            Err(DecimalError::InvalidPrecision {
+                error: u64::MAX.to_string()
+            })
+        );
+    }
 
     #[test]
     fn we_can_deserialize_valid_precision() {


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage for `Precision::new` and `TryFrom<u64>` constructor boundaries.
- Verifies valid minimum precision, zero precision rejection, and oversized `u64` conversion rejection with the expected `DecimalError::InvalidPrecision` payload.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test precision --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-precision-constructors-refresh122
- Commit: ffcdfdf2
- Payout wallet EVM/Base USDC/FNDRY: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`