### PR TITLE
test: cover add const edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const_test.rs
@@ -7,3 +7,21 @@ fn test_add_const() {
     let b = vec![1 + 10, 2 + 10, 3 + 10, 4 + 10];
     assert_eq!(a, b);
 }
+
+#[test]
+fn we_can_add_const_to_empty_slice() {
+    let mut values: Vec<i64> = vec![];
+
+    add_const(&mut values, 10);
+
+    assert!(values.is_empty());
+}
+
+#[test]
+fn we_can_add_convertible_const() {
+    let mut values = vec![10_i64, 20, 30];
+
+    add_const(&mut values, 7_i32);
+
+    assert_eq!(values, vec![17, 27, 37]);
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds edge coverage for `add_const` on an empty slice.
- Verifies `add_const` accepts a convertible constant input by adding an `i32` value into an `i64` slice.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test add_const --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-add-const-edge-cases-refresh123
- Commit: 9eaa4b87
- Payout wallet EVM/Base USDC/FNDRY: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`