### PR TITLE
test: cover query proof index range

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -553,3 +553,54 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::get_index_range;
+    use crate::base::{
+        database::{MetadataAccessor, TableRef},
+        map::{indexmap, IndexMap},
+    };
+
+    struct RangeAccessor {
+        spans: IndexMap<TableRef, (usize, usize)>,
+    }
+
+    impl MetadataAccessor for RangeAccessor {
+        fn get_length(&self, table_ref: &TableRef) -> usize {
+            self.spans[table_ref].0
+        }
+
+        fn get_offset(&self, table_ref: &TableRef) -> usize {
+            self.spans[table_ref].1
+        }
+    }
+
+    #[test]
+    fn index_range_covers_all_referenced_table_spans() {
+        let first = TableRef::new("s", "first");
+        let second = TableRef::new("s", "second");
+        let third = TableRef::new("s", "third");
+        let accessor = RangeAccessor {
+            spans: indexmap! {
+                first.clone() => (3, 10),
+                second.clone() => (8, 4),
+                third.clone() => (2, 20),
+            },
+        };
+
+        assert_eq!(
+            get_index_range(&accessor, [&first, &second, &third]),
+            (4, 22)
+        );
+    }
+
+    #[test]
+    fn index_range_defaults_to_single_row_for_empty_inputs() {
+        let accessor = RangeAccessor {
+            spans: IndexMap::default(),
+        };
+
+        assert_eq!(get_index_range(&accessor, core::iter::empty()), (0, 1));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for `get_index_range` in `query_proof.rs`.
- Verifies multiple referenced table spans use the minimum offset and maximum `offset + length` end row.
- Verifies empty table-reference inputs use the existing `(0, 1)` fallback for empty plans.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-query-proof-index-range-refresh198
- `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4650164480

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test index_range_covers_all_referenced_table_spans -- --quiet` passed with 1 passed, 0 failed, 961 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test index_range_defaults_to_single_row_for_empty_inputs -- --quiet` passed with 1 passed, 0 failed, 961 filtered out.
- `cargo test -p proof-of-sql --lib --no-default-features --features test query_proof -- --quiet` passed with 2 passed, 0 failed, 960 filtered out.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.