### PR TITLE
test: enable record batch conversion coverage

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -99,7 +99,7 @@ impl<C: Commitment> TableCommitment<C> {
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{


### PR DESCRIPTION
Part of #560

/claim #560

## Summary
- enable the existing RecordBatch conversion commitment test under the standard test configuration instead of only when `blitzar` is enabled
- covers `batch_to_columns`, `TableCommitment::try_from_record_batch`, and `TableCommitment::try_append_record_batch` for a mixed int/string batch
- avoids overlap with existing query-result coverage PRs #1590 and #2152

## Coverage impact
Under the bounty coverage command, `crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs` moved from:
- before: 0/56 lines, 0/7 functions, 0/69 regions
- after: 95/101 lines, 8/8 functions, 137/151 regions

Overall package line coverage moved from 81.81% to 82.22% in the local `cargo llvm-cov` summary.

## Validation
```bash
cargo fmt --check
TMPDIR=/work/tmp CARGO_TARGET_DIR=/work/sxt-target-test cargo test -p proof-of-sql we_can_create_and_append_table_commitments_with_record_batches --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"
TMPDIR=/work/tmp CARGO_TARGET_DIR=/work/sxt-target-cov cargo llvm-cov --package proof-of-sql --json --summary-only --output-path /work/tmp/sxt_cov_summary_after_record.json --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"
source scripts/run_ci_checks.sh
```

The full instrumented coverage run passed 1054 tests. The local CI quality script completed successfully.
