### PR TITLE
test: cover dynamic dory evaluation proof invalid offset

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
@@ -131,3 +131,30 @@ impl CommitmentEvaluationProof for DynamicDoryEvaluationProof {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{test_rng, ProverSetup, PublicParameters};
+    use super::*;
+    use crate::base::{commitment::CommitmentEvaluationProof, scalar::Scalar};
+    use alloc::vec;
+    use merlin::Transcript;
+
+    #[test]
+    fn invalid_generators_offset_creates_default_dynamic_dory_evaluation_proof() {
+        let mut rng = test_rng();
+        let public_parameters = PublicParameters::test_rand(2, &mut rng);
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let mut transcript = Transcript::new(b"dynamic_dory_invalid_generators_offset");
+
+        let proof = DynamicDoryEvaluationProof::new(
+            &mut transcript,
+            &vec![DoryScalar::ZERO],
+            &vec![DoryScalar::ZERO],
+            1,
+            &&prover_setup,
+        );
+
+        assert_eq!(proof, DynamicDoryEvaluationProof::default());
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for dynamic Dory evaluation proof invalid generator offset handling.

## Scope
- Touches only `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs`.
- Adds `invalid_generators_offset_creates_default_dynamic_dory_evaluation_proof`.
- Verifies `DynamicDoryEvaluationProof::new` returns the default/empty proof when `generators_offset` is nonzero.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dynamic-eval-proof-invalid-offset-refresh183
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649060045

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test invalid_generators_offset_creates_default_dynamic_dory_evaluation_proof --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dynamic_dory_commitment_evaluation_proof --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet` passed: 6 passed, 0 failed, 955 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified with ffprobe: H.264, 1280x720, yuv420p, 6.0 seconds.