### PR TITLE
test: cover InequalityExpr and MultiplyExpr constructors and accessors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -158,3 +158,73 @@ impl ProofExpr for InequalityExpr {
         self.rhs.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::{proof_exprs::DynProofExpr, AnalyzeError},
+    };
+
+    fn bigint_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::BigInt(0),
+        )))
+    }
+
+    fn bool_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::Boolean(false),
+        )))
+    }
+
+    #[test]
+    fn try_new_numeric_lt_succeeds() {
+        assert!(InequalityExpr::try_new(bigint_literal(), bigint_literal(), true).is_ok());
+    }
+
+    #[test]
+    fn try_new_numeric_gt_succeeds() {
+        assert!(InequalityExpr::try_new(bigint_literal(), bigint_literal(), false).is_ok());
+    }
+
+    #[test]
+    fn try_new_mismatched_types_fails() {
+        let result = InequalityExpr::try_new(bigint_literal(), bool_literal(), true);
+        assert!(matches!(result, Err(AnalyzeError::DataTypeMismatch { .. })));
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let expr = InequalityExpr::try_new(bigint_literal(), bigint_literal(), true).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn lhs_rhs_accessors_preserved() {
+        let expr = InequalityExpr::try_new(bigint_literal(), bigint_literal(), true).unwrap();
+        assert_eq!(expr.lhs().data_type(), ColumnType::BigInt);
+        assert_eq!(expr.rhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn is_lt_flag_distinguishes_lt_from_gt() {
+        let lt = InequalityExpr::try_new(bigint_literal(), bigint_literal(), true).unwrap();
+        let gt = InequalityExpr::try_new(bigint_literal(), bigint_literal(), false).unwrap();
+        assert_ne!(lt, gt);
+    }
+
+    #[test]
+    fn equal_exprs_compare_equal() {
+        let a = InequalityExpr::try_new(bigint_literal(), bigint_literal(), true).unwrap();
+        let b = InequalityExpr::try_new(bigint_literal(), bigint_literal(), true).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_equals_original() {
+        let a = InequalityExpr::try_new(bigint_literal(), bigint_literal(), true).unwrap();
+        assert_eq!(a.clone(), a);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -138,3 +138,55 @@ impl ProofExpr for MultiplyExpr {
 }
 
 impl DecimalProofExpr for MultiplyExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::{proof_exprs::DynProofExpr, AnalyzeError},
+    };
+
+    fn bigint_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::BigInt(2),
+        )))
+    }
+
+    fn bool_literal() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::Literal(LiteralExpr::new(
+            LiteralValue::Boolean(true),
+        )))
+    }
+
+    #[test]
+    fn try_new_numeric_types_succeeds() {
+        assert!(MultiplyExpr::try_new(bigint_literal(), bigint_literal()).is_ok());
+    }
+
+    #[test]
+    fn try_new_with_boolean_fails() {
+        let result = MultiplyExpr::try_new(bool_literal(), bool_literal());
+        assert!(matches!(result, Err(AnalyzeError::DataTypeMismatch { .. })));
+    }
+
+    #[test]
+    fn lhs_rhs_accessors_preserved() {
+        let expr = MultiplyExpr::try_new(bigint_literal(), bigint_literal()).unwrap();
+        assert_eq!(expr.lhs().data_type(), ColumnType::BigInt);
+        assert_eq!(expr.rhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn equal_exprs_compare_equal() {
+        let a = MultiplyExpr::try_new(bigint_literal(), bigint_literal()).unwrap();
+        let b = MultiplyExpr::try_new(bigint_literal(), bigint_literal()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_equals_original() {
+        let a = MultiplyExpr::try_new(bigint_literal(), bigint_literal()).unwrap();
+        assert_eq!(a.clone(), a);
+    }
+}


### PR DESCRIPTION
Part of #560

/claim #560

## Summary

Adds `#[cfg(test)]` modules to `inequality_expr.rs` and `multiply_expr.rs`.

## InequalityExpr coverage

| Path | Test |
|---|---|
| `try_new` numeric LT (`is_lt=true`) → `Ok` | ✅ |
| `try_new` numeric GT (`is_lt=false`) → `Ok` | ✅ |
| `try_new` mismatched types → `DataTypeMismatch` | ✅ |
| `data_type()` is `Boolean` | ✅ |
| `lhs()` / `rhs()` types preserved | ✅ |
| LT ≠ GT (is_lt distinguishes them) | ✅ |
| `PartialEq` equal pair | ✅ |
| `Clone` equals original | ✅ |

## MultiplyExpr coverage

| Path | Test |
|---|---|
| `try_new` numeric types → `Ok` | ✅ |
| `try_new` boolean types → `DataTypeMismatch` | ✅ |
| `lhs()` / `rhs()` types preserved | ✅ |
| `PartialEq` equal pair | ✅ |
| `Clone` equals original | ✅ |

## Deconfliction

No open PR touches `inequality_expr.rs` or `multiply_expr.rs` at time of submission.