### PR TITLE
test: cover column commitments without blitzar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -349,7 +349,7 @@ impl<C> FromIterator<(Ident, ColumnCommitmentMetadata, C)> for ColumnCommitments
     }
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::{


### PR DESCRIPTION
/claim #560

## Summary
- Enable the existing `ColumnCommitments` test module under ordinary `#[cfg(test)]` instead of requiring the `blitzar` feature.
- Keep the change test-only and scoped to `crates/proof-of-sql/src/base/commitment/column_commitments.rs`.
- This brings construction, iteration, duplicate-ident, append/extend, add, subtract, and mismatch coverage into the no-default `test` coverage path.

## Coverage impact
- Before: full no-default coverage run showed `base/commitment/column_commitments.rs` at 17.01% line coverage with 161 missed lines.
- After: full no-default coverage run shows `base/commitment/column_commitments.rs` at 96.45% line coverage with 22 missed lines.

## Validation
- `~/.cargo/bin/cargo test --offline -p proof-of-sql --no-default-features --features test base::commitment::column_commitments::tests --lib`: 11 passed, 0 failed
- `~/.cargo/bin/cargo fmt --check`
- `git diff --check`
- `bash scripts/check_commits.sh`
- `~/.cargo/bin/cargo llvm-cov --offline --summary-only -p proof-of-sql --no-default-features --features test --lib`: 971 passed, 0 failed, total line coverage 81.73%

Algora payout GitHub user: `@jamilahmadzai`.