### PR TITLE
test: cover TableEvaluation, ColumnRef, arrow_schema_utility, and fold_util

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,74 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    fn schema_from_fields(fields: Vec<Field>) -> SchemaRef {
+        Arc::new(Schema::new(fields))
+    }
+
+    #[test]
+    fn test_float_types_converted_to_decimal() {
+        let schema = schema_from_fields(vec![
+            Field::new("f16", DataType::Float16, false),
+            Field::new("f32", DataType::Float32, false),
+            Field::new("f64", DataType::Float64, false),
+        ]);
+        let result = get_posql_compatible_schema(&schema);
+        for field in result.fields() {
+            assert_eq!(
+                field.data_type(),
+                &DataType::Decimal256(20, 10),
+                "field {} should be Decimal256",
+                field.name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_non_float_types_unchanged() {
+        let schema = schema_from_fields(vec![
+            Field::new("i64_col", DataType::Int64, false),
+            Field::new("bool_col", DataType::Boolean, false),
+            Field::new("str_col", DataType::Utf8, true),
+        ]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).data_type(), &DataType::Int64);
+        assert_eq!(result.field(1).data_type(), &DataType::Boolean);
+        assert_eq!(result.field(2).data_type(), &DataType::Utf8);
+        assert_eq!(result.field(2).is_nullable(), true);
+    }
+
+    #[test]
+    fn test_mixed_schema() {
+        let schema = schema_from_fields(vec![
+            Field::new("a", DataType::Float32, false),
+            Field::new("b", DataType::Int32, false),
+        ]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).data_type(), &DataType::Decimal256(20, 10));
+        assert_eq!(result.field(1).data_type(), &DataType::Int32);
+    }
+
+    #[test]
+    fn test_empty_schema() {
+        let schema = schema_from_fields(vec![]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.fields().len(), 0);
+    }
+
+    #[test]
+    fn test_field_names_preserved() {
+        let schema = schema_from_fields(vec![
+            Field::new("my_float", DataType::Float64, false),
+            Field::new("my_int", DataType::Int8, false),
+        ]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).name(), "my_float");
+        assert_eq!(result.field(1).name(), "my_int");
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,57 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::ColumnType;
+
+    fn make_column_ref() -> ColumnRef {
+        let table_ref: TableRef = "schema.table".parse().unwrap();
+        let column_id = Ident::new("col1");
+        ColumnRef::new(table_ref, column_id, ColumnType::BigInt)
+    }
+
+    #[test]
+    fn test_new_and_accessors() {
+        let table_ref: TableRef = "schema.table".parse().unwrap();
+        let column_id = Ident::new("col1");
+        let cr = ColumnRef::new(table_ref.clone(), column_id.clone(), ColumnType::BigInt);
+        assert_eq!(cr.table_ref(), table_ref);
+        assert_eq!(cr.column_id(), column_id);
+        assert_eq!(*cr.column_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn test_equality() {
+        let a = make_column_ref();
+        let b = make_column_ref();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_inequality_different_type() {
+        let table_ref: TableRef = "schema.table".parse().unwrap();
+        let col = Ident::new("col1");
+        let a = ColumnRef::new(table_ref.clone(), col.clone(), ColumnType::BigInt);
+        let b = ColumnRef::new(table_ref, col, ColumnType::Boolean);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = make_column_ref();
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn test_hash_consistency() {
+        use std::collections::HashSet;
+        let cr = make_column_ref();
+        let mut set = HashSet::new();
+        set.insert(cr.clone());
+        assert!(set.contains(&cr));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,55 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn test_new_and_accessors() {
+        let evals: Vec<TestScalar> = vec![TestScalar::from(1u64), TestScalar::from(2u64)];
+        let chi = (TestScalar::from(3u64), 4usize);
+        let te = TableEvaluation::new(evals.clone(), chi);
+        assert_eq!(te.column_evals(), evals.as_slice());
+        assert_eq!(te.chi_eval(), TestScalar::from(3u64));
+        assert_eq!(te.chi(), chi);
+    }
+
+    #[test]
+    fn test_equality() {
+        let a = TableEvaluation::new(
+            vec![TestScalar::from(1u64)],
+            (TestScalar::from(2u64), 3usize),
+        );
+        let b = TableEvaluation::new(
+            vec![TestScalar::from(1u64)],
+            (TestScalar::from(2u64), 3usize),
+        );
+        let c = TableEvaluation::new(
+            vec![TestScalar::from(9u64)],
+            (TestScalar::from(2u64), 3usize),
+        );
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = TableEvaluation::new(
+            vec![TestScalar::from(5u64)],
+            (TestScalar::from(6u64), 7usize),
+        );
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn test_empty_column_evals() {
+        let te: TableEvaluation<TestScalar> =
+            TableEvaluation::new(vec![], (TestScalar::from(0u64), 0usize));
+        assert!(te.column_evals().is_empty());
+        assert_eq!(te.chi_eval(), TestScalar::from(0u64));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
@@ -32,3 +32,70 @@ pub fn fold_vals<S: Scalar>(beta: S, vals: &[S]) -> S {
 fn powers<S: Scalar>(init: S, base: S) -> impl Iterator<Item = S> {
     core::iter::successors(Some(init), move |&m| Some(m * base))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn test_fold_vals_empty() {
+        let result: TestScalar = fold_vals(TestScalar::from(2u64), &[]);
+        assert_eq!(result, TestScalar::ZERO);
+    }
+
+    #[test]
+    fn test_fold_vals_single() {
+        // fold_vals(beta, [v]) = v
+        let beta = TestScalar::from(3u64);
+        let vals = [TestScalar::from(7u64)];
+        let result = fold_vals(beta, &vals);
+        assert_eq!(result, TestScalar::from(7u64));
+    }
+
+    #[test]
+    fn test_fold_vals_two_elements() {
+        // fold_vals(beta, [a, b]) = a * beta + b
+        let beta = TestScalar::from(2u64);
+        let a = TestScalar::from(3u64);
+        let b = TestScalar::from(5u64);
+        let expected = a * beta + b; // 3*2 + 5 = 11
+        let result = fold_vals(beta, &[a, b]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_fold_vals_three_elements() {
+        // fold_vals(beta, [a, b, c]) = (a * beta + b) * beta + c
+        let beta = TestScalar::from(2u64);
+        let a = TestScalar::from(1u64);
+        let b = TestScalar::from(2u64);
+        let c = TestScalar::from(3u64);
+        // (1*2 + 2)*2 + 3 = 4*2 + 3 = 11
+        let expected = (a * beta + b) * beta + c;
+        let result = fold_vals(beta, &[a, b, c]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_fold_vals_zero_beta() {
+        // fold_vals(0, [a, b, c]) = c (all but the last term vanishes)
+        let beta = TestScalar::ZERO;
+        let vals = [
+            TestScalar::from(10u64),
+            TestScalar::from(20u64),
+            TestScalar::from(30u64),
+        ];
+        let result = fold_vals(beta, &vals);
+        assert_eq!(result, TestScalar::from(30u64));
+    }
+
+    #[test]
+    fn test_fold_columns_empty_columns() {
+        // With zero columns nothing is added to res
+        let mut res = vec![TestScalar::from(5u64), TestScalar::from(7u64)];
+        let cols: &[&[TestScalar]] = &[];
+        fold_columns::<TestScalar>(&mut res, TestScalar::ONE, TestScalar::from(2u64), cols);
+        assert_eq!(res, vec![TestScalar::from(5u64), TestScalar::from(7u64)]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `#[cfg(test)]` modules covering four previously-untested files for issue #560.

## Files covered

| File | New tests |
|---|---|
| `base/database/table_evaluation.rs` | `new`/accessors, equality, clone, empty column evals |
| `base/database/column_ref.rs` | `new`/accessors, equality, column-type inequality, clone, `Hash` |
| `base/database/arrow_schema_utility.rs` | `Float16/32/64→Decimal256`, non-float unchanged, mixed, empty schema, field names preserved |
| `sql/proof_plans/fold_util.rs` | `fold_vals` empty/single/two/three elements, zero-beta; `fold_columns` empty-columns no-op |

## Validation

All tests are logic-only (no proof generation), use `TestScalar` for scalar types, and follow the existing style in the codebase.

Closes part of #560.