### PR TITLE
test: cover verifiable result coercion

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -53,7 +53,7 @@ pub(crate) use sumcheck_subpolynomial::{
 
 mod verifiable_query_result;
 pub use verifiable_query_result::VerifiableQueryResult;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod verifiable_query_result_test;
 
 #[cfg(all(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -3,9 +3,9 @@ use super::{
 };
 use crate::{
     base::{
-        commitment::InnerProductProof,
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
         database::{
-            owned_table_utility::{bigint, owned_table},
+            owned_table_utility::{bigint, owned_table, tinyint},
             table_utility::*,
             ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTableTestAccessor, Table,
             TableEvaluation, TableRef,
@@ -94,23 +94,123 @@ impl ProofPlan for EmptyTestQueryExpr {
     }
 }
 
+#[derive(Debug, Serialize, Default)]
+pub(super) struct ScalarResultTestQueryExpr {
+    pub(super) length: usize,
+    pub(super) columns: usize,
+}
+impl ProverEvaluate for ScalarResultTestQueryExpr {
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        _table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
+    ) -> PlaceholderResult<Table<'a, S>> {
+        let zeros = vec![S::ZERO; self.length];
+        builder.produce_chi_evaluation_length(self.length);
+        Ok(table_with_row_count(
+            (1..=self.columns)
+                .map(|i| borrowed_scalar(format!("a{i}").as_str(), zeros.clone(), alloc)),
+            self.length,
+        ))
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        _table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
+    ) -> PlaceholderResult<Table<'a, S>> {
+        let zeros = vec![S::ZERO; self.length];
+        let res: &[_] = alloc.alloc_slice_copy(&zeros);
+        let _ = std::iter::repeat_with(|| builder.produce_intermediate_mle(res))
+            .take(self.columns)
+            .collect::<Vec<_>>();
+        Ok(table_with_row_count(
+            (1..=self.columns)
+                .map(|i| borrowed_scalar(format!("a{i}").as_str(), zeros.clone(), alloc)),
+            self.length,
+        ))
+    }
+}
+impl ProofPlan for ScalarResultTestQueryExpr {
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
+        _chi_eval_map: &IndexMap<TableRef, (S, usize)>,
+        _params: &[LiteralValue],
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        assert_eq!(
+            builder.try_consume_final_round_mle_evaluations(self.columns)?,
+            vec![S::ZERO; self.columns]
+        );
+        Ok(TableEvaluation::new(
+            vec![S::ZERO; self.columns],
+            builder.try_consume_chi_evaluation()?,
+        ))
+    }
+
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        (1..=self.columns)
+            .map(|i| ColumnField::new(format!("a{i}").as_str().into(), ColumnType::TinyInt))
+            .collect()
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        indexset! {}
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        indexset![TableRef::new("sxt", "test")]
+    }
+}
+
 #[test]
 fn we_can_verify_queries_on_an_empty_table() {
     let expr = EmptyTestQueryExpr {
         columns: 1,
         ..Default::default()
     };
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+    let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
         TableRef::new("sxt", "test"),
         owned_table([bigint("a1", [0_i64; 0])]),
         0,
         (),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let QueryData {
         verification_hash: _,
         table,
     } = res.verify(&expr, &accessor, &(), &[]).unwrap();
     let expected_res = owned_table([bigint("a1", [0; 0])]);
+    assert_eq!(table, expected_res);
+}
+
+#[test]
+fn verify_coerces_scalar_result_columns_to_declared_numeric_fields() {
+    let expr = ScalarResultTestQueryExpr {
+        length: 2,
+        columns: 1,
+    };
+    let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        TableRef::new("sxt", "test"),
+        owned_table([bigint("a1", [0_i64, 0])]),
+        0,
+        (),
+    );
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    assert_eq!(res.result["a1"].column_type(), ColumnType::Scalar);
+
+    let QueryData {
+        verification_hash: _,
+        table,
+    } = res.verify(&expr, &accessor, &(), &[]).unwrap();
+
+    let expected_res = owned_table([tinyint("a1", [0_i8, 0])]);
     assert_eq!(table, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    FinalRoundBuilder, ProofPlan, ProverEvaluate, VerifiableQueryResult, VerificationBuilder,
+    FinalRoundBuilder, ProofPlan, ProverEvaluate, QueryError, VerifiableQueryResult,
+    VerificationBuilder,
 };
 use crate::{
     base::{
@@ -98,6 +99,7 @@ impl ProofPlan for EmptyTestQueryExpr {
 pub(super) struct ScalarResultTestQueryExpr {
     pub(super) length: usize,
     pub(super) columns: usize,
+    pub(super) value: i64,
 }
 impl ProverEvaluate for ScalarResultTestQueryExpr {
     fn first_round_evaluate<'a, S: Scalar>(
@@ -107,11 +109,11 @@ impl ProverEvaluate for ScalarResultTestQueryExpr {
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
     ) -> PlaceholderResult<Table<'a, S>> {
-        let zeros = vec![S::ZERO; self.length];
+        let values = vec![S::from(self.value); self.length];
         builder.produce_chi_evaluation_length(self.length);
         Ok(table_with_row_count(
             (1..=self.columns)
-                .map(|i| borrowed_scalar(format!("a{i}").as_str(), zeros.clone(), alloc)),
+                .map(|i| borrowed_scalar(format!("a{i}").as_str(), values.clone(), alloc)),
             self.length,
         ))
     }
@@ -123,14 +125,14 @@ impl ProverEvaluate for ScalarResultTestQueryExpr {
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
     ) -> PlaceholderResult<Table<'a, S>> {
-        let zeros = vec![S::ZERO; self.length];
-        let res: &[_] = alloc.alloc_slice_copy(&zeros);
+        let values = vec![S::from(self.value); self.length];
+        let res: &[_] = alloc.alloc_slice_copy(&values);
         let _ = std::iter::repeat_with(|| builder.produce_intermediate_mle(res))
             .take(self.columns)
             .collect::<Vec<_>>();
         Ok(table_with_row_count(
             (1..=self.columns)
-                .map(|i| borrowed_scalar(format!("a{i}").as_str(), zeros.clone(), alloc)),
+                .map(|i| borrowed_scalar(format!("a{i}").as_str(), values.clone(), alloc)),
             self.length,
         ))
     }
@@ -145,10 +147,10 @@ impl ProofPlan for ScalarResultTestQueryExpr {
     ) -> Result<TableEvaluation<S>, ProofError> {
         assert_eq!(
             builder.try_consume_final_round_mle_evaluations(self.columns)?,
-            vec![S::ZERO; self.columns]
+            vec![S::from(self.value); self.columns]
         );
         Ok(TableEvaluation::new(
-            vec![S::ZERO; self.columns],
+            vec![S::from(self.value); self.columns],
             builder.try_consume_chi_evaluation()?,
         ))
     }
@@ -195,6 +197,7 @@ fn verify_coerces_scalar_result_columns_to_declared_numeric_fields() {
     let expr = ScalarResultTestQueryExpr {
         length: 2,
         columns: 1,
+        value: 0,
     };
     let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
         TableRef::new("sxt", "test"),
@@ -213,4 +216,27 @@ fn verify_coerces_scalar_result_columns_to_declared_numeric_fields() {
 
     let expected_res = owned_table([tinyint("a1", [0_i8, 0])]);
     assert_eq!(table, expected_res);
+}
+
+#[test]
+fn verify_rejects_scalar_result_columns_outside_declared_numeric_range() {
+    let expr = ScalarResultTestQueryExpr {
+        length: 2,
+        columns: 1,
+        value: i64::from(i8::MAX) + 1,
+    };
+    let accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_from_table(
+        TableRef::new("sxt", "test"),
+        owned_table([bigint("a1", [0_i64, 0])]),
+        0,
+        (),
+    );
+    let res =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&expr, &accessor, &(), &[]).unwrap();
+    assert_eq!(res.result["a1"].column_type(), ColumnType::Scalar);
+
+    assert!(matches!(
+        res.verify(&expr, &accessor, &(), &[]),
+        Err(QueryError::Overflow)
+    ));
 }


### PR DESCRIPTION
/claim #560

## Summary
- run `verifiable_query_result_test` without requiring the Blitzar feature by using the existing `NaiveEvaluationProof` test proof
- add coverage for `VerifiableQueryResult::verify` coercing scalar result columns into declared numeric output fields

## Validation
- `cargo fmt --check`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.git@github.com:.insteadOf GIT_CONFIG_VALUE_0=https://github.com/ CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p proof-of-sql --no-default-features --features std,test verifiable_query_result_test --lib`

## Deconfliction
- kept the slice limited to verifiable result tests and the module gate required to run them without Blitzar
- avoided the heavily claimed bit/math/database utility files listed in recent #560 attempts