### PR TITLE
test: cover lagrange sum above domain length

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
@@ -174,3 +174,23 @@ where
         rho
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_truncated_lagrange_basis_sum;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn truncated_lagrange_basis_sum_saturates_when_length_exceeds_domain() {
+        let point = [
+            TestScalar::from(2u8),
+            TestScalar::from(5u8),
+            TestScalar::from(7u8),
+        ];
+
+        assert_eq!(
+            compute_truncated_lagrange_basis_sum(9, &point),
+            TestScalar::from(1u8)
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for `compute_truncated_lagrange_basis_sum` when the requested length is larger than the evaluation domain.

The new internal test verifies the documented behavior that lengths above `2^nu` saturate to the full basis sum of `1`.

## Evidence

- Branch: `elianguitarra:codex/sxt-560-lagrange-rho-padding`
- Commit: `62107632`
- File: `crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs`
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-lagrange-sum-above-domain-refresh185
- Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649211764

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test truncated_lagrange_basis_sum_saturates_when_length_exceeds_domain -- --quiet`
  - 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test lagrange_basis_evaluation -- --quiet`
  - 17 passed, 0 failed, 944 filtered out.
- `cargo fmt --check`
  - passed.
- `git diff --check`
  - passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.

Note: Windows Application Control blocked temporary target-dir executables, so final successful validation used the repo-local Cargo target directory.