### PR TITLE
test: cover dory vmv prover state builder

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/build_vmv_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/build_vmv_state.rs
@@ -46,3 +46,39 @@ pub(super) fn build_vmv_verifier_state(
         nu,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_ec::AffineRepr;
+
+    #[test]
+    fn we_can_build_vmv_prover_state_from_matrix_inputs() {
+        let a = vec![
+            F::from(1),
+            F::from(2),
+            F::from(3),
+            F::from(4),
+            F::from(5),
+            F::from(6),
+        ];
+        let b_point = vec![F::from(3), F::from(5), F::from(7)];
+        let T_vec_prime = vec![G1Affine::zero(); 4];
+        let sigma = 1;
+        let nu = 2;
+
+        let state = build_vmv_prover_state(&a, &b_point, T_vec_prime.clone(), sigma, nu);
+
+        let (expected_L_vec, expected_R_vec) = compute_L_R_vec(&b_point, sigma, nu);
+        let (expected_l_tensor, expected_r_tensor) = compute_l_r_tensors(&b_point, sigma, nu);
+        let expected_v_vec = compute_v_vec(&a, &expected_L_vec, sigma, nu);
+
+        assert_eq!(state.v_vec, expected_v_vec);
+        assert_eq!(state.T_vec_prime, T_vec_prime);
+        assert_eq!(state.l_tensor, expected_l_tensor);
+        assert_eq!(state.r_tensor, expected_r_tensor);
+        assert_eq!(state.L_vec, expected_L_vec);
+        assert_eq!(state.R_vec, expected_R_vec);
+        assert_eq!(state.nu, nu);
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for the Dory VMV prover state builder.

Scope:
- Adds `we_can_build_vmv_prover_state_from_matrix_inputs` in `crates/proof-of-sql/src/proof_primitive/dory/build_vmv_state.rs`.
- Covers `build_vmv_prover_state` propagation of `T_vec_prime`, `L_vec`, `R_vec`, tensors, `nu`, and computed `v_vec`.

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_build_vmv_prover_state_from_matrix_inputs --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test build_vmv_state --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Evidence MP4:
https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-build-vmv-prover-state-refresh166