### PR TITLE
test: cover dory random tensor helpers

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/rand_util.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/rand_util.rs
@@ -142,3 +142,28 @@ fn we_can_create_different_rand_F_vecs_from_different_seeds() {
         assert_ne!(s2, s2_2);
     }
 }
+
+#[test]
+fn we_can_create_rand_F_tensors() {
+    let mut rng = test_rng();
+    for nu in 0..5 {
+        let (s1, s2) = rand_F_tensors(nu, &mut rng);
+        assert_eq!(s1.len(), nu);
+        assert_eq!(s2.len(), nu);
+        if nu > 0 {
+            assert_ne!(s1, s2);
+        }
+    }
+}
+
+#[test]
+fn we_can_create_the_same_rand_F_tensors_from_the_same_seed() {
+    let mut rng = test_seed_rng([1; 32]);
+    let mut rng_2 = test_seed_rng([1; 32]);
+    for nu in 0..5 {
+        let (s1, s2) = rand_F_tensors(nu, &mut rng);
+        let (s1_2, s2_2) = rand_F_tensors(nu, &mut rng_2);
+        assert_eq!(s1, s1_2);
+        assert_eq!(s2, s2_2);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add direct test coverage for `rand_F_tensors` in `crates/proof-of-sql/src/proof_primitive/dory/rand_util.rs`
- assert returned tensor lengths follow `nu`
- assert non-empty tensor pairs differ and same-seed RNGs reproduce identical tensors

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-rand-tensors-refresh159
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647478030

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test rand_F_tensors --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 2 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test rand_util --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 10 passed, 0 failed, 952 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
- Local open-PR file map `sxt-open-pr-files-refresh159.json` did not list the touched file.