### PR TITLE
test: cover dory transpose trailing padding

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
@@ -108,6 +108,32 @@ mod tests {
     }
 
     #[test]
+    fn we_can_transpose_u64_column_with_trailing_padding() {
+        type T = u64;
+        let column: Vec<T> = vec![1, 2, 3, 4];
+        let offset = 0;
+        let rows = 2;
+        let cols = 3;
+        let data_size = mem::size_of::<T>();
+
+        let transpose = transpose_for_fixed_msm(&column, offset, rows, cols, data_size);
+
+        assert_eq!(transpose.len(), data_size * rows * cols);
+        assert_eq!(&transpose[0..data_size], column[0].as_bytes());
+        assert_eq!(&transpose[data_size..2 * data_size], column[3].as_bytes());
+        assert_eq!(
+            &transpose[2 * data_size..3 * data_size],
+            column[1].as_bytes()
+        );
+        assert_eq!(&transpose[3 * data_size..4 * data_size], 0_u64.as_bytes());
+        assert_eq!(
+            &transpose[4 * data_size..5 * data_size],
+            column[2].as_bytes()
+        );
+        assert_eq!(&transpose[5 * data_size..6 * data_size], 0_u64.as_bytes());
+    }
+
+    #[test]
     fn we_can_transpose_boolean_column_with_offset() {
         type T = bool;
         let column: Vec<T> = vec![true, false, true];


### PR DESCRIPTION
/claim #560

## Summary
- add trailing-padding coverage for `transpose_for_fixed_msm`
- verify a partially filled 2x3 `u64` transpose preserves input placement and leaves trailing cells zero-padded

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-transpose-padding-refresh162
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647725150

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_transpose_u64_column_with_trailing_padding --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test transpose --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 9 passed, 0 failed, 952 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
- Local open-PR file map `sxt-open-pr-files-refresh159.json` did not list the touched file.
- Checked newest own PRs #2384, #2385, and #2386; they touch different files.