### PR TITLE
test: add test for log_memory_usage function

### DIFF
--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -30,3 +30,13 @@ pub fn log_memory_usage(name: &str) {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_memory_usage_does_not_panic() {
+        log_memory_usage("test");
+    }
+}


### PR DESCRIPTION
Adds a basic test for the `log_memory_usage` function to verify it doesn't panic when called.

This is part of the test coverage improvement effort for #560.

Changes:
- Added `test_log_memory_usage_does_not_panic` test
- Verifies the function executes without errors