### PR TITLE
test: cover PoSQL-compatible Arrow schema conversion

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,39 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_all_floating_point_fields_to_decimal() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("half", DataType::Float16, false),
+            Field::new("single", DataType::Float32, true),
+            Field::new("double", DataType::Float64, false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        for field in converted.fields() {
+            assert_eq!(field.data_type(), &DataType::Decimal256(20, 10));
+        }
+        assert!(!converted.field(0).is_nullable());
+        assert!(converted.field(1).is_nullable());
+        assert!(!converted.field(2).is_nullable());
+    }
+
+    #[test]
+    fn preserves_non_floating_point_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("count", DataType::Int64, false),
+            Field::new("label", DataType::Utf8, true),
+            Field::new("amount", DataType::Decimal256(30, 8), false),
+        ]));
+
+        let converted = get_posql_compatible_schema(&schema);
+
+        assert_eq!(converted.fields(), schema.fields());
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -1,5 +1,7 @@
 use crate::base::{
-    database::{table_utility::*, Column, Table, TableError, TableOptions},
+    database::{
+        table_utility::*, Column, ColumnField, ColumnType, Table, TableError, TableOptions,
+    },
     map::{indexmap, IndexMap},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::test_scalar::TestScalar,
@@ -192,6 +194,72 @@ fn we_can_create_a_table_with_data() {
     expected_table.insert(Ident::new("boolean"), Column::Boolean(boolean_data));
 
     assert_eq!(borrowed_table.into_inner(), expected_table);
+}
+
+#[test]
+fn table_accessors_preserve_column_order_and_types() {
+    let alloc = Bump::new();
+    let table = table::<TestScalar>([
+        borrowed_bigint("bigint", [3_i64, 5], &alloc),
+        borrowed_boolean("flag", [true, false], &alloc),
+        borrowed_varchar("label", ["alpha", "beta"], &alloc),
+    ]);
+
+    let column_names: Vec<_> = table.column_names().cloned().collect();
+    assert_eq!(
+        column_names,
+        vec![
+            Ident::new("bigint"),
+            Ident::new("flag"),
+            Ident::new("label")
+        ]
+    );
+
+    assert_eq!(
+        table.schema(),
+        vec![
+            ColumnField::new(Ident::new("bigint"), ColumnType::BigInt),
+            ColumnField::new(Ident::new("flag"), ColumnType::Boolean),
+            ColumnField::new(Ident::new("label"), ColumnType::VarChar),
+        ]
+    );
+
+    assert_eq!(table.column(0), Some(&Column::BigInt(&[3_i64, 5])));
+    assert_eq!(table.column(1), Some(&Column::Boolean(&[true, false])));
+    assert!(matches!(table.column(2), Some(Column::VarChar(_))));
+    assert_eq!(table.column(3), None);
+
+    let column_types: Vec<_> = table.columns().map(Column::column_type).collect();
+    assert_eq!(
+        column_types,
+        vec![ColumnType::BigInt, ColumnType::Boolean, ColumnType::VarChar]
+    );
+}
+
+#[test]
+fn table_inner_views_expose_the_same_ordered_columns() {
+    let table = Table::<TestScalar>::try_new(indexmap! {
+        Ident::new("left") => Column::Int(&[1, 2]),
+        Ident::new("right") => Column::SmallInt(&[3, 4]),
+    })
+    .unwrap();
+
+    let inner_names: Vec<_> = table.inner_table().keys().cloned().collect();
+    assert_eq!(inner_names, vec![Ident::new("left"), Ident::new("right")]);
+
+    let inner_columns: Vec<_> = table.inner_table().values().copied().collect();
+    assert_eq!(
+        inner_columns,
+        vec![Column::Int(&[1, 2]), Column::SmallInt(&[3, 4])]
+    );
+
+    let owned_inner = table.into_inner();
+    assert_eq!(
+        owned_inner.keys().cloned().collect::<Vec<_>>(),
+        vec![Ident::new("left"), Ident::new("right")]
+    );
+    assert_eq!(owned_inner[0], Column::Int(&[1, 2]));
+    assert_eq!(owned_inner[1], Column::SmallInt(&[3, 4]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add direct coverage for Float16, Float32, and Float64 conversion to Decimal256(20, 10)
- verify field nullability is preserved during conversion
- verify non-floating-point fields remain unchanged

## Testing
- isolated Arrow 51 harness: 2 passed, 0 failed
- the full workspace cannot build on Windows because blitzar-sys supports Linux only; project CI can provide the Linux validation

/claim #560