### PR TITLE
test: cover dory vmv weighted rows

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
@@ -219,6 +219,31 @@ mod tests {
     }
 
     #[test]
+    fn we_can_compute_v_vec_from_weighted_rows() {
+        let a = vec![
+            F::from(1),
+            F::from(2),
+            F::from(3),
+            F::from(4),
+            F::from(5),
+            F::from(6),
+        ];
+        let L_vec = vec![F::from(2), F::from(3), F::from(7), F::from(11)];
+
+        let v_vec = compute_v_vec(&a, &L_vec, 1, 2);
+
+        assert_eq!(
+            v_vec,
+            vec![
+                F::from(2 * 1 + 3 * 3 + 7 * 5),
+                F::from(2 * 2 + 3 * 4 + 7 * 6),
+                F::from(0),
+                F::from(0),
+            ]
+        );
+    }
+
+    #[test]
     fn we_can_compute_l_and_r_when_num_vars_is_positive_and_less_than_sigma() {
         let b_point = vec![F::from(10)];
         let sigma = 2;


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for Dory VMV helper row accumulation.

Scope:
- Adds `we_can_compute_v_vec_from_weighted_rows` in `crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs`.
- Covers `compute_v_vec` with multiple weighted rows and verifies zero padding for untouched output columns.

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_compute_v_vec_from_weighted_rows --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dory_vmv_helper --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 7 passed, 0 failed, 954 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Evidence MP4:
https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-v-vec-weighted-rows-refresh165