### PR TITLE
test: cover sumcheck test case invariants

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/test_cases.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/test_cases.rs
@@ -91,3 +91,23 @@ pub fn sumcheck_test_cases<S: Scalar>(
             SumcheckTestCase::rand(num_vars, max_multiplicands, products, rng)
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::sumcheck_test_cases;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use ark_std::test_rng;
+
+    #[test]
+    fn generated_sumcheck_cases_preserve_declared_sums_and_variable_counts() {
+        let mut rng = test_rng();
+        let cases = sumcheck_test_cases::<TestScalar>(&mut rng).collect::<Vec<_>>();
+
+        assert_eq!(cases.len(), 224);
+        for case in cases {
+            let length = 1 << case.num_vars;
+            assert_eq!(case.polynomial.num_variables, case.num_vars);
+            assert_eq!(case.sum, case.polynomial.hypercube_sum(length));
+        }
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope
Adds a focused test-only coverage case in `crates/proof-of-sql/src/proof_primitive/sumcheck/test_cases.rs`.

The new test verifies `sumcheck_test_cases` emits 224 generated cases and that each case preserves its declared `num_vars` and `sum == polynomial.hypercube_sum(1 << num_vars)` invariant.

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-sumcheck-test-case-invariants-refresh193
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649694381
- Branch: `elianguitarra:codex/sxt-560-sumcheck-test-case-invariants`
- Commit: `758b36ba`

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test generated_sumcheck_cases_preserve_declared_sums_and_variable_counts -- --quiet`
- `cargo test -p proof-of-sql --lib --no-default-features --features test sumcheck::test_cases -- --quiet`
- `cargo fmt --check`
- `git diff --check`

The MP4 evidence was verified as H.264, 1280x720, yuv420p, 6.0 seconds.