### PR TITLE
test: cover arithmetic invalid boolean columns

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
@@ -323,3 +323,29 @@ impl ArithmeticOp for DivOp {
         try_divide_decimal_columns(lhs, rhs, left_column_type, right_column_type)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{AddOp, ArithmeticOp};
+    use crate::base::{
+        database::{ColumnOperationError, ColumnType, OwnedColumn},
+        scalar::test_scalar::TestScalar,
+    };
+
+    #[test]
+    fn arithmetic_rejects_boolean_columns_with_invalid_type_error() {
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false]);
+        let rhs = OwnedColumn::<TestScalar>::Boolean(vec![false, true]);
+
+        let result = AddOp::owned_column_element_wise_arithmetic(&lhs, &rhs);
+
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType {
+                left_type: ColumnType::Boolean,
+                right_type: ColumnType::Boolean,
+                ..
+            })
+        ));
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope
Adds a focused test-only coverage case in `crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs`.

The new test verifies that Boolean + Boolean arithmetic through `AddOp::owned_column_element_wise_arithmetic` returns `ColumnOperationError::BinaryOperationInvalidColumnType` and preserves the exact `ColumnType::Boolean` metadata for both operands.

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-arithmetic-invalid-bool-columns-refresh189
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649470220
- Branch: `elianguitarra:codex/sxt-560-arithmetic-invalid-bool-columns`
- Commit: `846340c4`

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test arithmetic_rejects_boolean_columns_with_invalid_type_error -- --quiet`
- `cargo test -p proof-of-sql --lib --no-default-features --features test column_arithmetic_operation -- --quiet`
- `cargo fmt --check`
- `git diff --check`

The MP4 evidence was verified as H.264, 1280x720, yuv420p, 6.0 seconds.