### PR TITLE
test: cover dynamic vmv prover state builder

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_build_vmv_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_build_vmv_state.rs
@@ -47,3 +47,33 @@ pub(super) fn build_dynamic_vmv_verifier_state(
         nu,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_build_dynamic_vmv_prover_state_from_matrix_inputs() {
+        let a: Vec<F> = (100..108).map(Into::into).collect();
+        let b_point = vec![F::from(3), F::from(5), F::from(7)];
+        let T_vec_prime = vec![G1Affine::identity(); 8];
+        let nu = 3;
+
+        let state = build_dynamic_vmv_prover_state(&a, &b_point, T_vec_prime.clone(), nu);
+
+        let (expected_lo_vec, expected_hi_vec) = compute_dynamic_vecs(
+            bytemuck::TransparentWrapper::wrap_slice(&b_point) as &[DoryScalar],
+        );
+        let expected_L_vec = bytemuck::TransparentWrapper::peel_slice(&expected_hi_vec);
+        let expected_R_vec = bytemuck::TransparentWrapper::peel_slice(&expected_lo_vec);
+        let expected_v_vec = compute_dynamic_v_vec(&a, expected_L_vec, nu);
+
+        assert_eq!(state.v_vec, expected_v_vec);
+        assert_eq!(state.T_vec_prime, T_vec_prime);
+        assert_eq!(state.L_vec, expected_L_vec);
+        assert_eq!(state.R_vec, expected_R_vec);
+        assert!(state.l_tensor.is_empty());
+        assert_eq!(state.r_tensor, b_point);
+        assert_eq!(state.nu, nu);
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for the dynamic Dory VMV prover state builder.

Scope:
- Adds `we_can_build_dynamic_vmv_prover_state_from_matrix_inputs` in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_build_vmv_state.rs`.
- Covers `build_dynamic_vmv_prover_state` propagation of `T_vec_prime`, dynamic `L_vec`/`R_vec`, tensors, `nu`, and computed `v_vec`.

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_build_dynamic_vmv_prover_state_from_matrix_inputs --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dynamic_build_vmv_state --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Evidence MP4:
https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dynamic-vmv-prover-state-refresh167