### PR TITLE
test: cover constant byte matrices

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -103,4 +103,30 @@ mod tests {
 
         assert_eq!(varying_columns, expected_word_columns);
     }
+
+    #[test]
+    fn constant_columns_produce_no_varying_byte_matrix() {
+        let alloc = Bump::new();
+        let scalars = vec![TestScalar::from(0x1234u64); 4];
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert!(varying_columns.is_empty());
+        assert_eq!(byte_distribution.varying_byte_count(), 0);
+    }
+
+    #[test]
+    fn empty_columns_produce_no_varying_byte_matrix() {
+        let alloc = Bump::new();
+        let scalars = Vec::<TestScalar>::new();
+        let expected_byte_distribution = ByteDistribution::new::<TestScalar, TestScalar>(&scalars);
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(byte_distribution, expected_byte_distribution);
+        assert!(varying_columns.is_empty());
+        assert_eq!(byte_distribution.varying_byte_count(), 0);
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- Add test coverage for `compute_varying_byte_matrix` when all input scalars are constant.
- Add test coverage for the empty input case.
- Assert both paths produce no varying byte matrix and preserve the expected `ByteDistribution`.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-byte-matrix-constant-refresh134
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4645993939

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test varying_byte_matrix --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed locally with 4 passed, 0 failed, 958 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.