### PR TITLE
test: add Dory metadata table coverage

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -300,6 +300,7 @@ mod tests {
         math::decimal::Precision,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     };
+    use ark_ec::AffineRepr;
 
     fn assert_blitzar_metadata(
         committable_columns: &[CommittableColumn],
@@ -323,6 +324,68 @@ mod tests {
             scalars, expected_scalars,
             "Scalars mismatch for offset {offset}"
         );
+    }
+
+    #[test]
+    fn we_can_get_minimum_offsets_for_supported_column_types() {
+        assert_eq!(min_as_f(ColumnType::TinyInt), MontFp!("-128"));
+        assert_eq!(min_as_f(ColumnType::SmallInt), MontFp!("-32768"));
+        assert_eq!(min_as_f(ColumnType::Int), MontFp!("-2147483648"));
+        assert_eq!(
+            min_as_f(ColumnType::BigInt),
+            MontFp!("-9223372036854775808")
+        );
+        assert_eq!(
+            min_as_f(ColumnType::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc()
+            )),
+            MontFp!("-9223372036854775808")
+        );
+        assert_eq!(
+            min_as_f(ColumnType::Int128),
+            MontFp!("-170141183460469231731687303715884105728")
+        );
+
+        for column_type in [
+            ColumnType::Decimal75(Precision::new(10).unwrap(), 2),
+            ColumnType::Uint8,
+            ColumnType::Scalar,
+            ColumnType::VarChar,
+            ColumnType::VarBinary,
+            ColumnType::Boolean,
+        ] {
+            assert_eq!(min_as_f(column_type), MontFp!("0"));
+        }
+    }
+
+    #[test]
+    fn we_can_offset_signed_commits_without_changing_unsigned_commits() {
+        let signed_values = [-1_i8, 2_i8];
+        let unsigned_values = [3_u8, 4_u8];
+        let committable_columns = [
+            CommittableColumn::TinyInt(&signed_values),
+            CommittableColumn::Uint8(&unsigned_values),
+        ];
+        let generator = G1Affine::generator();
+        let first_signed = generator.mul(MontFp!("2")).into_affine();
+        let first_unsigned = generator.mul(MontFp!("3")).into_affine();
+        let second_signed = generator.mul(MontFp!("5")).into_affine();
+        let second_unsigned = generator.mul(MontFp!("7")).into_affine();
+        let all_sub_commits = vec![first_signed, first_unsigned, second_signed, second_unsigned];
+
+        assert_eq!(
+            signed_commits(&all_sub_commits, &committable_columns),
+            vec![
+                (first_signed + second_signed.mul(min_as_f(ColumnType::TinyInt))).into_affine(),
+                first_unsigned,
+            ]
+        );
+    }
+
+    #[test]
+    fn we_can_handle_empty_committable_columns_in_signed_commits() {
+        assert!(signed_commits(&vec![], &[]).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This adds focused coverage for Dory metadata-table behavior as part of #560.

/claim #560

# What changes are included in this PR?

- Cover `min_as_f` offsets across signed, unsigned, scalar, text, binary, decimal, boolean, and timestamp column types.
- Cover `signed_commits` for signed-column offset handling while leaving unsigned-column commits unchanged.
- Cover empty input handling for `signed_commits`.

# Are these changes tested?

Yes.

- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test blitzar_metadata_table --lib`
