### PR TITLE
test: add focused bounty 560 coverage

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -7,7 +7,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 /// Converts an Arrow schema to a PoSQL-compatible schema.
 ///
 /// This function takes an Arrow `SchemaRef` and returns a new `SchemaRef` where
-/// floating-point data types (Float16, Float32, Float64) are converted to Decimal256(75, 30).
+/// floating-point data types (Float16, Float32, Float64) are converted to Decimal256(20, 10).
 /// Other data types remain unchanged.
 ///
 /// # Arguments
@@ -34,4 +34,62 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
         .collect();
 
     Arc::new(Schema::new(new_fields))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_posql_compatible_schema;
+    use alloc::{sync::Arc, vec};
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    #[test]
+    fn we_convert_all_floating_point_fields_to_decimal256() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("half", DataType::Float16, false),
+            Field::new("single", DataType::Float32, true),
+            Field::new("double", DataType::Float64, false),
+        ]));
+
+        let compatible_schema = get_posql_compatible_schema(&schema);
+
+        for (index, (name, nullable)) in [("half", false), ("single", true), ("double", false)]
+            .into_iter()
+            .enumerate()
+        {
+            let field = compatible_schema.field(index);
+            assert_eq!(field.name().as_str(), name);
+            assert_eq!(field.data_type(), &DataType::Decimal256(20, 10));
+            assert_eq!(field.is_nullable(), nullable);
+        }
+
+        assert_eq!(schema.field(0).data_type(), &DataType::Float16);
+        assert_eq!(schema.field(1).data_type(), &DataType::Float32);
+        assert_eq!(schema.field(2).data_type(), &DataType::Float64);
+    }
+
+    #[test]
+    fn we_preserve_non_floating_point_field_types_and_nullability() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("amount", DataType::Decimal256(75, 3), false),
+        ]));
+
+        let compatible_schema = get_posql_compatible_schema(&schema);
+
+        assert_eq!(compatible_schema.field(0).name().as_str(), "id");
+        assert_eq!(compatible_schema.field(0).data_type(), &DataType::Int64);
+        assert!(!compatible_schema.field(0).is_nullable());
+
+        assert_eq!(compatible_schema.field(1).name().as_str(), "name");
+        assert_eq!(compatible_schema.field(1).data_type(), &DataType::Utf8);
+        assert!(compatible_schema.field(1).is_nullable());
+
+        assert_eq!(compatible_schema.field(2).name().as_str(), "amount");
+        assert_eq!(
+            compatible_schema.field(2).data_type(),
+            &DataType::Decimal256(75, 3)
+        );
+        assert!(!compatible_schema.field(2).is_nullable());
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,60 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{QueryData, QueryError, QueryResult};
+    use crate::base::{
+        database::{ColumnCoercionError, OwnedTable, TableCoercionError},
+        map::IndexMap,
+        proof::ProofError,
+        scalar::test_scalar::TestScalar,
+    };
+
+    #[test]
+    fn we_convert_table_coercion_errors_to_query_errors() {
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCoercionError {
+                source: ColumnCoercionError::Overflow
+            }),
+            QueryError::Overflow
+        ));
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCoercionError {
+                source: ColumnCoercionError::InvalidTypeCoercion
+            }),
+            QueryError::ProofError {
+                source: ProofError::InvalidTypeCoercion
+            }
+        ));
+        assert!(matches!(
+            QueryError::from(TableCoercionError::NameMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldNamesMismatch
+            }
+        ));
+        assert!(matches!(
+            QueryError::from(TableCoercionError::ColumnCountMismatch),
+            QueryError::ProofError {
+                source: ProofError::FieldCountMismatch
+            }
+        ));
+    }
+
+    #[test]
+    fn query_result_can_hold_query_data() {
+        let table = OwnedTable::<TestScalar>::try_new(IndexMap::default()).unwrap();
+        let verification_hash = [7; 32];
+        let result: QueryResult<TestScalar> = Ok(QueryData {
+            table,
+            verification_hash,
+        });
+
+        let query_data = result.unwrap();
+
+        assert!(query_data.table.is_empty());
+        assert_eq!(query_data.table.num_rows(), 0);
+        assert_eq!(query_data.verification_hash, verification_hash);
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- Add focused unit coverage for `get_posql_compatible_schema`.
- Verify Float16, Float32, and Float64 fields convert to `Decimal256(20, 10)`.
- Verify non-floating fields preserve name, type, and nullability, and that the original floating-point schema is not mutated.
- Correct the function docs to match the implemented `Decimal256(20, 10)` conversion.
- Add `query_result` coverage for `TableCoercionError` to `QueryError` mapping and the `QueryData`/`QueryResult` success path.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p proof-of-sql --lib --no-default-features --features arrow,test arrow_schema_utility -- --nocapture` -- 2 passed, 1055 filtered out
- `cargo test -p proof-of-sql --lib --no-default-features --features arrow,test query_result -- --nocapture` -- 18 passed, 1041 filtered out
- `cargo test -p proof-of-sql --lib --no-default-features --features arrow,test` -- 1059 passed, 0 failed
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features arrow,test --text --output-path /tmp/arrow_schema_utility_coverage.txt -- arrow_schema_utility --nocapture` -- 2 passed; report shows `get_posql_compatible_schema` executed 2x, the floating-point branch executed 3x, and the non-floating branch executed 3x
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features arrow,test --text --output-path /tmp/query_result_coverage.txt -- query_result --nocapture` -- 18 passed; report shows `From<TableCoercionError>` executed 4x with all four match arms covered, plus the `QueryData` success path exercised

## Notes
- Branch is rebased onto current `origin/main`.
- GitHub Actions for this fork PR are currently `action_required` pending maintainer approval, so local validation is included above.
- Direct GitHub search shows substantial overlap on the original `arrow_schema_utility` target. The added `query_result` slice gives the PR another focused coverage area; broader `query_result` searches show some existing mapping PRs, while exact `QueryResult` search currently returns this PR only.