### PR TITLE
test: cover AnalyzeError/DecimalError string conversions and Precision::try_from

### DIFF
--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -168,6 +168,30 @@ pub fn try_convert_intermediate_decimal_to_scalar<S: Scalar>(
 }
 
 #[cfg(test)]
+mod conversion_tests {
+    use super::{DecimalError, Precision};
+    use alloc::string::{String, ToString};
+
+    #[test]
+    fn we_can_convert_decimal_error_into_string() {
+        // `String::from` delegates to the error's `Display` impl.
+        let make = || DecimalError::InvalidPrecision {
+            error: String::from("100"),
+        };
+        assert_eq!(String::from(make()), make().to_string());
+    }
+
+    #[test]
+    fn we_can_try_precision_from_u64() {
+        assert_eq!(Precision::try_from(10_u64).unwrap().value(), 10);
+        // 100 fits in a u8 but exceeds the max supported precision (75).
+        assert!(Precision::try_from(100_u64).is_err());
+        // Values that do not fit in a u8 are rejected.
+        assert!(Precision::try_from(u64::MAX).is_err());
+    }
+}
+
+#[cfg(test)]
 mod scale_adjust_test {
 
     use super::*;

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,18 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::AnalyzeError;
+    use alloc::string::String;
+
+    #[test]
+    fn we_can_convert_analyze_error_into_string() {
+        // `String::from` delegates to the error's `Display` impl.
+        assert_eq!(
+            String::from(AnalyzeError::NotEnoughInputPlans),
+            "Not enough input plans"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

More coverage for previously-uncovered pure-logic **conversion** paths in `proof-of-sql`:
- **`sql/error.rs`** — `From<AnalyzeError> for String`.
- **`base/math/decimal.rs`** — `From<DecimalError> for String`, and `TryFrom<u64> for Precision` (the valid case, the over-max-precision case, and the does-not-fit-in-`u8` case).

## Verification
- `cargo test -p proof-of-sql` (with `blitzar`) — **1422 passed, 0 failed**.
- `cargo llvm-cov` confirms the targeted lines are now covered.
- `cargo fmt` and `cargo clippy` clean.

/claim #560
