### PR TITLE
test: cover no-blitzar table accessors

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -212,3 +212,8 @@ impl<'a, CP: CommitmentEvaluationProof> OwnedTableTestAccessor<'a, CP> {
         res
     }
 }
+
+#[cfg(test)]
+mod tests {
+    include!("owned_table_test_accessor_test.rs");
+}

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -45,10 +45,16 @@ fn we_can_access_the_columns_of_a_table() {
     }
 
     let data2 = owned_table([
+        uint8("u8", [7, 8, 9, 10]),
+        tinyint("i8", [-1_i8, 2, -3, 4]),
+        smallint("i16", [-10_i16, 20, -30, 40]),
+        int("i32", [-100, 200, -300, 400]),
         bigint("a", [1, 2, 3, 4]),
         bigint("b", [4, 5, 6, 5]),
         int128("c128", [1, 2, 3, 4]),
+        decimal75("decimal", 10, 2, [100, 200, 300, 400]),
         varchar("varchar", ["a", "bc", "d", "e"]),
+        varbinary("varbinary", [vec![1_u8, 2], vec![3], vec![4, 5, 6], vec![]]),
         scalar("scalar", [1, 2, 3, 4]),
         boolean("boolean", [true, false, true, false]),
         timestamptz(
@@ -70,8 +76,40 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     }
 
+    match accessor.get_column(&table_ref_2, &"u8".into()) {
+        Column::Uint8(col) => assert_eq!(col.to_vec(), vec![7, 8, 9, 10]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"i8".into()) {
+        Column::TinyInt(col) => assert_eq!(col.to_vec(), vec![-1, 2, -3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"i16".into()) {
+        Column::SmallInt(col) => assert_eq!(col.to_vec(), vec![-10, 20, -30, 40]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"i32".into()) {
+        Column::Int(col) => assert_eq!(col.to_vec(), vec![-100, 200, -300, 400]),
+        _ => panic!("Invalid column type"),
+    }
+
     match accessor.get_column(&table_ref_2, &"c128".into()) {
         Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"decimal".into()) {
+        Column::Decimal75(precision, scale, col) => {
+            assert_eq!(precision.value(), 10);
+            assert_eq!(scale, 2);
+            assert_eq!(
+                col.to_vec(),
+                vec![100.into(), 200.into(), 300.into(), 400.into()]
+            );
+        }
         _ => panic!("Invalid column type"),
     }
 
@@ -84,6 +122,17 @@ fn we_can_access_the_columns_of_a_table() {
         Column::VarChar((col, scals)) => {
             assert_eq!(col.to_vec(), col_slice);
             assert_eq!(scals.to_vec(), col_scalars);
+        }
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"varbinary".into()) {
+        Column::VarBinary((col, scals)) => {
+            assert_eq!(
+                col.to_vec(),
+                vec![&[1_u8, 2][..], &[3][..], &[4, 5, 6][..], &[][..]]
+            );
+            assert_eq!(scals.len(), 4);
         }
         _ => panic!("Invalid column type"),
     }

--- a/crates/proof-of-sql/src/base/database/table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor.rs
@@ -168,3 +168,8 @@ impl<'a, CP: CommitmentEvaluationProof> TableTestAccessor<'a, CP> {
         res
     }
 }
+
+#[cfg(test)]
+mod tests {
+    include!("table_test_accessor_test.rs");
+}

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -57,9 +57,14 @@ fn we_can_access_the_columns_of_a_table() {
     }
 
     let data2 = table([
+        borrowed_uint8("u8", [7, 8, 9, 10], &alloc),
+        borrowed_tinyint("i8", [-1_i8, 2, -3, 4], &alloc),
+        borrowed_smallint("i16", [-10_i16, 20, -30, 40], &alloc),
+        borrowed_int("i32", [-100, 200, -300, 400], &alloc),
         borrowed_bigint("a", [1, 2, 3, 4], &alloc),
         borrowed_bigint("b", [4, 5, 6, 5], &alloc),
         borrowed_int128("c128", [1, 2, 3, 4], &alloc),
+        borrowed_decimal75("decimal", 10, 2, [100, 200, 300, 400], &alloc),
         borrowed_varchar("varchar", ["a", "bc", "d", "e"], &alloc),
         borrowed_scalar("scalar", [1, 2, 3, 4], &alloc),
         borrowed_boolean("boolean", [true, false, true, false], &alloc),
@@ -83,8 +88,40 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     }
 
+    match accessor.get_column(&table_ref_2, &"u8".into()) {
+        Column::Uint8(col) => assert_eq!(col.to_vec(), vec![7, 8, 9, 10]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"i8".into()) {
+        Column::TinyInt(col) => assert_eq!(col.to_vec(), vec![-1, 2, -3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"i16".into()) {
+        Column::SmallInt(col) => assert_eq!(col.to_vec(), vec![-10, 20, -30, 40]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"i32".into()) {
+        Column::Int(col) => assert_eq!(col.to_vec(), vec![-100, 200, -300, 400]),
+        _ => panic!("Invalid column type"),
+    }
+
     match accessor.get_column(&table_ref_2, &"c128".into()) {
         Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
+        _ => panic!("Invalid column type"),
+    }
+
+    match accessor.get_column(&table_ref_2, &"decimal".into()) {
+        Column::Decimal75(precision, scale, col) => {
+            assert_eq!(precision.value(), 10);
+            assert_eq!(scale, 2);
+            assert_eq!(
+                col.to_vec(),
+                vec![100.into(), 200.into(), 300.into(), 400.into()]
+            );
+        }
         _ => panic!("Invalid column type"),
     }
 


### PR DESCRIPTION
/claim #560

## Summary
- include the existing table accessor tests in the no-blitzar test build
- expand table accessor coverage for integer, decimal, and varbinary column variants
- keep the change limited to tests / cfg(test) wiring for the database test accessors

## Coverage notes
Before this slice, the full no-blitzar coverage summary showed both target implementation files at 0 covered lines:
- `owned_table_test_accessor.rs`: 0/121
- `table_test_accessor.rs`: 0/90

After this change, targeted no-blitzar coverage reports:
- `owned_table_test_accessor.rs`: 100/117
- `table_test_accessor.rs`: 72/88

I checked open PR file overlap before choosing these files and avoided shared files like `base/database/mod.rs`.

## Validation
- `cargo test -p proof-of-sql --no-default-features --features test table_test_accessor --lib`
- `cargo fmt --check`
- `git diff --check`
- `cargo llvm-cov -p proof-of-sql --no-default-features --features test --lib --lcov --output-path target\llvm-cov-accessor-current.lcov -- table_test_accessor`