### PR TITLE
test: cover BigDecimal bigint scaling

### DIFF
--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -89,4 +89,36 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, IntermediateDecimalError::ConversionFailure));
     }
+
+    #[test]
+    fn we_can_convert_decimal_to_bigint_at_matching_scale() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+
+        let bigint = big_decimal
+            .try_into_bigint_with_precision_and_scale(5, 2)
+            .unwrap();
+
+        assert_eq!(bigint, 12345.into());
+    }
+
+    #[test]
+    fn we_can_convert_decimal_to_bigint_with_scale_padding() {
+        let big_decimal: BigDecimal = "7.5".parse::<BigDecimal>().unwrap().normalized();
+
+        let bigint = big_decimal
+            .try_into_bigint_with_precision_and_scale(4, 3)
+            .unwrap();
+
+        assert_eq!(bigint, 7500.into());
+    }
+
+    #[test]
+    fn we_can_catch_precision_error_after_scaling() {
+        let big_decimal: BigDecimal = "123.45".parse::<BigDecimal>().unwrap().normalized();
+        let err = big_decimal
+            .try_into_bigint_with_precision_and_scale(4, 2)
+            .unwrap_err();
+
+        assert!(matches!(err, IntermediateDecimalError::LossyCast));
+    }
 }


### PR DESCRIPTION
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Part of #560.

`BigDecimalExt::try_into_bigint_with_precision_and_scale` already had coverage for the scale-too-small error path. This adds coverage for successful fixed-scale conversion, scale padding, and precision overflow after scaling.

# What changes are included in this PR?

- Add a matching-scale conversion test for `123.45` -> `12345`.
- Add a scale-padding conversion test for `7.5` at scale 3 -> `7500`.
- Add a precision-overflow test that expects `IntermediateDecimalError::LossyCast`.

# Are these changes tested?

Yes.

- `cargo fmt --check`
- `cargo test -p proof-of-sql --no-default-features --features test big_decimal_ext --lib`
- `source scripts/check_commits.sh`

I did not run the full CI script locally for this small test-only change.
