### PR TITLE
test: cover scalar product extra gt messages

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
@@ -79,3 +79,35 @@ pub fn scalar_product_verify(
 
     res
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{rand_G_vecs, test_rng, PublicParameters, GT};
+    use ark_std::UniformRand;
+    use merlin::Transcript;
+
+    #[test]
+    fn we_reject_scalar_product_verification_with_extra_gt_messages() {
+        let mut rng = test_rng();
+        let public_parameters = PublicParameters::test_rand(0, &mut rng);
+        let prover_setup = (&public_parameters).into();
+        let verifier_setup = (&public_parameters).into();
+        let (v1, v2) = rand_G_vecs(0, &mut rng);
+        let prover_state = ProverState::new(v1, v2, 0);
+        let verifier_state = prover_state.calculate_verifier_state(&prover_setup);
+
+        let mut messages = DoryMessages::default();
+        let mut transcript = Transcript::new(b"scalar_product_test");
+        scalar_product_prove(&mut messages, &mut transcript, &prover_state);
+        messages.GT_messages.push(GT::rand(&mut rng));
+
+        let mut transcript = Transcript::new(b"scalar_product_test");
+        assert!(!scalar_product_verify(
+            &mut messages,
+            &mut transcript,
+            verifier_state,
+            &verifier_setup
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds focused test-only coverage for `scalar_product_verify` rejecting proofs with extra GT messages.

Evidence MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-scalar-product-extra-gt-refresh171

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_reject_scalar_product_verification_with_extra_gt_messages --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test scalar_product --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Deconfliction: local open-PR file map `sxt-open-pr-files-refresh159.json` did not list this file as touched by open PRs; newest own PRs #2384 through #2395 touch different files.