### PR TITLE
test: cover extended dory inner product empty messages

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product.rs
@@ -60,3 +60,42 @@ pub fn extended_dory_inner_product_verify(
 
     res
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{
+        deferred_msm::DeferredMSM, test_rng, PublicParameters, VerifierState,
+    };
+    use merlin::Transcript;
+
+    #[test]
+    fn we_reject_extended_dory_inner_product_when_messages_are_empty() {
+        let public_parameters = PublicParameters::test_rand(1, &mut test_rng());
+        let verifier_setup = VerifierSetup::from(&public_parameters);
+        let verifier_state = ExtendedVerifierState {
+            base_state: VerifierState::new(
+                DeferredMSM::new([], []),
+                DeferredMSM::new([], []),
+                DeferredMSM::new([], []),
+                1,
+            ),
+            E_1: DeferredMSM::new([], []),
+            E_2: DeferredMSM::new([], []),
+            s1_tensor: vec![F::from(2)],
+            s2_tensor: vec![F::from(3)],
+            alphas: vec![F::from(0)],
+            alpha_invs: vec![F::from(0)],
+        };
+        let mut messages = DoryMessages::default();
+        let mut transcript = Transcript::new(b"extended_dory_inner_product_test");
+
+        assert!(!extended_dory_inner_product_verify(
+            &mut messages,
+            &mut transcript,
+            verifier_state,
+            &verifier_setup,
+            |_| panic!("folding should not run when reduction messages are empty")
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds focused test-only coverage for `extended_dory_inner_product_verify`, confirming empty message sets are rejected during the extended reduction stage before scalar folding is attempted.

Evidence MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-extended-inner-product-empty-messages-refresh174

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_reject_extended_dory_inner_product_when_messages_are_empty --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test extended_dory_inner_product --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 12 passed, 0 failed, 949 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Deconfliction: local open-PR file map `sxt-open-pr-files-refresh159.json` did not list this file as touched by open PRs; newest own PRs #2384 through #2398 touch different files.