### PR TITLE
test: cover slice reverse operation order

### DIFF
--- a/crates/proof-of-sql/src/base/database/slice_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_operation.rs
@@ -632,6 +632,13 @@ mod test {
     }
 
     #[test]
+    fn reverse_op_preserves_non_commutative_operand_order() {
+        let reversed_subtract = reverse_op(|l: &i32, r: &i32| l - r);
+
+        assert_eq!(reversed_subtract(&3, &10), 7);
+    }
+
+    #[test]
     fn we_can_repeat_a_slice() {
         // We can repeat a slice
         let slice = [1_i16, 2, 3];


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for `reverse_op` in `slice_operation.rs`.

The new test uses subtraction, a non-commutative operation, to verify the helper really reverses operand order rather than merely forwarding arguments.

## Evidence

- Branch: `elianguitarra:codex/sxt-560-slice-reverse-op-order`
- Commit: `ef3be78c`
- File: `crates/proof-of-sql/src/base/database/slice_operation.rs`
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-slice-reverse-op-order-refresh186
- Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649258647

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test reverse_op_preserves_non_commutative_operand_order -- --quiet`
  - 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test slice_operation -- --quiet`
  - 38 passed, 0 failed, 923 filtered out.
- `cargo fmt --check`
  - passed.
- `git diff --check`
  - passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.