### PR TITLE
test: add coverage for ParseError, ScalarConversionError, and fold_util (17 tests)

### DIFF
--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,46 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ParseError;
+
+    #[test]
+    fn invalid_table_reference_displays_reference() {
+        let err = ParseError::InvalidTableReference {
+            table_reference: "bad.ref".to_string(),
+        };
+        assert_eq!(err.to_string(), "Invalid table reference: bad.ref");
+    }
+
+    #[test]
+    fn invalid_table_reference_empty_string() {
+        let err = ParseError::InvalidTableReference {
+            table_reference: String::new(),
+        };
+        assert_eq!(err.to_string(), "Invalid table reference: ");
+    }
+
+    #[test]
+    fn parse_error_equality() {
+        let e1 = ParseError::InvalidTableReference { table_reference: "a.b".to_string() };
+        let e2 = ParseError::InvalidTableReference { table_reference: "a.b".to_string() };
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn parse_error_inequality_different_ref() {
+        let e1 = ParseError::InvalidTableReference { table_reference: "a".to_string() };
+        let e2 = ParseError::InvalidTableReference { table_reference: "b".to_string() };
+        assert_ne!(e1, e2);
+    }
+
+    #[test]
+    fn parse_error_debug_contains_variant_name() {
+        let err = ParseError::InvalidTableReference { table_reference: "foo".to_string() };
+        let debug = format!("{err:?}");
+        assert!(debug.contains("InvalidTableReference"));
+        assert!(debug.contains("foo"));
+    }
+}

--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,42 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ScalarConversionError;
+
+    #[test]
+    fn overflow_displays_error_message() {
+        let err = ScalarConversionError::Overflow {
+            error: "value too large".to_string(),
+        };
+        assert_eq!(err.to_string(), "Overflow error: value too large");
+    }
+
+    #[test]
+    fn overflow_with_empty_error_message() {
+        let err = ScalarConversionError::Overflow {
+            error: String::new(),
+        };
+        assert_eq!(err.to_string(), "Overflow error: ");
+    }
+
+    #[test]
+    fn overflow_debug_contains_variant_name() {
+        let err = ScalarConversionError::Overflow {
+            error: "x".to_string(),
+        };
+        let debug = format!("{err:?}");
+        assert!(debug.contains("Overflow"));
+    }
+
+    #[test]
+    fn overflow_debug_contains_error_content() {
+        let err = ScalarConversionError::Overflow {
+            error: "sentinel_value".to_string(),
+        };
+        let debug = format!("{err:?}");
+        assert!(debug.contains("sentinel_value"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
@@ -32,3 +32,93 @@ pub fn fold_vals<S: Scalar>(beta: S, vals: &[S]) -> S {
 fn powers<S: Scalar>(init: S, base: S) -> impl Iterator<Item = S> {
     core::iter::successors(Some(init), move |&m| Some(m * base))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{fold_vals, powers};
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn fold_vals_empty_slice_returns_zero() {
+        let result = fold_vals::<TestScalar>(TestScalar::from(2), &[]);
+        assert_eq!(result, TestScalar::from(0));
+    }
+
+    #[test]
+    fn fold_vals_single_element_returns_element_unchanged() {
+        let result = fold_vals::<TestScalar>(TestScalar::from(5), &[TestScalar::from(7)]);
+        assert_eq!(result, TestScalar::from(7));
+    }
+
+    #[test]
+    fn fold_vals_two_elements_applies_horner_scheme() {
+        // beta=2, vals=[3, 1]: 3*2 + 1 = 7
+        let result = fold_vals::<TestScalar>(
+            TestScalar::from(2),
+            &[TestScalar::from(3), TestScalar::from(1)],
+        );
+        assert_eq!(result, TestScalar::from(7));
+    }
+
+    #[test]
+    fn fold_vals_three_elements_computes_correctly() {
+        // beta=2, vals=[1, 2, 3]: 1*4 + 2*2 + 3 = 11
+        let result = fold_vals::<TestScalar>(
+            TestScalar::from(2),
+            &[TestScalar::from(1), TestScalar::from(2), TestScalar::from(3)],
+        );
+        assert_eq!(result, TestScalar::from(11));
+    }
+
+    #[test]
+    fn fold_vals_beta_zero_returns_last_element() {
+        // beta=0, vals=[5, 99]: 5*0 + 99 = 99
+        let result = fold_vals::<TestScalar>(
+            TestScalar::from(0),
+            &[TestScalar::from(5), TestScalar::from(99)],
+        );
+        assert_eq!(result, TestScalar::from(99));
+    }
+
+    #[test]
+    fn fold_vals_beta_one_sums_all_values() {
+        // beta=1, vals=[1, 2, 3]: 1 + 2 + 3 = 6
+        let result = fold_vals::<TestScalar>(
+            TestScalar::from(1),
+            &[TestScalar::from(1), TestScalar::from(2), TestScalar::from(3)],
+        );
+        assert_eq!(result, TestScalar::from(6));
+    }
+
+    #[test]
+    fn powers_produces_geometric_sequence() {
+        let vals: Vec<TestScalar> = powers(TestScalar::from(1), TestScalar::from(3))
+            .take(4)
+            .collect();
+        assert_eq!(
+            vals,
+            vec![
+                TestScalar::from(1),
+                TestScalar::from(3),
+                TestScalar::from(9),
+                TestScalar::from(27),
+            ]
+        );
+    }
+
+    #[test]
+    fn powers_with_init_two_and_base_two() {
+        let vals: Vec<TestScalar> = powers(TestScalar::from(2), TestScalar::from(2))
+            .take(4)
+            .collect();
+        assert_eq!(
+            vals,
+            vec![
+                TestScalar::from(2),
+                TestScalar::from(4),
+                TestScalar::from(8),
+                TestScalar::from(16),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Adds 17 unit tests across 3 files that previously had 0 test coverage:

- `base/database/error.rs` — 5 tests: `ParseError::InvalidTableReference` display format, empty reference, equality, inequality, debug output
- `base/scalar/error.rs` — 4 tests: `ScalarConversionError::Overflow` display format, empty message, debug variant name, debug content
- `sql/proof_plans/fold_util.rs` — 8 tests: `fold_vals` with empty slice, single element, two/three elements (Horner scheme), beta=0, beta=1; `powers` geometric sequence and init×base sequence

/attempt #560
/claim #560