### PR TITLE
test: cover ristretto transcript bytes

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs
@@ -62,4 +62,14 @@ mod tests {
             commitment2.to_transcript_bytes()
         );
     }
+
+    #[test]
+    fn we_serialize_ristretto_point_commitments_as_compressed_bytes() {
+        let commitment = RISTRETTO_BASEPOINT_POINT;
+
+        let transcript_bytes = commitment.to_transcript_bytes();
+
+        assert_eq!(transcript_bytes.len(), 32);
+        assert_eq!(transcript_bytes, commitment.compress().as_bytes());
+    }
 }


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for `RistrettoPoint` transcript byte serialization in `crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs`.

This covers:
- `to_transcript_bytes()` returns 32 bytes
- the returned bytes match `commitment.compress().as_bytes()` for the Ristretto basepoint

## Evidence

MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-ristretto-transcript-bytes-refresh155

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test we_serialize_ristretto_point_commitments_as_compressed_bytes --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed
- `cargo test -p proof-of-sql --lib --no-default-features --features test ristretto_point --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 2 passed, 0 failed
- `cargo fmt --check` passed
- `git diff --check` passed

## Deconfliction

I refreshed the local open-PR file map as `sxt-open-pr-files-refresh155.json`; `crates/proof-of-sql/src/proof_primitive/inner_product/ristretto_point.rs` was not listed as touched by open PRs. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647102842