### PR TITLE
test: cover prover state constructor

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -62,3 +62,27 @@ impl<S: Scalar> ProverState<S> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProverState;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn new_prover_state_preserves_inputs_and_starts_at_round_zero() {
+        let products = vec![(TestScalar::from(7), vec![0, 2])];
+        let flattened_extensions = vec![
+            vec![TestScalar::from(1), TestScalar::from(2)],
+            vec![TestScalar::from(3), TestScalar::from(4)],
+            vec![TestScalar::from(5), TestScalar::from(6)],
+        ];
+
+        let state = ProverState::new(products.clone(), flattened_extensions.clone(), 2, 2);
+
+        assert_eq!(state.list_of_products, products);
+        assert_eq!(state.flattened_ml_extensions, flattened_extensions);
+        assert_eq!(state.num_vars, 2);
+        assert_eq!(state.max_multiplicands, 2);
+        assert_eq!(state.round, 0);
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope
Adds a focused test-only coverage case in `crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs`.

The new test verifies `ProverState::new` preserves product inputs, flattened multilinear extensions, `num_vars`, `max_multiplicands`, and initializes `round` to zero.

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-prover-state-new-fields-refresh192
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649627879
- Branch: `elianguitarra:codex/sxt-560-prover-state-new-fields`
- Commit: `42230fc0`

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test new_prover_state_preserves_inputs_and_starts_at_round_zero -- --quiet`
- `cargo test -p proof-of-sql --lib --no-default-features --features test prover_state -- --quiet`
- `cargo fmt --check`
- `git diff --check`

The MP4 evidence was verified as H.264, 1280x720, yuv420p, 6.0 seconds.