### PR TITLE
test: cover column field and ref accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,21 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_field_preserves_name_and_type() {
+        let name: Ident = "revenue_cents".into();
+        let field = ColumnField::new(name.clone(), ColumnType::BigInt);
+
+        assert_eq!(field.name(), name);
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+
+        let renamed = field.name();
+        assert_eq!(renamed.value, "revenue_cents");
+        assert_eq!(field.name().value, "revenue_cents");
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,23 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_ref_preserves_table_column_and_type() {
+        let table_ref = TableRef::from_names(Some("analytics"), "sales");
+        let column_id: Ident = "amount".into();
+        let column_ref = ColumnRef::new(table_ref.clone(), column_id.clone(), ColumnType::Int);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), column_id);
+        assert_eq!(column_ref.column_type(), &ColumnType::Int);
+
+        let returned_column_id = column_ref.column_id();
+        assert_eq!(returned_column_id.value, "amount");
+        assert_eq!(column_ref.column_id().value, "amount");
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary

- add focused unit coverage for `ColumnField::new`, `name`, and `data_type`
- add focused unit coverage for `ColumnRef::new`, `table_ref`, `column_id`, and `column_type`
- keep production behavior unchanged

## Deconfliction

- searched open PRs for `column_field`, `ColumnField`, `column_ref`, and `ColumnRef`; no open PR overlap was found for this slice

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql column_field_preserves_name_and_type --no-default-features --features test`
- `cargo test -p proof-of-sql column_ref_preserves_table_column_and_type --no-default-features --features test`
- `cargo test -p proof-of-sql "base::database::column_" --no-default-features --features test`
- `bash scripts/check_commits.sh`

The focused test runs pass locally. The repository currently emits existing upstream warnings during test builds, but the targeted tests pass.

AI-assisted with OpenAI Codex; I reviewed the diff before submission.