### PR TITLE
test: cover add_const, mul_add_assign, inner_product, and bit_mask_utils

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
@@ -19,3 +19,38 @@ pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
 pub fn is_bit_mask_negative_representation(bit_mask: U256) -> bool {
     bit_mask & MSB_MASK == U256::ZERO
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn test_is_bit_mask_negative_representation_msb_set() {
+        // MSB set → NOT a negative representation → returns false
+        assert!(!is_bit_mask_negative_representation(MSB_MASK));
+    }
+
+    #[test]
+    fn test_is_bit_mask_negative_representation_msb_clear() {
+        // MSB clear → negative representation → returns true
+        assert!(is_bit_mask_negative_representation(U256::ZERO));
+        assert!(is_bit_mask_negative_representation(U256::ONE));
+    }
+
+    #[test]
+    fn test_make_bit_mask_non_negative_value() {
+        // For a non-negative value (x <= MAX_SIGNED), the bit mask
+        // has the MSB set (i.e. the result is NOT a negative representation).
+        let x = TestScalar::ZERO;
+        let mask = make_bit_mask(x);
+        assert!(!is_bit_mask_negative_representation(mask));
+    }
+
+    #[test]
+    fn test_make_bit_mask_consistency() {
+        // Two identical scalars should produce the same bit mask.
+        let x = TestScalar::from(42u64);
+        assert_eq!(make_bit_mask(x), make_bit_mask(x));
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/add_const.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const.rs
@@ -17,3 +17,43 @@ where
         *res_i += to_add.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_const_basic() {
+        let mut result = vec![1i64, 2, 3];
+        add_const(&mut result, 10i64);
+        assert_eq!(result, vec![11, 12, 13]);
+    }
+
+    #[test]
+    fn test_add_const_zero() {
+        let mut result = vec![5i64, 6, 7];
+        add_const(&mut result, 0i64);
+        assert_eq!(result, vec![5, 6, 7]);
+    }
+
+    #[test]
+    fn test_add_const_empty_slice() {
+        let mut result: Vec<i64> = vec![];
+        add_const(&mut result, 42i64); // no-op on empty
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_add_const_negative() {
+        let mut result = vec![10i64, 20, 30];
+        add_const(&mut result, -5i64);
+        assert_eq!(result, vec![5, 15, 25]);
+    }
+
+    #[test]
+    fn test_add_const_single_element() {
+        let mut result = vec![100u64];
+        add_const(&mut result, 1u64);
+        assert_eq!(result, vec![101u64]);
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -40,3 +40,63 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
         .sum()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn test_inner_product_basic() {
+        // [1,2,3] · [4,5,6] = 4 + 10 + 18 = 32
+        let a = [
+            TestScalar::from(1u64),
+            TestScalar::from(2u64),
+            TestScalar::from(3u64),
+        ];
+        let b = [
+            TestScalar::from(4u64),
+            TestScalar::from(5u64),
+            TestScalar::from(6u64),
+        ];
+        let result = inner_product(&a, &b);
+        assert_eq!(result, TestScalar::from(32u64));
+    }
+
+    #[test]
+    fn test_inner_product_empty() {
+        let a: Vec<TestScalar> = vec![];
+        let b: Vec<TestScalar> = vec![];
+        let result = inner_product(&a, &b);
+        assert_eq!(result, TestScalar::ZERO);
+    }
+
+    #[test]
+    fn test_inner_product_single_element() {
+        let a = [TestScalar::from(7u64)];
+        let b = [TestScalar::from(8u64)];
+        let result = inner_product(&a, &b);
+        assert_eq!(result, TestScalar::from(56u64));
+    }
+
+    #[test]
+    fn test_inner_product_longer_b_truncated() {
+        // a has 2 elements, b has 3; result should only use first 2 pairs
+        let a = [TestScalar::from(1u64), TestScalar::from(2u64)];
+        let b = [
+            TestScalar::from(3u64),
+            TestScalar::from(4u64),
+            TestScalar::from(999u64),
+        ];
+        let result = inner_product(&a, &b);
+        assert_eq!(result, TestScalar::from(1 * 3 + 2 * 4));
+    }
+
+    #[test]
+    fn test_inner_product_zeros() {
+        let a = [TestScalar::ZERO, TestScalar::ZERO];
+        let b = [TestScalar::from(100u64), TestScalar::from(200u64)];
+        let result = inner_product(&a, &b);
+        assert_eq!(result, TestScalar::ZERO);
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
@@ -24,3 +24,50 @@ where
         *res_i += multiplier * data_i.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mul_add_assign_basic() {
+        // result[i] += 2 * to_mul_add[i]
+        let mut result = vec![1i64, 2, 3];
+        let to_mul_add = vec![10i64, 20, 30];
+        mul_add_assign(&mut result, 2, &to_mul_add);
+        assert_eq!(result, vec![1 + 2 * 10, 2 + 2 * 20, 3 + 2 * 30]);
+    }
+
+    #[test]
+    fn test_mul_add_assign_zero_multiplier() {
+        let mut result = vec![5i64, 6, 7];
+        let to_mul_add = vec![100i64, 200, 300];
+        mul_add_assign(&mut result, 0, &to_mul_add);
+        assert_eq!(result, vec![5, 6, 7]);
+    }
+
+    #[test]
+    fn test_mul_add_assign_partial_overlap() {
+        // result is longer than to_mul_add; only first elements are updated
+        let mut result = vec![1i64, 2, 3, 4, 5];
+        let to_mul_add = vec![10i64, 20];
+        mul_add_assign(&mut result, 3, &to_mul_add);
+        assert_eq!(result, vec![1 + 30, 2 + 60, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_mul_add_assign_empty_to_mul_add() {
+        let mut result = vec![1i64, 2, 3];
+        let to_mul_add: Vec<i64> = vec![];
+        mul_add_assign(&mut result, 5, &to_mul_add);
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "The length of result must be greater than or equal")]
+    fn test_mul_add_assign_panics_when_result_shorter() {
+        let mut result = vec![1i64, 2];
+        let to_mul_add = vec![10i64, 20, 30];
+        mul_add_assign(&mut result, 1, &to_mul_add);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `#[cfg(test)]` modules to four previously-untested files for issue #560.

## Files covered

| File | New tests |
|---|---|
| `base/slice_ops/add_const.rs` | basic add, zero, empty slice, negative value, single element |
| `base/slice_ops/mul_add_assign.rs` | basic, zero multiplier, partial overlap, empty input, panic on short result |
| `base/slice_ops/inner_product.rs` | basic dot product, empty, single element, longer-b truncation, zeros |
| `base/bit/bit_mask_utils.rs` | MSB set/clear in `is_bit_mask_negative_representation`, `make_bit_mask` zero/arbitrary |

## Validation

All tests use primitive types or `TestScalar` and contain no proof generation.

Closes part of #560.