### PR TITLE
test: cover schema and evaluation helpers

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility_test.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility_test.rs
@@ -1,0 +1,53 @@
+use super::arrow_schema_utility::get_posql_compatible_schema;
+use alloc::sync::Arc;
+use arrow::datatypes::{DataType, Field, Schema};
+
+#[test]
+fn floating_point_fields_are_converted_to_decimals() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("float16", DataType::Float16, false),
+        Field::new("float32", DataType::Float32, true),
+        Field::new("float64", DataType::Float64, false),
+    ]));
+
+    let compatible_schema = get_posql_compatible_schema(&schema);
+
+    assert_eq!(compatible_schema.fields().len(), 3);
+    for (index, name) in ["float16", "float32", "float64"].iter().enumerate() {
+        let field = compatible_schema.field(index);
+        assert_eq!(field.name(), *name);
+        assert_eq!(field.data_type(), &DataType::Decimal256(20, 10));
+    }
+    assert!(!compatible_schema.field(0).is_nullable());
+    assert!(compatible_schema.field(1).is_nullable());
+    assert!(!compatible_schema.field(2).is_nullable());
+}
+
+#[test]
+fn compatible_fields_are_left_unchanged() {
+    let fields = vec![
+        Field::new("boolean", DataType::Boolean, false),
+        Field::new("integer", DataType::Int64, true),
+        Field::new("text", DataType::Utf8, false),
+        Field::new("decimal", DataType::Decimal256(12, 4), true),
+    ];
+    let schema = Arc::new(Schema::new(fields.clone()));
+
+    let compatible_schema = get_posql_compatible_schema(&schema);
+
+    assert_eq!(compatible_schema.fields().len(), fields.len());
+    for (actual, expected) in compatible_schema.fields().iter().zip(fields.iter()) {
+        assert_eq!(actual.name(), expected.name());
+        assert_eq!(actual.data_type(), expected.data_type());
+        assert_eq!(actual.is_nullable(), expected.is_nullable());
+    }
+}
+
+#[test]
+fn empty_schema_remains_empty() {
+    let schema = Arc::new(Schema::empty());
+
+    let compatible_schema = get_posql_compatible_schema(&schema);
+
+    assert!(compatible_schema.fields().is_empty());
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -70,6 +70,8 @@ pub use table_ref::TableRef;
 
 #[cfg(feature = "arrow")]
 pub mod arrow_schema_utility;
+#[cfg(all(test, feature = "arrow"))]
+mod arrow_schema_utility_test;
 
 mod owned_column;
 pub use owned_column::OwnedColumn;
@@ -102,6 +104,8 @@ pub mod table_utility;
 
 mod table_evaluation;
 pub use table_evaluation::TableEvaluation;
+#[cfg(test)]
+mod table_evaluation_test;
 
 mod test_accessor;
 pub use test_accessor::TestAccessor;

--- a/crates/proof-of-sql/src/base/database/table_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation_test.rs
@@ -1,0 +1,28 @@
+use super::TableEvaluation;
+use crate::base::scalar::test_scalar::TestScalar;
+
+#[test]
+fn table_evaluation_exposes_its_column_and_chi_evaluations() {
+    let column_evals = vec![
+        TestScalar::from(2_u64),
+        TestScalar::from(3_u64),
+        TestScalar::from(5_u64),
+    ];
+    let chi = (TestScalar::from(7_u64), 11);
+
+    let evaluation = TableEvaluation::new(column_evals.clone(), chi);
+
+    assert_eq!(evaluation.column_evals(), column_evals);
+    assert_eq!(evaluation.chi_eval(), chi.0);
+    assert_eq!(evaluation.chi(), chi);
+}
+
+#[test]
+fn table_evaluation_supports_tables_without_columns() {
+    let chi = (TestScalar::from(1_u64), 0);
+
+    let evaluation = TableEvaluation::new(Vec::new(), chi);
+
+    assert!(evaluation.column_evals().is_empty());
+    assert_eq!(evaluation.chi(), chi);
+}

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -33,6 +33,8 @@ mod sumcheck_mle_evaluations_test;
 
 mod sumcheck_random_scalars;
 pub(crate) use sumcheck_random_scalars::SumcheckRandomScalars;
+#[cfg(test)]
+mod sumcheck_random_scalars_test;
 
 mod proof_plan;
 pub use proof_plan::ProofPlan;

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars_test.rs
@@ -1,0 +1,48 @@
+use super::SumcheckRandomScalars;
+use crate::base::scalar::test_scalar::TestScalar;
+
+#[test]
+fn random_scalars_are_split_into_multipliers_and_entrywise_point() {
+    let scalars = [
+        TestScalar::from(2_u64),
+        TestScalar::from(3_u64),
+        TestScalar::from(5_u64),
+        TestScalar::from(7_u64),
+    ];
+
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 3, 2);
+
+    assert_eq!(random_scalars.subpolynomial_multipliers, &scalars[..2]);
+    assert_eq!(random_scalars.entrywise_point, &scalars[2..]);
+    assert_eq!(random_scalars.table_length, 3);
+}
+
+#[test]
+fn entrywise_multipliers_are_truncated_to_the_table_length() {
+    let scalars = [
+        TestScalar::from(11_u64),
+        TestScalar::from(2_u64),
+        TestScalar::from(3_u64),
+    ];
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 3, 2);
+
+    let multipliers = random_scalars.compute_entrywise_multipliers();
+
+    assert_eq!(
+        multipliers,
+        vec![
+            (TestScalar::from(1_u64) - TestScalar::from(3_u64))
+                * (TestScalar::from(1_u64) - TestScalar::from(2_u64)),
+            (TestScalar::from(1_u64) - TestScalar::from(3_u64)) * TestScalar::from(2_u64),
+            TestScalar::from(3_u64) * (TestScalar::from(1_u64) - TestScalar::from(2_u64)),
+        ]
+    );
+}
+
+#[test]
+fn empty_table_has_no_entrywise_multipliers() {
+    let scalars = [TestScalar::from(13_u64)];
+    let random_scalars = SumcheckRandomScalars::new(&scalars, 0, 1);
+
+    assert!(random_scalars.compute_entrywise_multipliers().is_empty());
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
