### PR TITLE
test: cover test scalar config

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -20,3 +20,37 @@ impl MontConfig<4> for TestMontConfig {
     const TWO_ADIC_ROOT_OF_UNITY: ark_ff::Fp<ark_ff::MontBackend<Self, 4>, 4> =
         Fp::new(<ark_curve25519::FrConfig as MontConfig<4>>::TWO_ADIC_ROOT_OF_UNITY.0);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{TestMontConfig, TestScalar};
+    use crate::base::scalar::Scalar;
+    use ark_ff::{Fp, MontBackend, MontConfig};
+
+    #[test]
+    fn test_mont_config_matches_curve25519_config() {
+        assert_eq!(
+            <TestMontConfig as MontConfig<4>>::MODULUS,
+            <ark_curve25519::FrConfig as MontConfig<4>>::MODULUS
+        );
+        assert_eq!(
+            <TestMontConfig as MontConfig<4>>::GENERATOR,
+            Fp::<MontBackend<TestMontConfig, 4>, 4>::new(
+                <ark_curve25519::FrConfig as MontConfig<4>>::GENERATOR.0
+            )
+        );
+        assert_eq!(
+            <TestMontConfig as MontConfig<4>>::TWO_ADIC_ROOT_OF_UNITY,
+            Fp::<MontBackend<TestMontConfig, 4>, 4>::new(
+                <ark_curve25519::FrConfig as MontConfig<4>>::TWO_ADIC_ROOT_OF_UNITY.0
+            )
+        );
+    }
+
+    #[test]
+    fn test_scalar_alias_uses_the_test_mont_config() {
+        assert_eq!(TestScalar::ZERO + TestScalar::ONE, TestScalar::ONE);
+        assert_eq!(TestScalar::TWO * TestScalar::from(5_u64), TestScalar::TEN);
+        assert_eq!(TestScalar::TEN - TestScalar::ONE, TestScalar::from(9_u64));
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage in crates/proof-of-sql/src/base/scalar/test_scalar.rs for the test scalar configuration:

- verifies TestMontConfig mirrors the Curve25519 FrConfig Montgomery constants (MODULUS, GENERATOR, and TWO_ADIC_ROOT_OF_UNITY)
- verifies the TestScalar alias performs basic arithmetic through that test config

## Deconfliction

I posted /attempt #560 before opening this PR: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4651642680

The refreshed open-PR file map sxt-open-pr-files-refresh212.json showed no open PR touching crates/proof-of-sql/src/base/scalar/test_scalar.rs, and my local ledger has no prior direct claim for this exact slice.

## Evidence

MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-test-scalar-config-refresh212

The MP4 was verified locally as H.264, 1280x720, yuv420p, duration 7.0 seconds.

## Validation

- cargo test -p proof-of-sql --lib --no-default-features --features test test_mont_config_matches_curve25519_config -- --quiet passed with 1 passed, 0 failed, 961 filtered out
- cargo test -p proof-of-sql --lib --no-default-features --features test test_scalar_alias_uses_the_test_mont_config -- --quiet passed with 1 passed, 0 failed, 961 filtered out
- cargo test -p proof-of-sql --lib --no-default-features --features test test_scalar -- --quiet passed with 12 passed, 0 failed, 950 filtered out
- cargo fmt --check passed
- git diff --check passed