### PR TITLE
test: cover table inspection helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -1,5 +1,7 @@
 use crate::base::{
-    database::{table_utility::*, Column, Table, TableError, TableOptions},
+    database::{
+        table_utility::*, Column, ColumnField, ColumnType, Table, TableError, TableOptions,
+    },
     map::{indexmap, IndexMap},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
@@ -63,6 +65,45 @@ fn we_can_create_a_table_with_specified_row_count() {
     .unwrap();
     assert_eq!(table.num_columns(), 2);
     assert_eq!(table.num_rows(), 0);
+}
+
+#[test]
+fn we_can_inspect_table_schema_and_columns_in_order() {
+    let name_scalars = [TestScalar::from("x"), TestScalar::from("y")];
+    let table = Table::<TestScalar>::try_new(indexmap! {
+        "a".into() => Column::BigInt(&[1, 2]),
+        "flag".into() => Column::Boolean(&[true, false]),
+        "name".into() => Column::VarChar((&["x", "y"], &name_scalars)),
+    })
+    .unwrap();
+
+    assert!(!table.is_empty());
+    assert_eq!(
+        table.schema(),
+        vec![
+            ColumnField::new("a".into(), ColumnType::BigInt),
+            ColumnField::new("flag".into(), ColumnType::Boolean),
+            ColumnField::new("name".into(), ColumnType::VarChar),
+        ]
+    );
+    assert_eq!(
+        table.column_names().cloned().collect::<Vec<_>>(),
+        vec![Ident::new("a"), Ident::new("flag"), Ident::new("name")]
+    );
+    assert_eq!(
+        table.columns().cloned().collect::<Vec<_>>(),
+        vec![
+            Column::BigInt(&[1, 2]),
+            Column::Boolean(&[true, false]),
+            Column::VarChar((&["x", "y"], &name_scalars)),
+        ]
+    );
+    assert_eq!(table.column(0), Some(&Column::BigInt(&[1, 2])));
+    assert_eq!(
+        table.column(2),
+        Some(&Column::VarChar((&["x", "y"], &name_scalars)))
+    );
+    assert_eq!(table.column(3), None);
 }
 
 #[test]


### PR DESCRIPTION
/claim #560

## Summary
- Adds focused test coverage for `Table` inspection helpers in `table_test.rs`.
- Verifies `schema()`, `column_names()`, `columns()`, and `column(index)` preserve insertion order and column types.
- Covers the out-of-range `column(3) == None` path and confirms a populated table is not empty.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test inspect_table_schema --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet`
- Result: 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check`
- `git diff --check`

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-table-inspection-accessors-refresh130
- Commit: f2d345fa

## Payout
- EVM/Base/USDC/FNDRY wallet: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`