### PR TITLE
test: cover dory offset byte conversions

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -60,3 +60,34 @@ impl OffsetToBytes<32> for [u64; 4] {
         bytemuck::cast(*self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OffsetToBytes;
+
+    #[test]
+    fn we_offset_signed_integers_before_serializing() {
+        assert_eq!(i8::MIN.offset_to_bytes(), [0]);
+        assert_eq!(0_i8.offset_to_bytes(), [128]);
+        assert_eq!(i8::MAX.offset_to_bytes(), [255]);
+
+        assert_eq!(i16::MIN.offset_to_bytes(), 0_u16.to_le_bytes());
+        assert_eq!(0_i16.offset_to_bytes(), 32768_u16.to_le_bytes());
+        assert_eq!(i16::MAX.offset_to_bytes(), u16::MAX.to_le_bytes());
+    }
+
+    #[test]
+    fn we_serialize_unsigned_bool_and_limb_arrays_without_offsets() {
+        assert_eq!(false.offset_to_bytes(), [0]);
+        assert_eq!(true.offset_to_bytes(), [1]);
+        assert_eq!(7_u8.offset_to_bytes(), [7]);
+        assert_eq!(11_u64.offset_to_bytes(), 11_u64.to_le_bytes());
+
+        let limbs = [1_u64, 2, 3, 4];
+        let mut expected = [0_u8; 32];
+        for (index, limb) in limbs.iter().enumerate() {
+            expected[index * 8..(index + 1) * 8].copy_from_slice(&limb.to_le_bytes());
+        }
+        assert_eq!(limbs.offset_to_bytes(), expected);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add direct tests for Dory `OffsetToBytes` conversions
- cover signed integer offsetting for `i8` and `i16`
- cover bool, unsigned integer, and `[u64; 4]` limb-array serialization

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-offset-bytes-refresh163
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647800645

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test offset_to_bytes --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 2 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
- Local open-PR file map `sxt-open-pr-files-refresh159.json` did not list the touched file.
- Newest own PRs #2384, #2385, #2386, and #2387 touch different files.