### PR TITLE
test: cover dory public setup accessors

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
@@ -57,3 +57,27 @@ impl<'a> DoryVerifierPublicSetup<'a> {
         self.verifier_setup
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof_primitive::dory::{test_rng, PublicParameters};
+
+    #[test]
+    fn we_can_read_dory_public_setup_accessors() {
+        let public_parameters = PublicParameters::test_rand(2, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let verifier_setup = VerifierSetup::from(&public_parameters);
+
+        let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 1);
+        assert_eq!(dory_prover_setup.sigma(), 1);
+        assert_eq!(dory_prover_setup.prover_setup().max_nu, prover_setup.max_nu);
+
+        let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 2);
+        assert_eq!(dory_verifier_setup.sigma(), 2);
+        assert_eq!(
+            dory_verifier_setup.verifier_setup().max_nu,
+            verifier_setup.max_nu
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds focused test-only coverage for the Dory public setup accessor methods, confirming sigma and wrapped setup values are exposed correctly for prover and verifier public setups.

Evidence MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-public-setup-accessors-refresh177

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_read_dory_public_setup_accessors --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dory_public_setup --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Deconfliction: local open-PR file map `sxt-open-pr-files-refresh159.json` did not list this file as touched by open PRs; newest own PRs #2384 through #2401 touch different files.