### PR TITLE
test: cover hyperkzg scalar arithmetic

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/scalar.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/scalar.rs
@@ -6,9 +6,7 @@ pub type BNScalar = MontScalar<ark_bn254::FrConfig>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::test_scalar_constants;
-    #[cfg(feature = "hyperkzg_proof")]
-    use crate::base::scalar::Scalar;
+    use crate::base::scalar::{test_scalar_constants, Scalar};
     #[cfg(feature = "hyperkzg_proof")]
     use ark_std::UniformRand;
     #[cfg(feature = "hyperkzg_proof")]
@@ -17,6 +15,13 @@ mod tests {
     #[test]
     fn we_have_correct_constants_for_bn_scalar() {
         test_scalar_constants::<BNScalar>();
+    }
+
+    #[test]
+    fn we_can_use_bn_scalar_basic_arithmetic_constants() {
+        assert_eq!(BNScalar::ONE + BNScalar::ONE, BNScalar::TWO);
+        assert_eq!(BNScalar::TEN - BNScalar::ONE, BNScalar::from(9_u64));
+        assert_eq!(BNScalar::TWO * BNScalar::from(5_u64), BNScalar::TEN);
     }
 
     #[test]


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for `BNScalar` arithmetic constants in `crates/proof-of-sql/src/proof_primitive/hyperkzg/scalar.rs`.

This covers:
- `ONE + ONE = TWO`
- `TEN - ONE = 9`
- `TWO * 5 = TEN`

## Evidence

MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-hyperkzg-bn-scalar-refresh157

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_use_bn_scalar_basic_arithmetic_constants --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed
- `cargo test -p proof-of-sql --lib --no-default-features --features test hyperkzg::scalar --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 2 passed, 0 failed
- `cargo fmt --check` passed
- `git diff --check` passed

## Deconfliction

I refreshed the local open-PR file map as `sxt-open-pr-files-refresh157.json`; `crates/proof-of-sql/src/proof_primitive/hyperkzg/scalar.rs` was not listed as touched by open PRs. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647257212