### PR TITLE
test: cover aliased proof expressions

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -10,3 +10,38 @@ pub struct AliasedDynProofExpr {
     /// The alias for the expression.
     pub alias: Ident,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::LiteralValue;
+
+    #[test]
+    fn we_can_clone_and_compare_aliased_dyn_proof_exprs() {
+        let aliased_expr = AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::Int(42)),
+            alias: "answer".into(),
+        };
+
+        assert_eq!(aliased_expr.clone(), aliased_expr);
+        assert!(format!("{aliased_expr:?}").contains("answer"));
+        assert_eq!(aliased_expr.alias.value, "answer");
+        assert_eq!(
+            aliased_expr.expr,
+            DynProofExpr::new_literal(LiteralValue::Int(42))
+        );
+    }
+
+    #[test]
+    fn we_can_serialize_and_deserialize_aliased_dyn_proof_exprs() {
+        let aliased_expr = AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::VarChar("north".into())),
+            alias: "direction".into(),
+        };
+
+        let json = serde_json::to_string(&aliased_expr).unwrap();
+        let decoded: AliasedDynProofExpr = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded, aliased_expr);
+    }
+}


### PR DESCRIPTION
## Summary
- add focused coverage for `AliasedDynProofExpr` clone/equality/debug behavior
- add serde JSON round-trip coverage for aliased literal proof expressions

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p proof-of-sql --no-default-features --features test aliased_dyn_proof_expr --lib` in `rust:1.91-bookworm` with `clang`/`lld` installed
- `scripts/check_commits.sh` via Docker with CRLF-stripped script input

/claim #560