### PR TITLE
test: cover placeholder error display

### DIFF
--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,45 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{PlaceholderError, ProofError};
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn we_display_invalid_placeholder_index_details() {
+        let error = PlaceholderError::InvalidPlaceholderIndex {
+            index: 3,
+            num_params: 2,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Invalid placeholder index: 3, number of params: 2"
+        );
+    }
+
+    #[test]
+    fn we_display_invalid_placeholder_type_details() {
+        let error = PlaceholderError::InvalidPlaceholderType {
+            index: 1,
+            expected: ColumnType::Int,
+            actual: ColumnType::BigInt,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Invalid placeholder type: 1, expected: INT, actual: BIGINT"
+        );
+    }
+
+    #[test]
+    fn proof_error_transparently_displays_placeholder_errors() {
+        let error = ProofError::PlaceholderError {
+            source: PlaceholderError::ZeroPlaceholderId,
+        };
+
+        assert_eq!(error.to_string(), "Placeholder id must be greater than 0");
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add direct coverage for `PlaceholderError::InvalidPlaceholderIndex` display details.
- Add direct coverage for `PlaceholderError::InvalidPlaceholderType` display details.
- Add direct coverage that `ProofError::PlaceholderError` transparently displays the wrapped placeholder error.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_display_invalid_placeholder_index_details --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_display_invalid_placeholder_type_details --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test proof_error_transparently_displays_placeholder_errors --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test placeholder --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 11 passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
Local open-PR file map `sxt-open-pr-files-refresh143.json` did not list the touched file:
- `crates/proof-of-sql/src/base/proof/error.rs`

## Evidence
MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-placeholder-error-display-refresh144