### PR TITLE
test: cover base error display

### DIFF
--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,20 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ParseError;
+
+    #[test]
+    fn we_display_invalid_table_reference_errors() {
+        let error = ParseError::InvalidTableReference {
+            table_reference: "bad.schema.table.name".into(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Invalid table reference: bad.schema.table.name"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,20 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ScalarConversionError;
+
+    #[test]
+    fn we_display_scalar_conversion_overflow_errors() {
+        let error = ScalarConversionError::Overflow {
+            error: "BigInt too large for Scalar".into(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Overflow error: BigInt too large for Scalar"
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for base error display behavior.
- Covers `ParseError::InvalidTableReference` and `ScalarConversionError::Overflow` messages.
- Keeps production behavior unchanged.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-base-error-display-refresh151
- Deconfliction attempt: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4646854484

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test scalar_conversion_overflow --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` -> 1 passed, 0 failed
- `cargo test -p proof-of-sql --lib --no-default-features --features test invalid_table_reference --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` -> 1 passed, 0 failed
- `cargo fmt --check`
- `git diff --check`