### PR TITLE
test: cover test accessor contract

### DIFF
--- a/crates/proof-of-sql/src/base/database/test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor.rs
@@ -26,3 +26,74 @@ pub trait TestAccessor<C: Commitment>:
     /// Update the table offset alongside its column commitments
     fn update_offset(&mut self, table_ref: &TableRef, new_offset: usize);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TestAccessor;
+    use crate::base::{
+        commitment::{
+            naive_commitment::NaiveCommitment, naive_evaluation_proof::NaiveEvaluationProof,
+        },
+        database::{
+            owned_table_utility::{bigint, boolean, owned_table},
+            table_utility::{borrowed_bigint, borrowed_boolean, table},
+            ColumnType, OwnedTable, OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
+        },
+        scalar::test_scalar::TestScalar,
+    };
+    use bumpalo::Bump;
+
+    fn assert_test_accessor_contract<A>(mut accessor: A, table: A::Table)
+    where
+        A: TestAccessor<NaiveCommitment>,
+    {
+        let table_ref = TableRef::new("sxt", "contract");
+
+        accessor.add_table(table_ref.clone(), table, 2);
+
+        assert_eq!(
+            accessor.get_column_names(&table_ref),
+            vec!["amount", "flag"]
+        );
+        assert_eq!(accessor.get_length(&table_ref), 3);
+        assert_eq!(accessor.get_offset(&table_ref), 2);
+        assert_eq!(
+            accessor.lookup_column(&table_ref, &"amount".into()),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            accessor.lookup_schema(&table_ref),
+            vec![
+                ("amount".into(), ColumnType::BigInt),
+                ("flag".into(), ColumnType::Boolean)
+            ]
+        );
+
+        accessor.update_offset(&table_ref, 5);
+
+        assert_eq!(accessor.get_offset(&table_ref), 5);
+    }
+
+    #[test]
+    fn table_test_accessor_satisfies_the_test_accessor_contract() {
+        let alloc = Bump::new();
+        let table: Table<'_, TestScalar> = table([
+            borrowed_bigint("amount", [10, 20, 30], &alloc),
+            borrowed_boolean("flag", [true, false, true], &alloc),
+        ]);
+        let accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+
+        assert_test_accessor_contract(accessor, table);
+    }
+
+    #[test]
+    fn owned_table_test_accessor_satisfies_the_test_accessor_contract() {
+        let owned_table: OwnedTable<TestScalar> = owned_table([
+            bigint("amount", [10, 20, 30]),
+            boolean("flag", [true, false, true]),
+        ]);
+        let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+
+        assert_test_accessor_contract(accessor, owned_table);
+    }
+}


### PR DESCRIPTION
/claim #560

## Scope

Adds test-only coverage in crates/proof-of-sql/src/base/database/test_accessor.rs for the shared TestAccessor contract.

The new generic helper is exercised against both TableTestAccessor and OwnedTableTestAccessor, covering:

- add_table
- get_column_names
- get_length / get_offset
- lookup_column / lookup_schema
- update_offset

## Deconfliction

I posted /attempt #560 before opening this PR: https://github.com/spaceandtimefdn/sxt-proof-of-sql/issues/560#issuecomment-4651692513

The refreshed open-PR file map sxt-open-pr-files-refresh212.json showed no open PR touching crates/proof-of-sql/src/base/database/test_accessor.rs, and my local ledger has no prior direct claim for this exact slice.

## Evidence

MP4 evidence release: https://github.com/elianguitarra/sxt-proof-of-sql/releases/tag/evidence-sxt-560-test-accessor-contract-refresh213

The MP4 was verified locally as H.264, 1280x720, yuv420p, duration 7.0 seconds.

## Validation

- cargo test -p proof-of-sql --lib --no-default-features --features test test_accessor_contract -- --quiet passed with 2 passed, 0 failed, 960 filtered out
- cargo fmt --check passed
- git diff --check passed