### PR TITLE
test: cover mock verification result helpers

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -567,6 +567,104 @@ mod tests {
     }
 
     #[test]
+    fn identity_results_track_each_constraint_for_each_row() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(
+                Vec::new(),
+                2,
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            );
+
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::ZERO,
+                1,
+            )
+            .unwrap();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::ONE,
+                1,
+            )
+            .unwrap();
+        verification_builder.increment_row_index();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::TWO,
+                1,
+            )
+            .unwrap();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::ZERO,
+                1,
+            )
+            .unwrap();
+
+        assert_eq!(
+            verification_builder.get_identity_results(),
+            vec![vec![true, false], vec![false, true]]
+        );
+    }
+
+    #[test]
+    fn zero_sum_results_fold_each_constraint_across_rows() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(
+                Vec::new(),
+                2,
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            );
+
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::ZeroSum,
+                TestScalar::ONE,
+                2,
+            )
+            .unwrap();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::ZeroSum,
+                TestScalar::TWO,
+                2,
+            )
+            .unwrap();
+        verification_builder.increment_row_index();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::ZeroSum,
+                -TestScalar::ONE,
+                2,
+            )
+            .unwrap();
+        verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::ZeroSum,
+                TestScalar::ONE,
+                2,
+            )
+            .unwrap();
+
+        assert_eq!(
+            verification_builder.get_zero_sum_results(),
+            vec![true, false]
+        );
+    }
+
+    #[test]
     fn we_can_get_first_round_mle_evaluations() {
         let mut verification_builder: MockVerificationBuilder<TestScalar> =
             MockVerificationBuilder::new(


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for `MockVerificationBuilder::get_identity_results`.
- Adds test-only coverage for `MockVerificationBuilder::get_zero_sum_results`.
- Verifies identity subpolynomial booleans are tracked per constraint per row, and zero-sum subpolynomial evaluations fold across rows per constraint.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-mock-verification-results-refresh196
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4649959704

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test identity_results_track_each_constraint_for_each_row -- --quiet` passed with 1 passed, 0 failed, 961 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test zero_sum_results_fold_each_constraint_across_rows -- --quiet` passed with 1 passed, 0 failed, 961 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test mock_verification_builder -- --quiet` passed with 19 passed, 0 failed, 943 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.