### PR TITLE
test: cover query error conversions

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,83 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::QueryError;
+    use crate::base::{
+        database::{ColumnCoercionError, TableCoercionError},
+        proof::ProofError,
+    };
+
+    #[test]
+    fn we_display_basic_query_errors() {
+        assert_eq!(QueryError::Overflow.to_string(), "Overflow error");
+        assert_eq!(QueryError::InvalidString.to_string(), "String decode error");
+        assert_eq!(
+            QueryError::MiscellaneousDecodingError.to_string(),
+            "Miscellaneous decoding error"
+        );
+        assert_eq!(
+            QueryError::MiscellaneousEvaluationError.to_string(),
+            "Miscellaneous evaluation error"
+        );
+        assert_eq!(
+            QueryError::InvalidColumnCount.to_string(),
+            "Invalid number of columns"
+        );
+    }
+
+    #[test]
+    fn we_convert_table_coercion_overflow_to_query_overflow() {
+        let error: QueryError = TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::Overflow,
+        }
+        .into();
+
+        assert!(matches!(error, QueryError::Overflow));
+        assert_eq!(error.to_string(), "Overflow error");
+    }
+
+    #[test]
+    fn we_convert_table_coercion_verifier_errors() {
+        let invalid_type: QueryError = TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::InvalidTypeCoercion,
+        }
+        .into();
+        assert!(matches!(
+            invalid_type,
+            QueryError::ProofError {
+                source: ProofError::InvalidTypeCoercion
+            }
+        ));
+        assert_eq!(
+            invalid_type.to_string(),
+            "Result does not match query: type mismatch"
+        );
+
+        let name_mismatch: QueryError = TableCoercionError::NameMismatch.into();
+        assert!(matches!(
+            name_mismatch,
+            QueryError::ProofError {
+                source: ProofError::FieldNamesMismatch
+            }
+        ));
+        assert_eq!(
+            name_mismatch.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+
+        let count_mismatch: QueryError = TableCoercionError::ColumnCountMismatch.into();
+        assert!(matches!(
+            count_mismatch,
+            QueryError::ProofError {
+                source: ProofError::FieldCountMismatch
+            }
+        ));
+        assert_eq!(
+            count_mismatch.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for `QueryError` display behavior and `TableCoercionError` conversion mapping.
- Covers basic query error messages, overflow coercion mapping, invalid type coercion, field name mismatch, and field count mismatch.
- Keeps production behavior unchanged.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-query-error-conversions-refresh149
- Deconfliction attempt: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4646741720

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test query_result::tests --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` -> 3 passed, 0 failed
- `cargo fmt --check`
- `git diff --check`