### PR TITLE
test: cover final round builder challenges

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
@@ -156,3 +156,33 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
         self.post_result_challenges.pop_front().unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FinalRoundBuilder;
+    use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+    use alloc::{collections::VecDeque, vec};
+
+    #[test]
+    fn new_builder_preserves_variables_and_consumes_challenges_in_order() {
+        let mut builder = FinalRoundBuilder::new(
+            3,
+            VecDeque::from(vec![
+                TestScalar::ONE,
+                TestScalar::TWO,
+                TestScalar::from(3u64),
+            ]),
+        );
+
+        assert_eq!(builder.num_sumcheck_variables(), 3);
+        assert_eq!(builder.num_sumcheck_subpolynomials(), 0);
+        assert!(builder.pcs_proof_mles().is_empty());
+        assert!(builder.bit_distributions().is_empty());
+        assert_eq!(builder.consume_post_result_challenge(), TestScalar::ONE);
+        assert_eq!(builder.consume_post_result_challenge(), TestScalar::TWO);
+        assert_eq!(
+            builder.consume_post_result_challenge(),
+            TestScalar::from(3u64)
+        );
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for `FinalRoundBuilder::new`.
- Verifies the configured `num_sumcheck_variables` is preserved.
- Verifies a new builder starts with no sumcheck subpolynomials, no PCS proof MLEs, and no bit distributions.
- Verifies post-result challenges are consumed in FIFO order.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-final-round-builder-challenges-refresh197
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4650058998

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test new_builder_preserves_variables_and_consumes_challenges_in_order -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test final_round_builder -- --quiet` passed with 1 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.