### PR TITLE
test: cover decimal equality extreme rhs scaling

### DIFF
--- a/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
@@ -585,6 +585,24 @@ mod test {
     }
 
     #[test]
+    fn eq_decimal_columns_handles_extreme_scale_difference_when_rhs_is_upscaled() {
+        let lhs = [0_i64, 9, -3]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let rhs = [0_i16, 1, -1]
+            .into_iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        let left_column_type = ColumnType::Decimal75(Precision::new(40).unwrap(), 26);
+        let right_column_type = ColumnType::Decimal75(Precision::new(10).unwrap(), -50);
+
+        let actual = eq_decimal_columns(&lhs, &rhs, left_column_type, right_column_type);
+
+        assert_eq!(actual, vec![true, false, false]);
+    }
+
+    #[test]
     fn we_can_le_decimal_columns() {
         // lhs is integer and rhs is decimal with nonnegative scale
         let lhs = [1_i8, -2, 3];


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage for `eq_decimal_columns` in `slice_decimal_operation.rs`.

The new test covers the extreme scale-difference branch where the right-hand decimal would require upscaling beyond the left decimal precision. It verifies that only zero equals zero and nonzero values remain unequal without huge scaling.

## Evidence

- Branch: `elianguitarra:codex/sxt-560-decimal-extreme-scale-equality`
- Commit: `580d1912`
- File: `crates/proof-of-sql/src/base/database/slice_decimal_operation.rs`
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-decimal-extreme-scale-equality-refresh188
- Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649394505

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test eq_decimal_columns_handles_extreme_scale_difference_when_rhs_is_upscaled -- --quiet`
  - 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test slice_decimal_operation -- --quiet`
  - 8 passed, 0 failed, 953 filtered out.
- `cargo fmt --check`
  - passed.
- `git diff --check`
  - passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.