### PR TITLE
test: cover utility helpers

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -67,7 +67,7 @@ merlin = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["std"] }
 rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 

--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,38 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_posql_compatible_schema_converts_float_fields_and_preserves_other_metadata() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("f16", DataType::Float16, true),
+            Field::new("f32", DataType::Float32, false),
+            Field::new("f64", DataType::Float64, true),
+            Field::new("label", DataType::Utf8, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(
+            converted.field(0).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert!(converted.field(0).is_nullable());
+        assert_eq!(
+            converted.field(1).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert!(!converted.field(1).is_nullable());
+        assert_eq!(
+            converted.field(2).data_type(),
+            &DataType::Decimal256(20, 10)
+        );
+        assert_eq!(converted.field(3).name(), "label");
+        assert_eq!(converted.field(3).data_type(), &DataType::Utf8);
+        assert!(!converted.field(3).is_nullable());
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,22 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use alloc::vec;
+
+    #[test]
+    fn table_evaluation_accessors_return_constructor_values() {
+        let column_evals = vec![TestScalar::from(3), TestScalar::from(5)];
+        let chi = (TestScalar::from(7), 11);
+
+        let evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+        assert_eq!(evaluation.column_evals(), column_evals.as_slice());
+        assert_eq!(evaluation.chi_eval(), chi.0);
+        assert_eq!(evaluation.chi(), chi);
+    }
+}

--- a/crates/proof-of-sql/src/base/encode/mod.rs
+++ b/crates/proof-of-sql/src/base/encode/mod.rs
@@ -1,5 +1,7 @@
 mod u256;
 pub(crate) use u256::U256;
+#[cfg(test)]
+mod u256_test;
 
 mod zigzag;
 pub(crate) use zigzag::ZigZag;

--- a/crates/proof-of-sql/src/base/encode/u256_test.rs
+++ b/crates/proof-of-sql/src/base/encode/u256_test.rs
@@ -1,0 +1,36 @@
+use super::U256;
+use crate::base::scalar::test_scalar::TestScalar;
+
+#[test]
+fn from_words_preserves_low_and_high_halves() {
+    let value = U256::from_words(
+        0x0123_4567_89ab_cdef_fedc_ba98_7654_3210,
+        0x0000_0000_0000_1234_abcd_0000_ffff_0000,
+    );
+
+    assert_eq!(value.low, 0x0123_4567_89ab_cdef_fedc_ba98_7654_3210);
+    assert_eq!(value.high, 0x0000_0000_0000_1234_abcd_0000_ffff_0000);
+}
+
+#[test]
+fn u256_round_trips_through_test_scalar_when_value_is_in_field() {
+    let value = U256::from_words(
+        0xfedc_ba98_7654_3210_0123_4567_89ab_cdef,
+        0x0000_0000_0000_0000_0000_0000_0000_1234,
+    );
+
+    let scalar: TestScalar = (&value).into();
+    let round_trip = U256::from(&scalar);
+
+    assert_eq!(round_trip.low, value.low);
+    assert_eq!(round_trip.high, value.high);
+}
+
+#[test]
+fn scalar_to_u256_uses_little_endian_word_ordering() {
+    let scalar = TestScalar::from(0x1234_5678_90ab_cdef_u64);
+    let encoded = U256::from(&scalar);
+
+    assert_eq!(encoded.low, 0x1234_5678_90ab_cdef);
+    assert_eq!(encoded.high, 0);
+}

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,51 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::{String, ToString};
+
+    #[test]
+    fn timestamp_errors_display_descriptive_messages() {
+        let cases = [
+            (
+                PoSQLTimestampError::InvalidTimezone {
+                    timezone: "Mars/Phobos".to_string(),
+                },
+                "invalid timezone string: Mars/Phobos",
+            ),
+            (
+                PoSQLTimestampError::InvalidTimezoneOffset,
+                "invalid timezone offset",
+            ),
+            (
+                PoSQLTimestampError::InvalidTimeUnit {
+                    error: "fortnight".to_string(),
+                },
+                "Invalid time unit",
+            ),
+            (
+                PoSQLTimestampError::UnsupportedPrecision {
+                    error: "picoseconds".to_string(),
+                },
+                "Unsupported precision for timestamp: picoseconds",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn timestamp_error_converts_into_string_via_display() {
+        let message: String = PoSQLTimestampError::InvalidTimezone {
+            timezone: "Moon/Base".to_string(),
+        }
+        .into();
+
+        assert_eq!(message, "invalid timezone string: Moon/Base");
+    }
+}

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,134 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{PlaceholderError, ProofError, ProofSizeMismatch};
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn proof_error_display_messages_are_stable() {
+        let cases = [
+            (
+                ProofError::VerificationError { error: "bad proof" }.to_string(),
+                "Verification error: bad proof",
+            ),
+            (
+                ProofError::UnsupportedQueryPlan { error: "join" }.to_string(),
+                "Unsupported query plan: join",
+            ),
+            (
+                ProofError::InvalidTypeCoercion.to_string(),
+                "Result does not match query: type mismatch",
+            ),
+            (
+                ProofError::FieldNamesMismatch.to_string(),
+                "Result does not match query: field names mismatch",
+            ),
+            (
+                ProofError::FieldCountMismatch.to_string(),
+                "Result does not match query: field count mismatch",
+            ),
+            (
+                ProofError::ProofSizeMismatch {
+                    source: ProofSizeMismatch::SumcheckProofTooSmall,
+                }
+                .to_string(),
+                "Sumcheck proof is too small",
+            ),
+            (
+                ProofError::PlaceholderError {
+                    source: PlaceholderError::ZeroPlaceholderId,
+                }
+                .to_string(),
+                "Placeholder id must be greater than 0",
+            ),
+        ];
+
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn proof_size_mismatch_display_messages_are_stable() {
+        let cases = [
+            (
+                ProofSizeMismatch::SumcheckProofTooSmall.to_string(),
+                "Sumcheck proof is too small",
+            ),
+            (
+                ProofSizeMismatch::TooFewMLEEvaluations.to_string(),
+                "Proof has too few MLE evaluations",
+            ),
+            (
+                ProofSizeMismatch::PostResultCountMismatch.to_string(),
+                "Post result challenge count mismatch",
+            ),
+            (
+                ProofSizeMismatch::ConstraintCountMismatch.to_string(),
+                "Constraint count mismatch",
+            ),
+            (
+                ProofSizeMismatch::TooFewBitDistributions.to_string(),
+                "Proof has too few bit distributions",
+            ),
+            (
+                ProofSizeMismatch::TooFewChiLengths.to_string(),
+                "Proof has too few one lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewRhoLengths.to_string(),
+                "Proof has too few rho lengths",
+            ),
+            (
+                ProofSizeMismatch::TooFewSumcheckVariables.to_string(),
+                "Proof has too few sumcheck variables",
+            ),
+            (
+                ProofSizeMismatch::ChiLengthNotFound.to_string(),
+                "Proof doesn't have requested one length",
+            ),
+            (
+                ProofSizeMismatch::RhoLengthNotFound.to_string(),
+                "Proof doesn't have requested rho length",
+            ),
+        ];
+
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn placeholder_error_display_messages_include_context() {
+        let cases = [
+            (
+                PlaceholderError::InvalidPlaceholderIndex {
+                    index: 3,
+                    num_params: 2,
+                }
+                .to_string(),
+                "Invalid placeholder index: 3, number of params: 2",
+            ),
+            (
+                PlaceholderError::InvalidPlaceholderType {
+                    index: 1,
+                    expected: ColumnType::Int,
+                    actual: ColumnType::VarChar,
+                }
+                .to_string(),
+                "Invalid placeholder type: 1, expected: INT, actual: VARCHAR",
+            ),
+            (
+                PlaceholderError::ZeroPlaceholderId.to_string(),
+                "Placeholder id must be greater than 0",
+            ),
+        ];
+
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+    }
+}

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -30,3 +30,49 @@ pub fn log_memory_usage(name: &str) {
         );
     }
 }
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use tracing::{
+        metadata::LevelFilter,
+        span::{Attributes, Id, Record},
+        subscriber::Interest,
+        Event, Metadata, Subscriber,
+    };
+
+    struct TraceSubscriber;
+
+    impl Subscriber for TraceSubscriber {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, _event: &Event<'_>) {}
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+
+        fn register_callsite(&self, _metadata: &'static Metadata<'static>) -> Interest {
+            Interest::always()
+        }
+
+        fn max_level_hint(&self) -> Option<LevelFilter> {
+            Some(LevelFilter::TRACE)
+        }
+    }
+
+    #[test]
+    fn log_memory_usage_runs_when_trace_is_enabled() {
+        tracing::subscriber::with_default(TraceSubscriber, || log_memory_usage("coverage"));
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add coverage for Arrow schema conversion of float fields to PoSQL-compatible decimals while preserving non-float field metadata
- add coverage for `TableEvaluation` constructor/accessors
- add coverage for the local `U256` helper constructor and scalar conversion ordering
- add coverage for `PoSQLTimestampError` display messages and `String` conversion
- add coverage for `ProofError`, `ProofSizeMismatch`, and `PlaceholderError` display/transparent wrapper messages
- add a TRACE-enabled smoke test for `log_memory_usage`
- enable `tracing/std` for dev builds so the logging test can install a test subscriber without changing production dependencies

## Validation
- `cargo fmt --check`
- `rustfmt --check crates/proof-of-sql/src/base/proof/error.rs`
- `cargo test -p proof-of-sql --no-default-features --features std,arrow,test table_evaluation_accessors_return_constructor_values --lib`
- `cargo test -p proof-of-sql --no-default-features --features std,arrow,test get_posql_compatible_schema_converts_float_fields_and_preserves_other_metadata --lib`
- `cargo test -p proof-of-sql --no-default-features --features std,arrow,test log_memory_usage_runs_when_trace_is_enabled --lib`
- `cargo test -p proof-of-sql --no-default-features --features std,arrow,test u256 --lib`
- `cargo test -p proof-of-sql --no-default-features --features std,arrow,test timestamp_error --lib`
- `cargo test -p proof-of-sql --no-default-features --features std,arrow,test base::proof::error::tests --lib`
- `git diff --check`

Note: local default-feature test builds fail on Apple Silicon before this patch due to `halo2curves` `asm` only supporting x86_64, so I used the ARM-safe feature set above.