### PR TITLE
test: cover eval vmv empty messages

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
@@ -80,3 +80,34 @@ pub fn eval_vmv_re_verify(
         E_1, E_2, s1_tensor, s2_tensor, C, D_1, D_2, nu,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{test_rng, DeferredGT, PublicParameters, VMVVerifierState, F};
+    use super::*;
+    use alloc::vec;
+    use merlin::Transcript;
+
+    #[test]
+    fn we_reject_eval_vmv_re_verification_when_no_messages_are_present() {
+        let mut rng = test_rng();
+        let pp = PublicParameters::test_rand(1, &mut rng);
+        let verifier_setup = (&pp).into();
+        let state = VMVVerifierState {
+            y: F::default(),
+            T: DeferredGT::new([], []),
+            l_tensor: vec![F::default()],
+            r_tensor: vec![F::default()],
+            nu: 1,
+        };
+        let mut messages = DoryMessages::default();
+        let mut transcript = Transcript::new(b"eval_vmv_re_empty_messages");
+
+        assert_eq!(
+            eval_vmv_re_verify(&mut messages, &mut transcript, state, &verifier_setup),
+            None
+        );
+        assert!(messages.GT_messages.is_empty());
+        assert!(messages.G1_messages.is_empty());
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for the Eval-VMV-RE verifier guard when no proof messages are present.

## Scope
- Touches only `crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs`.
- Adds `we_reject_eval_vmv_re_verification_when_no_messages_are_present`.
- Verifies `eval_vmv_re_verify` returns `None` before attempting to read empty GT/G1 queues.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-eval-vmv-empty-messages-refresh180
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4648853943

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_reject_eval_vmv_re_verification_when_no_messages_are_present --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test eval_vmv_re --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 9 passed, 0 failed, 952 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified with ffprobe: H.264, 1280x720, yuv420p, 6.0 seconds.