### PR TITLE
fix: avoid multiply precision overflow

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -113,7 +113,8 @@ pub fn try_multiply_column_types(
     } else {
         let left_precision_value = lhs.precision_value().expect("Numeric types have precision");
         let right_precision_value = rhs.precision_value().expect("Numeric types have precision");
-        let precision_value = (left_precision_value + right_precision_value + 1).min(75_u8);
+        let precision_value =
+            (u16::from(left_precision_value) + u16::from(right_precision_value) + 1).min(75) as u8;
         let precision =
             Precision::new(precision_value).expect("Precision value should be in range 0-75");
         let left_scale = lhs.scale().expect("Numeric types have scale");
@@ -934,6 +935,12 @@ mod test {
 
         let lhs = ColumnType::Int;
         let rhs = ColumnType::Decimal75(Precision::new(65).unwrap(), 0);
+        let expected = ColumnType::Decimal75(Precision::new(75).unwrap(), 0);
+        let actual = try_multiply_column_types(lhs, rhs).unwrap();
+        assert_eq!(expected, actual);
+
+        let lhs = ColumnType::Decimal75(Precision::new(75).unwrap(), -1);
+        let rhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 1);
         let expected = ColumnType::Decimal75(Precision::new(75).unwrap(), 0);
         let actual = try_multiply_column_types(lhs, rhs).unwrap();
         assert_eq!(expected, actual);


### PR DESCRIPTION
/claim #560

## Summary
- Fixes `try_multiply_column_types` so Decimal75 precision calculation widens before addition.
- Prevents high-precision operands from overflowing before the multiplication result is capped at precision 75.
- Adds regression coverage for `Decimal75(75, -1) * Decimal75(75, 1)` returning `Decimal75(75, 0)`.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-multiply-precision-overflow-refresh140
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4646275112

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_multiply_some_numeric_types_with_precision_capping --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed, 0 failed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test column_type_operation --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 30 passed, 0 failed.
- `cargo fmt --check` passed.
- `git diff --check` passed.