### PR TITLE
test: cover EVM proof plan errors

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,49 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::EVMProofPlanError;
+
+    #[test]
+    fn evm_proof_plan_errors_render_stable_messages() {
+        let cases = [
+            (EVMProofPlanError::NotSupported, "plan not yet supported"),
+            (EVMProofPlanError::ColumnNotFound, "column not found"),
+            (EVMProofPlanError::TableNotFound, "table not found"),
+            (
+                EVMProofPlanError::InvalidTableName,
+                "table name can not be parsed into TableRef",
+            ),
+            (
+                EVMProofPlanError::InvalidOutputColumnName,
+                "invalid or missing output column name",
+            ),
+            (
+                EVMProofPlanError::InconsistentGroupByColumnCounts,
+                "column counts in group by plans are inconsistent",
+            ),
+            (
+                EVMProofPlanError::IncorrectScalingFactor,
+                "incorrect scaling factor",
+            ),
+        ];
+
+        for (error, expected_message) in cases {
+            assert_eq!(error.to_string(), expected_message);
+        }
+    }
+
+    #[test]
+    fn evm_proof_plan_errors_compare_by_variant() {
+        assert_eq!(
+            EVMProofPlanError::ColumnNotFound,
+            EVMProofPlanError::ColumnNotFound
+        );
+        assert_ne!(
+            EVMProofPlanError::ColumnNotFound,
+            EVMProofPlanError::TableNotFound
+        );
+    }
+}


### PR DESCRIPTION
## Summary

/claim #560

Adds a narrow, non-overlapping test-only coverage slice for `crates/proof-of-sql/src/sql/evm_proof_plan/error.rs`.

Scope:
- covers stable display messages for the concrete `EVMProofPlanError` variants
- covers variant equality/inequality behavior from the derived `PartialEq`
- does not change production behavior

Deconfliction:
- Checked the current open PR file map before opening this PR. No open PR touched `crates/proof-of-sql/src/sql/evm_proof_plan/error.rs` at the time of submission.
- This is independent from my open `TableRef` PR #2443 and does not touch `base/database/mod.rs` or the table-ref files.

## Validation

- `cargo test -p proof-of-sql --lib --no-default-features --features test evm_proof_plan_errors -- --quiet`
- `cargo fmt --check`
- `git diff --check`
