### PR TITLE
test: cover merlin transcript message order

### DIFF
--- a/crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs
@@ -14,7 +14,7 @@ impl super::transcript_core::TranscriptCore for merlin::Transcript {
 
 #[cfg(test)]
 mod tests {
-    use super::super::transcript_core::test_util::*;
+    use super::super::transcript_core::{test_util::*, TranscriptCore};
     #[test]
     fn we_get_equivalent_challenges_with_equivalent_merlin_transcripts() {
         we_get_equivalent_challenges_with_equivalent_transcripts::<merlin::Transcript>();
@@ -26,5 +26,18 @@ mod tests {
     #[test]
     fn we_get_different_nontrivial_consecutive_challenges_from_keccak256_transcript() {
         we_get_different_nontrivial_consecutive_challenges_from_transcript::<merlin::Transcript>();
+    }
+
+    #[test]
+    fn we_get_different_challenges_when_merlin_message_order_changes() {
+        let mut transcript1 = <merlin::Transcript as TranscriptCore>::new();
+        transcript1.raw_append(b"first");
+        transcript1.raw_append(b"second");
+
+        let mut transcript2 = <merlin::Transcript as TranscriptCore>::new();
+        transcript2.raw_append(b"second");
+        transcript2.raw_append(b"first");
+
+        assert_ne!(transcript1.raw_challenge(), transcript2.raw_challenge());
     }
 }


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for Merlin transcript message ordering in `crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs`.

This covers:
- appending `first` then `second`
- appending `second` then `first`
- asserting those transcript histories produce different raw challenges

## Evidence

MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-merlin-transcript-order-refresh153

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test we_get_different_challenges_when_merlin_message_order_changes --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed
- `cargo test -p proof-of-sql --lib --no-default-features --features test merlin_transcript_core --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 4 passed, 0 failed
- `cargo fmt --check` passed
- `git diff --check` passed

## Deconfliction

I refreshed the local open-PR file map as `sxt-open-pr-files-refresh153.json`; `crates/proof-of-sql/src/base/proof/merlin_transcript_core.rs` was not listed as touched by open PRs. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4646976366