### PR TITLE
feat: add `IN` operator via product-form `InExpr`

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -3,13 +3,16 @@ use super::{
     PlannerError, PlannerResult,
 };
 use datafusion::logical_expr::{
-    expr::{Alias, Cast, Placeholder},
+    expr::{Alias, Cast, InList, Placeholder},
     BinaryExpr, Expr, Operator,
 };
 use indexmap::IndexSet;
 use proof_of_sql::{
-    base::database::ColumnType,
-    sql::{proof_exprs::DynProofExpr, scale_cast_binary_op},
+    base::database::{ColumnType, LiteralValue},
+    sql::{
+        proof_exprs::{DynProofExpr, ProofExpr},
+        scale_cast_binary_op,
+    },
 };
 use sqlparser::ast::Ident;
 
@@ -27,6 +30,13 @@ pub(crate) fn get_column_idents_from_expr(expr: &Expr) -> IndexSet<Ident> {
             left_idents
         }
         Expr::Not(inner) => get_column_idents_from_expr(inner),
+        Expr::InList(InList { expr, list, .. }) => {
+            let mut idents = get_column_idents_from_expr(expr);
+            for value in list {
+                idents.extend(get_column_idents_from_expr(value));
+            }
+            idents
+        }
         Expr::Alias(Alias { expr, .. }) | Expr::Cast(Cast { expr, .. }) => {
             get_column_idents_from_expr(expr)
         }
@@ -119,10 +129,12 @@ fn binary_expr_to_proof_expr(
     }
 }
 
-/// Convert an [`datafusion::expr::Expr`] to [`DynProofExpr`]
+/// Convert a `DataFusion` [`Expr`] into a provable [`DynProofExpr`], using `schema`
+/// to resolve column references and their types.
 ///
-/// # Panics
-/// The function should not panic if Proof of SQL is working correctly
+/// # Errors
+/// Returns a [`PlannerError`] if the expression (or any subexpression) is unsupported,
+/// references an unknown column, or cannot be lowered to a `DynProofExpr`.
 pub fn expr_to_proof_expr(
     expr: &Expr,
     schema: &[(Ident, ColumnType)],
@@ -140,6 +152,67 @@ pub fn expr_to_proof_expr(
         Expr::Not(expr) => {
             let proof_expr = expr_to_proof_expr(expr, schema)?;
             Ok(DynProofExpr::try_new_not(proof_expr)?)
+        }
+        Expr::InList(InList {
+            expr,
+            list,
+            negated,
+        }) => {
+            // Lower `a IN (v_1, ..., v_k)`. The list length is uncapped in both branches.
+            //
+            //   - numeric `a`: use the product form `(a - v_1) * ... * (a - v_k) = 0`.
+            //     A field is an integral domain, so the product is zero iff some factor is.
+            //   - non-numeric `a` (e.g. varchar): the typed `-` operator rejects these, so
+            //     fall back to `a = v_1 OR ... OR a = v_k`. Equality subtracts the embedded
+            //     hashes internally, which is exactly what a membership zero-test needs.
+            let needle = expr_to_proof_expr(expr, schema)?;
+            // Split off the first value. `None` means `a IN ()`, which is always false;
+            // keeping that here (not an early return) lets the `negated` wrap below
+            // still apply, so `a NOT IN ()` correctly negates to `true`.
+            let comparison = match list.split_first() {
+                None => DynProofExpr::new_literal(LiteralValue::Boolean(false)),
+                Some((first, rest)) => {
+                    if needle.data_type().is_numeric() {
+                        // product form: (a - v_1) * ... * (a - v_k) = 0. `scale_cast_binary_op`
+                        // aligns the needle to each `v_i`'s scale before subtracting; this is a
+                        // numeric-only concern, so it stays out of the varchar branch.
+                        let term = |value: &Expr| -> PlannerResult<_> {
+                            let (n, v) = scale_cast_binary_op(
+                                needle.clone(),
+                                expr_to_proof_expr(value, schema)?,
+                            )?;
+                            Ok(DynProofExpr::try_new_subtract(n, v)?)
+                        };
+                        let product = rest.iter().try_fold(
+                            term(first)?,
+                            |acc, value| -> PlannerResult<_> {
+                                Ok(DynProofExpr::try_new_multiply(acc, term(value)?)?)
+                            },
+                        )?;
+                        let zero = DynProofExpr::new_literal(LiteralValue::BigInt(0));
+                        let (product, zero) = scale_cast_binary_op(product, zero)?;
+                        DynProofExpr::try_new_equals(product, zero)?
+                    } else {
+                        // a = v_1 OR ... OR a = v_k. The needle is non-numeric, so there is no
+                        // scale to align; `=` compares the lowered operands directly.
+                        let eq = |value: &Expr| -> PlannerResult<_> {
+                            Ok(DynProofExpr::try_new_equals(
+                                needle.clone(),
+                                expr_to_proof_expr(value, schema)?,
+                            )?)
+                        };
+                        rest.iter()
+                            .try_fold(eq(first)?, |acc, value| -> PlannerResult<_> {
+                                Ok(DynProofExpr::try_new_or(acc, eq(value)?)?)
+                            })?
+                    }
+                }
+            };
+            if *negated {
+                Ok(DynProofExpr::try_new_not(comparison)?)
+            } else {
+                Ok(comparison)
+            }
         }
         Expr::Cast(cast) => {
             match &*cast.expr {
@@ -180,7 +253,7 @@ mod tests {
     use datafusion::{
         catalog::TableReference,
         common::{Column, ScalarValue},
-        logical_expr::{expr::Placeholder, Cast},
+        logical_expr::{expr::Placeholder, lit, Cast},
     };
     use proof_of_sql::base::{
         database::{ColumnRef, ColumnType, LiteralValue, TableRef},
@@ -272,6 +345,66 @@ mod tests {
         let expr = df_column("namespace.table_name", "column");
         let schema = vec![("column".into(), ColumnType::Int)];
         assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), COLUMN_INT());
+    }
+
+    // IN
+    #[test]
+    fn we_can_convert_in_list_to_proof_expr() {
+        // `a IN (...)` lowers to `(product of differences) = 0`, i.e. a top-level equals.
+        let expr = df_column("namespace.table_name", "column")
+            .in_list(vec![lit(1_i64), lit(2_i64), lit(3_i64)], false);
+        let schema = vec![("column".into(), ColumnType::BigInt)];
+        assert!(matches!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::Equals(_)
+        ));
+    }
+
+    #[test]
+    fn we_can_convert_not_in_list_to_proof_expr() {
+        // `NOT IN` wraps the lowered `IN` expression in a `NOT`.
+        let expr = df_column("namespace.table_name", "column").in_list(vec![lit(1_i64)], true);
+        let schema = vec![("column".into(), ColumnType::BigInt)];
+        assert!(matches!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::Not(_)
+        ));
+    }
+
+    #[test]
+    fn we_convert_an_empty_in_list_to_a_false_literal() {
+        // `a IN ()` is always false.
+        let expr = df_column("namespace.table_name", "column").in_list(vec![], false);
+        let schema = vec![("column".into(), ColumnType::BigInt)];
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::new_literal(LiteralValue::Boolean(false))
+        );
+    }
+
+    #[test]
+    fn we_convert_an_empty_not_in_list_to_a_true_literal() {
+        // `a NOT IN ()` is always true: the empty-list `false` must still flow
+        // through the `negated` NOT wrap rather than short-circuiting.
+        let expr = df_column("namespace.table_name", "column").in_list(vec![], true);
+        let schema = vec![("column".into(), ColumnType::BigInt)];
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_not(DynProofExpr::new_literal(LiteralValue::Boolean(false)))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_convert_a_varchar_in_list_to_an_or_chain() {
+        // `-` rejects varchar, so non-numeric `IN` falls back to `a = v_1 OR a = v_2`.
+        let expr =
+            df_column("namespace.table_name", "column").in_list(vec![lit("a"), lit("b")], false);
+        let schema = vec![("column".into(), ColumnType::VarChar)];
+        assert!(matches!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::Or(_)
+        ));
     }
 
     // BinaryExpr
@@ -877,6 +1010,18 @@ mod tests {
         let expected: IndexSet<Ident> = ["a".into(), "b".into(), "c".into(), "d".into()]
             .into_iter()
             .collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_extract_column_idents_from_in_list_expr() {
+        // a IN (b, c) references the needle column and every column in the list.
+        let expr = df_column("table", "a").in_list(
+            vec![df_column("table", "b"), df_column("table", "c")],
+            false,
+        );
+        let result = get_column_idents_from_expr(&expr);
+        let expected: IndexSet<Ident> = ["a".into(), "b".into(), "c".into()].into_iter().collect();
         assert_eq!(result, expected);
     }
 

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -707,3 +707,135 @@ fn test_implicit_casts() {
         &[],
     );
 }
+
+#[test]
+fn test_in_list() {
+    let alloc = Bump::new();
+    // Numeric `IN`/`NOT IN`/single-value, plus varchar `IN`/`NOT IN` (which lowers to an
+    // OR-chain of equalities rather than the product form).
+    let sql = "SELECT id, name FROM sxt.cats WHERE id IN (1, 3, 5);
+        SELECT id FROM sxt.cats WHERE id NOT IN (1, 3, 5);
+        SELECT name FROM sxt.cats WHERE id IN (4);
+        SELECT id FROM sxt.cats WHERE name IN ('Chloe', 'Katy');
+        SELECT id FROM sxt.cats WHERE name NOT IN ('Chloe', 'Katy', 'Lucy');";
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(Some("sxt"), "cats") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4, 5], &alloc),
+                borrowed_varchar("name", ["Chloe", "Margaret", "Katy", "Lucy", "Prudence"], &alloc),
+            ]
+        ),
+    };
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        owned_table([
+            int("id", [1, 3, 5]),
+            varchar("name", ["Chloe", "Katy", "Prudence"]),
+        ]),
+        owned_table([int("id", [2, 4])]),
+        owned_table([varchar("name", ["Lucy"])]),
+        owned_table([int("id", [1, 3])]),
+        owned_table([int("id", [2, 5])]),
+    ];
+    // Create public parameters for DynamicDoryEvaluationProof
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}
+
+/// `IN` with no matches (empty result), `IN` composed with another predicate (two `IN`s
+/// `AND`ed), and a longer list.
+#[test]
+fn test_in_list_more_cases() {
+    let alloc = Bump::new();
+    let sql = "SELECT id FROM sxt.cats WHERE id IN (100, 200);
+        SELECT id FROM sxt.cats WHERE id IN (1, 3, 5) AND name IN ('Chloe', 'Katy');
+        SELECT id FROM sxt.cats WHERE id IN (1, 2, 3, 4, 5, 6);";
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(Some("sxt"), "cats") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4, 5], &alloc),
+                borrowed_varchar("name", ["Chloe", "Margaret", "Katy", "Lucy", "Prudence"], &alloc),
+            ]
+        ),
+    };
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        owned_table([int("id", [0; 0])]),          // no match -> empty
+        owned_table([int("id", [1, 3])]),          // id IN (1,3,5) AND name IN ('Chloe','Katy')
+        owned_table([int("id", [1, 2, 3, 4, 5])]), // 6-element list -> all rows match
+    ];
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}
+
+/// `IN` over a decimal column, exercising the scale-cast / product path with a non-integer type.
+#[test]
+fn test_in_list_decimal() {
+    let alloc = Bump::new();
+    let sql = "SELECT id FROM sxt.items WHERE amount IN (1.5, 3.0);";
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(Some("sxt"), "items") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4], &alloc),
+                // amount = 1.5, 2.5, 1.5, 3.0  (decimal with scale 1)
+                borrowed_decimal75("amount", 3, 1, [15, 25, 15, 30], &alloc),
+            ]
+        ),
+    };
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![owned_table([int("id", [1, 3, 4])])];
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}
+
+/// A long numeric `IN` list proves and verifies fine. In the product form the result type's
+/// precision saturates at 75 (`(p1 + p2 + 1).min(75)`, so it never errors), and integer factors
+/// keep scale 0, so there is no practical length limit for numeric lists. The membership zero-test
+/// stays correct regardless of the precision metadata. (Only very long *decimal* lists could hit
+/// `i8` scale accumulation.)
+#[test]
+fn test_in_list_long_numeric_list() {
+    let alloc = Bump::new();
+    let sql = "SELECT id FROM sxt.cats WHERE id IN (2, 4, 6, 8, 10, 12, 14, 16, 18, 20);";
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(Some("sxt"), "cats") => table(
+            vec![borrowed_int("id", [1, 2, 3, 4, 5], &alloc)]
+        ),
+    };
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![owned_table([int("id", [2, 4])])];
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}


### PR DESCRIPTION
# Rationale for this change

SQL `IN` / `NOT IN` weren't supported by the planner. This adds them by lowering `Expr::InList` into expressions we already have, so there's no new proof expr.

# What changes are included in this PR?

`a IN (v1, …, vk)` is lowered by operand type:
- **numeric** → `(a - v1) * … * (a - vk) = 0` (product is zero iff one factor is)
- **varchar** → `a = v1 OR … OR a = vk`
- **empty** `IN ()` → `false`
- **`NOT IN`** → the above wrapped in `NOT`

# Are these changes tested?

Yes — planner unit tests (product/or-chain/empty/negation) and end-to-end prove/verify for numeric and varchar `IN`/`NOT IN`.
