### PR TITLE
test: cover bit mask signed boundaries

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils_test.rs
@@ -1,7 +1,7 @@
 use super::bit_mask_utils::make_bit_mask;
 use crate::base::{
     bit::bit_mask_utils::is_bit_mask_negative_representation,
-    scalar::{test_scalar::TestScalar, Scalar},
+    scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
 };
 use bnum::types::U256;
 use core::ops::Shl;
@@ -28,6 +28,31 @@ fn we_can_make_negative_bit_mask() {
 
     // ASSERT
     assert_eq!(bit_mask, (U256::ONE.shl(255)) - U256::TWO);
+}
+
+#[test]
+fn we_can_make_zero_bit_mask() {
+    let bit_mask = make_bit_mask(TestScalar::ZERO);
+
+    assert_eq!(bit_mask, U256::ONE.shl(255));
+    assert!(!is_bit_mask_negative_representation(bit_mask));
+}
+
+#[test]
+fn we_can_make_signed_boundary_bit_masks() {
+    let max_signed_mask = make_bit_mask(TestScalar::MAX_SIGNED);
+    assert_eq!(
+        max_signed_mask,
+        (U256::ONE.shl(255)) + TestScalar::MAX_SIGNED.into_u256_wrapping()
+    );
+    assert!(!is_bit_mask_negative_representation(max_signed_mask));
+
+    let min_signed_mask = make_bit_mask(-TestScalar::MAX_SIGNED);
+    assert_eq!(
+        min_signed_mask,
+        (U256::ONE.shl(255)) - TestScalar::MAX_SIGNED_U256
+    );
+    assert!(is_bit_mask_negative_representation(min_signed_mask));
 }
 
 #[test]


### PR DESCRIPTION
/claim #560

## Summary
- Adds direct coverage for bit mask signed-boundary behavior.
- Exercises the zero mask, `MAX_SIGNED`, and `-MAX_SIGNED` to pin down positive and negative representation boundaries.
- Keeps the change scoped to `bit_mask_utils_test.rs` with no production code changes.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test bit_mask --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-bit-mask-boundaries-refresh128
- Commit: 54940dbd

## Payout
- EVM/Base/ETH/USDC/FNDRY wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022