### PR TITLE
ci: parallelize Foundry and Slither checks

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -288,14 +288,41 @@ jobs:
           version: v1.0.0
       - name: Install dependencies
         run: solidity/scripts/install_deps.sh
-      - name: Run tests without via-ir or optimization
-        run: solidity/scripts/pre_forge.sh test
-      - name: Run tests with via-ir but without optimization
-        run: solidity/scripts/pre_forge.sh test --via-ir
-      - name: Run tests with optimization but without via-ir
-        run: solidity/scripts/pre_forge.sh test --optimize
-      - name: Run tests with via-ir and optimization
-        run: solidity/scripts/pre_forge.sh test --via-ir --optimize
+      - name: Run Foundry test modes
+        run: |
+          set -euo pipefail
+          cd solidity
+
+          find . -type f -name '*.post.sol' -delete
+          python3 preprocessor/yul_preprocessor.py .
+
+          pids=()
+          run_mode() {
+            local label="$1"
+            local out_dir="$2"
+            local cache_dir="$3"
+            shift 3
+
+            echo "Running Foundry tests: ${label}"
+            forge test --threads 2 --out "${out_dir}" --cache-path "${cache_dir}" "$@"
+          }
+
+          run_mode "without via-ir or optimization" out-test-default cache-test-default &
+          pids+=($!)
+          run_mode "with via-ir but without optimization" out-test-via-ir cache-test-via-ir --via-ir &
+          pids+=($!)
+          run_mode "with optimization but without via-ir" out-test-optimize cache-test-optimize --optimize &
+          pids+=($!)
+          run_mode "with via-ir and optimization" out-test-via-ir-optimize cache-test-via-ir-optimize --via-ir --optimize &
+          pids+=($!)
+
+          failed=0
+          for pid in "${pids[@]}"; do
+            if ! wait "${pid}"; then
+              failed=1
+            fi
+          done
+          exit "${failed}"
       - name: Remove preprocessor test files (for they are already tested in the check-yul-preprocessor job)
         run: rm -rf solidity/preprocessor/test_files
       - name: Install lcov
@@ -313,14 +340,25 @@ jobs:
       - name: Install Slither
         run: pip install slither-analyzer
 
-      - name: Run slither on verifier
-        run: slither solidity/src/verifier/Verifier.post.sol --config-file solidity/slither.config.json
+      - name: Run Slither checks
+        run: |
+          set -euo pipefail
 
-      - name: Run slither on errors
-        run: slither solidity/src/base/Errors.sol --config-file solidity/slither.config.json
+          pids=()
+          slither solidity/src/verifier/Verifier.post.sol --config-file solidity/slither.config.json &
+          pids+=($!)
+          slither solidity/src/base/Errors.sol --config-file solidity/slither.config.json &
+          pids+=($!)
+          slither solidity/src/base/Constants.sol --config-file solidity/slither.config.json &
+          pids+=($!)
 
-      - name: Run slither on constants
-        run: slither solidity/src/base/Constants.sol --config-file solidity/slither.config.json
+          failed=0
+          for pid in "${pids[@]}"; do
+            if ! wait "${pid}"; then
+              failed=1
+            fi
+          done
+          exit "${failed}"
 
 
   rustevmtests:


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit message adhere to the conventional commit guidelines.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`.
- [x] The latest changes from `main` have been incorporated to this PR.

# Rationale for this change

Issue #557 asks for test and CI runtime improvements without removing or weakening tests. The Foundry CI job currently runs four independent Forge test modes serially, and later runs three independent Slither analyses serially.

This PR keeps the same test and analyzer coverage, but reduces wall-clock time by running independent work concurrently inside the existing `foundrycheck` job:

- preprocess Solidity sources once before the Forge test modes;
- run the four existing Forge test modes in parallel;
- give each Forge mode its own artifact and compiler-cache directories via `--out` and `--cache-path` to avoid shared output/cache races;
- cap each Forge mode at `--threads 2` so the four modes fit the existing 8-core runner instead of oversubscribing it;
- run the three existing Slither target analyses in parallel and preserve failure propagation.

/claim #557

# What changes are included in this PR?

- Replace the four serial Foundry test steps with one parallel `Run Foundry test modes` step.
- Replace the three serial Slither steps with one parallel `Run Slither checks` step.
- Keep coverage, formatting, solhint, dependency installation, and the Rust EVM job unchanged.

# Are these changes tested?

Local/static validation:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lint-and-test.yml"); puts "yaml ok"'`
- `python3 - <<'PY' ... bash -n -c step['run'] ... PY` for the two changed shell blocks
- `git diff --check`
- `source scripts/check_commits.sh`

I did not complete `source scripts/run_ci_checks.sh` locally. This is a workflow-only Linux CI change, and this local macOS/Apple Silicon environment does not match the Linux runner/toolchain assumptions. I validated the changed YAML and shell blocks directly and left full runtime validation to GitHub Actions / maintainer CI.

Disclosure: prepared with AI assistance in Codex. I reviewed the workflow behavior, checked for overlap with existing #557 PRs, and validated the changed YAML/shell blocks before submission.
