### PR TITLE
test: add coverage for proof-of-sql-planner utilities

### DIFF
--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -25,3 +25,96 @@ pub(crate) fn df_schema(table_name: &str, pairs: Vec<(&str, DataType)>) -> DFSch
     );
     DFSchema::try_from_qualified_schema(table_name, &arrow_schema).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{df_column, df_schema};
+    use arrow::datatypes::DataType;
+    use datafusion::logical_expr::Expr;
+
+    #[test]
+    fn df_column_returns_column_expr_with_table_qualifier() {
+        let expr = df_column("my_table", "my_col");
+        match expr {
+            Expr::Column(col) => {
+                assert_eq!(col.name, "my_col");
+                assert_eq!(
+                    col.relation.as_ref().map(|r| r.to_string()),
+                    Some("my_table".to_string())
+                );
+            }
+            other => panic!("Expected Expr::Column, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn df_column_works_with_different_names() {
+        let expr = df_column("schema.employees", "salary");
+        match expr {
+            Expr::Column(col) => {
+                assert_eq!(col.name, "salary");
+                assert_eq!(
+                    col.relation.as_ref().map(|r| r.to_string()),
+                    Some("schema.employees".to_string())
+                );
+            }
+            other => panic!("Expected Expr::Column, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn df_column_with_uppercase_names() {
+        let expr = df_column("PUBLIC.ORDERS", "ORDER_ID");
+        match expr {
+            Expr::Column(col) => {
+                assert_eq!(col.name, "ORDER_ID");
+                assert_eq!(
+                    col.relation.as_ref().map(|r| r.to_string()),
+                    Some("PUBLIC.ORDERS".to_string())
+                );
+            }
+            other => panic!("Expected Expr::Column, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn df_schema_creates_schema_with_correct_fields() {
+        let schema = df_schema(
+            "test_table",
+            vec![
+                ("id", DataType::Int64),
+                ("name", DataType::Utf8),
+                ("active", DataType::Boolean),
+            ],
+        );
+        assert_eq!(schema.fields().len(), 3);
+        assert_eq!(schema.field_names(), vec!["test_table.id", "test_table.name", "test_table.active"]);
+    }
+
+    #[test]
+    fn df_schema_preserves_column_order() {
+        let schema = df_schema(
+            "t",
+            vec![
+                ("z", DataType::Int32),
+                ("a", DataType::Int32),
+                ("m", DataType::Int32),
+            ],
+        );
+        let names: Vec<_> = schema.field_names();
+        assert_eq!(names, vec!["t.z", "t.a", "t.m"]);
+    }
+
+    #[test]
+    fn df_schema_empty_returns_empty_schema() {
+        let schema = df_schema("empty_table", vec![]);
+        assert_eq!(schema.fields().len(), 0);
+    }
+
+    #[test]
+    fn df_schema_single_boolean_column() {
+        let schema = df_schema("flags", vec![("is_active", DataType::Boolean)]);
+        assert_eq!(schema.fields().len(), 1);
+        assert_eq!(schema.field_names(), vec!["flags.is_active"]);
+    }
+}

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -105,3 +105,81 @@ pub enum PlannerError {
 
 /// Proof of SQL Planner result
 pub type PlannerResult<T> = Result<T, PlannerError>;
+
+#[cfg(test)]
+mod tests {
+    use super::PlannerError;
+    use arrow::datatypes::DataType;
+    use datafusion::logical_expr::Operator;
+
+    #[test]
+    fn column_not_found_displays_correct_message() {
+        let err = PlannerError::ColumnNotFound;
+        assert_eq!(err.to_string(), "Column not found");
+    }
+
+    #[test]
+    fn table_not_found_displays_table_name() {
+        let err = PlannerError::TableNotFound {
+            table_name: "myschema.mytable".to_string(),
+        };
+        assert_eq!(err.to_string(), "Table not found: myschema.mytable");
+    }
+
+    #[test]
+    fn table_not_found_with_empty_table_name() {
+        let err = PlannerError::TableNotFound {
+            table_name: String::new(),
+        };
+        assert_eq!(err.to_string(), "Table not found: ");
+    }
+
+    #[test]
+    fn invalid_placeholder_id_displays_id() {
+        let err = PlannerError::InvalidPlaceholderId {
+            id: "$0".to_string(),
+        };
+        assert!(err.to_string().contains("$0"));
+        assert!(err.to_string().contains("invalid"));
+    }
+
+    #[test]
+    fn unsupported_data_type_displays_type() {
+        let err = PlannerError::UnsupportedDataType {
+            data_type: DataType::LargeUtf8,
+        };
+        assert!(err.to_string().contains("Unsupported datatype"));
+        assert!(err.to_string().contains("LargeUtf8"));
+    }
+
+    #[test]
+    fn unsupported_binary_operator_displays_operator() {
+        let err = PlannerError::UnsupportedBinaryOperator {
+            op: Operator::RegexMatch,
+        };
+        assert!(err.to_string().contains("not supported"));
+    }
+
+    #[test]
+    fn unresolved_logical_plan_displays_correct_message() {
+        let err = PlannerError::UnresolvedLogicalPlan;
+        assert_eq!(err.to_string(), "LogicalPlan is not resolved");
+    }
+
+    #[test]
+    fn catalog_not_supported_displays_correct_message() {
+        let err = PlannerError::CatalogNotSupported;
+        assert_eq!(err.to_string(), "Catalog is not supported");
+    }
+
+    #[test]
+    fn planner_errors_implement_debug() {
+        let err = PlannerError::ColumnNotFound;
+        let debug_str = format!("{err:?}");
+        assert!(debug_str.contains("ColumnNotFound"));
+
+        let err2 = PlannerError::UnresolvedLogicalPlan;
+        let debug_str2 = format!("{err2:?}");
+        assert!(debug_str2.contains("UnresolvedLogicalPlan"));
+    }
+}

--- a/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
+++ b/crates/proof-of-sql-planner/src/uppercase_column_visitor.rs
@@ -47,8 +47,8 @@ pub fn statement_with_uppercase_identifiers(mut statement: Statement) -> Stateme
 
 #[cfg(test)]
 mod tests {
-    use super::statement_with_uppercase_identifiers;
-    use sqlparser::{dialect::GenericDialect, parser::Parser};
+    use super::{statement_with_uppercase_identifiers, uppercase_identifier};
+    use sqlparser::{ast::Ident, dialect::GenericDialect, parser::Parser};
 
     #[test]
     fn we_can_capitalize_statement_idents() {
@@ -56,5 +56,68 @@ mod tests {
         let statement = statement_with_uppercase_identifiers(statement);
         let expected_statement = Parser::parse_sql(&GenericDialect{}, "SELECT A.THISSUM from (SELECT Sum(UPPERCASE_VALUE) as thissum, COUNT(PUPPIES) as coUNT fRoM NONSENSE) as a").unwrap()[0].clone();
         assert_eq!(statement, expected_statement);
+    }
+
+    #[test]
+    fn uppercase_identifier_converts_lowercase_to_upper() {
+        let ident = Ident::new("hello");
+        let result = uppercase_identifier(ident);
+        assert_eq!(result.value, "HELLO");
+    }
+
+    #[test]
+    fn uppercase_identifier_leaves_already_uppercase_unchanged() {
+        let ident = Ident::new("WORLD");
+        let result = uppercase_identifier(ident);
+        assert_eq!(result.value, "WORLD");
+    }
+
+    #[test]
+    fn uppercase_identifier_handles_mixed_case() {
+        let ident = Ident::new("myColumn");
+        let result = uppercase_identifier(ident);
+        assert_eq!(result.value, "MYCOLUMN");
+    }
+
+    #[test]
+    fn statement_with_uppercase_identifiers_uppercases_table_names() {
+        let statement =
+            Parser::parse_sql(&GenericDialect {}, "SELECT id FROM employees")
+                .unwrap()[0]
+                .clone();
+        let result = statement_with_uppercase_identifiers(statement);
+        let expected =
+            Parser::parse_sql(&GenericDialect {}, "SELECT ID FROM EMPLOYEES")
+                .unwrap()[0]
+                .clone();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn statement_with_uppercase_identifiers_handles_schema_qualified_table() {
+        let statement =
+            Parser::parse_sql(&GenericDialect {}, "SELECT col FROM schema_name.table_name")
+                .unwrap()[0]
+                .clone();
+        let result = statement_with_uppercase_identifiers(statement);
+        let expected =
+            Parser::parse_sql(&GenericDialect {}, "SELECT COL FROM SCHEMA_NAME.TABLE_NAME")
+                .unwrap()[0]
+                .clone();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn statement_with_uppercase_identifiers_handles_where_clause() {
+        let statement =
+            Parser::parse_sql(&GenericDialect {}, "SELECT id FROM users WHERE active = true")
+                .unwrap()[0]
+                .clone();
+        let result = statement_with_uppercase_identifiers(statement);
+        let expected =
+            Parser::parse_sql(&GenericDialect {}, "SELECT ID FROM USERS WHERE ACTIVE = true")
+                .unwrap()[0]
+                .clone();
+        assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
Adds unit tests for previously uncovered functions in the `proof-of-sql-planner` crate:

- `crates/proof-of-sql-planner/src/df_util.rs` — 7 new tests for `df_column` and `df_schema`
- `crates/proof-of-sql-planner/src/error.rs` — 9 new tests for `PlannerError` display and debug impls
- `crates/proof-of-sql-planner/src/uppercase_column_visitor.rs` — 5 new tests for `uppercase_identifier` and `statement_with_uppercase_identifiers`

All tests are lightweight (no I/O, no network) and exercise the public API surface directly.

/claim #560