### PR TITLE
test: cover big decimal conversion

### DIFF
--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -89,4 +89,26 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, IntermediateDecimalError::ConversionFailure));
     }
+
+    #[test]
+    fn we_can_convert_decimal_with_requested_precision_and_scale() {
+        let big_decimal: BigDecimal = "-123.45".parse::<BigDecimal>().unwrap().normalized();
+
+        let value = big_decimal
+            .try_into_bigint_with_precision_and_scale(5, 2)
+            .unwrap();
+
+        assert_eq!(value, BigInt::from(-12345));
+    }
+
+    #[test]
+    fn we_reject_scaled_decimals_that_exceed_precision() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+
+        let err = big_decimal
+            .try_into_bigint_with_precision_and_scale(4, 2)
+            .unwrap_err();
+
+        assert!(matches!(err, IntermediateDecimalError::LossyCast));
+    }
 }


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for `BigDecimalExt::try_into_bigint_with_precision_and_scale` in `crates/proof-of-sql/src/base/math/big_decimal_ext.rs`.

This covers:
- successful conversion of a negative decimal with requested precision and scale
- `LossyCast` rejection when the scaled decimal exceeds the requested precision

## Evidence

MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-big-decimal-conversion-refresh152

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test big_decimal_ext --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 6 passed, 0 failed
- `cargo fmt --check` passed
- `git diff --check` passed

## Deconfliction

I refreshed the local open-PR file map as `sxt-open-pr-files-refresh152.json`; `crates/proof-of-sql/src/base/math/big_decimal_ext.rs` was not listed as touched by open PRs. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4646919417