### PR TITLE
test: cover zerosum subpolynomial iteration

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -119,4 +119,20 @@ mod tests {
 
         assert!(iter.next().is_none());
     }
+
+    #[test]
+    fn we_iter_mul_by_preserves_zerosum_terms() {
+        let mle = vec![TestScalar::from(1), TestScalar::from(2)];
+        let terms: Vec<SumcheckSubpolynomialTerm<_>> =
+            vec![(TestScalar::from(7), vec![Box::new(&mle)])];
+        let subpoly = SumcheckSubpolynomial::new(SumcheckSubpolynomialType::ZeroSum, terms);
+
+        let mut iter = subpoly.iter_mul_by(TestScalar::from(3));
+
+        let (subpoly_type, coeff, extensions) = iter.next().unwrap();
+        assert_eq!(subpoly_type, SumcheckSubpolynomialType::ZeroSum);
+        assert_eq!(coeff, TestScalar::from(21));
+        assert_eq!(extensions.len(), 1);
+        assert!(iter.next().is_none());
+    }
 }


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for `SumcheckSubpolynomial::iter_mul_by` in `crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs`.

This covers:
- `ZeroSum` subpolynomial type preservation
- coefficient multiplication by the provided multiplier
- multiplicand retention for the yielded term

## Evidence

MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-zerosum-subpolynomial-refresh156

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test we_iter_mul_by_preserves_zerosum_terms --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed
- `cargo test -p proof-of-sql --lib --no-default-features --features test sumcheck_subpolynomial --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 2 passed, 0 failed
- `cargo fmt --check` passed
- `git diff --check` passed

## Deconfliction

I refreshed the local open-PR file map as `sxt-open-pr-files-refresh156.json`; `crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs` was not listed as touched by open PRs. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647163014