### PR TITLE
test: cover keccak transcript message order

### DIFF
--- a/crates/proof-of-sql/src/base/proof/keccak256_transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/keccak256_transcript.rs
@@ -38,7 +38,10 @@ impl TranscriptCore for Keccak256Transcript {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::transcript_core::test_util::*, Keccak256Transcript};
+    use super::{
+        super::transcript_core::{test_util::*, TranscriptCore},
+        Keccak256Transcript,
+    };
     #[test]
     fn we_get_equivalent_challenges_with_equivalent_keccak256_transcripts() {
         we_get_equivalent_challenges_with_equivalent_transcripts::<Keccak256Transcript>();
@@ -50,5 +53,18 @@ mod tests {
     #[test]
     fn we_get_different_nontrivial_consecutive_challenges_from_keccak256_transcript() {
         we_get_different_nontrivial_consecutive_challenges_from_transcript::<Keccak256Transcript>();
+    }
+
+    #[test]
+    fn we_get_different_challenges_when_keccak256_message_order_changes() {
+        let mut transcript1 = Keccak256Transcript::new();
+        transcript1.raw_append(b"first");
+        transcript1.raw_append(b"second");
+
+        let mut transcript2 = Keccak256Transcript::new();
+        transcript2.raw_append(b"second");
+        transcript2.raw_append(b"first");
+
+        assert_ne!(transcript1.raw_challenge(), transcript2.raw_challenge());
     }
 }


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for Keccak256 transcript message ordering in `crates/proof-of-sql/src/base/proof/keccak256_transcript.rs`.

This covers:
- appending `first` then `second`
- appending `second` then `first`
- asserting those transcript histories produce different raw challenges

## Evidence

MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-keccak-transcript-order-refresh154

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test we_get_different_challenges_when_keccak256_message_order_changes --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed
- `cargo test -p proof-of-sql --lib --no-default-features --features test keccak256_transcript --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 6 passed, 0 failed
- `cargo fmt --check` passed
- `git diff --check` passed

## Deconfliction

I refreshed the local open-PR file map as `sxt-open-pr-files-refresh154.json`; `crates/proof-of-sql/src/base/proof/keccak256_transcript.rs` was not listed as touched by open PRs. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647032180