### PR TITLE
test: cover extended verifier state tensor constructor

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs
@@ -133,3 +133,49 @@ impl ExtendedVerifierState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{rand_F_tensors, rand_G_vecs, test_rng, ProverSetup, PublicParameters};
+    use super::*;
+    use ark_ec::pairing::Pairing;
+
+    #[test]
+    fn we_can_build_extended_verifier_state_from_tensor_commitments() {
+        let mut rng = test_rng();
+        let max_nu = 4;
+        let nu = 3;
+        let pp = PublicParameters::test_rand(max_nu, &mut rng);
+        let prover_setup: ProverSetup = (&pp).into();
+        let (v1, v2) = rand_G_vecs(nu, &mut rng);
+        let (s1_tensor, s2_tensor) = rand_F_tensors(nu, &mut rng);
+
+        let C: DeferredGT = Pairing::multi_pairing(&v1, &v2).into();
+        let D_1: DeferredGT = Pairing::multi_pairing(&v1, prover_setup.Gamma_2[nu]).into();
+        let D_2: DeferredGT = Pairing::multi_pairing(prover_setup.Gamma_1[nu], &v2).into();
+        let E_1 = DeferredG1::from(v1[0]);
+        let E_2 = DeferredG2::from(v2[0]);
+
+        let verifier_state = ExtendedVerifierState::new_tensor(
+            E_1.clone(),
+            E_2.clone(),
+            s1_tensor.clone(),
+            s2_tensor.clone(),
+            C.clone(),
+            D_1.clone(),
+            D_2.clone(),
+            nu,
+        );
+
+        assert_eq!(verifier_state.E_1, E_1);
+        assert_eq!(verifier_state.E_2, E_2);
+        assert_eq!(verifier_state.s1_tensor, s1_tensor);
+        assert_eq!(verifier_state.s2_tensor, s2_tensor);
+        assert_eq!(verifier_state.base_state.C, C);
+        assert_eq!(verifier_state.base_state.D_1, D_1);
+        assert_eq!(verifier_state.base_state.D_2, D_2);
+        assert_eq!(verifier_state.base_state.nu, nu);
+        assert_eq!(verifier_state.alphas, vec![F::default(); nu]);
+        assert_eq!(verifier_state.alpha_invs, vec![F::default(); nu]);
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for extended Dory verifier state tensor construction.

## Scope
- Touches only `crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs`.
- Adds `we_can_build_extended_verifier_state_from_tensor_commitments`.
- Verifies `ExtendedVerifierState::new_tensor` preserves `E_1`, `E_2`, tensors, base `C`, `D_1`, `D_2`, and `nu`, and initializes `alphas`/`alpha_invs` to the expected zero vectors.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-extended-verifier-state-tensor-refresh179
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4648798773

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_can_build_extended_verifier_state_from_tensor_commitments --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test extended_state --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 2 passed, 0 failed, 959 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified with ffprobe: H.264, 1280x720, yuv420p, 6.0 seconds.