### PR TITLE
test: cover zero-sum sumcheck state indexes

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
+++ b/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
@@ -172,6 +172,41 @@ mod tests {
     }
 
     #[test]
+    fn zero_sum_only_state_does_not_reserve_entrywise_multiplier_slot() {
+        let mle1 = &[5, 6];
+        let mle2 = &[7, 8];
+
+        let subpolynomials = vec![SumcheckSubpolynomial::new(
+            SumcheckSubpolynomialType::ZeroSum,
+            vec![
+                (TestScalar::from(11), vec![Box::new(mle1)]),
+                (TestScalar::from(13), vec![Box::new(mle2), Box::new(mle1)]),
+            ],
+        )];
+        let scalars = vec![TestScalar::from(17), TestScalar::from(19)];
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 1, 1);
+
+        let prover_state = make_sumcheck_prover_state(&subpolynomials, 1, &random_scalars);
+
+        assert_eq!(
+            prover_state.list_of_products,
+            vec![
+                (TestScalar::from(11 * 17), vec![0]),
+                (TestScalar::from(13 * 17), vec![1, 0])
+            ]
+        );
+        assert_eq!(
+            prover_state.flattened_ml_extensions,
+            vec![
+                vec![TestScalar::from(5), TestScalar::from(6)],
+                vec![TestScalar::from(7), TestScalar::from(8)]
+            ]
+        );
+        assert_eq!(prover_state.num_vars, 1);
+        assert_eq!(prover_state.max_multiplicands, 2);
+    }
+
+    #[test]
     #[expect(clippy::too_many_lines)]
     fn we_can_make_complex_sumcheck_prover_state() {
         let mle1 = &[0; 0];


### PR DESCRIPTION
/claim #560

This PR adds test-only coverage for a ZeroSum-only `make_sumcheck_prover_state` path.

Scope:
- Verifies a ZeroSum-only state does not reserve the entrywise multiplier slot used by Identity subpolynomials.
- Verifies multiplicand indexes begin at zero and preserve flattened MLE order.
- Verifies `max_multiplicands` reflects the largest ZeroSum term.

Evidence MP4: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-sumcheck-zero-sum-indexes-refresh201
Deconfliction attempt: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4650497658

Validation:
- `cargo test -p proof-of-sql --lib --no-default-features --features test zero_sum_only_state_does_not_reserve_entrywise_multiplier_slot -- --quiet` passed: 1 passed, 0 failed.
- `cargo test -p proof-of-sql --lib --no-default-features --features test make_sumcheck_state -- --quiet` passed: 3 passed, 0 failed.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- MP4 verified as H.264, 1280x720, yuv420p, 6.0 seconds.