### PR TITLE
test: add timezone parsing coverage

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -104,6 +104,26 @@ mod timezone_parsing_tests {
     }
 
     #[test]
+    fn we_can_parse_utc_time_zone_aliases() {
+        for timezone in ["Z", "UTC", "00:00", "+00:00", "0:00", "+0:00"] {
+            let timezone_as_str: Option<Arc<str>> = Some(timezone.into());
+            assert_eq!(
+                PoSQLTimeZone::try_from(&timezone_as_str).unwrap(),
+                PoSQLTimeZone::utc()
+            );
+        }
+    }
+
+    #[test]
+    fn we_can_parse_positive_time_zone_offsets() {
+        let timezone_as_str: Option<Arc<str>> = Some("+05:30".into());
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+        let expected_time_zone = PoSQLTimeZone::new(19_800);
+        assert_eq!(timezone, expected_time_zone);
+        assert_eq!(format!("{timezone}"), "+05:30");
+    }
+
+    #[test]
     fn we_can_parse_none_time_zone() {
         let timezone = PoSQLTimeZone::try_from(&None).unwrap();
         let expected_time_zone = PoSQLTimeZone::utc();
@@ -118,5 +138,16 @@ mod timezone_parsing_tests {
             timezone_err,
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
         ));
+    }
+
+    #[test]
+    fn we_cannot_parse_time_zone_offsets_with_invalid_numbers() {
+        for timezone in ["+AA:00", "+01:BB"] {
+            let timezone_as_str: Option<Arc<str>> = Some(timezone.into());
+            assert!(matches!(
+                PoSQLTimeZone::try_from(&timezone_as_str),
+                Err(PoSQLTimestampError::InvalidTimezoneOffset)
+            ));
+        }
     }
 }


### PR DESCRIPTION
/claim #560

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Adds focused timezone parsing coverage for the bounty in #560.

# What changes are included in this PR?

- Cover UTC timezone aliases accepted by `PoSQLTimeZone`.
- Cover a positive fixed offset parse and display round trip.
- Cover invalid numeric offset components returning `InvalidTimezoneOffset`.

# Are these changes tested?

Yes. I ran:

- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test timezone --lib`
- `source scripts/check_commits.sh`
