### PR TITLE
test: cover type and error conversion paths in base modules

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -96,4 +96,31 @@ mod tests {
             prop_assert_eq!(actual, column_type);
         }
     }
+
+    #[test]
+    fn we_can_convert_timestamp_types_between_column_type_and_arrow() {
+        // The proptest above does not generate the `TimestampTZ` variant, so cover
+        // the timestamp conversion arms (in both directions) explicitly.
+        for (posql_unit, arrow_unit) in [
+            (PoSQLTimeUnit::Second, ArrowTimeUnit::Second),
+            (PoSQLTimeUnit::Millisecond, ArrowTimeUnit::Millisecond),
+            (PoSQLTimeUnit::Microsecond, ArrowTimeUnit::Microsecond),
+            (PoSQLTimeUnit::Nanosecond, ArrowTimeUnit::Nanosecond),
+        ] {
+            // ColumnType -> arrow DataType
+            let data_type =
+                DataType::from(&ColumnType::TimestampTZ(posql_unit, PoSQLTimeZone::utc()));
+            assert!(
+                matches!(&data_type, DataType::Timestamp(unit, Some(_)) if *unit == arrow_unit)
+            );
+            // arrow DataType -> ColumnType
+            let column_type = ColumnType::try_from(DataType::Timestamp(arrow_unit, None)).unwrap();
+            assert!(matches!(column_type, ColumnType::TimestampTZ(unit, _) if unit == posql_unit));
+        }
+    }
+
+    #[test]
+    fn we_cannot_convert_unsupported_arrow_data_type_to_column_type() {
+        assert!(ColumnType::try_from(DataType::Float32).is_err());
+    }
 }

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,17 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PoSQLTimestampError;
+    use alloc::string::String;
+
+    #[test]
+    fn we_can_convert_timestamp_error_into_string() {
+        assert_eq!(
+            String::from(PoSQLTimestampError::InvalidTimezoneOffset),
+            "invalid timezone offset"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -81,4 +81,30 @@ mod time_unit_tests {
             ));
         }
     }
+
+    #[test]
+    fn we_can_convert_time_unit_to_u64() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn we_can_display_time_units() {
+        use alloc::string::ToString;
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Improves test coverage for `proof-of-sql` by covering previously-uncovered type/error **conversion** paths (all pure-logic `From`/`TryFrom`/`Display` impls).

Tests added:
- **`base/posql_time/unit.rs`** — `From<PoSQLTimeUnit> for u64` and the `Display` impl for `PoSQLTimeUnit`.
- **`base/posql_time/error.rs`** — `From<PoSQLTimestampError> for String`.
- **`base/arrow/column_arrow_conversions.rs`** — the `TimestampTZ` conversion arms between `ColumnType` and arrow `DataType` in **both** directions (the existing proptest does not generate the `TimestampTZ` variant), plus the unsupported-arrow-type error path.

## Verification
- `cargo test -p proof-of-sql` (with `blitzar`) — **1424 passed, 0 failed**.
- `cargo llvm-cov` confirms the targeted lines in all three files are now covered (the only remaining uncovered line is the `ColumnType::Scalar` `unimplemented!()` arm, which panics by design and is intentionally not exercised).
- `cargo fmt` and `cargo clippy` are clean.

/claim #560
