### PR TITLE
fix: reject nullable arrow arrays

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -148,6 +148,9 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
     /// - `Decimal256Array` when converting from `DataType::Decimal256` if precision is less than or equal to 75.
     /// - `StringArray` when converting from `DataType::Utf8`.
     fn try_from(value: &ArrayRef) -> Result<Self, Self::Error> {
+        if value.null_count() > 0 {
+            return Err(OwnedArrowConversionError::NullNotSupportedYet);
+        }
         match &value.data_type() {
             // Arrow uses a bit-packed representation for booleans.
             // Hence we need to unpack the bits to get the actual boolean values.

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -8,7 +8,7 @@ use alloc::sync::Arc;
 use arrow::{
     array::{
         ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, LargeBinaryArray,
-        StringArray,
+        StringArray, UInt8Array,
     },
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
@@ -99,6 +99,24 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
         OwnedColumn::<TestScalar>::try_from(array_ref),
         Err(OwnedArrowConversionError::UnsupportedType { .. })
     ));
+}
+
+#[test]
+fn we_reject_nullable_numeric_arrow_arrays() {
+    let array_ref: ArrayRef = Arc::new(UInt8Array::from(vec![Some(1), None, Some(3)]));
+    assert!(matches!(
+        OwnedColumn::<TestScalar>::try_from(array_ref),
+        Err(OwnedArrowConversionError::NullNotSupportedYet)
+    ));
+}
+
+#[test]
+fn we_can_convert_dense_numeric_arrow_arrays() {
+    let array_ref: ArrayRef = Arc::new(UInt8Array::from(vec![1, 2, 3]));
+    assert_eq!(
+        OwnedColumn::<TestScalar>::try_from(array_ref).unwrap(),
+        OwnedColumn::Uint8(vec![1, 2, 3])
+    );
 }
 
 fn we_can_convert_between_owned_table_and_record_batch_impl(


### PR DESCRIPTION
/claim #560

## Summary
- Reject nullable Arrow arrays before converting an `ArrayRef` into an `OwnedColumn`.
- Add regression coverage for nullable numeric Arrow input returning `OwnedArrowConversionError::NullNotSupportedYet`.
- Add dense numeric Arrow coverage to confirm non-null `UInt8Array` conversion still works.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test,arrow we_reject_nullable_numeric_arrow_arrays --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test,arrow we_can_convert_dense_numeric_arrow_arrays --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test,arrow owned_and_arrow --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 7 passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
Local open-PR file map `sxt-open-pr-files-refresh141.json` did not list either touched file:
- `crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs`
- `crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs`

## Evidence
MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-arrow-null-guard-refresh142