### PR TITLE
test: cover truncated evaluation vector

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -67,3 +67,17 @@ where
 
     log::log_memory_usage("End");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_evaluation_vector;
+
+    #[test]
+    fn truncated_evaluation_vector_scales_unpaired_left_values() {
+        let mut evaluation = [0_i64; 3];
+
+        compute_evaluation_vector(&mut evaluation, &[2, 3]);
+
+        assert_eq!(evaluation, [2, -4, -3]);
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope
Adds a focused test-only coverage case in `crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs`.

The new test verifies truncated `compute_evaluation_vector` output when the left side is longer than the right side during expansion. It confirms unpaired left-side values are still scaled by `one_minus_p`, preserving the partial-vector branch in `compute_evaluation_vector_impl`.

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-evaluation-vector-truncated-left-refresh191
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649580832
- Branch: `elianguitarra:codex/sxt-560-evaluation-vector-truncated-left`
- Commit: `e056a8cc`

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test truncated_evaluation_vector_scales_unpaired_left_values -- --quiet`
- `cargo test -p proof-of-sql --lib --no-default-features --features test evaluation_vector -- --quiet`
- `cargo fmt --check`
- `git diff --check`

The MP4 evidence was verified as H.264, 1280x720, yuv420p, 6.0 seconds.