### PR TITLE
test: cover primitive column filtering

### DIFF
--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,6 +1,7 @@
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
@@ -116,5 +117,64 @@ fn we_can_filter_columns_with_varbinary() {
             Column::VarBinary((filtered_bytes.as_slice(), filtered_scalars.as_slice())),
             Column::BigInt(&[10, 30, 40]),
         ]
+    );
+}
+
+#[test]
+fn we_can_filter_primitive_columns_by_index() {
+    let alloc = Bump::new();
+    let indexes = &[3, 0, 2];
+
+    assert_eq!(
+        filter_column_by_index(
+            &alloc,
+            &Column::<TestScalar>::Boolean(&[true, false, true, false]),
+            indexes
+        ),
+        Column::Boolean(&[false, true, true])
+    );
+    assert_eq!(
+        filter_column_by_index(&alloc, &Column::<TestScalar>::Uint8(&[1, 2, 3, 4]), indexes),
+        Column::Uint8(&[4, 1, 3])
+    );
+    assert_eq!(
+        filter_column_by_index(
+            &alloc,
+            &Column::<TestScalar>::TinyInt(&[-1, -2, -3, -4]),
+            indexes
+        ),
+        Column::TinyInt(&[-4, -1, -3])
+    );
+    assert_eq!(
+        filter_column_by_index(
+            &alloc,
+            &Column::<TestScalar>::SmallInt(&[10, 20, 30, 40]),
+            indexes
+        ),
+        Column::SmallInt(&[40, 10, 30])
+    );
+    assert_eq!(
+        filter_column_by_index(
+            &alloc,
+            &Column::<TestScalar>::Int(&[100, 200, 300, 400]),
+            indexes
+        ),
+        Column::Int(&[400, 100, 300])
+    );
+    assert_eq!(
+        filter_column_by_index(
+            &alloc,
+            &Column::<TestScalar>::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                &[1000, 2000, 3000, 4000],
+            ),
+            indexes
+        ),
+        Column::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            &[4000, 1000, 3000]
+        )
     );
 }


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage for `filter_column_by_index` across primitive and timestamp column variants.
- Exercises Boolean, Uint8, TinyInt, SmallInt, Int, and TimestampTZ filtering with non-monotonic indexes.
- Keeps the change scoped to `filter_util_test.rs` with no production code changes.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test filter_primitive_columns_by_index --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-filter-primitive-columns-refresh126
- Commit: 5f885371

## Payout
- EVM/Base/ETH/USDC/FNDRY wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022