### PR TITLE
test: cover hyperkzg setup slice errors

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
@@ -55,6 +55,22 @@ pub fn deserialize_flat_compressed_hyperkzg_public_setup_from_slice(
         .collect()
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_reject_incomplete_compressed_setup_chunks_from_slice() {
+        let err = deserialize_flat_compressed_hyperkzg_public_setup_from_slice(
+            &[0; COMPRESSED_SIZE - 1],
+            Validate::Yes,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, SerializationError::IoError(_)));
+    }
+}
+
 #[cfg(feature = "hyperkzg_proof")]
 #[must_use]
 /// Load a small setup for testing.


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for `deserialize_flat_compressed_hyperkzg_public_setup_from_slice` in `crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs`.

This covers:
- incomplete compressed setup chunk input
- slice deserialization returning `SerializationError::IoError` for the short chunk path

## Evidence

MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-hyperkzg-setup-slice-errors-refresh158

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test we_reject_incomplete_compressed_setup_chunks_from_slice --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed
- `cargo test -p proof-of-sql --lib --no-default-features --features test public_setup --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 5 passed, 0 failed
- `cargo fmt --check` passed
- `git diff --check` passed

## Deconfliction

I refreshed the local open-PR file map as `sxt-open-pr-files-refresh158.json`; `crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs` was not listed as touched by open PRs. Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647353766