### PR TITLE
test: cover timestamp error display

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,60 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PoSQLTimestampError;
+    use alloc::string::String;
+
+    #[test]
+    fn we_display_timestamp_errors() {
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezone {
+                timezone: "Mars/Base".into()
+            }
+            .to_string(),
+            "invalid timezone string: Mars/Base"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezoneOffset.to_string(),
+            "invalid timezone offset"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimeUnit {
+                error: "century".into()
+            }
+            .to_string(),
+            "Invalid time unit"
+        );
+        assert_eq!(
+            PoSQLTimestampError::UnsupportedPrecision {
+                error: "Picosecond".into()
+            }
+            .to_string(),
+            "Unsupported precision for timestamp: Picosecond"
+        );
+    }
+
+    #[test]
+    fn we_convert_timestamp_errors_to_strings() {
+        let message: String = PoSQLTimestampError::InvalidTimezone {
+            timezone: "+01x03".into(),
+        }
+        .into();
+
+        assert_eq!(message, "invalid timezone string: +01x03");
+    }
+
+    #[test]
+    fn we_serialize_timestamp_errors_with_payloads() {
+        let error = PoSQLTimestampError::UnsupportedPrecision {
+            error: "Minute".into(),
+        };
+
+        let serialized = serde_json::to_string(&error).unwrap();
+        let deserialized: PoSQLTimestampError = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, error);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for `PoSQLTimestampError` display, `From<PoSQLTimestampError> for String`, and serde roundtrip behavior.
- Covers `InvalidTimezone`, `InvalidTimezoneOffset`, `InvalidTimeUnit`, and `UnsupportedPrecision` messages.
- Keeps production behavior unchanged.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-timestamp-error-display-refresh148
- Deconfliction attempt: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4646687720

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test timestamp_errors --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` -> 3 passed, 0 failed
- `cargo fmt --check`
- `git diff --check`