### PR TITLE
fix: compare varbinary rows in order utility

### DIFF
--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -88,6 +88,9 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
             (Column::VarChar((left_col, _)), Column::VarChar((right_col, _))) => {
                 left_col[left_row_index].cmp(right_col[right_row_index])
             }
+            (Column::VarBinary((left_col, _)), Column::VarBinary((right_col, _))) => {
+                left_col[left_row_index].cmp(right_col[right_row_index])
+            }
             // Should never happen since we checked the column types
             _ => unreachable!(),
         };

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -136,6 +136,41 @@ fn we_cannot_compare_single_row_of_tables_if_type_mismatch() {
 }
 
 #[test]
+fn we_can_compare_single_row_of_tables_for_varbinary_columns() {
+    let left_bytes = [b"foo".as_ref(), b"bar".as_ref(), b"baz".as_ref()];
+    let right_bytes = [b"bar".as_ref(), b"foo".as_ref(), b"baz".as_ref()];
+    let left_scalars: Vec<TestScalar> = left_bytes
+        .iter()
+        .map(|b| TestScalar::from_le_bytes_mod_order(b))
+        .collect();
+    let right_scalars: Vec<TestScalar> = right_bytes
+        .iter()
+        .map(|b| TestScalar::from_le_bytes_mod_order(b))
+        .collect();
+    let left = &[Column::VarBinary((
+        left_bytes.as_slice(),
+        left_scalars.as_slice(),
+    ))];
+    let right = &[Column::VarBinary((
+        right_bytes.as_slice(),
+        right_scalars.as_slice(),
+    ))];
+
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 0, 0).unwrap(),
+        Ordering::Greater
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 1, 1).unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        compare_single_row_of_tables(left, right, 2, 2).unwrap(),
+        Ordering::Equal
+    );
+}
+
+#[test]
 fn we_can_compare_indexes_by_columns_for_scalar_columns() {
     let slice_a = &[55, 44, 66, 66, 66, 77, 66, 66, 66, 66];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];


### PR DESCRIPTION
/claim #560

## Summary
- Adds `VarBinary` support to `compare_single_row_of_tables` after type-compatible row comparisons passed the column-type check.
- Adds coverage for greater-than, less-than, and equal `VarBinary` row comparisons.
- Keeps the change scoped to the order-by utility and its test.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test varbinary_columns --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-varbinary-row-compare-refresh129
- Commit: 96b3f91f

## Payout
- EVM/Base/ETH/USDC/FNDRY wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022