### PR TITLE
test: cover owned column error display

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,59 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnCoercionError, OwnedColumnError};
+    use crate::base::database::ColumnType;
+    use alloc::string::ToString;
+
+    #[test]
+    fn we_display_owned_column_type_cast_errors() {
+        let error = OwnedColumnError::TypeCastError {
+            from_type: ColumnType::VarChar,
+            to_type: ColumnType::BigInt,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Can not perform type casting from VarChar to BigInt"
+        );
+    }
+
+    #[test]
+    fn we_display_owned_column_scalar_conversion_errors() {
+        let error = OwnedColumnError::ScalarConversionError {
+            error: "value exceeds scalar modulus".into(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Error in converting scalars to a given column type: value exceeds scalar modulus"
+        );
+    }
+
+    #[test]
+    fn we_display_owned_column_unsupported_errors() {
+        let error = OwnedColumnError::Unsupported {
+            error: "column variant has no scalar view".into(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Unsupported operation: column variant has no scalar view"
+        );
+    }
+
+    #[test]
+    fn we_display_column_coercion_errors() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add direct coverage for `OwnedColumnError::TypeCastError` display output.
- Add direct coverage for `OwnedColumnError::ScalarConversionError` display output.
- Add direct coverage for `OwnedColumnError::Unsupported` display output.
- Add direct coverage for `ColumnCoercionError` display output.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_display_owned_column_type_cast_errors --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_display_owned_column_scalar_conversion_errors --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_display_owned_column_unsupported_errors --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_display_column_coercion_errors --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 1 passed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test owned_column --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed: 38 passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
Local open-PR file map `sxt-open-pr-files-refresh144.json` did not list the touched file:
- `crates/proof-of-sql/src/base/database/owned_column_error.rs`

## Evidence
MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-owned-column-error-display-refresh145