### PR TITLE
fix: make column scalar_at bounds check lazy

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -302,17 +302,21 @@ impl<'a, S: Scalar> Column<'a, S> {
     ///
     /// Note that if index is out of bounds, this function will return None
     pub(crate) fn scalar_at(&self, index: usize) -> Option<S> {
-        (index < self.len()).then_some(match self {
-            Self::Boolean(col) => S::from(col[index]),
-            Self::Uint8(col) => S::from(col[index]),
-            Self::TinyInt(col) => S::from(col[index]),
-            Self::SmallInt(col) => S::from(col[index]),
-            Self::Int(col) => S::from(col[index]),
-            Self::BigInt(col) | Self::TimestampTZ(_, _, col) => S::from(col[index]),
-            Self::Int128(col) => S::from(col[index]),
-            Self::Scalar(col) | Self::Decimal75(_, _, col) => col[index],
-            Self::VarChar((_, scals)) | Self::VarBinary((_, scals)) => scals[index],
-        })
+        if index < self.len() {
+            Some(match self {
+                Self::Boolean(col) => S::from(col[index]),
+                Self::Uint8(col) => S::from(col[index]),
+                Self::TinyInt(col) => S::from(col[index]),
+                Self::SmallInt(col) => S::from(col[index]),
+                Self::Int(col) => S::from(col[index]),
+                Self::BigInt(col) | Self::TimestampTZ(_, _, col) => S::from(col[index]),
+                Self::Int128(col) => S::from(col[index]),
+                Self::Scalar(col) | Self::Decimal75(_, _, col) => col[index],
+                Self::VarChar((_, scals)) | Self::VarBinary((_, scals)) => scals[index],
+            })
+        } else {
+            None
+        }
     }
 
     /// Convert a column to a vector of Scalar values
@@ -577,5 +581,47 @@ mod tests {
 
         let round_trip_owned: OwnedColumn<TestScalar> = (&column).into();
         assert_eq!(owned_varbinary, round_trip_owned);
+    }
+
+    #[test]
+    fn we_can_use_column_accessors_and_scalar_at_for_supported_types() {
+        let decimal_scalars = [TestScalar::from(7), TestScalar::from(11)];
+        let decimal_column = Column::Decimal75(Precision::new(12).unwrap(), 3, &decimal_scalars);
+        assert_eq!(
+            decimal_column.as_decimal75(),
+            Some(decimal_scalars.as_slice())
+        );
+        assert_eq!(decimal_column.scalar_at(1), Some(TestScalar::from(11)));
+        assert_eq!(decimal_column.scalar_at(2), None);
+
+        let scalar_values = [TestScalar::from(13), TestScalar::from(17)];
+        let scalar_column = Column::Scalar(&scalar_values);
+        assert_eq!(scalar_column.as_scalar(), Some(scalar_values.as_slice()));
+        assert_eq!(scalar_column.scalar_at(0), Some(TestScalar::from(13)));
+
+        let timestamps = [42_i64, 84];
+        let timestamp_column = Column::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::new(0),
+            &timestamps,
+        );
+        assert_eq!(
+            timestamp_column.as_timestamptz(),
+            Some(timestamps.as_slice())
+        );
+        assert_eq!(timestamp_column.scalar_at(1), Some(TestScalar::from(84)));
+
+        let bytes: &[&[u8]] = &[b"a", b"bc"];
+        let byte_scalars = [
+            TestScalar::from_byte_slice_via_hash(b"a"),
+            TestScalar::from_byte_slice_via_hash(b"bc"),
+        ];
+        let varbinary_column = Column::VarBinary((bytes, &byte_scalars));
+        assert_eq!(
+            varbinary_column.as_varbinary(),
+            Some((bytes, byte_scalars.as_slice()))
+        );
+        assert_eq!(varbinary_column.scalar_at(0), Some(byte_scalars[0]));
+        assert_eq!(varbinary_column.as_varchar(), None);
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- Fix `Column::scalar_at` so out-of-bounds indices return `None` as documented instead of panicking from eager `then_some` evaluation.
- Add direct coverage for Decimal75, Scalar, TimestampTZ, and VarBinary accessors and scalar lookups.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-column-scalar-at-bounds-refresh137
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4646118127

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_use_column_accessors_and_scalar_at_for_supported_types --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed locally with 1 passed, 0 failed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test column --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed locally with 280 passed, 0 failed, 681 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.