### PR TITLE
test: cover evm proof plan error display

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,55 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::EVMProofPlanError;
+    use crate::{base::database::ColumnType, sql::AnalyzeError};
+
+    #[test]
+    fn we_display_basic_evm_proof_plan_errors() {
+        assert_eq!(
+            EVMProofPlanError::NotSupported.to_string(),
+            "plan not yet supported"
+        );
+        assert_eq!(
+            EVMProofPlanError::ColumnNotFound.to_string(),
+            "column not found"
+        );
+        assert_eq!(
+            EVMProofPlanError::TableNotFound.to_string(),
+            "table not found"
+        );
+        assert_eq!(
+            EVMProofPlanError::InvalidTableName.to_string(),
+            "table name can not be parsed into TableRef"
+        );
+        assert_eq!(
+            EVMProofPlanError::InvalidOutputColumnName.to_string(),
+            "invalid or missing output column name"
+        );
+        assert_eq!(
+            EVMProofPlanError::InconsistentGroupByColumnCounts.to_string(),
+            "column counts in group by plans are inconsistent"
+        );
+        assert_eq!(
+            EVMProofPlanError::IncorrectScalingFactor.to_string(),
+            "incorrect scaling factor"
+        );
+    }
+
+    #[test]
+    fn we_transparently_display_analyze_errors() {
+        let error = EVMProofPlanError::AnalyzeError {
+            source: AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::VarBinary,
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Expression has datatype BINARY, which was not valid"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for `EVMProofPlanError` display behavior.
- Covers all simple EVM proof plan error messages and transparent display of an underlying `AnalyzeError`.
- Keeps production behavior unchanged.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-evm-proof-plan-error-display-refresh150
- Deconfliction attempt: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4646795243

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test evm_proof_plan::error::tests --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` -> 2 passed, 0 failed
- `cargo fmt --check`
- `git diff --check`