### PR TITLE
test: cover borrowed halo2 conversions

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/halo2_conversions.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/halo2_conversions.rs
@@ -91,7 +91,7 @@ impl From<super::BNScalar> for halo2curves::bn256::Fr {
 mod tests {
     use super::super::{BNScalar, HyperKZGCommitment};
     use crate::base::scalar::MontScalar;
-    use ark_ec::{AdditiveGroup, AffineRepr};
+    use ark_ec::{AdditiveGroup, AffineRepr, CurveGroup};
     use ark_ff::Field as _;
     use ark_std::UniformRand;
     use ff::Field as _;
@@ -127,6 +127,35 @@ mod tests {
         let point = halo2curves::bn256::Fr::ONE;
         assert_eq!(halo2curves::bn256::Fr::from(scalar), point);
         assert_eq!(scalar, BNScalar::from(point));
+    }
+
+    #[test]
+    fn borrowed_commitment_conversion_matches_owned_conversion() {
+        let ark_point = ark_bn254::G1Affine::generator() * ark_bn254::Fr::from(42_u64);
+        let commitment = HyperKZGCommitment::from(&ark_point.into_affine());
+
+        let borrowed_point = halo2curves::bn256::G1Affine::from(&commitment);
+        let owned_point = halo2curves::bn256::G1Affine::from(commitment);
+
+        assert_eq!(borrowed_point, owned_point);
+        assert_eq!(
+            HyperKZGCommitment::from(borrowed_point),
+            HyperKZGCommitment::from(owned_point)
+        );
+    }
+
+    #[test]
+    fn borrowed_scalar_conversion_matches_owned_conversion() {
+        let scalar: BNScalar = MontScalar(ark_bn254::Fr::from(42_u64));
+
+        let borrowed_scalar = halo2curves::bn256::Fr::from(&scalar);
+        let owned_scalar = halo2curves::bn256::Fr::from(scalar);
+
+        assert_eq!(borrowed_scalar, owned_scalar);
+        assert_eq!(
+            BNScalar::from(borrowed_scalar),
+            BNScalar::from(owned_scalar)
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/halo2_conversions.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/halo2_conversions.rs
@@ -132,12 +132,14 @@ mod tests {
     #[test]
     fn borrowed_commitment_conversion_matches_owned_conversion() {
         let ark_point = ark_bn254::G1Affine::generator() * ark_bn254::Fr::from(42_u64);
-        let commitment = HyperKZGCommitment::from(&ark_point.into_affine());
+        let ark_point = ark_point.into_affine();
+        let commitment = HyperKZGCommitment::from(&ark_point);
 
         let borrowed_point = halo2curves::bn256::G1Affine::from(&commitment);
         let owned_point = halo2curves::bn256::G1Affine::from(commitment);
 
         assert_eq!(borrowed_point, owned_point);
+        assert_eq!(HyperKZGCommitment::from(borrowed_point), commitment);
         assert_eq!(
             HyperKZGCommitment::from(borrowed_point),
             HyperKZGCommitment::from(owned_point)
@@ -152,6 +154,7 @@ mod tests {
         let owned_scalar = halo2curves::bn256::Fr::from(scalar);
 
         assert_eq!(borrowed_scalar, owned_scalar);
+        assert_eq!(BNScalar::from(borrowed_scalar), scalar);
         assert_eq!(
             BNScalar::from(borrowed_scalar),
             BNScalar::from(owned_scalar)


### PR DESCRIPTION
/claim #560

## Summary

Adds focused test coverage for the borrowed Halo2 conversion implementations in `crates/proof-of-sql/src/proof_primitive/hyperkzg/halo2_conversions.rs`:

- `From<&HyperKZGCommitment> for halo2curves::bn256::G1Affine`
- `From<&BNScalar> for halo2curves::bn256::Fr`

The new tests verify that borrowed conversions match their owned counterparts and round-trip back to the expected proof-of-sql types.

## Deconfliction

I posted `/attempt #560` before opening this PR: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4651569918

Refresh210 open-PR file map found no open PR touching `crates/proof-of-sql/src/proof_primitive/hyperkzg/halo2_conversions.rs`, and my local claim ledger has no prior direct claim for this file.

## Evidence

MP4 evidence: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-halo2-borrowed-conversions-refresh210

## Validation

```text
cargo test -p proof-of-sql --lib --no-default-features --features test,hyperkzg_proof borrowed_commitment_conversion_matches_owned_conversion -- --quiet
cargo test -p proof-of-sql --lib --no-default-features --features test,hyperkzg_proof borrowed_scalar_conversion_matches_owned_conversion -- --quiet
cargo test -p proof-of-sql --lib --no-default-features --features test,hyperkzg_proof we_can_convert -- --quiet
cargo fmt --check
git diff --check
```

Results:

```text
borrowed_commitment_conversion_matches_owned_conversion: 1 passed, 0 failed, 984 filtered out
borrowed_scalar_conversion_matches_owned_conversion: 1 passed, 0 failed, 984 filtered out
we_can_convert group: 31 passed, 0 failed, 954 filtered out
cargo fmt --check: passed
git diff --check: passed
```