### PR TITLE
test: cover matrix index round trips

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/matrix_structure.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dynamic_matrix_utils/matrix_structure.rs
@@ -273,4 +273,18 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn we_can_round_trip_boundary_indexes_through_row_and_column() {
+        let indexes = [
+            0, 1, 2, 3, 4, 7, 8, 15, 16, 23, 24, 63, 64, 79, 80, 127, 128, 255,
+        ];
+
+        for index in indexes {
+            let (row, column) = row_and_column_from_index(index);
+
+            assert_eq!(index_from_row_and_column(row, column), Some(index));
+            assert!(column < full_width_of_row(row));
+        }
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add boundary round-trip coverage for dynamic matrix index helpers
- verify `row_and_column_from_index(index)` maps back through `index_from_row_and_column(row, column)`
- assert boundary columns remain inside `full_width_of_row(row)`

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-matrix-index-roundtrip-refresh160
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647540847

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_round_trip_boundary_indexes_through_row_and_column --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test matrix_structure --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 7 passed, 0 failed, 954 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
- Local open-PR file map `sxt-open-pr-files-refresh159.json` did not list the touched file.