### PR TITLE
test: cover table expression serde

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -7,3 +7,24 @@ pub struct TableExpr {
     /// The `TableRef` for the table
     pub table_ref: TableRef,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_expr_preserves_table_ref_through_clone_and_serde() {
+        let table_ref = TableRef::new("public", "orders");
+        let expr = TableExpr {
+            table_ref: table_ref.clone(),
+        };
+
+        assert_eq!(expr.clone(), expr);
+        assert_eq!(expr.table_ref, table_ref);
+
+        let json = serde_json::to_string(&expr).unwrap();
+        let round_trip: TableExpr = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(round_trip, expr);
+    }
+}


### PR DESCRIPTION
## Summary
- Add focused `TableExpr` coverage for preserving its `TableRef` through clone/equality.
- Verify serde JSON round-tripping keeps the table reference intact.

/claim #560

## Deconfliction
- Filtered #560 issue comments for claimed file/path mentions and found no `table_expr.rs` / `TableExpr` claim.
- Checked open and closed PR search for `table_expr` / `TableExpr`; no overlapping PR was found.
- This PR is limited to `crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs`.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql table_expr_preserves_table_ref_through_clone_and_serde --no-default-features --features test`
- `cargo test -p proof-of-sql table_expr --no-default-features --features test`
- `bash scripts/check_commits.sh`