### PR TITLE
test: add unit tests for `TableRef`

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -60,6 +60,8 @@ mod error;
 pub use error::ParseError;
 
 mod table_ref;
+#[cfg(test)]
+mod table_ref_test;
 #[cfg(feature = "arrow")]
 pub use crate::base::arrow::{
     arrow_array_to_column_conversion::{ArrayRefExt, ArrowArrayToColumnConversionError},

--- a/crates/proof-of-sql/src/base/database/table_ref_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref_test.rs
@@ -1,0 +1,137 @@
+use crate::base::database::{ParseError, TableRef};
+use alloc::{format, string::ToString, vec::Vec};
+use core::str::FromStr;
+use indexmap::Equivalent;
+use sqlparser::ast::Ident;
+
+#[test]
+fn we_can_create_a_table_ref_with_schema_and_table() {
+    let table_ref = TableRef::new("sch", "tab");
+    assert_eq!(table_ref.schema_id(), Some(&Ident::new("sch")));
+    assert_eq!(table_ref.table_id(), &Ident::new("tab"));
+    assert_eq!(format!("{table_ref}"), "sch.tab");
+}
+
+#[test]
+fn we_can_create_a_table_ref_without_schema_using_new() {
+    let table_ref = TableRef::new("", "tab");
+    assert_eq!(table_ref.schema_id(), None);
+    assert_eq!(table_ref.table_id(), &Ident::new("tab"));
+    assert_eq!(format!("{table_ref}"), "tab");
+    assert_eq!(table_ref, TableRef::from_names(None, "tab"));
+}
+
+#[test]
+fn we_can_create_a_table_ref_from_names() {
+    let with_schema = TableRef::from_names(Some("sch"), "tab");
+    assert_eq!(with_schema.schema_id(), Some(&Ident::new("sch")));
+    assert_eq!(with_schema.table_id(), &Ident::new("tab"));
+
+    let without_schema = TableRef::from_names(None, "tab");
+    assert_eq!(without_schema.schema_id(), None);
+    assert_eq!(without_schema.table_id(), &Ident::new("tab"));
+}
+
+#[test]
+fn we_can_create_a_table_ref_from_idents() {
+    let with_schema = TableRef::from_idents(Some(Ident::new("sch")), Ident::new("tab"));
+    assert_eq!(with_schema.schema_id(), Some(&Ident::new("sch")));
+    assert_eq!(with_schema.table_id(), &Ident::new("tab"));
+    assert_eq!(format!("{with_schema}"), "sch.tab");
+
+    let without_schema = TableRef::from_idents(None, Ident::new("tab"));
+    assert_eq!(without_schema.schema_id(), None);
+    assert_eq!(format!("{without_schema}"), "tab");
+}
+
+#[test]
+fn we_can_create_a_table_ref_from_one_or_two_strs() {
+    let table_only = TableRef::from_strs(&["tab"]).unwrap();
+    assert_eq!(table_only, TableRef::from_names(None, "tab"));
+
+    let with_schema = TableRef::from_strs(&["sch", "tab"]).unwrap();
+    assert_eq!(with_schema, TableRef::from_names(Some("sch"), "tab"));
+}
+
+#[test]
+fn we_cannot_create_a_table_ref_from_zero_or_three_strs() {
+    let empty: &[&str] = &[];
+    let empty_err = TableRef::from_strs(empty).unwrap_err();
+    assert!(matches!(
+        empty_err,
+        ParseError::InvalidTableReference { ref table_reference } if table_reference.is_empty()
+    ));
+
+    let three_err = TableRef::from_strs(&["a", "b", "c"]).unwrap_err();
+    assert!(matches!(
+        three_err,
+        ParseError::InvalidTableReference { ref table_reference } if table_reference == "a,b,c"
+    ));
+}
+
+#[test]
+fn we_can_parse_a_table_ref_from_a_dotted_string() {
+    let table_only = TableRef::try_from("tab").unwrap();
+    assert_eq!(table_only.schema_id(), None);
+    assert_eq!(table_only.table_id(), &Ident::new("tab"));
+
+    let with_schema = TableRef::try_from("sch.tab").unwrap();
+    assert_eq!(with_schema.schema_id(), Some(&Ident::new("sch")));
+    assert_eq!(with_schema.table_id(), &Ident::new("tab"));
+
+    let from_str = TableRef::from_str("sch.tab").unwrap();
+    assert_eq!(from_str, with_schema);
+}
+
+#[test]
+fn we_cannot_parse_a_table_ref_with_too_many_components() {
+    let err = TableRef::try_from("a.b.c").unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::InvalidTableReference { ref table_reference } if table_reference == "a.b.c"
+    ));
+    assert_eq!(format!("{err}"), "Invalid table reference: a.b.c");
+}
+
+#[test]
+fn we_can_compare_table_refs_with_equivalent() {
+    let table_ref = TableRef::new("sch", "tab");
+    let same = TableRef::new("sch", "tab");
+    let different_schema = TableRef::new("other", "tab");
+    let different_table = TableRef::new("sch", "other");
+
+    assert!((&table_ref).equivalent(&same));
+    assert!(!(&table_ref).equivalent(&different_schema));
+    assert!(!(&table_ref).equivalent(&different_table));
+}
+
+#[test]
+fn we_can_serialize_and_deserialize_a_table_ref() {
+    let with_schema = TableRef::new("sch", "tab");
+    let serialized = serde_json::to_string(&with_schema).unwrap();
+    assert_eq!(serialized, r#""sch.tab""#);
+    let deserialized: TableRef = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized, with_schema);
+
+    let without_schema: TableRef = serde_json::from_str(r#""tab""#).unwrap();
+    assert_eq!(without_schema, TableRef::from_names(None, "tab"));
+}
+
+#[test]
+fn we_cannot_deserialize_an_invalid_table_ref() {
+    let result: Result<TableRef, _> = serde_json::from_str(r#""a.b.c""#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn we_can_round_trip_a_table_ref_through_display_and_parse() {
+    let originals: Vec<TableRef> = alloc::vec![
+        TableRef::new("sch", "tab"),
+        TableRef::from_names(None, "tab"),
+    ];
+    for original in originals {
+        let displayed = original.to_string();
+        let reparsed = TableRef::from_str(&displayed).unwrap();
+        assert_eq!(reparsed, original);
+    }
+}


### PR DESCRIPTION
## Rationale

Part of #560 (improve test coverage — maintainers note this can/should be broken into smaller parallel PRs).

`crates/proof-of-sql/src/base/database/table_ref.rs` (144 lines) currently has no unit coverage: no inline `#[cfg(test)]` module, no sibling `table_ref_test.rs`, and no other test in the workspace exercises `TableRef::new`, `from_names`, `from_idents`, `from_strs`, `TryFrom<&str>`/`FromStr`, the `Equivalent` impl, `Display`, or the custom `Serialize`/`Deserialize` impls. `from_strs` and `from_idents` have zero call sites in the repo, so their error path has never been executed by CI.

## What's changed

- Adds `crates/proof-of-sql/src/base/database/table_ref_test.rs` with 12 focused unit tests covering:
  - construction via `new` (including the empty-schema -> `None` normalization), `from_names`, and `from_idents`
  - `from_strs` happy paths (1 and 2 components) and error paths (0 and 3 components, including the comma-joined `table_reference` payload)
  - dotted-string parsing via `TryFrom<&str>` and `FromStr`, including the `ParseError::InvalidTableReference` Display message
  - the `indexmap::Equivalent` impl (equal / schema-differs / table-differs)
  - serde round-trip (serializes as a plain dotted string; deserialize rejects invalid input through the `FromStr` path)
  - Display <-> parse round-trip
- Registers the test module in `base/database/mod.rs` via the repo's sibling-file convention (`#[cfg(test)] mod table_ref_test;`).

No production code is modified.

## Test plan

Verified locally against current `main` (aarch64, feature set matching CI's test-feature dry run):

```
cargo test -p proof-of-sql --no-default-features --features="test" table_ref_test
# test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 960 filtered out
```

Tests follow the repo's `we_can_…` / `we_cannot_…` naming and sibling `*_test.rs` convention, use `alloc` (not `std`) imports for `no_std` compatibility, and rely only on existing dev-dependencies (`serde_json`).