### PR TITLE
test: reject truncated evm proof plan bytes

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use alloc::boxed::Box;
-use core::iter;
+use core::{iter, mem::size_of};
 use sqlparser::ast::Ident;
 use std::sync::LazyLock;
 

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -141,3 +141,18 @@ fn we_can_deserialize_proof_plan_for_simple_filter() {
     let plan = deserialized.0.inner();
     assert_eq!(plan, &expected_plan);
 }
+
+#[test]
+fn truncated_simple_filter_proof_plan_bytes_fail_to_deserialize() {
+    for len in [
+        0,
+        size_of::<usize>(),
+        SIMPLE_FILTER_SERIALIZED_BYTES.len() / 2,
+        SIMPLE_FILTER_SERIALIZED_BYTES.len() - 1,
+    ] {
+        assert!(try_standard_binary_deserialization::<EVMProofPlan>(
+            &SIMPLE_FILTER_SERIALIZED_BYTES[..len]
+        )
+        .is_err());
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add test-only regression coverage for serialized EVM proof plan deserialization.
- Verify truncated byte slices of the existing simple filter `EVMProofPlan` fixture return errors instead of deserializing successfully.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test truncated_simple_filter_proof_plan_bytes_fail_to_deserialize -- --quiet` passed with 1 test.
- `cargo test -p proof-of-sql --lib --no-default-features --features test evm_proof_plan::tests -- --quiet` passed with 3 tests.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Evidence
MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-evm-plan-truncated-bytes-refresh206

Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4650993015