### PR TITLE
test: cover bigdecimal parsing filters

### DIFF
--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -92,4 +92,29 @@ mod tests {
             &empty_vec
         );
     }
+
+    #[test]
+    fn test_find_bigdecimals_ignores_non_tables_and_small_decimals() {
+        let sql = "
+            CREATE VIEW ETHEREUM.BLOCK_REWARDS AS SELECT 1 AS reward;
+
+            CREATE TABLE ETHEREUM.TOKEN_TRANSFERS(
+                TRANSFER_ID BIGINT NOT NULL,
+                PRECISE_AMOUNT DECIMAL(39, 18),
+                STANDARD_AMOUNT DECIMAL(38, 18),
+                INTEGER_AMOUNT DECIMAL(18),
+                UNBOUNDED_AMOUNT DECIMAL,
+                SYMBOL VARCHAR
+            );
+        ";
+
+        let bigdecimals = find_bigdecimals(sql);
+
+        assert_eq!(bigdecimals.len(), 1);
+        assert_eq!(
+            bigdecimals.get("ETHEREUM.TOKEN_TRANSFERS").unwrap(),
+            &[("PRECISE_AMOUNT".to_string(), 39, 18)]
+        );
+        assert!(!bigdecimals.contains_key("ETHEREUM.BLOCK_REWARDS"));
+    }
 }


### PR DESCRIPTION
## Summary
- add focused coverage for `find_bigdecimals` so it ignores non-table DDL and decimal declarations that should not be returned
- verify only the high-precision table column is reported in mixed DDL input

/claim #560

## Validation
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test test_find_bigdecimals -- --nocapture`

Note: this environment does not have `clang`, while the repo config points at it, so the targeted cargo test command above overrides the linker to `cc` and clears the repo-level `-fuse-ld=lld` rustflag.

## Maintenance
- Rebased on current `upstream/main` on 2026-06-26 after the PR was marked behind.