### PR TITLE
test: cover curve25519 scalar u8 conversions

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
@@ -145,6 +145,28 @@ fn test_curve25519_scalar_to_bool_overflow() {
 }
 
 #[test]
+fn test_curve25519_scalar_to_u8() {
+    assert_eq!(u8::try_from(Curve25519Scalar::ZERO).unwrap(), 0);
+    assert_eq!(u8::try_from(Curve25519Scalar::ONE).unwrap(), 1);
+    assert_eq!(
+        u8::try_from(Curve25519Scalar::from(u8::MAX)).unwrap(),
+        u8::MAX
+    );
+}
+
+#[test]
+fn test_curve25519_scalar_to_u8_overflow() {
+    assert!(matches!(
+        u8::try_from(-Curve25519Scalar::ONE),
+        Err(ScalarConversionError::Overflow { .. })
+    ));
+    assert!(matches!(
+        u8::try_from(Curve25519Scalar::from(u16::from(u8::MAX) + 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    ));
+}
+
+#[test]
 fn test_curve25519_scalar_to_i8() {
     assert_eq!(i8::try_from(Curve25519Scalar::from(0)).unwrap(), 0);
     assert_eq!(i8::try_from(Curve25519Scalar::ONE).unwrap(), 1);


### PR DESCRIPTION
/claim #560

## Summary
- Add test-only coverage for `Curve25519Scalar` to `u8` conversions.
- Cover successful conversion for zero, one, and `u8::MAX`.
- Cover overflow errors for negative scalar values and values larger than `u8::MAX`.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test test_curve25519_scalar_to_u8 -- --quiet` passed with 2 tests.
- `cargo test -p proof-of-sql --lib --no-default-features --features test curve_25519_tests -- --quiet` passed with 38 tests.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Evidence
MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-curve25519-u8-conversions-refresh205

Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4650913704