### PR TITLE
test: cover database filter and ordering utilities

### DIFF
--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,6 +1,7 @@
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
@@ -115,6 +116,46 @@ fn we_can_filter_columns_with_varbinary() {
         vec![
             Column::VarBinary((filtered_bytes.as_slice(), filtered_scalars.as_slice())),
             Column::BigInt(&[10, 30, 40]),
+        ]
+    );
+}
+
+#[test]
+fn we_can_filter_all_primitive_and_timestamp_columns() {
+    let selection = [false, true, true, false];
+    let decimals: [TestScalar; 4] = [10.into(), 20.into(), 30.into(), 40.into()];
+    let columns = [
+        Column::Boolean(&[false, true, false, true]),
+        Column::Uint8(&[1, 2, 3, 4]),
+        Column::TinyInt(&[-1, -2, 3, 4]),
+        Column::SmallInt(&[-10, 20, 30, 40]),
+        Column::Int(&[-100, 200, 300, 400]),
+        Column::Decimal75(Precision::new(10).unwrap(), 2, &decimals),
+        Column::TimestampTZ(
+            PoSQLTimeUnit::Millisecond,
+            PoSQLTimeZone::new(3_600),
+            &[1_000, 2_000, 3_000, 4_000],
+        ),
+    ];
+    let alloc = Bump::new();
+
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+
+    assert_eq!(len, 2);
+    assert_eq!(
+        result,
+        vec![
+            Column::Boolean(&[true, false]),
+            Column::Uint8(&[2, 3]),
+            Column::TinyInt(&[-2, 3]),
+            Column::SmallInt(&[20, 30]),
+            Column::Int(&[200, 300]),
+            Column::Decimal75(Precision::new(10).unwrap(), 2, &[20.into(), 30.into()]),
+            Column::TimestampTZ(
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::new(3_600),
+                &[2_000, 3_000],
+            ),
         ]
     );
 }

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
         database::{order_by_util::*, Column, ColumnType, TableOperationError},
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
@@ -187,4 +189,80 @@ fn we_can_compare_indexes_by_columns_for_varbinary_columns() {
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Equal); // "baz" vs "baz"
     assert_eq!(compare_indexes_by_columns(columns, 3, 4), Ordering::Greater); // "baz" vs "bar"
     assert_eq!(compare_indexes_by_columns(columns, 1, 4), Ordering::Equal); // "bar" vs "bar"
+}
+
+#[test]
+fn we_can_compare_indexes_for_every_primitive_numeric_and_timestamp_type() {
+    let decimal_values: [TestScalar; 3] = [(-1).into(), 1.into(), 1.into()];
+    let columns = [
+        Column::Boolean(&[false, true, true]),
+        Column::Uint8(&[1, 2, 2]),
+        Column::TinyInt(&[-2, -1, -1]),
+        Column::SmallInt(&[-20, 10, 10]),
+        Column::Int(&[-200, 100, 100]),
+        Column::Decimal75(Precision::new(3).unwrap(), 1, &decimal_values),
+        Column::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::utc(),
+            &[1_000, 2_000, 2_000],
+        ),
+    ];
+
+    for column in columns {
+        assert_eq!(compare_indexes_by_columns(&[column], 0, 1), Ordering::Less);
+        assert_eq!(compare_indexes_by_columns(&[column], 1, 2), Ordering::Equal);
+        assert_eq!(
+            compare_indexes_by_columns(&[column], 2, 0),
+            Ordering::Greater
+        );
+    }
+}
+
+#[test]
+fn we_can_compare_single_rows_for_every_supported_primitive_type() {
+    let left_decimal: [TestScalar; 1] = [(-1).into()];
+    let right_decimal: [TestScalar; 1] = [1.into()];
+    let left_scalar: [TestScalar; 1] = [1.into()];
+    let right_scalar: [TestScalar; 1] = [2.into()];
+    let left_varchar_scalar: [TestScalar; 1] = ["alpha".into()];
+    let right_varchar_scalar: [TestScalar; 1] = ["beta".into()];
+    let left = [
+        Column::Boolean(&[false]),
+        Column::Uint8(&[1]),
+        Column::TinyInt(&[-2]),
+        Column::SmallInt(&[-20]),
+        Column::Int(&[-200]),
+        Column::Int128(&[-2_000]),
+        Column::Decimal75(Precision::new(3).unwrap(), 1, &left_decimal),
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1_000]),
+        Column::Scalar(&left_scalar),
+        Column::VarChar((&["alpha"], &left_varchar_scalar)),
+    ];
+    let right = [
+        Column::Boolean(&[true]),
+        Column::Uint8(&[2]),
+        Column::TinyInt(&[-1]),
+        Column::SmallInt(&[10]),
+        Column::Int(&[100]),
+        Column::Int128(&[1_000]),
+        Column::Decimal75(Precision::new(3).unwrap(), 1, &right_decimal),
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[2_000]),
+        Column::Scalar(&right_scalar),
+        Column::VarChar((&["beta"], &right_varchar_scalar)),
+    ];
+
+    for (left_column, right_column) in left.into_iter().zip(right) {
+        assert_eq!(
+            compare_single_row_of_tables(&[left_column], &[right_column], 0, 0).unwrap(),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_single_row_of_tables(&[right_column], &[left_column], 0, 0).unwrap(),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_single_row_of_tables(&[left_column], &[left_column], 0, 0).unwrap(),
+            Ordering::Equal
+        );
+    }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
