### PR TITLE
test: cover rho 256 evaluation

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations_test.rs
@@ -3,7 +3,8 @@ use crate::{
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::SumcheckRandomScalars,
 };
-use num_traits::One;
+use alloc::{vec, vec::Vec};
+use num_traits::{One, Zero};
 
 #[test]
 fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
@@ -46,5 +47,41 @@ fn we_can_track_the_evaluation_of_mles_used_within_sumcheck() {
     assert_eq!(
         *evals.chi_evaluations.values().next().unwrap(),
         expected_eval
+    );
+}
+
+fn compute_rho_256_evaluation(point: &[u64]) -> Option<Curve25519Scalar> {
+    let evaluation_point: Vec<_> = point.iter().copied().map(Curve25519Scalar::from).collect();
+    let random_scalars = vec![Curve25519Scalar::zero(); point.len()];
+    let sumcheck_random_scalars =
+        SumcheckRandomScalars::new(&random_scalars, 1, evaluation_point.len());
+
+    SumcheckMleEvaluations::new(
+        1,
+        [],
+        [],
+        &evaluation_point,
+        &sumcheck_random_scalars,
+        &[],
+        &[],
+    )
+    .rho_256_evaluation
+}
+
+#[test]
+fn rho_256_evaluation_uses_little_endian_bits_and_gates_higher_variables() {
+    let five = [1, 0, 1, 0, 0, 0, 0, 0];
+
+    assert_eq!(
+        compute_rho_256_evaluation(&five),
+        Some(Curve25519Scalar::from(5_u64))
+    );
+    assert_eq!(
+        compute_rho_256_evaluation(&[1, 0, 1, 0, 0, 0, 0, 0, 0, 0]),
+        Some(Curve25519Scalar::from(5_u64))
+    );
+    assert_eq!(
+        compute_rho_256_evaluation(&[1, 0, 1, 0, 0, 0, 0, 0, 0, 1]),
+        Some(Curve25519Scalar::zero())
     );
 }


### PR DESCRIPTION
## Summary

Adds focused coverage for the `rho_256_evaluation` path in `SumcheckMleEvaluations::new`.

The test verifies both parts of the calculation:
- the first eight coordinates are interpreted as little-endian bits (`1 + 4 = 5`)
- coordinates above bit 7 gate the value through the `(1 - x)` factors

## Coverage

A before/after full `cargo llvm-cov` run for `sumcheck_mle_evaluations.rs` changed line coverage from **46/58 (79.31%)** to **56/58 (96.55%)**, covering 10 previously uncovered production lines.

## Validation

- `cargo test -p proof-of-sql --no-default-features --features=std,test sumcheck_mle_evaluations_test --lib` (2 passed)
- `cargo llvm-cov -p proof-of-sql --no-default-features --features=std,test --json --output-path target/coverage-rho.json --lib` (961 passed)
- `cargo clippy -p proof-of-sql --no-default-features --features=std,test --tests` (passes with existing repository warnings)
- `cargo fmt --check`
- `git diff --check`

/claim #560