### PR TITLE
test: cover dory verifier challenge inverse

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
@@ -1,6 +1,19 @@
 use super::{test_rng, DoryMessages, G1Affine, G2Affine, F, GT};
+use ark_ff::One;
 use ark_std::UniformRand;
 use merlin::Transcript;
+use num_traits::Zero;
+
+#[test]
+fn verifier_f_message_returns_a_nonzero_challenge_and_inverse() {
+    let mut messages = DoryMessages::default();
+    let mut transcript = Transcript::new(b"test");
+
+    let (message, message_inv) = messages.verifier_F_message(&mut transcript);
+
+    assert!(!message.is_zero());
+    assert_eq!(message * message_inv, F::one());
+}
 
 #[test]
 fn we_can_send_and_receive_the_correct_messages_in_the_same_order() {


### PR DESCRIPTION
/claim #560

## Summary
- add direct coverage for `DoryMessages::verifier_F_message`
- assert the verifier challenge is nonzero
- assert the returned inverse multiplies back to one

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-verifier-challenge-refresh164
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4647888171

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test verifier_f_message_returns_a_nonzero_challenge_and_inverse --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dory_messages --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 5 passed, 0 failed, 956 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Deconfliction
- Local open-PR file map `sxt-open-pr-files-refresh159.json` did not list the touched file.
- Newest own PRs #2384 through #2388 touch different files.