### PR TITLE
test: cover dory inner product empty messages

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_inner_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_inner_product.rs
@@ -39,3 +39,31 @@ pub fn dory_inner_product_verify(
     }
     scalar_product_verify(messages, transcript, state, setup)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{deferred_msm::DeferredMSM, test_rng, PublicParameters};
+    use merlin::Transcript;
+
+    #[test]
+    fn we_reject_dory_inner_product_verification_when_messages_are_empty() {
+        let public_parameters = PublicParameters::test_rand(1, &mut test_rng());
+        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let verifier_state = VerifierState::new(
+            DeferredMSM::new([], []),
+            DeferredMSM::new([], []),
+            DeferredMSM::new([], []),
+            1,
+        );
+        let mut messages = DoryMessages::default();
+        let mut transcript = Transcript::new(b"dory_inner_product_test");
+
+        assert!(!dory_inner_product_verify(
+            &mut messages,
+            &mut transcript,
+            verifier_state,
+            &verifier_setup
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds focused test-only coverage for `dory_inner_product_verify`, confirming empty message sets are rejected during the reduction stage.

Evidence MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-inner-product-empty-messages-refresh173

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_reject_dory_inner_product_verification_when_messages_are_empty --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dory_inner_product --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 22 passed, 0 failed, 939 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Deconfliction: local open-PR file map `sxt-open-pr-files-refresh159.json` did not list this file as touched by open PRs; newest own PRs #2384 through #2397 touch different files.