### PR TITLE
test: cover sign verifier error paths

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -158,7 +158,7 @@ mod tests {
     use crate::{
         base::{
             bit::BitDistribution,
-            proof::ProofError,
+            proof::{ProofError, ProofSizeMismatch},
             scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
         },
         sql::{
@@ -371,6 +371,83 @@ mod tests {
         ));
         // Should fail because the highest value is too big to be held by an i251
         let err = verifier_evaluate_sign(&mut builder, expr_eval, chi_eval, Some(251)).unwrap_err();
+        assert!(matches!(
+            err,
+            ProofError::VerificationError {
+                error: "invalid bit_decomposition"
+            }
+        ));
+    }
+
+    #[test]
+    fn we_error_when_verifier_has_no_bit_distribution() {
+        let mut builder = MockVerificationBuilder::new(
+            Vec::new(),
+            3,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![],
+            Vec::new(),
+        );
+
+        let err = verifier_evaluate_sign(&mut builder, TestScalar::ZERO, TestScalar::ONE, None)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewBitDistributions
+            }
+        ));
+    }
+
+    #[test]
+    fn we_error_when_verifier_has_too_few_final_round_evaluations() {
+        let dist =
+            BitDistribution::new::<TestScalar, TestScalar>(&[TestScalar::ZERO, TestScalar::ONE]);
+        let mut builder = MockVerificationBuilder::new(
+            vec![dist],
+            3,
+            Vec::new(),
+            vec![Vec::new()],
+            Vec::new(),
+            vec![],
+            Vec::new(),
+        );
+
+        let err = verifier_evaluate_sign(&mut builder, TestScalar::ZERO, TestScalar::ONE, None)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewMLEEvaluations
+            }
+        ));
+    }
+
+    #[test]
+    fn we_error_when_num_bits_allowed_exceeds_scalar_capacity() {
+        let dist = BitDistribution::new::<TestScalar, TestScalar>(&[TestScalar::ZERO]);
+        let mut builder = MockVerificationBuilder::new(
+            vec![dist],
+            3,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![],
+            Vec::new(),
+        );
+
+        let err = verifier_evaluate_sign(
+            &mut builder,
+            TestScalar::ZERO,
+            TestScalar::ONE,
+            Some(TestScalar::MAX_BITS + 1),
+        )
+        .unwrap_err();
+
         assert!(matches!(
             err,
             ProofError::VerificationError {


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a narrow test-only coverage slice for #560. It covers verifier error paths in `sign_expr.rs` that were not exercised by the existing happy-path verifier tests.

Deconfliction: before opening this PR I checked the open PR file list and an exact open-PR search for `sign_expr.rs`; I only found #2011 touching `proof_gadgets/mod.rs`, not this file.

# What changes are included in this PR?

- Add coverage for missing bit distribution errors.
- Add coverage for missing final-round MLE errors.
- Add coverage for `num_bits_allowed` exceeding `Scalar::MAX_BITS`.

# Are these changes tested?

Yes. Local validation:

```sh
env PATH=/Users/sun/Documents/Codex/2026-06-18/goal-chrome-200/work/cargo/bin:/usr/bin:/bin:/usr/sbin:/sbin CARGO_HOME=/Users/sun/Documents/Codex/2026-06-18/goal-chrome-200/work/cargo RUSTUP_HOME=/Users/sun/Documents/Codex/2026-06-18/goal-chrome-200/work/rustup cargo fmt --all -- --check
env PATH=/Users/sun/Documents/Codex/2026-06-18/goal-chrome-200/work/cargo/bin:/usr/bin:/bin:/usr/sbin:/sbin CARGO_HOME=/Users/sun/Documents/Codex/2026-06-18/goal-chrome-200/work/cargo RUSTUP_HOME=/Users/sun/Documents/Codex/2026-06-18/goal-chrome-200/work/rustup cargo test -p proof-of-sql --no-default-features --features test sign_expr --lib
git diff --check
source scripts/check_commits.sh
```

The focused test command passed with 7 `sign_expr` tests.

LLM assistance disclosure: implemented with Codex assistance and manually reviewed before submission.
