### PR TITLE
test: cover join multiplicity output order

### DIFF
--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -780,6 +780,17 @@ mod tests {
         assert_eq!(result, &[1, 0, 3, 1], "Expected multiplicities");
     }
 
+    #[test]
+    fn multiplicities_preserve_original_unique_row_order_after_sorting() {
+        let alloc = Bump::new();
+        let data = vec![Column::<TestScalar>::Int(&[4, 2, 4, 1, 2, 2])];
+        let unique = vec![Column::<TestScalar>::Int(&[2, 4, 1, 9])];
+
+        let result = get_multiplicities(&data, &unique, &alloc);
+
+        assert_eq!(result, &[3, 2, 1, 0]);
+    }
+
     // Get Columns of Table
     #[test]
     fn we_can_get_columns_of_table() {


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for `get_multiplicities` in `join_util.rs`.

The new test verifies that multiplicity counts are returned in the original `unique` row order even though the function sorts unique/data indexes internally to compute matches.

## Evidence

- Branch: `elianguitarra:codex/sxt-560-join-multiplicity-order`
- Commit: `112108c7`
- File: `crates/proof-of-sql/src/base/database/join_util.rs`
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-join-multiplicity-order-refresh187
- Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649326126

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test multiplicities_preserve_original_unique_row_order_after_sorting -- --quiet`
  - 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test join_util -- --quiet`
  - 20 passed, 0 failed, 941 filtered out.
- `cargo fmt --check`
  - passed.
- `git diff --check`
  - passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.