### PR TITLE
test: cover RefInto reference conversion

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,25 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Wrapper(u8);
+
+    impl From<&Wrapper> for u16 {
+        fn from(value: &Wrapper) -> Self {
+            u16::from(value.0)
+        }
+    }
+
+    #[test]
+    fn ref_into_uses_reference_conversion_without_consuming_value() {
+        let wrapper = Wrapper(7);
+
+        assert_eq!(wrapper.ref_into(), 7_u16);
+        assert_eq!(wrapper, Wrapper(7));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a focused unit test for `RefInto`
- Verifies the blanket implementation uses `From<&T>` without consuming the original value

/claim #560

## Validation
- `git diff --check`

I could not run `cargo test` locally because this environment does not have `cargo` or `rustc` installed.