### PR TITLE
test: cover low byte distribution boundary

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_distribution.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_distribution.rs
@@ -201,6 +201,19 @@ mod tests {
     }
 
     #[test]
+    fn low_byte_variation_keeps_the_positive_sign_byte_constant() {
+        let column = [0u8, 1, 255].map(TestScalar::from);
+        let byte_distribution = ByteDistribution::new::<TestScalar, _>(&column);
+        assert_eq!(byte_distribution.vary_mask, 1);
+        assert_eq!(byte_distribution.constant_mask(), U256::ONE.shl(255));
+        assert_eq!(byte_distribution.varying_byte_count(), 1);
+        assert_eq!(
+            byte_distribution.varying_byte_indices().collect_vec(),
+            [0u8].into_iter().collect_vec()
+        );
+    }
+
+    #[test]
     fn we_can_get_byte_distribution_from_variable_negative_column() {
         let column = [
             1_974_179_073u32,


### PR DESCRIPTION
/claim #560

## Summary
- Add direct `ByteDistribution` coverage for a positive column where only the low byte varies.
- Verify `vary_mask == 1`, the only varying byte index is `0`, and the positive sign byte remains constant in `constant_mask`.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-byte-distribution-boundary-refresh135
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4646030131

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test low_byte_variation_keeps_the_positive_sign_byte_constant --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed locally with 1 passed, 0 failed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test byte_distribution --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed locally with 10 passed, 0 failed, 951 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.