### PR TITLE
test: cover dory verifier state constructor

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/state.rs
@@ -68,3 +68,31 @@ impl VerifierState {
         VerifierState { C, D_1, D_2, nu }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{rand_G_vecs, test_rng, ProverSetup, PublicParameters};
+    use super::*;
+    use ark_ec::pairing::Pairing;
+
+    #[test]
+    fn we_can_build_verifier_state_from_deferred_commitments() {
+        let mut rng = test_rng();
+        let max_nu = 4;
+        let nu = 3;
+        let pp = PublicParameters::test_rand(max_nu, &mut rng);
+        let prover_setup: ProverSetup = (&pp).into();
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+
+        let C = Pairing::multi_pairing(&v1, &v2);
+        let D_1 = Pairing::multi_pairing(&v1, prover_setup.Gamma_2[nu]);
+        let D_2 = Pairing::multi_pairing(prover_setup.Gamma_1[nu], &v2);
+
+        let verifier_state = VerifierState::new(C.into(), D_1.into(), D_2.into(), nu);
+
+        assert_eq!(verifier_state.C, C);
+        assert_eq!(verifier_state.D_1, D_1);
+        assert_eq!(verifier_state.D_2, D_2);
+        assert_eq!(verifier_state.nu, nu);
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for Dory verifier state construction.

## Scope
- Touches only `crates/proof-of-sql/src/proof_primitive/dory/state.rs`.
- Adds `we_can_build_verifier_state_from_deferred_commitments`.
- Verifies `VerifierState::new` preserves deferred `C`, `D_1`, `D_2`, and `nu` when built from real pairing commitments.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-verifier-state-constructor-refresh178
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4648749967

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_build_verifier_state_from_deferred_commitments --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test state --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 7 passed, 0 failed, 954 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified with ffprobe: H.264, 1280x720, yuv420p, 6.0 seconds.