### PR TITLE
test: cover dory reduce empty messages

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce.rs
@@ -53,3 +53,32 @@ pub fn dory_reduce_verify(
     state.nu -= 1;
     true
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{deferred_msm::DeferredMSM, test_rng, PublicParameters};
+    use merlin::Transcript;
+
+    #[test]
+    fn we_reject_dory_reduce_verification_when_messages_are_empty() {
+        let public_parameters = PublicParameters::test_rand(1, &mut test_rng());
+        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let mut messages = DoryMessages::default();
+        let mut transcript = Transcript::new(b"dory_reduce_test");
+        let mut state = VerifierState::new(
+            DeferredMSM::new([], []),
+            DeferredMSM::new([], []),
+            DeferredMSM::new([], []),
+            1,
+        );
+
+        assert!(!dory_reduce_verify(
+            &mut messages,
+            &mut transcript,
+            &mut state,
+            &verifier_setup
+        ));
+        assert_eq!(state.nu, 1);
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for Dory reduce verification with missing messages.

Scope:
- Adds `we_reject_dory_reduce_verification_when_messages_are_empty` in `crates/proof-of-sql/src/proof_primitive/dory/dory_reduce.rs`.
- Covers the verifier returning `false` before mutating `nu` when fewer than the required six GT messages are available.

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_reject_dory_reduce_verification_when_messages_are_empty --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dory_reduce --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-116 -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Evidence MP4:
https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-reduce-empty-messages-refresh168