### PR TITLE
test: cover zigzag decode round trips

### DIFF
--- a/crates/proof-of-sql/src/base/encode/zigzag_test.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag_test.rs
@@ -99,3 +99,36 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
             == U256::from_words(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128, 0x1_u128)
     );
 }
+
+#[test]
+fn u256_zigzag_values_decode_back_to_scalars() {
+    let zero: TestScalar = U256::from_words(0, 0).zigzag();
+    assert_eq!(zero, TestScalar::from(0_u64));
+
+    let positive_one: TestScalar = U256::from_words(2, 0).zigzag();
+    assert_eq!(positive_one, TestScalar::from(1_u64));
+
+    let positive_large: TestScalar = U256::from_words(0, 1).zigzag();
+    assert_eq!(
+        positive_large,
+        (&U256::from_words(0x8000_0000_0000_0000_0000_0000_0000_0000, 0)).into()
+    );
+
+    let negative_one: TestScalar = U256::from_words(1, 0).zigzag();
+    assert_eq!(negative_one, -TestScalar::from(1_u64));
+
+    let negative_with_low_carry: TestScalar =
+        U256::from_words(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff, 1).zigzag();
+    let expected_magnitude: TestScalar = (&U256::from_words(0, 1)).into();
+    assert_eq!(negative_with_low_carry, -expected_magnitude);
+
+    for value in 1..1000_u128 {
+        let positive = TestScalar::from(value);
+        let positive_roundtrip: TestScalar = positive.zigzag().zigzag();
+        assert_eq!(positive_roundtrip, positive);
+
+        let negative = -TestScalar::from(value);
+        let negative_roundtrip: TestScalar = negative.zigzag().zigzag();
+        assert_eq!(negative_roundtrip, negative);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage for decoding ZigZag-encoded `U256` values back into `TestScalar`.
- Exercises even positive encodings, odd negative encodings, a carry-sensitive negative decode, and positive/negative scalar round trips.
- Keeps the change scoped to `zigzag_test.rs` with no production code changes.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test u256_zigzag_values_decode_back_to_scalars --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-zigzag-roundtrip-refresh127
- Commit: cc4bf1c8

## Payout
- EVM/Base/ETH/USDC/FNDRY wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022