### PR TITLE
test: cover zigzag decoding

### DIFF
--- a/crates/proof-of-sql/src/base/encode/zigzag_test.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag_test.rs
@@ -99,3 +99,56 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
             == U256::from_words(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128, 0x1_u128)
     );
 }
+
+#[test]
+fn even_zigzag_values_decode_to_positive_scalars() {
+    let zero: TestScalar = U256::from_words(0, 0).zigzag();
+    let one: TestScalar = U256::from_words(2, 0).zigzag();
+    let two: TestScalar = U256::from_words(4, 0).zigzag();
+
+    assert_eq!(zero, TestScalar::from(0_u64));
+    assert_eq!(one, TestScalar::from(1_u64));
+    assert_eq!(two, TestScalar::from(2_u64));
+
+    let encoded = U256::from_words(0, 1);
+    let decoded: TestScalar = encoded.zigzag();
+    let expected: TestScalar = (&U256::from_words(1_u128 << 127, 0)).into();
+
+    assert_eq!(decoded, expected);
+}
+
+#[test]
+fn odd_zigzag_values_decode_to_negative_scalars() {
+    let minus_one: TestScalar = U256::from_words(1, 0).zigzag();
+    let minus_two: TestScalar = U256::from_words(3, 0).zigzag();
+    let minus_three: TestScalar = U256::from_words(5, 0).zigzag();
+
+    assert_eq!(minus_one, -TestScalar::from(1_u64));
+    assert_eq!(minus_two, -TestScalar::from(2_u64));
+    assert_eq!(minus_three, -TestScalar::from(3_u64));
+}
+
+#[test]
+fn odd_zigzag_decode_carries_from_low_to_high_word() {
+    let decoded: TestScalar = U256::from_words(u128::MAX, 1).zigzag();
+    let expected_magnitude: TestScalar = (&U256::from_words(0, 1)).into();
+
+    assert_eq!(decoded, -expected_magnitude);
+}
+
+#[test]
+fn zigzag_round_trips_positive_and_negative_scalars() {
+    for value in 0..1000_u128 {
+        let scalar = TestScalar::from(value);
+        let decoded: TestScalar = scalar.zigzag().zigzag();
+
+        assert_eq!(decoded, scalar);
+    }
+
+    for value in 1..1000_u128 {
+        let scalar = -TestScalar::from(value);
+        let decoded: TestScalar = scalar.zigzag().zigzag();
+
+        assert_eq!(decoded, scalar);
+    }
+}


### PR DESCRIPTION
﻿/claim #560

## Summary
- add focused test-only coverage for `base::encode::ZigZag<U256> for U256`
- verify even encoded values decode to positive scalars, including a high-word shift case
- verify odd encoded values decode to negative scalars
- cover the odd decode carry path from the low word into the high word
- add positive and negative scalar encode/decode round-trip checks

## Non-overlap
This slice is limited to `crates/proof-of-sql/src/base/encode/zigzag_test.rs` and targets the `U256 -> TestScalar` decode direction. Before choosing it, I checked the visible #560 comments for `zigzag` and did not find a prior claim for this file/path. I also avoided the heavily claimed areas around record batch errors, ColumnField/ColumnRef, OwnedColumn errors, standard serialization limbs, RefInto, table/proof-plan helpers, Dory pairing wrappers, and existing utility coverage PRs.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test zigzag -- --nocapture` -- 8 passed
- `git diff --check`

Note: the focused test command emits existing unused warnings in unrelated modules, but the zigzag tests pass and this PR only changes tests.
