### PR TITLE
test: cover NotExpr and AndExpr constructors and accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -147,3 +147,67 @@ impl ProofExpr for AndExpr {
         self.rhs.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::{proof_exprs::DynProofExpr, AnalyzeError},
+    };
+
+    fn bool_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::Boolean(true),
+        )))
+    }
+
+    fn bigint_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::BigInt(0),
+        )))
+    }
+
+    #[test]
+    fn try_new_boolean_boolean_succeeds() {
+        assert!(AndExpr::try_new(bool_literal(), bool_literal()).is_ok());
+    }
+
+    #[test]
+    fn try_new_bool_bigint_fails() {
+        let result = AndExpr::try_new(bool_literal(), bigint_literal());
+        assert!(matches!(result, Err(AnalyzeError::DataTypeMismatch { .. })));
+    }
+
+    #[test]
+    fn try_new_bigint_bigint_fails() {
+        let result = AndExpr::try_new(bigint_literal(), bigint_literal());
+        assert!(matches!(result, Err(AnalyzeError::DataTypeMismatch { .. })));
+    }
+
+    #[test]
+    fn lhs_rhs_are_boolean() {
+        let expr = AndExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        assert_eq!(expr.lhs().data_type(), ColumnType::Boolean);
+        assert_eq!(expr.rhs().data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let expr = AndExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn equal_exprs_compare_equal() {
+        let a = AndExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        let b = AndExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_equals_original() {
+        let a = AndExpr::try_new(bool_literal(), bool_literal()).unwrap();
+        assert_eq!(a.clone(), a);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -99,3 +99,60 @@ impl ProofExpr for NotExpr {
         self.expr.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::{proof_exprs::DynProofExpr, AnalyzeError},
+    };
+
+    fn bool_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::Boolean(false),
+        )))
+    }
+
+    fn bigint_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::BigInt(1),
+        )))
+    }
+
+    #[test]
+    fn try_new_boolean_succeeds() {
+        assert!(NotExpr::try_new(bool_literal()).is_ok());
+    }
+
+    #[test]
+    fn try_new_non_boolean_fails() {
+        let result = NotExpr::try_new(bigint_literal());
+        assert!(matches!(result, Err(AnalyzeError::InvalidDataType { .. })));
+    }
+
+    #[test]
+    fn input_accessor_returns_boolean() {
+        let expr = NotExpr::try_new(bool_literal()).unwrap();
+        assert_eq!(expr.input().data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let expr = NotExpr::try_new(bool_literal()).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn equal_exprs_compare_equal() {
+        let a = NotExpr::try_new(bool_literal()).unwrap();
+        let b = NotExpr::try_new(bool_literal()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_equals_original() {
+        let a = NotExpr::try_new(bool_literal()).unwrap();
+        assert_eq!(a.clone(), a);
+    }
+}


### PR DESCRIPTION
Part of #560

/claim #560

## Summary

Adds `#[cfg(test)]` modules to `not_expr.rs` and `and_expr.rs` covering previously untested constructor, accessor, and equality paths.

## NotExpr coverage

| Path | Test |
|---|---|
| `try_new(bool)` → `Ok` | ✅ |
| `try_new(bigint)` → `InvalidDataType` | ✅ |
| `input()` accessor returns `Boolean` | ✅ |
| `data_type()` is `Boolean` | ✅ |
| `PartialEq` equal pair | ✅ |
| `Clone` equals original | ✅ |

## AndExpr coverage

| Path | Test |
|---|---|
| `try_new(bool, bool)` → `Ok` | ✅ |
| `try_new(bool, bigint)` → `DataTypeMismatch` | ✅ |
| `try_new(bigint, bigint)` → `DataTypeMismatch` | ✅ |
| `lhs()` / `rhs()` are `Boolean` | ✅ |
| `data_type()` is `Boolean` | ✅ |
| `PartialEq` equal pair | ✅ |
| `Clone` equals original | ✅ |

## Deconfliction

No open PR touches `not_expr.rs` or `and_expr.rs` at time of submission.