### PR TITLE
test: cover interpolation coefficient round trips

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
@@ -9,6 +9,12 @@ use ark_std::UniformRand;
 use core::iter;
 use num_traits::{Inv, Zero};
 
+fn eval_reverse_coefficients(coefficients: &[S], x: S) -> S {
+    coefficients
+        .iter()
+        .fold(S::zero(), |acc, &coefficient| acc * x + coefficient)
+}
+
 #[test]
 fn test_interpolate_uni_poly_for_random_polynomials() {
     let mut prng = ark_std::test_rng();
@@ -160,4 +166,23 @@ fn we_can_interpolate_evaluations_to_reverse_coefficients_with_degree_3_degenera
         ]),
         vec![S::from(0), S::from(0), S::from(2), S::from(1)]
     );
+}
+
+#[test]
+fn reverse_coefficients_reproduce_original_evaluations() {
+    let evaluations = [
+        S::from(4),
+        S::from(9),
+        S::from(15),
+        S::from(28),
+        S::from(55),
+    ];
+    let coefficients = interpolate_evaluations_to_reverse_coefficients(&evaluations);
+
+    for (x, expected) in evaluations.into_iter().enumerate() {
+        assert_eq!(
+            eval_reverse_coefficients(&coefficients, S::from(i32::try_from(x).unwrap())),
+            expected
+        );
+    }
 }


### PR DESCRIPTION
/claim #560

## Summary
- add round-trip coverage for interpolation reverse coefficients
- introduce a small local evaluator helper in `interpolate_test.rs`
- verify coefficients returned by `interpolate_evaluations_to_reverse_coefficients` reproduce the original evaluations at `x = 0..n`

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-interpolate-coefficient-roundtrip-refresh161
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647649090

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test reverse_coefficients_reproduce_original_evaluations --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test interpolate --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 15 passed, 0 failed, 946 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
- Local open-PR file map `sxt-open-pr-files-refresh159.json` did not list the touched file.
- Checked newest own PRs #2384 and #2385; both touch different files.