### PR TITLE
test: cover projection exec accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -191,3 +191,41 @@ impl ProverEvaluate for ProjectionExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProjectionExec;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::{
+            proof::ProofPlan,
+            proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+            proof_plans::DynProofPlan,
+        },
+    };
+
+    #[test]
+    fn projection_constructor_preserves_input_results_and_output_fields() {
+        let input = DynProofPlan::new_empty();
+        let aliased_results = vec![
+            AliasedDynProofExpr {
+                expr: DynProofExpr::new_literal(LiteralValue::BigInt(7)),
+                alias: "total".into(),
+            },
+            AliasedDynProofExpr {
+                expr: DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+                alias: "flag".into(),
+            },
+        ];
+
+        let projection = ProjectionExec::new(aliased_results.clone(), Box::new(input.clone()));
+
+        assert_eq!(projection.input(), &input);
+        assert_eq!(projection.aliased_results(), aliased_results.as_slice());
+        let fields = projection.get_column_result_fields();
+        assert_eq!(fields[0].name().value, "total");
+        assert_eq!(fields[0].data_type(), ColumnType::BigInt);
+        assert_eq!(fields[1].name().value, "flag");
+        assert_eq!(fields[1].data_type(), ColumnType::Boolean);
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for `ProjectionExec` constructor and accessor behavior.

Scope:
- Verifies `ProjectionExec::new` preserves the boxed input plan.
- Verifies `aliased_results()` returns the same aliased expressions passed to the constructor.
- Verifies `get_column_result_fields()` preserves aliases and literal-derived output types for BigInt and Boolean projections.

Evidence MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-projection-exec-accessors-refresh199
Deconfliction attempt: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4650294782

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test projection_constructor_preserves_input_results_and_output_fields -- --quiet` passed: 1 passed, 0 failed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test projection_exec -- --quiet` passed: 2 passed, 0 failed.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.