### PR TITLE
test: cover extended dory reduce empty messages

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
@@ -111,3 +111,42 @@ pub fn extended_dory_reduce_verify(
 
     true
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{
+        deferred_msm::DeferredMSM, test_rng, PublicParameters, VerifierState, F,
+    };
+    use merlin::Transcript;
+
+    #[test]
+    fn we_reject_extended_dory_reduce_verification_when_messages_are_empty() {
+        let public_parameters = PublicParameters::test_rand(1, &mut test_rng());
+        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let mut messages = DoryMessages::default();
+        let mut transcript = Transcript::new(b"extended_dory_reduce_test");
+        let mut state = ExtendedVerifierState {
+            base_state: VerifierState::new(
+                DeferredMSM::new([], []),
+                DeferredMSM::new([], []),
+                DeferredMSM::new([], []),
+                1,
+            ),
+            E_1: DeferredMSM::new([], []),
+            E_2: DeferredMSM::new([], []),
+            s1_tensor: vec![F::from(2)],
+            s2_tensor: vec![F::from(3)],
+            alphas: vec![F::from(0)],
+            alpha_invs: vec![F::from(0)],
+        };
+
+        assert!(!extended_dory_reduce_verify(
+            &mut messages,
+            &mut transcript,
+            &mut state,
+            &verifier_setup
+        ));
+        assert_eq!(state.base_state.nu, 1);
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds focused test-only coverage for `extended_dory_reduce_verify` rejecting empty Dory message sets without reducing `base_state.nu`.

Evidence MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-extended-reduce-empty-messages-refresh170

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_reject_extended_dory_reduce_verification_when_messages_are_empty --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test extended_dory_reduce --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Deconfliction: local open-PR file map `sxt-open-pr-files-refresh159.json` did not list this file as touched by open PRs; newest own PRs #2384 through #2394 touch different files.