### PR TITLE
test: cover limb serialization order

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,42 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn we_serialize_limbs_in_reverse_order() {
+        let wrapper = LimbWrapper {
+            limbs: [1, 2, 3, 4],
+        };
+
+        assert_eq!(
+            serde_json::to_string(&wrapper).unwrap(),
+            r#"{"limbs":[4,3,2,1]}"#
+        );
+    }
+
+    #[test]
+    fn we_deserialize_limbs_back_to_internal_order() {
+        let wrapper: LimbWrapper = serde_json::from_str(r#"{"limbs":[4,3,2,1]}"#).unwrap();
+
+        assert_eq!(
+            wrapper,
+            LimbWrapper {
+                limbs: [1, 2, 3, 4]
+            }
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add direct coverage for `serialize_limbs` external limb order.
- Add direct coverage for `deserialize_to_limbs` restoring the internal limb order.
- Keep this as test-only coverage in the standard serialization helper module.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_serialize_limbs_in_reverse_order --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_deserialize_limbs_back_to_internal_order --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test standard_serializations --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 3 passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
Local open-PR file map `sxt-open-pr-files-refresh142.json` did not list the touched file:
- `crates/proof-of-sql/src/base/standard_serializations/limbs.rs`

## Evidence
MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-limb-serialization-order-refresh143