### PR TITLE
Make Scalar VarInt implementation blanket

### DIFF
--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -1,8 +1,7 @@
 use crate::base::{
     encode::{ZigZag, U256},
-    scalar::MontScalar,
+    scalar::Scalar,
 };
-use ark_ff::MontConfig;
 use core::cmp::{max, Ordering};
 
 /// This function writes the input scalar x as a varint encoding to buf slice
@@ -14,7 +13,7 @@ use core::cmp::{max, Ordering};
 ///
 /// crash:
 /// - in case N is bigger than `buf.len()`
-pub fn write_scalar_varint<T: MontConfig<4>>(buf: &mut [u8], x: &MontScalar<T>) -> usize {
+pub fn write_scalar_varint<S: Scalar>(buf: &mut [u8], x: &S) -> usize {
     write_u256_varint(buf, x.zigzag())
 }
 
@@ -61,7 +60,7 @@ pub fn write_u256_varint(buf: &mut [u8], mut zig_x: U256) -> usize {
 ///  Since read-scalar stores the buf into a U256 type, which can only
 ///  hold up to 256 bit numbers, the non-continuation bits
 ///  257 up to 259 from buf are ignored.
-pub fn read_scalar_varint<T: MontConfig<4>>(buf: &[u8]) -> Option<(MontScalar<T>, usize)> {
+pub fn read_scalar_varint<S: Scalar>(buf: &[u8]) -> Option<(S, usize)> {
     read_u256_varint(buf).map(|(val, s)| (val.zigzag(), s))
 }
 pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
@@ -113,7 +112,7 @@ pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
 /// error:
 /// - in case buf has not enough space to hold all the scalars encoding.
 #[cfg(test)]
-pub fn write_scalar_varints<T: MontConfig<4>>(buf: &mut [u8], scals: &[MontScalar<T>]) -> usize {
+pub fn write_scalar_varints<S: Scalar>(buf: &mut [u8], scals: &[S]) -> usize {
     let mut total_bytes_written = 0;
 
     for scal in scals {
@@ -133,8 +132,8 @@ pub fn write_scalar_varints<T: MontConfig<4>>(buf: &mut [u8], scals: &[MontScala
 /// error:
 /// - in case it's not possible to read all specified scalars from `input_buf`
 #[cfg(test)]
-pub fn read_scalar_varints<T: MontConfig<4>>(
-    scals_buf: &mut [MontScalar<T>],
+pub fn read_scalar_varints<S: Scalar>(
+    scals_buf: &mut [S],
     input_buf: &[u8],
 ) -> Option<()> {
     let mut buf = input_buf;
@@ -153,7 +152,7 @@ pub fn read_scalar_varints<T: MontConfig<4>>(
 ///
 /// This function should be used to get an upper bound on the buffer size
 /// used by the `write_scalar_varint` function.
-pub fn scalar_varint_size<T: MontConfig<4>>(x: &MontScalar<T>) -> usize {
+pub fn scalar_varint_size<S: Scalar>(x: &S) -> usize {
     u256_varint_size(x.zigzag())
 }
 pub fn u256_varint_size(zig_x: U256) -> usize {
@@ -173,7 +172,7 @@ pub fn u256_varint_size(zig_x: U256) -> usize {
 /// This function should be used to get an upper bound on the buffer size
 /// used by the `write_scalar_varints` function.
 #[cfg(test)]
-pub fn scalar_varints_size<T: MontConfig<4>>(scals: &[MontScalar<T>]) -> usize {
+pub fn scalar_varints_size<S: Scalar>(scals: &[S]) -> usize {
     let mut all_size: usize = 0;
 
     for x in scals {

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -16,15 +16,31 @@ impl U256 {
     pub const fn from_words(low: u128, high: u128) -> Self {
         U256 { low, high }
     }
+
+    #[inline]
+    pub const fn from_limbs(limbs: [u64; 4]) -> Self {
+        let low = limbs[0] as u128 | ((limbs[1] as u128) << 64);
+        let high = limbs[2] as u128 | ((limbs[3] as u128) << 64);
+        U256 { low, high }
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    #[inline]
+    pub const fn to_limbs(self) -> [u64; 4] {
+        [
+            self.low as u64,
+            (self.low >> 64) as u64,
+            self.high as u64,
+            (self.high >> 64) as u64,
+        ]
+    }
 }
 
 /// This trait converts a dalek scalar into a U256 integer
 impl<T: MontConfig<4>> From<&MontScalar<T>> for U256 {
     fn from(val: &MontScalar<T>) -> Self {
         let buf: [u64; 4] = val.into();
-        let low: u128 = u128::from(buf[0]) | (u128::from(buf[1]) << 64);
-        let high: u128 = u128::from(buf[2]) | (u128::from(buf[3]) << 64);
-        U256::from_words(low, high)
+        U256::from_limbs(buf)
     }
 }
 

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -16,10 +16,9 @@ use super::{
     },
     U256,
 };
-use crate::base::scalar::MontScalar;
+use crate::base::scalar::Scalar;
 #[cfg(test)]
 use alloc::{vec, vec::Vec};
-use ark_ff::MontConfig;
 
 /// Most-significant byte, == 0x80
 pub const MSB: u8 = 0b1000_0000;
@@ -282,7 +281,7 @@ impl VarInt for i128 {
     }
 }
 
-impl<T: MontConfig<4>> VarInt for MontScalar<T> {
+impl<S: Scalar> VarInt for S {
     fn required_space(self) -> usize {
         scalar_varint_size(&self)
     }

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -1,4 +1,4 @@
-use super::VarInt;
+use super::{U256, VarInt};
 use crate::base::scalar::{test_scalar::TestScalar, Scalar};
 use alloc::{vec, vec::Vec};
 use core::{
@@ -23,6 +23,26 @@ fn scalar_types_use_blanket_varint_impl() {
     fn assert_blanket_impl<S: Scalar + VarInt>() {}
 
     assert_blanket_impl::<TestScalar>();
+}
+
+#[test]
+fn u256_limb_roundtrips_preserve_little_endian_order() {
+    let limbs = [
+        0x0011_2233_4455_6677,
+        0x8899_aabb_ccdd_eeff,
+        0x1020_3040_5060_7080,
+        0x90a0_b0c0_d0e0_f001,
+    ];
+
+    assert_eq!(U256::from_limbs(limbs).to_limbs(), limbs);
+
+    let value = U256::from_words(
+        0x8899_aabb_ccdd_eeff_0011_2233_4455_6677,
+        0x90a0_b0c0_d0e0_f001_1020_3040_5060_7080,
+    );
+
+    assert_eq!(value.to_limbs(), limbs);
+    assert_eq!(U256::from_limbs(value.to_limbs()).to_limbs(), limbs);
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -19,6 +19,13 @@ use rand::Rng;
 // -----------------------------------------------------------------------------------------------------
 
 #[test]
+fn scalar_types_use_blanket_varint_impl() {
+    fn assert_blanket_impl<S: Scalar + VarInt>() {}
+
+    assert_blanket_impl::<TestScalar>();
+}
+
+#[test]
 fn test_required_space() {
     assert_eq!(0_u32.required_space(), 1);
     assert_eq!(1_u32.required_space(), 1);

--- a/crates/proof-of-sql/src/base/encode/zigzag.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag.rs
@@ -1,5 +1,4 @@
-use crate::base::{encode::U256, scalar::MontScalar};
-use ark_ff::MontConfig;
+use crate::base::{encode::U256, ref_into::RefInto, scalar::Scalar};
 
 /// A trait for enabling zig-zag encoding
 ///
@@ -24,12 +23,12 @@ pub trait ZigZag<T> {
 /// which represents a positive [`ZigZag`] encoding.
 /// Otherwise, we remap `y` to `2 * y + 1` u256 integer,
 /// which represents a negative [`ZigZag`] encoding (-y).
-impl<T: MontConfig<4>> ZigZag<U256> for MontScalar<T> {
+impl<S: Scalar> ZigZag<U256> for S {
     fn zigzag(&self) -> U256 {
         // since self is a dalek scalar, we never have the last bit 255 set
         // therefore, we should never expect overflow when multiplying by 2
-        let mut x: U256 = self.into();
-        let mut y: U256 = (&-self).into(); // x + y = 0 ==> y = -x
+        let mut x = U256::from_limbs(self.ref_into());
+        let mut y = U256::from_limbs((-*self).ref_into()); // x + y = 0 ==> y = -x
 
         // we return the smallest ZigZag number between x and y
         // in case x is bigger than y, we return -y (encoded in the ZigZag format)
@@ -74,8 +73,8 @@ impl<T: MontConfig<4>> ZigZag<U256> for MontScalar<T> {
 ///
 /// Finally, we return either `-1 * dalek::Scalar(y)` or `dalek::Scalar(x)`,
 /// which in both cases represents the `x` scalar.
-impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
-    fn zigzag(&self) -> MontScalar<T> {
+impl<S: Scalar> ZigZag<S> for U256 {
+    fn zigzag(&self) -> S {
         // we need to divide self by 2 to remove the ZigZag encoding
         let mut zig_val = U256 {
             low: (self.low >> 1) | ((self.high & 1) << 127),
@@ -98,11 +97,11 @@ impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
             // even though the encoding represented a -y,
             // zig_val actually represents a `y` (we simply divided self by 2).
             // Also, since x + y = 0, we need to compute -(zig_val.into()) to return x
-            let scal: MontScalar<T> = (&zig_val).into();
+            let scal = S::from(zig_val.to_limbs());
 
             -scal
         } else {
-            let scal: MontScalar<T> = (&zig_val).into();
+            let scal = S::from(zig_val.to_limbs());
 
             // return x
             scal

--- a/crates/proof-of-sql/src/base/encode/zigzag.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag.rs
@@ -9,7 +9,7 @@ pub trait ZigZag<T> {
     fn zigzag(&self) -> T;
 }
 
-/// Zigzag conversion from a dalek Scalar to a [`ZigZag`] u256 integer
+/// Zigzag conversion from a [`Scalar`] to a [`ZigZag`] u256 integer
 ///
 /// For this conversion, we compute:
 ///
@@ -25,8 +25,8 @@ pub trait ZigZag<T> {
 /// which represents a negative [`ZigZag`] encoding (-y).
 impl<S: Scalar> ZigZag<U256> for S {
     fn zigzag(&self) -> U256 {
-        // since self is a dalek scalar, we never have the last bit 255 set
-        // therefore, we should never expect overflow when multiplying by 2
+        // Scalars are represented by normalized limbs with enough headroom
+        // for this ZigZag doubling step, so this shift should not overflow.
         let mut x = U256::from_limbs(self.ref_into());
         let mut y = U256::from_limbs((-*self).ref_into()); // x + y = 0 ==> y = -x
 
@@ -60,7 +60,7 @@ impl<S: Scalar> ZigZag<U256> for S {
     }
 }
 
-/// Zigzag conversion from an u256 integer to a dalek Scalar.
+/// Zigzag conversion from an u256 integer to a [`Scalar`].
 ///
 /// For this conversion, we first verify if `self` is an odd or even number.
 /// In case `self` is odd, the encoded number represents a negative
@@ -71,7 +71,7 @@ impl<S: Scalar> ZigZag<U256> for S {
 /// In both cases, we divide the `self` value by 2 in order
 /// to remove the [`ZigZag`] encoding (`y = self / 2` or `x = self / 2`).
 ///
-/// Finally, we return either `-1 * dalek::Scalar(y)` or `dalek::Scalar(x)`,
+/// Finally, we return either `-1 * S(y)` or `S(x)`,
 /// which in both cases represents the `x` scalar.
 impl<S: Scalar> ZigZag<S> for U256 {
     fn zigzag(&self) -> S {

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
+use crate::base::{ref_into::RefInto, scalar::ScalarConversionError};
 use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
@@ -53,7 +53,6 @@ pub trait Scalar:
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
     + for<'a> core::convert::From<&'a String>
-    + VarInt
     + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>


### PR DESCRIPTION
/claim #228

## Summary
- remove `VarInt` from the `Scalar` supertrait bounds
- replace the `MontScalar<T>`-specific `VarInt` implementation with a blanket `impl<S: Scalar> VarInt for S`
- generalize the scalar varint and zigzag helpers through the existing limb-based scalar conversions
- add a compile-time test proving `TestScalar` receives `VarInt` through the blanket implementation

This PR is intentionally scoped to the third checklist item in #228. It does not touch the limb-conversion or string-hash slices covered by other PRs.

## Testing
- `git diff --check`

I could not run `cargo fmt` or Rust tests locally because this Windows environment does not have `cargo` installed.