### PR TITLE
test: cover dory reduce cross pairings

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce_helper.rs
@@ -145,3 +145,26 @@ pub fn dory_reduce_verify_update_Ds(
         + DeferredGT::from(setup.Delta_2L[state.nu]) * beta_inv * alpha_inv
         + DeferredGT::from(setup.Delta_2R[state.nu]) * beta_inv;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{rand_G_vecs, test_rng, ProverState};
+    use ark_ec::pairing::Pairing;
+
+    #[test]
+    fn we_can_compute_cross_pairings_for_dory_reduce() {
+        let mut rng = test_rng();
+        let nu = 2;
+        let half_n = 1 << (nu - 1);
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let expected_c_plus = Pairing::multi_pairing(&v1[..half_n], &v2[half_n..]);
+        let expected_c_minus = Pairing::multi_pairing(&v1[half_n..], &v2[..half_n]);
+        let state = ProverState::new(v1, v2, nu);
+
+        let (c_plus, c_minus) = dory_reduce_prove_compute_Cs(&state, half_n);
+
+        assert_eq!(c_plus, expected_c_plus);
+        assert_eq!(c_minus, expected_c_minus);
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds focused test-only coverage for `dory_reduce_prove_compute_Cs`, confirming it computes the expected left/right cross pairings used by Dory reduction.

Evidence MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-reduce-cross-pairings-refresh175

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_compute_cross_pairings_for_dory_reduce --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dory_reduce_helper --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Deconfliction: local open-PR file map `sxt-open-pr-files-refresh159.json` did not list this file as touched by open PRs; newest own PRs #2384 through #2399 touch different files.