### PR TITLE
fix: compare timestamptz owned columns

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
@@ -264,6 +264,10 @@ pub trait ComparisonOp {
             (OwnedColumn::Boolean(lhs), OwnedColumn::Boolean(rhs)) => {
                 Ok(slice_binary_op(lhs, rhs, Self::op))
             }
+            (
+                OwnedColumn::TimestampTZ(left_tu, _, lhs),
+                OwnedColumn::TimestampTZ(right_tu, _, rhs),
+            ) if left_tu == right_tu => Ok(slice_binary_op(lhs, rhs, Self::op)),
             (OwnedColumn::VarChar(lhs), OwnedColumn::VarChar(rhs)) => Self::string_op(lhs, rhs),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: "ComparisonOp".to_string(),

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -64,12 +64,12 @@ impl<S: Scalar> OwnedColumn<S> {
         EqualOp::owned_column_element_wise_comparison(self, rhs)
     }
 
-    /// Element-wise less than or equal to check for two columns
+    /// Element-wise less-than check for two columns
     pub fn element_wise_lt(&self, rhs: &Self) -> ColumnOperationResult<Self> {
         LessThanOp::owned_column_element_wise_comparison(self, rhs)
     }
 
-    /// Element-wise greater than or equal to check for two columns
+    /// Element-wise greater-than check for two columns
     pub fn element_wise_gt(&self, rhs: &Self) -> ColumnOperationResult<Self> {
         GreaterThanOp::owned_column_element_wise_comparison(self, rhs)
     }
@@ -98,7 +98,11 @@ impl<S: Scalar> OwnedColumn<S> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::base::{math::decimal::Precision, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+        scalar::test_scalar::TestScalar,
+    };
     use alloc::vec;
 
     #[test]
@@ -313,6 +317,23 @@ mod test {
             result,
             Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]))
         );
+
+        // Timestamps
+        let lhs = OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            vec![0, 10, 20],
+        );
+        let rhs = OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::new(3600),
+            vec![0, 9, 21],
+        );
+        let result = lhs.element_wise_eq(&rhs);
+        assert_eq!(
+            result,
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, false]))
+        );
     }
 
     #[test]
@@ -372,10 +393,27 @@ mod test {
             result,
             Ok(OwnedColumn::<TestScalar>::Boolean(vec![false, false, true]))
         );
+
+        // Timestamps
+        let lhs = OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            vec![0, 10, 20],
+        );
+        let rhs = OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::new(3600),
+            vec![0, 9, 21],
+        );
+        let result = lhs.element_wise_lt(&rhs);
+        assert_eq!(
+            result,
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![false, false, true]))
+        );
     }
 
     #[test]
-    fn we_can_do_ge_operation_on_numeric_and_boolean_columns() {
+    fn we_can_do_gt_operation_on_numeric_and_boolean_columns() {
         // Booleans
         let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]);
         let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]);
@@ -430,6 +468,23 @@ mod test {
         assert_eq!(
             result,
             Ok(OwnedColumn::<TestScalar>::Boolean(vec![true, false, false]))
+        );
+
+        // Timestamps
+        let lhs = OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            vec![0, 10, 20],
+        );
+        let rhs = OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::new(3600),
+            vec![0, 9, 21],
+        );
+        let result = lhs.element_wise_gt(&rhs);
+        assert_eq!(
+            result,
+            Ok(OwnedColumn::<TestScalar>::Boolean(vec![false, true, false]))
         );
     }
 
@@ -504,6 +559,36 @@ mod test {
                 .map(ToString::to_string)
                 .collect(),
         );
+        let result = lhs.element_wise_lt(&rhs);
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+
+        let result = lhs.element_wise_gt(&rhs);
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+
+        // Timestamps with different units are not directly comparable in the
+        // non-scaling postprocessing path.
+        let lhs = OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            vec![0, 10, 20],
+        );
+        let rhs = OwnedColumn::<TestScalar>::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::utc(),
+            vec![0, 10_000, 20_000],
+        );
+        let result = lhs.element_wise_eq(&rhs);
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+
         let result = lhs.element_wise_lt(&rhs);
         assert!(matches!(
             result,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Fixes #149.

The owned-column comparison dispatch did not handle `TimestampTZ` columns after the comparison code was refactored. The type rules already allow same-unit `TimestampTZ` equality and inequality comparisons, so postprocessing should follow the same rule.

# What changes are included in this PR?

- Add `TimestampTZ` handling to owned-column equality and strict inequality comparison dispatch when both columns use the same `PoSQLTimeUnit`.
- Keep cross-unit `TimestampTZ` comparisons on this non-scaling path as invalid column-type errors.
- Add coverage for same-unit `TimestampTZ` equality, less-than, greater-than, and cross-unit rejection.
- Correct the `element_wise_lt` / `element_wise_gt` doc comments and the corresponding `gt` test name to match their strict comparison behavior.

# Are these changes tested?

Yes.

- `cargo test -p proof-of-sql --no-default-features --features "std test" owned_column_operation --lib`
- `cargo f --check`
- `cargo check -p proof-of-sql --no-default-features`
- `cargo check -p proof-of-sql --all-targets --no-default-features --features std`
- `cargo cl -- -D warnings`
- `source scripts/run_ci_checks.sh`
- `source scripts/check_commits.sh`
- `git diff --check`
