### PR TITLE
test: cover prover round fix variable

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
@@ -124,3 +124,19 @@ fn in_place_fix_variable<S: Scalar>(multiplicand: &mut [S], r_as_field: S, num_v
 fn vec_elementwise_add<S: Scalar>(a: Vec<S>, b: Vec<S>) -> Vec<S> {
     a.into_iter().zip(b).map(|(x, y)| x + y).collect::<Vec<S>>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::in_place_fix_variable;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn fix_variable_updates_each_pair_in_place() {
+        let mut multiplicand = [2, 6, 10, 18].map(TestScalar::from);
+
+        in_place_fix_variable(&mut multiplicand, TestScalar::from(3), 1);
+
+        assert_eq!(multiplicand[0], TestScalar::from(14));
+        assert_eq!(multiplicand[1], TestScalar::from(34));
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope
Adds a focused test-only coverage case in `crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs`.

The new test verifies `in_place_fix_variable` updates each left/right pair in place using `left + r * (right - left)`, covering the state-reduction helper used between prover rounds.

## Evidence
- MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-prover-round-fix-variable-refresh194
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649767012
- Branch: `elianguitarra:codex/sxt-560-prover-round-fix-variable`
- Commit: `dae1e85d`

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test fix_variable_updates_each_pair_in_place -- --quiet`
- `cargo test -p proof-of-sql --lib --no-default-features --features test prover_round -- --quiet`
- `cargo fmt --check`
- `git diff --check`

The MP4 evidence was verified as H.264, 1280x720, yuv420p, 6.0 seconds.