### PR TITLE
test: cover dory gt message ordering

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
@@ -124,3 +124,34 @@ impl DoryMessages {
         (message, message_inv)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{test_rng, GT};
+    use super::*;
+    use ark_std::UniformRand;
+    use merlin::Transcript;
+
+    #[test]
+    fn gt_messages_are_received_in_the_order_the_prover_sent_them() {
+        let mut rng = test_rng();
+        let first = GT::rand(&mut rng);
+        let second = GT::rand(&mut rng);
+        let mut messages = DoryMessages::default();
+        let mut prover_transcript = Transcript::new(b"dory_gt_message_order");
+
+        messages.prover_send_GT_message(&mut prover_transcript, first);
+        messages.prover_send_GT_message(&mut prover_transcript, second);
+
+        let mut verifier_transcript = Transcript::new(b"dory_gt_message_order");
+        assert_eq!(
+            messages.prover_receive_GT_message(&mut verifier_transcript),
+            first
+        );
+        assert_eq!(
+            messages.prover_receive_GT_message(&mut verifier_transcript),
+            second
+        );
+        assert!(messages.GT_messages.is_empty());
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for Dory GT message ordering.

## Scope
- Touches only `crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs`.
- Adds `gt_messages_are_received_in_the_order_the_prover_sent_them`.
- Verifies `prover_send_GT_message` and `prover_receive_GT_message` preserve prover-send order and empty the GT queue after both messages are consumed.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dory-gt-message-order-refresh181
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4648891253

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test gt_messages_are_received_in_the_order_the_prover_sent_them --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dory_messages --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 5 passed, 0 failed, 956 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified with ffprobe: H.264, 1280x720, yuv420p, 6.0 seconds.