### PR TITLE
refactor: make Scalar limb conversions explicit

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
@@ -14,7 +14,7 @@ const MAX_SUPPORTED_I256: i256 = i256::from_parts(
 pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
     let is_negative = val > &S::MAX_SIGNED;
     let abs_scalar = if is_negative { -*val } else { *val };
-    let limbs: [u64; 4] = abs_scalar.into();
+    let limbs = abs_scalar.to_limbs();
 
     let low = u128::from(limbs[0]) | (u128::from(limbs[1]) << 64);
     let high = i128::from(limbs[2]) | (i128::from(limbs[3]) << 64);
@@ -47,7 +47,7 @@ pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
         ];
 
         // Convert limbs to Scalar and adjust for sign
-        let scalar: S = limbs.into();
+        let scalar = S::from_limbs(limbs);
         Some(if value.is_negative() { -scalar } else { scalar })
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -3,7 +3,6 @@ use crate::base::{
     if_rayon,
     math::decimal::Precision,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    ref_into::RefInto,
     scalar::{Scalar, ScalarExt},
 };
 use alloc::vec::Vec;
@@ -116,16 +115,16 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::BigInt(ints) => CommittableColumn::BigInt(ints),
             Column::Int128(ints) => CommittableColumn::Int128(ints),
             Column::Decimal75(precision, scale, decimals) => {
-                let as_limbs: Vec<_> = decimals.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = decimals.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::Decimal75(*precision, *scale, as_limbs)
             }
             Column::Scalar(scalars) => (scalars as &[_]).into(),
             Column::VarChar((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarChar(as_limbs)
             }
             Column::VarBinary((_, scalars)) => {
-                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                let as_limbs: Vec<_> = scalars.iter().map(Scalar::to_limbs).collect();
                 CommittableColumn::VarBinary(as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
@@ -155,7 +154,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 decimals
                     .iter()
                     .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             OwnedColumn::Scalar(scalars) => (scalars as &[_]).into(),
@@ -163,14 +162,14 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 strings
                     .iter()
                     .map(Into::<S>::into)
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             OwnedColumn::VarBinary(bytes) => CommittableColumn::VarBinary(
                 bytes
                     .iter()
                     .map(|b| S::from_byte_slice_via_hash(b))
-                    .map(Into::<[u64; 4]>::into)
+                    .map(|scalar| scalar.to_limbs())
                     .collect(),
             ),
             OwnedColumn::TimestampTZ(tu, tz, times) => {
@@ -216,7 +215,7 @@ impl<'a, S: Scalar> From<&'a [S]> for CommittableColumn<'a> {
     fn from(value: &'a [S]) -> Self {
         CommittableColumn::Scalar(
             if_rayon!(value.par_iter(), value.iter())
-                .map(RefInto::<[u64; 4]>::ref_into)
+                .map(Scalar::to_limbs)
                 .collect(),
         )
     }

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -275,7 +275,7 @@ impl<T: MontConfig<4>> num_traits::Inv for MontScalar<T> {
 }
 impl<T: MontConfig<4>> Serialize for MontScalar<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut limbs: [u64; 4] = self.into();
+        let mut limbs = self.to_limbs();
         limbs.reverse();
         limbs.serialize(serializer)
     }
@@ -297,13 +297,13 @@ impl<T: MontConfig<4>> core::ops::Neg for &MontScalar<T> {
 
 impl<T: MontConfig<4>> From<MontScalar<T>> for [u64; 4] {
     fn from(value: MontScalar<T>) -> Self {
-        (&value).into()
+        value.to_limbs()
     }
 }
 
 impl<T: MontConfig<4>> From<&MontScalar<T>> for [u64; 4] {
     fn from(value: &MontScalar<T>) -> Self {
-        value.0.into_bigint().0
+        value.to_limbs()
     }
 }
 
@@ -403,6 +403,14 @@ where
         255 - T::MODULUS.0[3].leading_zeros() as u8
     };
     const MAX_SIGNED_U256: U256 = U256::from_digits(T::MODULUS.divide_by_2_round_down().0);
+
+    fn from_limbs(val: [u64; 4]) -> Self {
+        Self(Fp::new(ark_ff::BigInt(val)))
+    }
+
+    fn to_limbs(&self) -> [u64; 4] {
+        self.0.into_bigint().0
+    }
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool
@@ -447,7 +455,7 @@ where
             });
         }
 
-        let abs: [u64; 4] = value.into();
+        let abs = value.to_limbs();
 
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -603,7 +611,7 @@ where
         } else {
             num_bigint::Sign::Plus
         };
-        let value_abs: [u64; 4] = (if is_negative { -value } else { value }).into();
+        let value_abs = (if is_negative { -value } else { value }).to_limbs();
         let bits: &[u8] = bytemuck::cast_slice(&value_abs);
         BigInt::from_bytes_le(sign, bits)
     }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
+use crate::base::{encode::VarInt, scalar::ScalarConversionError};
 use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
@@ -40,8 +40,6 @@ pub trait Scalar:
     + core::convert::TryInto <i32>
     + core::convert::TryInto <i64>
     + core::convert::TryInto <i128>
-    + core::convert::Into<[u64; 4]>
-    + core::convert::From<[u64; 4]>
     + core::convert::From<u8>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
@@ -51,7 +49,6 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + RefInto<[u64; 4]>
     + for<'a> core::convert::From<&'a String>
     + VarInt
     + core::convert::From<String>
@@ -85,4 +82,10 @@ pub trait Scalar:
     const MAX_BITS: u8;
     /// A U256 representation of the largest signed value in the field.
     const MAX_SIGNED_U256: U256;
+
+    /// Create a scalar from non-Montgomery little-endian limbs.
+    fn from_limbs(val: [u64; 4]) -> Self;
+
+    /// Convert this scalar to non-Montgomery little-endian limbs.
+    fn to_limbs(&self) -> [u64; 4];
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -24,12 +24,12 @@ pub trait ScalarExt: Scalar {
     /// Converts a U256 to Scalar, wrapping as needed
     fn from_wrapping(value: U256) -> Self {
         let value_as_limbs: [u64; 4] = value.into();
-        Self::from(value_as_limbs)
+        Self::from_limbs(value_as_limbs)
     }
 
     /// Converts a Scalar to U256. Note that any values above `MAX_SIGNED` shall remain positive, even if they are representative of negative values.
     fn into_u256_wrapping(self) -> U256 {
-        U256::from(Into::<[u64; 4]>::into(self))
+        U256::from(self.to_limbs())
     }
 
     /// Converts a byte slice to a Scalar using a hash function, preventing collisions.
@@ -102,7 +102,7 @@ mod tests {
             u64::from_le_bytes(limbs_native[2].to_le_bytes()),
             u64::from_le_bytes(limbs_native[3].to_le_bytes()),
         ];
-        let scalar_from_ref = TestScalar::from(limbs_le);
+        let scalar_from_ref = TestScalar::from_limbs(limbs_le);
 
         assert_eq!(
             scalar_from_bytes, scalar_from_ref,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -191,7 +191,7 @@ where
             .take(31)
             .collect();
     for (i, scalar) in column_data.iter().enumerate() {
-        let scalar_array = Into::<S>::into(*scalar).to_limbs();
+        let scalar_array = (*scalar).into().to_limbs();
         // Convert the [u64; 4] into a slice of bytes
         let scalar_bytes = &cast_slice::<u64, u8>(&scalar_array)[..31];
 

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -191,7 +191,7 @@ where
             .take(31)
             .collect();
     for (i, scalar) in column_data.iter().enumerate() {
-        let scalar_array: [u64; 4] = (*scalar).into().into();
+        let scalar_array = Into::<S>::into(*scalar).to_limbs();
         // Convert the [u64; 4] into a slice of bytes
         let scalar_bytes = &cast_slice::<u64, u8>(&scalar_array)[..31];
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Fixes #228.

This PR addresses the limb-conversion portion of the issue by making scalar limb conversions explicit on the `Scalar` trait. The goal is to replace implicit limb conversions through generic trait bounds with explicit conversion methods.

# What changes are included in this PR?

- Adds `Scalar::from_limbs`.
- Adds `Scalar::to_limbs`.
- Removes the `Into<[u64; 4]>`, `From<[u64; 4]>`, and `RefInto<[u64; 4]>` bounds from `Scalar`.
- Updates generic call sites to use the explicit methods.
- Keeps the existing `MontScalar` `From` impls for compatibility with existing concrete-code call sites.

# Are these changes tested?

Partially.

Verification completed:
- `git diff --check`

I could not run `cargo check -p proof-of-sql`, `source scripts/run_ci_checks.sh`, or `source scripts/check_commits.sh` in my local environment because `cargo` is not installed there.

I am happy to adjust the implementation if CI or maintainers identify required changes.