### PR TITLE
test: cover add expr constructor accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -117,3 +117,28 @@ impl ProofExpr for AddExpr {
 }
 
 impl DecimalProofExpr for AddExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::AddExpr;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        base::math::decimal::Precision,
+        sql::proof_exprs::{DynProofExpr, ProofExpr},
+    };
+
+    #[test]
+    fn add_expr_constructor_preserves_operands_and_result_type() {
+        let lhs = DynProofExpr::new_literal(LiteralValue::Int(7));
+        let rhs = DynProofExpr::new_literal(LiteralValue::SmallInt(2));
+
+        let expr = AddExpr::try_new(Box::new(lhs.clone()), Box::new(rhs.clone())).unwrap();
+
+        assert_eq!(expr.lhs(), &lhs);
+        assert_eq!(expr.rhs(), &rhs);
+        assert_eq!(
+            expr.data_type(),
+            ColumnType::Decimal75(Precision::new(11).unwrap(), 0)
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for `AddExpr::try_new`.
- Verifies the constructor preserves lhs/rhs operands through `lhs()` and `rhs()`.
- Verifies Int + SmallInt literal operands produce the expected `ColumnType::Decimal75(Precision::new(11).unwrap(), 0)` result type.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-add-expr-constructor-accessors-refresh195
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649858399

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test add_expr_constructor_preserves_operands_and_result_type -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test add_expr -- --quiet` passed with 3 passed, 0 failed, 958 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.