### PR TITLE
test: cover scalar conversion error display

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,21 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn scalar_conversion_overflow_display_includes_source_error() {
+        let error = ScalarConversionError::Overflow {
+            error: "value exceeds scalar modulus".into(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Overflow error: value exceeds scalar modulus"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add focused coverage for `ScalarConversionError::Overflow` display formatting.
- Verify the original overflow source text is preserved in the rendered error message.

/claim #560

## Deconfliction
- Checked open PRs for `scalar/error`, `ScalarConversionError`, and scalar conversion coverage before submitting; no open overlapping PR was found.
- This is limited to `crates/proof-of-sql/src/base/scalar/error.rs` and does not overlap with the recent conversion-path tests in `mont_scalar` / `curve_25519` / `dory` modules.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql scalar_conversion_overflow_display_includes_source_error --no-default-features --features test`
- `cargo test -p proof-of-sql base::scalar --no-default-features --features test`
- `bash scripts/check_commits.sh`