### PR TITLE
test: cover verification builder evaluation queues

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -1,5 +1,6 @@
 use super::{SumcheckMleEvaluations, VerificationBuilderImpl};
 use crate::{
+    base::{map::indexmap, proof::ProofSizeMismatch},
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::{SumcheckSubpolynomialType, VerificationBuilder},
 };
@@ -88,4 +89,94 @@ fn we_can_consume_post_result_challenges_in_verification_builder() {
         Curve25519Scalar::from(789),
         builder.try_consume_post_result_challenge().unwrap()
     );
+}
+
+#[test]
+fn we_consume_chi_and_rho_evaluations_by_requested_lengths() {
+    let mle_evaluations = SumcheckMleEvaluations {
+        chi_evaluations: indexmap! {
+            3 => Curve25519Scalar::from(30u64),
+            5 => Curve25519Scalar::from(50u64),
+        },
+        rho_evaluations: indexmap! {
+            2 => Curve25519Scalar::from(20u64),
+            4 => Curve25519Scalar::from(40u64),
+        },
+        ..Default::default()
+    };
+    let mut builder = VerificationBuilderImpl::new(
+        mle_evaluations,
+        &[][..],
+        &[][..],
+        VecDeque::new(),
+        vec![3, 5],
+        vec![2, 4],
+        0,
+    );
+
+    assert_eq!(
+        builder.try_consume_chi_evaluation().unwrap(),
+        (Curve25519Scalar::from(30u64), 3)
+    );
+    assert_eq!(
+        builder.try_consume_rho_evaluation().unwrap(),
+        Curve25519Scalar::from(20u64)
+    );
+    assert_eq!(
+        builder.try_consume_chi_evaluation().unwrap(),
+        (Curve25519Scalar::from(50u64), 5)
+    );
+    assert_eq!(
+        builder.try_consume_rho_evaluation().unwrap(),
+        Curve25519Scalar::from(40u64)
+    );
+    assert!(matches!(
+        builder.try_consume_chi_evaluation(),
+        Err(ProofSizeMismatch::TooFewChiLengths)
+    ));
+    assert!(matches!(
+        builder.try_consume_rho_evaluation(),
+        Err(ProofSizeMismatch::TooFewRhoLengths)
+    ));
+}
+
+#[test]
+fn missing_chi_or_rho_length_is_reported() {
+    let mut missing_chi_builder = VerificationBuilderImpl::<Curve25519Scalar>::new(
+        SumcheckMleEvaluations {
+            rho_evaluations: indexmap! {
+                2 => Curve25519Scalar::from(20u64),
+            },
+            ..Default::default()
+        },
+        &[][..],
+        &[][..],
+        VecDeque::new(),
+        vec![3],
+        vec![2],
+        0,
+    );
+    assert!(matches!(
+        missing_chi_builder.try_consume_chi_evaluation(),
+        Err(ProofSizeMismatch::ChiLengthNotFound)
+    ));
+
+    let mut missing_rho_builder = VerificationBuilderImpl::<Curve25519Scalar>::new(
+        SumcheckMleEvaluations {
+            chi_evaluations: indexmap! {
+                3 => Curve25519Scalar::from(30u64),
+            },
+            ..Default::default()
+        },
+        &[][..],
+        &[][..],
+        VecDeque::new(),
+        vec![3],
+        vec![2],
+        0,
+    );
+    assert!(matches!(
+        missing_rho_builder.try_consume_rho_evaluation(),
+        Err(ProofSizeMismatch::RhoLengthNotFound)
+    ));
 }


### PR DESCRIPTION
﻿/claim #560

## Summary
- Add test coverage for `VerificationBuilderImpl` chi/rho evaluation queue consumption by requested lengths.
- Add missing requested-length error coverage for `ChiLengthNotFound` and `RhoLengthNotFound`.
- Test-only change; no production behavior changed.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-verification-builder-queues-refresh204
- Deconfliction `/attempt #560`: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4650727259

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test we_consume_chi_and_rho_evaluations_by_requested_lengths -- --quiet`
- `cargo test -p proof-of-sql --lib --no-default-features --features test missing_chi_or_rho_length_is_reported -- --quiet`
- `cargo test -p proof-of-sql --lib --no-default-features --features test verification_builder -- --quiet`
- `cargo fmt --check`
- `git diff --check`
