### PR TITLE
test: cover zero row result decoding

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -406,6 +406,16 @@ mod tests {
     }
 
     #[test]
+    fn zero_requested_rows_decode_without_consuming_bytes() {
+        let data = [121_i64, -345_i64];
+        let out = encode_multiple_rows(&data);
+        let (decoded_data, decoded_bytes) = decode_multiple_elements::<i64>(&out[..], 0).unwrap();
+
+        assert!(decoded_data.is_empty());
+        assert_eq!(decoded_bytes, 0);
+    }
+
+    #[test]
     fn empty_buffers_will_fail_to_decode_to_integers() {
         let value = 123_i64;
         let mut out = vec![0_u8; value.required_bytes()];


### PR DESCRIPTION
/claim #560

## Summary
- Add test-only coverage for `decode_multiple_elements` when zero rows are requested.
- Verify the decoder returns an empty vector and consumes zero bytes while leaving a non-empty encoded input untouched.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test zero_requested_rows_decode_without_consuming_bytes -- --quiet` passed with 1 test.
- `cargo test -p proof-of-sql --lib --no-default-features --features test multiple_integer_rows_are_correctly_encoded_and_decoded -- --quiet` passed with 1 related test.
- `cargo fmt --check` passed.
- `git diff --check` passed.

Note: a full `result_element_serialization` filter run is not locally viable on this Windows machine because an existing test in this module allocates more than 2GB (`we_cannot_decode_strings_with_more_than_i32_bytes`).

## Evidence
MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-result-zero-row-decode-refresh207

Attempt comment: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4651092932