### PR TITLE
test: cover ContextProvider::options and planner error paths

### DIFF
--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -181,6 +181,16 @@ mod tests {
         assert_eq!(context_provider.get_function_meta(""), None);
         assert_eq!(context_provider.get_aggregate_meta(""), None);
         assert_eq!(context_provider.get_window_meta(""), None);
+        // The provider exposes datafusion's default config options.
+        assert_eq!(
+            context_provider
+                .options()
+                .sql_parser
+                .enable_ident_normalization,
+            ConfigOptions::default()
+                .sql_parser
+                .enable_ident_normalization
+        );
 
         // Non-empty
         let accessor = SchemaAccessorImpl::new(indexmap_with_default! {AHasher;

--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -165,6 +165,16 @@ AND s.salary > (
     }
 
     #[test]
+    fn we_cannot_get_table_references_with_a_catalog_qualified_name() {
+        // A catalog-qualified (three-part) table name cannot be parsed into a
+        // `TableRef`, so collecting references must surface the parse error.
+        let statement = Parser::parse_sql(&GenericDialect {}, "SELECT a FROM catalog.schema.table")
+            .unwrap()[0]
+            .clone();
+        assert!(get_table_refs_from_statement(&statement).is_err());
+    }
+
+    #[test]
     fn we_can_use_abs() {
         let statements = Parser::parse_sql(&GenericDialect {}, "SELECT ABS(-1-1);").unwrap();
         sql_to_posql_plans(

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -236,6 +236,20 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn we_cannot_convert_placeholder_with_unsupported_type() {
+        // Proof of SQL has no floating point column type, so a `Float32`
+        // placeholder cannot be converted and must surface as an error.
+        let placeholder = Placeholder {
+            id: "$1".to_string(),
+            data_type: Some(DataType::Float32),
+        };
+        assert!(matches!(
+            placeholder_to_placeholder_expr(&placeholder),
+            Err(PlannerError::UnsupportedDataType { .. })
+        ));
+    }
+
     // TableReference to TableRef
     #[test]
     fn we_can_convert_table_reference_to_table_ref() {


### PR DESCRIPTION
## Summary

Improves test coverage for `proof-of-sql-planner` by covering lines previously reported as uncovered by `cargo llvm-cov`.

Three unit tests are added:
- **`context.rs`** — assert `PoSqlContextProvider::options()` returns datafusion's default config options (covers the `ContextProvider::options` impl).
- **`util.rs`** — `placeholder_to_placeholder_expr` returns `PlannerError::UnsupportedDataType` for a `Float32` placeholder, since Proof of SQL has no floating-point column type.
- **`conversion.rs`** — `get_table_refs_from_statement` returns an error for a catalog-qualified (three-part) table name that cannot be parsed into a `TableRef`.

## Verification
- `cargo test -p proof-of-sql-planner` — all 109 tests pass.
- `cargo llvm-cov -p proof-of-sql-planner --show-missing-lines` — the targeted lines in `context.rs`, `util.rs`, and `conversion.rs` are now covered (crate missed-lines 37 → 30).
- `cargo fmt` and `cargo clippy -p proof-of-sql-planner` are clean.

/claim #560