### PR TITLE
test: cover permutation comparator constructor

### DIFF
--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -29,7 +29,7 @@ pub struct Permutation {
 
 impl Permutation {
     /// Create a new permutation from a comparison function with the given length
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn unchecked_new_from_cmp<F>(length: usize, cmp: F) -> Self
     where
         F: Fn(&usize, &usize) -> Ordering + Sync,
@@ -99,6 +99,24 @@ mod test {
         assert_eq!(
             permutation.try_apply(&["and", "Space", "Time"]).unwrap(),
             vec!["Space", "and", "Time"]
+        );
+    }
+
+    #[test]
+    fn test_unchecked_new_from_cmp_orders_indexes_by_comparator() {
+        let priorities = [30, 10, 20, 10];
+        let permutation = Permutation::unchecked_new_from_cmp(priorities.len(), |left, right| {
+            priorities[*left]
+                .cmp(&priorities[*right])
+                .then_with(|| left.cmp(right))
+        });
+
+        assert_eq!(permutation.size(), priorities.len());
+        assert_eq!(
+            permutation
+                .try_apply(&["thirty", "ten-a", "twenty", "ten-b"])
+                .unwrap(),
+            vec!["ten-a", "ten-b", "twenty", "thirty"]
         );
     }
 

--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -29,6 +29,8 @@ pub struct Permutation {
 
 impl Permutation {
     /// Create a new permutation from a comparison function with the given length
+    // Tests exercise this constructor directly, so the dead-code expectation only
+    // applies to non-test builds.
     #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn unchecked_new_from_cmp<F>(length: usize, cmp: F) -> Self
     where


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Contributes to #560 by adding focused coverage for the comparator-based `Permutation::unchecked_new_from_cmp` constructor.

# What changes are included in this PR?

- Adds a deterministic unit test that builds a permutation from custom comparator ordering.
- Verifies the generated permutation size and the result of applying it to a slice.
- Changes the existing dead-code expectation to apply only outside test builds, since the constructor is now exercised by a unit test.

# Are these changes tested?

Yes.

```text
cargo test -p proof-of-sql --lib permutation::test::test_unchecked_new_from_cmp_orders_indexes_by_comparator --no-default-features --features test
```

The local environment does not have `clang`/`lld`, so the command was run with a temporary local-only Cargo linker override to `/usr/bin/gcc`; `.cargo/config.toml` was restored and is not changed in this PR.
