### PR TITLE
test: cover empty wrapped transcript binding

### DIFF
--- a/crates/proof-of-sql/src/base/proof/transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript.rs
@@ -141,6 +141,22 @@ mod tests {
     }
 
     #[test]
+    fn empty_wrapped_transcripts_are_still_bound_to_the_outer_transcript() {
+        let mut untouched_transcript: Keccak256Transcript = Transcript::new();
+        let mut transcript1: Keccak256Transcript = Transcript::new();
+        let mut transcript2: Keccak256Transcript = Transcript::new();
+
+        transcript1.wrap_transcript(|_transcript: &mut merlin::Transcript| ());
+        transcript2.wrap_transcript(|_transcript: &mut merlin::Transcript| ());
+
+        assert_eq!(transcript1.challenge_as_le(), transcript2.challenge_as_le());
+        assert_ne!(
+            transcript1.challenge_as_le(),
+            untouched_transcript.challenge_as_le()
+        );
+    }
+
+    #[test]
     fn we_can_extend_transcript_with_extend_as_be_from_refs() {
         let mut transcript1: Keccak256Transcript = Transcript::new();
         let mut transcript2: Keccak256Transcript = Transcript::new();


### PR DESCRIPTION
/claim #560

## Summary
- Adds test-only coverage for empty `wrap_transcript` closures on `Keccak256Transcript`.
- Verifies two transcripts with an empty wrapped transcript derive matching challenges.
- Verifies that wrapped transcripts still differ from an untouched transcript, proving the outer transcript was bound even when the wrapped closure is a no-op.

## Evidence
- MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-empty-wrapped-transcript-refresh208
- Attempt marker: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4651191315

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test empty_wrapped_transcripts_are_still_bound_to_the_outer_transcript -- --quiet`
- `cargo test -p proof-of-sql --lib --no-default-features --features test transcript::tests -- --quiet`
- `cargo fmt --check`
- `git diff --check`