### PR TITLE
test: cover EqualsExpr and OrExpr constructors and accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -213,3 +213,69 @@ pub fn verifier_evaluate_equals_zero<S: Scalar>(
 
     Ok(selection_eval)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::{proof_exprs::DynProofExpr, AnalyzeError},
+    };
+
+    fn bool_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::Boolean(true),
+        )))
+    }
+
+    fn bigint_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::BigInt(42),
+        )))
+    }
+
+    // ── try_new ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn try_new_matching_types_succeeds() {
+        let result = EqualsExpr::try_new(bigint_literal(), bigint_literal());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_mismatched_types_returns_error() {
+        // Boolean vs BigInt — not equals-compatible
+        let result = EqualsExpr::try_new(bool_literal(), bigint_literal());
+        assert!(matches!(result, Err(AnalyzeError::DataTypeMismatch { .. })));
+    }
+
+    // ── accessors ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn lhs_rhs_data_types_are_preserved() {
+        let expr = EqualsExpr::try_new(bigint_literal(), bigint_literal()).unwrap();
+        assert_eq!(expr.lhs().data_type(), ColumnType::BigInt);
+        assert_eq!(expr.rhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let expr = EqualsExpr::try_new(bigint_literal(), bigint_literal()).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    // ── PartialEq / Clone ────────────────────────────────────────────────────
+
+    #[test]
+    fn equal_exprs_are_equal() {
+        let a = EqualsExpr::try_new(bigint_literal(), bigint_literal()).unwrap();
+        let b = EqualsExpr::try_new(bigint_literal(), bigint_literal()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_equals_original() {
+        let a = EqualsExpr::try_new(bigint_literal(), bigint_literal()).unwrap();
+        assert_eq!(a.clone(), a);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -184,3 +184,75 @@ pub fn verifier_evaluate_or<S: Scalar>(
     // selection
     Ok(*lhs + *rhs - lhs_and_rhs)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::{proof_exprs::DynProofExpr, AnalyzeError},
+    };
+
+    fn bool_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::Boolean(true),
+        )))
+    }
+
+    fn bigint_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::BigInt(0),
+        )))
+    }
+
+    // ── try_new ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn try_new_boolean_boolean_succeeds() {
+        let result = OrExpr::try_new(bool_literal(), bool_literal());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_boolean_bigint_fails() {
+        let result = OrExpr::try_new(bool_literal(), bigint_literal());
+        assert!(matches!(result, Err(AnalyzeError::DataTypeMismatch { .. })));
+    }
+
+    #[test]
+    fn try_new_bigint_bigint_fails() {
+        // OR only valid on booleans
+        let result = OrExpr::try_new(bigint_literal(), bigint_literal());
+        assert!(matches!(result, Err(AnalyzeError::DataTypeMismatch { .. })));
+    }
+
+    // ── accessors ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn lhs_rhs_are_boolean() {
+        let expr = OrExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        assert_eq!(expr.lhs().data_type(), ColumnType::Boolean);
+        assert_eq!(expr.rhs().data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let expr = OrExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    // ── PartialEq / Clone ────────────────────────────────────────────────────
+
+    #[test]
+    fn equal_exprs_compare_equal() {
+        let a = OrExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        let b = OrExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_equals_original() {
+        let a = OrExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        assert_eq!(a.clone(), a);
+    }
+}


### PR DESCRIPTION
Part of #560

/claim #560

## Summary

Adds `#[cfg(test)]` modules to `equals_expr.rs` and `or_expr.rs` covering previously untested constructor, accessor, and trait paths.

## EqualsExpr coverage

| Path | Test |
|---|---|
| `try_new` matching types → `Ok` | ✅ |
| `try_new` mismatched types → `DataTypeMismatch` | ✅ |
| `lhs()` / `rhs()` data type preserved | ✅ |
| `data_type()` returns `Boolean` | ✅ |
| `PartialEq` equal pair | ✅ |
| `Clone` equals original | ✅ |

## OrExpr coverage

| Path | Test |
|---|---|
| `try_new(bool, bool)` → `Ok` | ✅ |
| `try_new(bool, bigint)` → `DataTypeMismatch` | ✅ |
| `try_new(bigint, bigint)` → `DataTypeMismatch` (OR requires booleans) | ✅ |
| `lhs()` / `rhs()` are `Boolean` | ✅ |
| `data_type()` returns `Boolean` | ✅ |
| `PartialEq` equal pair | ✅ |
| `Clone` equals original | ✅ |

## Deconfliction

No open PR touches `equals_expr.rs` or `or_expr.rs` at time of submission.