### PR TITLE
test: cover table equality column order

### DIFF
--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -168,3 +168,26 @@ impl<'a, S: Scalar> core::ops::Index<&str> for Table<'a, S> {
         self.table.get(&Ident::new(index)).unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn table_equality_preserves_column_order() {
+        let table = Table::<TestScalar>::try_from_iter([
+            ("first".into(), Column::Int(&[1, 2])),
+            ("second".into(), Column::Boolean(&[true, false])),
+        ])
+        .unwrap();
+        let same_columns_different_order = Table::<TestScalar>::try_from_iter([
+            ("second".into(), Column::Boolean(&[true, false])),
+            ("first".into(), Column::Int(&[1, 2])),
+        ])
+        .unwrap();
+
+        assert_eq!(table.num_rows(), same_columns_different_order.num_rows());
+        assert_ne!(table, same_columns_different_order);
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope
Adds a focused test-only coverage case in `crates/proof-of-sql/src/base/database/table.rs`.

The new test verifies that `Table` equality remains column-order-sensitive: two tables with the same column names, values, and row count but different column order compare unequal. This preserves the explicit `PartialEq` contract that aligns with RecordBatch-style ordering behavior.

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-table-equality-column-order-refresh190
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649526114
- Branch: `elianguitarra:codex/sxt-560-table-equality-column-order`
- Commit: `a795c002`

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test table_equality_preserves_column_order -- --quiet`
- `cargo test -p proof-of-sql --lib --no-default-features --features test table -- --quiet`
- `cargo fmt --check`
- `git diff --check`

The MP4 evidence was verified as H.264, 1280x720, yuv420p, 6.0 seconds.