### PR TITLE
test: cover ColumnType integer-promotion methods

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type.rs
+++ b/crates/proof-of-sql/src/base/database/column_type.rs
@@ -303,6 +303,57 @@ mod tests {
     use crate::base::scalar::test_scalar::TestScalar;
 
     #[test]
+    fn we_can_get_the_max_integer_type_of_two_integer_column_types() {
+        // The larger signed integer type wins, regardless of argument order.
+        assert_eq!(
+            ColumnType::Int.max_integer_type(&ColumnType::BigInt),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::BigInt.max_integer_type(&ColumnType::Int),
+            Some(ColumnType::BigInt)
+        );
+        assert_eq!(
+            ColumnType::TinyInt.max_integer_type(&ColumnType::SmallInt),
+            Some(ColumnType::SmallInt)
+        );
+        assert_eq!(
+            ColumnType::Int128.max_integer_type(&ColumnType::Int),
+            Some(ColumnType::Int128)
+        );
+        // `Uint8` (8 bits) widens to the larger signed type.
+        assert_eq!(
+            ColumnType::Uint8.max_integer_type(&ColumnType::Int),
+            Some(ColumnType::Int)
+        );
+    }
+
+    #[test]
+    fn we_cannot_get_the_max_integer_type_when_a_column_type_is_not_an_integer() {
+        assert_eq!(ColumnType::Boolean.max_integer_type(&ColumnType::Int), None);
+        assert_eq!(ColumnType::Int.max_integer_type(&ColumnType::VarChar), None);
+    }
+
+    #[test]
+    fn we_can_get_the_max_unsigned_integer_type() {
+        // Both operands are 8-bit, so the unsigned result is `Uint8`.
+        assert_eq!(
+            ColumnType::Uint8.max_unsigned_integer_type(&ColumnType::Uint8),
+            Some(ColumnType::Uint8)
+        );
+        // No unsigned integer type wider than 8 bits exists, so this is `None`.
+        assert_eq!(
+            ColumnType::Int.max_unsigned_integer_type(&ColumnType::BigInt),
+            None
+        );
+        // A non-integer operand yields `None`.
+        assert_eq!(
+            ColumnType::Boolean.max_unsigned_integer_type(&ColumnType::Uint8),
+            None
+        );
+    }
+
+    #[test]
     fn column_type_serializes_to_string() {
         let column_type = ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc());
         let serialized = serde_json::to_string(&column_type).unwrap();


### PR DESCRIPTION
## Summary

Improves test coverage for `proof-of-sql` by covering the previously-untested integer-promotion methods on `ColumnType`.

Tests added (in the existing `column_type` test module):
- **`ColumnType::max_integer_type`** — the larger signed integer type of two integer column types (both argument orders), `Uint8` widening to a larger signed type, and the non-integer cases that return `None`.
- **`ColumnType::max_unsigned_integer_type`** — the 8-bit unsigned result, the "no unsigned type wider than 8 bits" `None` case, and the non-integer `None` case.

These also exercise the private helpers `to_integer_bits`, `from_signed_integer_bits`, and `from_unsigned_integer_bits` transitively.

## Verification
- `cargo test -p proof-of-sql` (with `blitzar`) — **1427 passed, 0 failed**.
- `cargo llvm-cov` confirms the targeted lines are now covered (`column_type.rs` 51 → 11 uncovered lines).
- `cargo fmt` and `cargo clippy` are clean.

/claim #560
