### PR TITLE
test: add coverage for slice ops, ColumnField, and limbs serialization (31 tests)

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,76 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnField;
+    use crate::base::database::ColumnType;
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn column_field_stores_name_and_type() {
+        let field = ColumnField::new(Ident::new("my_col"), ColumnType::BigInt);
+        assert_eq!(field.name(), Ident::new("my_col"));
+        assert_eq!(field.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_field_name_returns_correct_value() {
+        let field = ColumnField::new(Ident::new("age"), ColumnType::Int);
+        assert_eq!(field.name().value, "age");
+    }
+
+    #[test]
+    fn column_field_data_type_returns_correct_type() {
+        let field = ColumnField::new(Ident::new("flag"), ColumnType::Boolean);
+        assert_eq!(field.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn column_field_equality_same_fields() {
+        let f1 = ColumnField::new(Ident::new("col"), ColumnType::Boolean);
+        let f2 = ColumnField::new(Ident::new("col"), ColumnType::Boolean);
+        assert_eq!(f1, f2);
+    }
+
+    #[test]
+    fn column_field_inequality_different_name() {
+        let f1 = ColumnField::new(Ident::new("col_a"), ColumnType::BigInt);
+        let f2 = ColumnField::new(Ident::new("col_b"), ColumnType::BigInt);
+        assert_ne!(f1, f2);
+    }
+
+    #[test]
+    fn column_field_inequality_different_type() {
+        let f1 = ColumnField::new(Ident::new("col"), ColumnType::BigInt);
+        let f2 = ColumnField::new(Ident::new("col"), ColumnType::Int);
+        assert_ne!(f1, f2);
+    }
+
+    #[test]
+    fn column_field_clone_equals_original() {
+        let f = ColumnField::new(Ident::new("x"), ColumnType::VarChar);
+        assert_eq!(f.clone(), f);
+    }
+
+    #[test]
+    fn column_field_debug_output_contains_field_name() {
+        let f = ColumnField::new(Ident::new("score"), ColumnType::BigInt);
+        let debug = format!("{f:?}");
+        assert!(debug.contains("score"));
+    }
+
+    #[test]
+    fn column_field_int128_type() {
+        let field = ColumnField::new(Ident::new("amount"), ColumnType::Int128);
+        assert_eq!(field.data_type(), ColumnType::Int128);
+    }
+
+    #[test]
+    fn column_field_varchar_type() {
+        let field = ColumnField::new(Ident::new("name"), ColumnType::VarChar);
+        assert_eq!(field.data_type(), ColumnType::VarChar);
+        assert_eq!(field.name().value, "name");
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/add_const.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const.rs
@@ -17,3 +17,58 @@ where
         *res_i += to_add.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::add_const;
+
+    #[test]
+    fn add_const_empty_slice_is_noop() {
+        let mut result: Vec<i32> = vec![];
+        add_const(&mut result, 5i32);
+        assert_eq!(result, Vec::<i32>::new());
+    }
+
+    #[test]
+    fn add_const_adds_to_every_element() {
+        let mut result = vec![1i32, 2, 3, 4];
+        add_const(&mut result, 10i32);
+        assert_eq!(result, vec![11, 12, 13, 14]);
+    }
+
+    #[test]
+    fn add_const_zero_is_identity() {
+        let mut result = vec![5i32, 10, 15];
+        add_const(&mut result, 0i32);
+        assert_eq!(result, vec![5, 10, 15]);
+    }
+
+    #[test]
+    fn add_const_negative_value_decrements() {
+        let mut result = vec![10i32, 20, 30];
+        add_const(&mut result, -5i32);
+        assert_eq!(result, vec![5, 15, 25]);
+    }
+
+    #[test]
+    fn add_const_single_element() {
+        let mut result = vec![42i32];
+        add_const(&mut result, 1i32);
+        assert_eq!(result, vec![43]);
+    }
+
+    #[test]
+    fn add_const_with_u64() {
+        let mut result = vec![100u64, 200, 300];
+        add_const(&mut result, 50u64);
+        assert_eq!(result, vec![150, 250, 350]);
+    }
+
+    #[test]
+    fn add_const_accumulates_over_multiple_calls() {
+        let mut result = vec![0i32; 3];
+        add_const(&mut result, 5i32);
+        add_const(&mut result, 3i32);
+        assert_eq!(result, vec![8, 8, 8]);
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
@@ -24,3 +24,70 @@ where
         *res_i += multiplier * data_i.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::mul_add_assign;
+
+    #[test]
+    fn mul_add_assign_empty_to_mul_add_is_noop() {
+        let mut result = vec![1i32, 2, 3];
+        mul_add_assign(&mut result, 5i32, &[] as &[i32]);
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn mul_add_assign_basic_multiply_and_add() {
+        let mut result = vec![0i32; 3];
+        let to_add = vec![1i32, 2, 3];
+        mul_add_assign(&mut result, 2i32, &to_add);
+        assert_eq!(result, vec![2, 4, 6]);
+    }
+
+    #[test]
+    fn mul_add_assign_accumulates_into_existing_values() {
+        let mut result = vec![10i32, 20, 30];
+        let to_add = vec![1i32, 2, 3];
+        mul_add_assign(&mut result, 3i32, &to_add);
+        assert_eq!(result, vec![13, 26, 39]);
+    }
+
+    #[test]
+    fn mul_add_assign_zero_multiplier_leaves_result_unchanged() {
+        let mut result = vec![5i32, 10, 15];
+        let to_add = vec![100i32, 200, 300];
+        mul_add_assign(&mut result, 0i32, &to_add);
+        assert_eq!(result, vec![5, 10, 15]);
+    }
+
+    #[test]
+    fn mul_add_assign_result_longer_than_to_mul_add_only_affects_prefix() {
+        let mut result = vec![1i32, 2, 3, 4, 5];
+        let to_add = vec![10i32, 20];
+        mul_add_assign(&mut result, 1i32, &to_add);
+        assert_eq!(result, vec![11, 22, 3, 4, 5]);
+    }
+
+    #[test]
+    #[should_panic(expected = "The length of result must be greater than or equal to")]
+    fn mul_add_assign_panics_if_result_shorter_than_to_mul_add() {
+        let mut result = vec![1i32, 2];
+        let to_add = vec![10i32, 20, 30];
+        mul_add_assign(&mut result, 1i32, &to_add);
+    }
+
+    #[test]
+    fn mul_add_assign_negative_multiplier() {
+        let mut result = vec![100i32, 200, 300];
+        let to_add = vec![10i32, 20, 30];
+        mul_add_assign(&mut result, -1i32, &to_add);
+        assert_eq!(result, vec![90, 180, 270]);
+    }
+
+    #[test]
+    fn mul_add_assign_single_element() {
+        let mut result = vec![5i32];
+        mul_add_assign(&mut result, 3i32, &[4i32]);
+        assert_eq!(result, vec![17]);
+    }
+}

--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,65 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct LimbsWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn serialize_reverses_limb_order() {
+        let w = LimbsWrapper { limbs: [1, 2, 3, 4] };
+        let json = serde_json::to_string(&w).unwrap();
+        assert!(json.contains("[4,3,2,1]"), "expected reversed order, got: {json}");
+    }
+
+    #[test]
+    fn deserialize_reverses_limb_order_back() {
+        let json = r#"{"limbs":[4,3,2,1]}"#;
+        let result: LimbsWrapper = serde_json::from_str(json).unwrap();
+        assert_eq!(result.limbs, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn roundtrip_preserves_original_limbs() {
+        let original = LimbsWrapper { limbs: [10, 20, 30, 40] };
+        let json = serde_json::to_string(&original).unwrap();
+        let recovered: LimbsWrapper = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered.limbs, original.limbs);
+    }
+
+    #[test]
+    fn zero_limbs_roundtrip() {
+        let w = LimbsWrapper { limbs: [0, 0, 0, 0] };
+        let json = serde_json::to_string(&w).unwrap();
+        let recovered: LimbsWrapper = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered.limbs, [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn all_distinct_limbs_roundtrip() {
+        let w = LimbsWrapper { limbs: [u64::MAX, 0, u64::MAX / 2, 12345] };
+        let json = serde_json::to_string(&w).unwrap();
+        let recovered: LimbsWrapper = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered.limbs, w.limbs);
+    }
+
+    #[test]
+    fn serialize_positions_are_reversed() {
+        let w = LimbsWrapper { limbs: [0, 0, 0, 99] };
+        let json = serde_json::to_string(&w).unwrap();
+        let inner: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(inner["limbs"][0], serde_json::json!(99));
+        assert_eq!(inner["limbs"][3], serde_json::json!(0));
+    }
+}


### PR DESCRIPTION
Adds 31 unit tests across 4 files that previously had 0 test coverage:

- `base/slice_ops/add_const.rs` — 7 tests: empty slice, element-wise addition, identity (zero), negative values, single element, u64 type, multiple calls
- `base/slice_ops/mul_add_assign.rs` — 8 tests: empty to_mul_add, basic multiply-and-add, accumulation, zero multiplier, partial slice (result longer), panic on too-short result, negative multiplier, single element
- `base/database/column_field.rs` — 10 tests: new/name/data_type accessors, equality, inequality (name/type), clone, debug output, Int128 and VarChar types
- `base/standard_serializations/limbs.rs` — 6 tests: serialize reverses limb order, deserialize reverses back, roundtrip, zero limbs, all-distinct limbs, byte position verification

/attempt #560
/claim #560