### PR TITLE
test: cover UnionExec constructor and input_plans accessor

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -204,3 +204,69 @@ impl ProverEvaluate for UnionExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::proof_plans::DynProofPlan;
+
+    fn empty() -> DynProofPlan {
+        DynProofPlan::new_empty()
+    }
+
+    // ── try_new error/success ────────────────────────────────────────────────
+
+    #[test]
+    fn try_new_with_empty_inputs_fails() {
+        let result = UnionExec::try_new(vec![]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_new_with_one_input_fails() {
+        let result = UnionExec::try_new(vec![empty()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_new_with_two_inputs_succeeds() {
+        let result = UnionExec::try_new(vec![empty(), empty()]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_with_three_inputs_succeeds() {
+        let result = UnionExec::try_new(vec![empty(), empty(), empty()]);
+        assert!(result.is_ok());
+    }
+
+    // ── input_plans accessor ─────────────────────────────────────────────────
+
+    #[test]
+    fn input_plans_returns_all_inputs() {
+        let exec = UnionExec::try_new(vec![empty(), empty(), empty()]).unwrap();
+        assert_eq!(exec.input_plans().len(), 3);
+    }
+
+    // ── PartialEq / Clone ────────────────────────────────────────────────────
+
+    #[test]
+    fn two_equal_unions_are_equal() {
+        let a = UnionExec::try_new(vec![empty(), empty()]).unwrap();
+        let b = UnionExec::try_new(vec![empty(), empty()]).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn unions_with_different_input_counts_are_not_equal() {
+        let a = UnionExec::try_new(vec![empty(), empty()]).unwrap();
+        let b = UnionExec::try_new(vec![empty(), empty(), empty()]).unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn clone_equals_original() {
+        let a = UnionExec::try_new(vec![empty(), empty()]).unwrap();
+        assert_eq!(a.clone(), a);
+    }
+}


### PR DESCRIPTION
Part of #560

/claim #560

## Summary

Adds a `#[cfg(test)]` module to `crates/proof-of-sql/src/sql/proof_plans/union_exec.rs` covering `try_new` error/success paths and the `input_plans` accessor.

## Coverage

| Path | Test |
|---|---|
| `try_new([]))` → `Err` | ✅ |
| `try_new([x])` → `Err` (needs > 1) | ✅ |
| `try_new([x, y])` → `Ok` | ✅ |
| `try_new([x, y, z])` → `Ok` | ✅ |
| `input_plans().len()` | ✅ |
| `PartialEq` equal pair | ✅ |
| `PartialEq` different input-count | ✅ |
| `clone` equals original | ✅ |

## Deconfliction

No open PR touches `union_exec.rs` at time of submission.