### PR TITLE
test: cover parser and serialization edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,42 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct LimbFixture {
+        #[serde(
+            deserialize_with = "deserialize_to_limbs",
+            serialize_with = "serialize_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn we_serialize_limbs_in_big_endian_word_order() {
+        let fixture = LimbFixture {
+            limbs: [1, 2, 3, 4],
+        };
+
+        assert_eq!(
+            serde_json::to_string(&fixture).unwrap(),
+            r#"{"limbs":[4,3,2,1]}"#
+        );
+    }
+
+    #[test]
+    fn we_deserialize_limbs_back_to_internal_word_order() {
+        let fixture: LimbFixture = serde_json::from_str(r#"{"limbs":[4,3,2,1]}"#).unwrap();
+
+        assert_eq!(
+            fixture,
+            LimbFixture {
+                limbs: [1, 2, 3, 4]
+            }
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,38 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_convert_analyze_errors_to_their_display_string() {
+        let error = AnalyzeError::DifferentColumnLength { len_a: 2, len_b: 3 };
+
+        let message: String = error.into();
+
+        assert_eq!(message, "Columns have different lengths: 2 != 3");
+    }
+
+    #[test]
+    fn we_wrap_intermediate_decimal_errors_as_decimal_conversion_errors() {
+        let error = AnalyzeError::from(IntermediateDecimalError::LossyCast);
+
+        assert!(matches!(
+            error,
+            AnalyzeError::DecimalConversionError {
+                source: DecimalError::IntermediateDecimalConversionError {
+                    source: IntermediateDecimalError::LossyCast
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn transparent_decimal_errors_preserve_the_source_message() {
+        let error = AnalyzeError::from(IntermediateDecimalError::OutOfRange);
+
+        assert_eq!(error.to_string(), "Value out of range for target type");
+    }
+}

--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -73,7 +73,10 @@ pub fn scale_cast_binary_op(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::{ColumnRef, TableRef};
+    use crate::base::{
+        database::{ColumnRef, TableRef},
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    };
 
     #[expect(non_snake_case)]
     fn COLUMN1_BOOLEAN() -> DynProofExpr {
@@ -126,6 +129,24 @@ mod tests {
                 Precision::new(75).expect("Precision is definitely valid"),
                 10,
             ),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN1_TIMESTAMP_MILLISECOND() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN2_TIMESTAMP_MICROSECOND() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column2".into(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc()),
         ))
     }
 
@@ -234,5 +255,38 @@ mod tests {
         let right = COLUMN2_DECIMAL_25_5();
         let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
         assert_eq!(proof_exprs, (left, right));
+    }
+
+    #[test]
+    fn we_can_scale_cast_timestamp_left_to_match_timestamp_right() {
+        let left = COLUMN1_TIMESTAMP_MILLISECOND();
+        let right = COLUMN2_TIMESTAMP_MICROSECOND();
+
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+
+        assert_eq!(
+            proof_exprs,
+            (
+                DynProofExpr::try_new_scaling_cast(left, right.data_type()).unwrap(),
+                right
+            )
+        );
+    }
+
+    #[test]
+    fn we_can_scale_cast_timestamp_right_to_match_timestamp_left() {
+        let left = COLUMN2_TIMESTAMP_MICROSECOND();
+        let right = COLUMN1_TIMESTAMP_MILLISECOND();
+        let left_type = left.data_type();
+
+        let proof_exprs = scale_cast_binary_op(left.clone(), right.clone()).unwrap();
+
+        assert_eq!(
+            proof_exprs,
+            (
+                left,
+                DynProofExpr::try_new_scaling_cast(right, left_type).unwrap()
+            )
+        );
     }
 }

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,52 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn find_bigdecimals_ignores_decimal_columns_at_or_below_i128_precision() {
+        let sql = "CREATE TABLE metrics(
+            exact_fit DECIMAL(38, 0),
+            too_large DECIMAL(39, 4),
+            plain_int INT
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(
+            bigdecimals.get("metrics").unwrap(),
+            &[("too_large".to_string(), 39, 4)]
+        );
+    }
+
+    #[test]
+    fn find_bigdecimals_ignores_non_create_table_statements() {
+        let sql = "
+            SELECT CAST(1 AS DECIMAL(78, 0));
+            CREATE VIEW high_precision_view AS SELECT CAST(1 AS DECIMAL(78, 0));
+            CREATE TABLE stored_values(value DECIMAL(78, 2));
+        ";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("stored_values").unwrap(),
+            &[("value".to_string(), 78, 2)]
+        );
+    }
+
+    #[test]
+    fn find_bigdecimals_preserves_qualified_table_names() {
+        let sql = "CREATE TABLE analytics.events(
+            id BIGINT,
+            amount DECIMAL(76, 5)
+        );";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(
+            bigdecimals.get("analytics.events").unwrap(),
+            &[("amount".to_string(), 76, 5)]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

/claim #560

Adds focused coverage for several small, non-overlapping library paths:
- standard limb serialization/deserialization word order
- AnalyzeError string conversion and IntermediateDecimalError wrapping
- timestamp scale-cast alignment in scale_cast_binary_op
- high-precision DECIMAL discovery edge cases in utils::parse

## Validation

- cargo fmt --all -- --check
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --lib --no-default-features --features std,arrow,test standard_serializations::limbs::tests
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --lib --no-default-features --features std,arrow,test utils::parse::tests
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --lib --no-default-features --features std,arrow,test sql::scale::tests
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo test -p proof-of-sql --lib --no-default-features --features std,arrow,test sql::error::tests
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc cargo llvm-cov test -p proof-of-sql --lib --no-default-features --features std,arrow,test --summary-only --json --output-path /tmp/sxt_lib_summary.json

Coverage report summary for touched files after the full non-Blitzar library run:
- crates/proof-of-sql/src/base/standard_serializations/limbs.rs: 23/23 lines
- crates/proof-of-sql/src/sql/error.rs: 22/22 lines
- crates/proof-of-sql/src/sql/scale.rs: 195/195 lines
- crates/proof-of-sql/src/utils/parse.rs: 97/97 lines

Note: this local environment does not have clang/lld installed, so I used the repo-local linker override CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc for Rust test and coverage commands.