### PR TITLE
test: cache Dory evaluation proof setups

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -58,12 +58,14 @@ fn test_random_ipa_with_various_lengths() {
         let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let verifier_setup = VerifierSetup::from(&public_parameters);
+        let prover_public_setup = DoryProverPublicSetup::new(&prover_setup, setup_p.1);
+        let verifier_public_setup = DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1);
         for length in lengths {
             test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
                 length,
                 0,
-                &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
+                &prover_public_setup,
+                &verifier_public_setup,
             );
         }
     }


### PR DESCRIPTION
## Summary

- cache the Dory prover/verifier public setups once per setup-size case in `test_random_ipa_with_various_lengths`
- keep the same public parameter sizes, setup sizes, offsets, and tested length matrix
- avoid rebuilding identical public setup wrappers for every length in the inner loop

## Validation

- Not run locally; authored through the GitHub web editor without a local checkout.
- Reviewed the patch against the current test structure to confirm test inputs and assertions are unchanged.

/claim #557