### PR TITLE
test: cover dynamic dory default commitment identity

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
@@ -94,6 +94,7 @@ impl Commitment for DynamicDoryCommitment {
 mod tests {
     use super::{DynamicDoryCommitment, GT};
     use crate::{
+        base::scalar::Scalar,
         base::{
             commitment::{ColumnCommitments, Commitment, TableCommitment},
             database::{
@@ -120,6 +121,14 @@ mod tests {
             commitment1.to_transcript_bytes(),
             commitment2.to_transcript_bytes()
         );
+    }
+
+    #[test]
+    fn default_dynamic_dory_commitment_is_preserved_by_one_scalar() {
+        let default_commitment = DynamicDoryCommitment::default();
+
+        assert_eq!(DoryScalar::ONE * default_commitment, default_commitment);
+        assert_eq!(DoryScalar::ONE * &default_commitment, default_commitment);
     }
 
     /// Under no circumstances should this test be modified. Unless you know what you're doing.


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for the default `DynamicDoryCommitment` identity path.

The new test verifies that multiplying `DynamicDoryCommitment::default()` by `DoryScalar::ONE` preserves the commitment for both the owned and borrowed `Mul` implementations.

## Evidence

- Branch: `elianguitarra:codex/sxt-560-dynamic-commitment-default-identity`
- Commit: `f624cecf`
- File: `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs`
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-dynamic-commitment-default-identity-refresh184
- Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649141929

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test default_dynamic_dory_commitment_is_preserved_by_one_scalar --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet`
  - 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test dynamic_dory_commitment --target-dir C:\Users\malow\AppData\Local\Temp\sxt-target-117 -- --quiet`
  - 17 passed, 0 failed, 944 filtered out.
- `cargo fmt --check`
  - passed.
- `git diff --check`
  - passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.