### PR TITLE
build: add gpu-enabled shell to nix flake

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -408,3 +408,29 @@ jobs:
         run: nix flake check
       - name: Check project with flake
         run: nix develop --command cargo check
+
+  test-cpu-shell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Test project with cpu shell
+        run: nix develop --command cargo test --all-features
+
+  test-gpu-shell:
+    runs-on: nvidia-nc4as-t4
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
+
+      - name: Test project with gpu shell
+        run: nix develop --extra-experimental-features "nix-command flakes" ".#gpu" --command cargo test --all-features

--- a/crates/proof-of-sql/README.md
+++ b/crates/proof-of-sql/README.md
@@ -29,7 +29,7 @@ Get started with Proof of SQL by using the published crate on [crates.io](https:
 
 ## Setup
 
-### Prerequisites
+### For use as a cargo dependency
 
 * Linux `x86_64` (NOTE: Most of the codebase _should_ work for most rust targets. However, proofs are accelerated using NVIDIA GPUs, so other targets would run very slowly and may require modification.)
 * NVIDIA GPU & Drivers (Strongly Recommended)
@@ -54,6 +54,25 @@ Workaround for non-Linux and/or non-GPU machines.
 
 </details>
 
+### For building from source
+This repository provides nix shells for build environments.
+
+Prerequisites:
+* [nix](https://nixos.org/download/) with experimental features "nix-command" and "flakes" [enabled](https://nixos.wiki/wiki/flakes).
+* `x86_64` Linux instance.
+* Optionally, NVIDIA GPU & Drivers
+
+Then, to enter the build environment:
+```bash
+nix develop
+# or, explicitly
+nix develop .#cpu
+```
+
+If an NVIDIA GPU is available, you can use the gpu-enabled shell:
+```bash
+nix develop .#gpu
+```
 
 ## Examples
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768127708,
-        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1768272338,
-        "narHash": "sha256-Tg/kL8eKMpZtceDvBDQYU8zowgpr7ucFRnpP/AtfuRM=",
+        "lastModified": 1780024773,
+        "narHash": "sha256-aU9nlrS9S+IJ2EiCzsaxzOXUhggogqTrJojBicE6Oeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "03dda130a8701b08b0347fcaf850a190c53a3c1e",
+        "rev": "40b0a3a193e0840c76174b4a322874c8f6dd0a63",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,16 +20,15 @@
           inherit system overlays;
           config.allowUnfree = true;
         };
+        cpuBuildInputs = with pkgs; [
+          (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
+          # additional .cargo config dependencies
+          clang
+          lld
+        ];
       in {
         devShells = rec {
           default = cpu;
-
-          cpuBuildInputs = with pkgs; [
-            (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
-            # additional .cargo config dependencies
-            clang
-            lld
-          ];
 
           cpu = with pkgs;
             (mkShell.override {stdenv = gcc13Stdenv;}) {

--- a/flake.nix
+++ b/flake.nix
@@ -18,19 +18,42 @@
         overlays = [(import rust-overlay)];
         pkgs = import nixpkgs {
           inherit system overlays;
+          config.allowUnfree = true;
         };
       in {
-        devShells.default = with pkgs;
-          (mkShell.override {stdenv = gcc13Stdenv;}) {
-            buildInputs = [
-              (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
-              # additional .cargo config dependencies
-              clang
-              lld
-            ];
+        devShells = rec {
+          default = cpu;
 
-            BLITZAR_BACKEND = "cpu";
-          };
+          cpuBuildInputs = with pkgs; [
+            (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
+            # additional .cargo config dependencies
+            clang
+            lld
+          ];
+
+          cpu = with pkgs;
+            (mkShell.override {stdenv = gcc13Stdenv;}) {
+              buildInputs = cpuBuildInputs;
+
+              BLITZAR_BACKEND = "cpu";
+            };
+
+          gpu = with pkgs;
+            (mkShell.override {stdenv = gcc13Stdenv;}) {
+              buildInputs =
+                cpuBuildInputs
+                ++ [
+                  cudatoolkit
+                ];
+
+              BLITZAR_BACKEND = "gpu";
+
+              LD_LIBRARY_PATH = lib.makeLibraryPath [
+                "/usr/lib/wsl"
+                pkgs.linuxPackages.nvidia_x11
+              ];
+            };
+        };
       }
     );
 }


### PR DESCRIPTION
# Rationale for this change
The nix flake that has been added to this repository is useful for sharing a build environment, but thus far has not been able to use the gpu backend. This change adds an alternative shell "gpu" to the nix flake that allows for use of the gpu backend.

# What changes are included in this PR?
- **build: add gpu-enabled shell to nix flake**
- **docs: update README.md to include instructions for nix flake**

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
