### PR TITLE
test: cover scaled batch inversion

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
@@ -56,6 +56,29 @@ fn we_can_pseudo_invert_arrays_of_length_bigger_than_1_with_zeros_and_non_zeros(
 }
 
 #[test]
+fn we_can_pseudo_invert_and_scale_arrays_with_zeros_and_non_zeros() {
+    let input = [
+        TestScalar::from(0_u32),
+        TestScalar::from(2_u32),
+        (-33_i32).into(),
+        TestScalar::from(0_u32),
+        TestScalar::from(45_u32),
+    ];
+    let coeff = TestScalar::from(7_u32);
+    let mut res = input.to_vec();
+
+    slice_ops::batch_inversion_and_mul(&mut res[..], coeff);
+
+    for (input_val, res_val) in input.iter().zip(res) {
+        if *input_val == TestScalar::zero() {
+            assert_eq!(TestScalar::zero(), res_val);
+        } else {
+            assert_eq!(input_val.inv().unwrap() * coeff, res_val);
+        }
+    }
+}
+
+#[test]
 fn we_can_pseudo_invert_arrays_with_nonzero_count_bigger_than_min_chunking_size_with_zeros_and_non_zeros(
 ) {
     let input: Vec<_> = vec![


### PR DESCRIPTION
/claim #560

## Summary
- Adds coverage for `batch_inversion_and_mul`.
- Verifies zero entries remain unchanged while non-zero entries are inverted and scaled by the provided coefficient.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test batch_inverse --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-batch-inversion-scaled-refresh124
- Commit: 06cfe88a
- Payout wallet EVM/Base USDC/FNDRY: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`