### PR TITLE
test: cover sort merge join accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -584,3 +584,69 @@ impl ProverEvaluate for SortMergeJoinExec {
         .expect("Can not create table"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SortMergeJoinExec;
+    use crate::{
+        base::database::{ColumnField, ColumnType, TableRef},
+        sql::{
+            proof::ProofPlan,
+            proof_plans::{DynProofPlan, TableExec},
+        },
+    };
+    use alloc::{boxed::Box, vec};
+    use sqlparser::ast::Ident;
+
+    fn field(name: &str, column_type: ColumnType) -> ColumnField {
+        ColumnField::new(Ident::new(name), column_type)
+    }
+
+    #[test]
+    fn constructor_preserves_join_inputs_and_result_field_order() {
+        let left = DynProofPlan::Table(TableExec::new(
+            TableRef::new("", "left_table"),
+            vec![
+                field("id", ColumnType::BigInt),
+                field("left_value", ColumnType::VarChar),
+            ],
+        ));
+        let right = DynProofPlan::Table(TableExec::new(
+            TableRef::new("", "right_table"),
+            vec![
+                field("flag", ColumnType::Boolean),
+                field("id", ColumnType::BigInt),
+            ],
+        ));
+        let result_idents = vec![
+            Ident::new("joined_id"),
+            Ident::new("left_value"),
+            Ident::new("flag"),
+        ];
+
+        let join = SortMergeJoinExec::new(
+            Box::new(left.clone()),
+            Box::new(right.clone()),
+            vec![0],
+            vec![1],
+            result_idents.clone(),
+        );
+
+        assert_eq!(join.left_plan(), &left);
+        assert_eq!(join.right_plan(), &right);
+        assert_eq!(join.left_join_column_indexes(), &vec![0]);
+        assert_eq!(join.right_join_column_indexes(), &vec![1]);
+        assert_eq!(join.result_idents(), &result_idents);
+
+        let fields = join.get_column_result_fields();
+        assert_eq!(fields[0].name().value, "joined_id");
+        assert_eq!(fields[0].data_type(), ColumnType::BigInt);
+        assert_eq!(fields[1].name().value, "left_value");
+        assert_eq!(fields[1].data_type(), ColumnType::VarChar);
+        assert_eq!(fields[2].name().value, "flag");
+        assert_eq!(fields[2].data_type(), ColumnType::Boolean);
+
+        assert_eq!(join.get_table_references().len(), 2);
+        assert_eq!(join.get_column_references().len(), 4);
+    }
+}


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for `SortMergeJoinExec` constructor/accessor behavior and output field ordering.

Scope:
- Verifies constructor preservation of left/right plans, join-column indexes, and result identifiers.
- Verifies `get_column_result_fields()` returns join columns first, then remaining left columns, then remaining right columns using the supplied result identifiers.
- Verifies table and column reference aggregation includes both input plans.

Evidence MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-sort-merge-join-accessors-refresh200
Deconfliction attempt: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4650378950

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test constructor_preserves_join_inputs_and_result_field_order -- --quiet` passed: 1 passed, 0 failed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test sort_merge_join_exec -- --quiet` passed: 2 passed, 0 failed.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.