### PR TITLE
test: cover inner product ref cast

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -123,6 +123,20 @@ fn test_inner_product_different_lengths() {
     assert_eq!(TestScalar::from(40), inner_product(&a, &b));
 }
 
+#[test]
+fn test_inner_product_ref_cast() {
+    let a = [1, 2, 3, 4].map(TestScalar::from).to_vec();
+    let b = [2, 3, 4, 5].map(TestScalar::from).to_vec();
+    assert_eq!(TestScalar::from(40), inner_product_ref_cast(&a, &b));
+}
+
+#[test]
+fn test_inner_product_ref_cast_different_lengths() {
+    let a = [1, 2, 3, 4].map(TestScalar::from).to_vec();
+    let b = [2, 3, 4, 5, 6].map(TestScalar::from).to_vec();
+    assert_eq!(TestScalar::from(40), inner_product_ref_cast(&a, &b));
+}
+
 /// test inner producr with scalar
 #[test]
 fn test_inner_product_scalar() {


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage for `inner_product_ref_cast`.
- Verifies the normal equal-length path and the truncation behavior when the right-hand slice is longer.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test inner_product_ref_cast --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-inner-product-ref-cast-refresh125
- Commit: 23720a6f
- Payout wallet EVM/Base USDC/FNDRY: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`