### PR TITLE
test: add coverage for 4 modules — EVMProofPlanError, PoSQLTimestampError, OwnedColumnError, inner_product (32 tests)

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -13,7 +13,7 @@ pub enum OwnedColumnError {
         /// The type to which we are trying to cast.
         to_type: ColumnType,
     },
-    /// Error in converting scalars to a given column type.   
+    /// Error in converting scalars to a given column type.
     #[snafu(display("Error in converting scalars to a given column type: {error}"))]
     ScalarConversionError {
         /// The underlying error
@@ -40,3 +40,77 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnCoercionError, OwnedColumnError};
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn type_cast_error_displays_from_and_to_types() {
+        let err = OwnedColumnError::TypeCastError {
+            from_type: ColumnType::BigInt,
+            to_type: ColumnType::Boolean,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Can not perform type casting"));
+        assert!(msg.contains("BigInt"));
+        assert!(msg.contains("Boolean"));
+    }
+
+    #[test]
+    fn scalar_conversion_error_displays_message() {
+        let err = OwnedColumnError::ScalarConversionError {
+            error: "overflow".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Error in converting scalars to a given column type: overflow"
+        );
+    }
+
+    #[test]
+    fn unsupported_error_displays_message() {
+        let err = OwnedColumnError::Unsupported {
+            error: "not implemented".to_string(),
+        };
+        assert_eq!(err.to_string(), "Unsupported operation: not implemented");
+    }
+
+    #[test]
+    fn owned_column_errors_implement_partial_eq() {
+        let e1 = OwnedColumnError::Unsupported { error: "x".to_string() };
+        let e2 = OwnedColumnError::Unsupported { error: "x".to_string() };
+        assert_eq!(e1, e2);
+        let e3 = OwnedColumnError::Unsupported { error: "y".to_string() };
+        assert_ne!(e1, e3);
+    }
+
+    #[test]
+    fn owned_column_error_debug_contains_variant_name() {
+        let debug = format!("{:?}", OwnedColumnError::Unsupported { error: "x".to_string() });
+        assert!(debug.contains("Unsupported"));
+    }
+
+    #[test]
+    fn column_coercion_overflow_displays_correctly() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+    }
+
+    #[test]
+    fn column_coercion_invalid_type_displays_correctly() {
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+
+    #[test]
+    fn column_coercion_errors_implement_partial_eq() {
+        assert_eq!(ColumnCoercionError::Overflow, ColumnCoercionError::Overflow);
+        assert_ne!(ColumnCoercionError::Overflow, ColumnCoercionError::InvalidTypeCoercion);
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,61 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PoSQLTimestampError;
+
+    #[test]
+    fn invalid_timezone_displays_timezone_string() {
+        let err = PoSQLTimestampError::InvalidTimezone {
+            timezone: "Mars/UTC".to_string(),
+        };
+        assert_eq!(err.to_string(), "invalid timezone string: Mars/UTC");
+    }
+
+    #[test]
+    fn invalid_timezone_offset_displays_correct_message() {
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezoneOffset.to_string(),
+            "invalid timezone offset"
+        );
+    }
+
+    #[test]
+    fn invalid_time_unit_displays_message() {
+        let err = PoSQLTimestampError::InvalidTimeUnit {
+            error: "unknown unit".to_string(),
+        };
+        assert_eq!(err.to_string(), "Invalid time unit");
+    }
+
+    #[test]
+    fn unsupported_precision_displays_error() {
+        let err = PoSQLTimestampError::UnsupportedPrecision {
+            error: "picoseconds".to_string(),
+        };
+        assert_eq!(err.to_string(), "Unsupported precision for timestamp: picoseconds");
+    }
+
+    #[test]
+    fn from_impl_converts_to_string_via_display() {
+        let err = PoSQLTimestampError::InvalidTimezoneOffset;
+        let s: String = err.into();
+        assert_eq!(s, "invalid timezone offset");
+    }
+
+    #[test]
+    fn timestamp_errors_implement_partial_eq() {
+        assert_eq!(PoSQLTimestampError::InvalidTimezoneOffset, PoSQLTimestampError::InvalidTimezoneOffset);
+        let e1 = PoSQLTimestampError::InvalidTimezone { timezone: "x".to_string() };
+        let e2 = PoSQLTimestampError::InvalidTimezone { timezone: "x".to_string() };
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn timestamp_error_debug_contains_variant_name() {
+        let debug = format!("{:?}", PoSQLTimestampError::InvalidTimezoneOffset);
+        assert!(debug.contains("InvalidTimezoneOffset"));
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -40,3 +40,58 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
         .sum()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::inner_product;
+
+    #[test]
+    fn inner_product_empty_slices_returns_zero() {
+        let result = inner_product::<i64, i64>(&[], &[]);
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn inner_product_single_element() {
+        let result = inner_product::<i64, i64>(&[5], &[3]);
+        assert_eq!(result, 15);
+    }
+
+    #[test]
+    fn inner_product_two_elements() {
+        let result = inner_product::<i64, i64>(&[1, 2], &[3, 4]);
+        assert_eq!(result, 11); // 1*3 + 2*4 = 3 + 8 = 11
+    }
+
+    #[test]
+    fn inner_product_three_elements() {
+        let result = inner_product::<i64, i64>(&[1, 2, 3], &[4, 5, 6]);
+        assert_eq!(result, 32); // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
+    }
+
+    #[test]
+    fn inner_product_first_slice_longer_ignores_extra() {
+        let result = inner_product::<i64, i64>(&[1, 2, 100], &[3, 4]);
+        assert_eq!(result, 11); // 1*3 + 2*4 = 11; 100 is ignored
+    }
+
+    #[test]
+    fn inner_product_with_zeros() {
+        let result = inner_product::<i64, i64>(&[0, 0, 0], &[1, 2, 3]);
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn inner_product_with_negative_values() {
+        let result = inner_product::<i64, i64>(&[-1, 2], &[3, -4]);
+        assert_eq!(result, -11); // -1*3 + 2*(-4) = -3 - 8 = -11
+    }
+
+    #[test]
+    fn inner_product_identity_like_operation() {
+        let a = vec![1i64, 2, 3, 4, 5];
+        let b = vec![1i64; 5];
+        let result = inner_product(&a, &b);
+        assert_eq!(result, 15); // sum of a
+    }
+}

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,67 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::EVMProofPlanError;
+
+    #[test]
+    fn not_supported_displays_correct_message() {
+        assert_eq!(EVMProofPlanError::NotSupported.to_string(), "plan not yet supported");
+    }
+
+    #[test]
+    fn column_not_found_displays_correct_message() {
+        assert_eq!(EVMProofPlanError::ColumnNotFound.to_string(), "column not found");
+    }
+
+    #[test]
+    fn table_not_found_displays_correct_message() {
+        assert_eq!(EVMProofPlanError::TableNotFound.to_string(), "table not found");
+    }
+
+    #[test]
+    fn invalid_table_name_displays_correct_message() {
+        assert_eq!(
+            EVMProofPlanError::InvalidTableName.to_string(),
+            "table name can not be parsed into TableRef"
+        );
+    }
+
+    #[test]
+    fn invalid_output_column_name_displays_correct_message() {
+        assert_eq!(
+            EVMProofPlanError::InvalidOutputColumnName.to_string(),
+            "invalid or missing output column name"
+        );
+    }
+
+    #[test]
+    fn inconsistent_group_by_column_counts_displays_correctly() {
+        assert_eq!(
+            EVMProofPlanError::InconsistentGroupByColumnCounts.to_string(),
+            "column counts in group by plans are inconsistent"
+        );
+    }
+
+    #[test]
+    fn incorrect_scaling_factor_displays_correct_message() {
+        assert_eq!(
+            EVMProofPlanError::IncorrectScalingFactor.to_string(),
+            "incorrect scaling factor"
+        );
+    }
+
+    #[test]
+    fn evm_proof_plan_errors_implement_partial_eq() {
+        assert_eq!(EVMProofPlanError::NotSupported, EVMProofPlanError::NotSupported);
+        assert_ne!(EVMProofPlanError::NotSupported, EVMProofPlanError::ColumnNotFound);
+    }
+
+    #[test]
+    fn evm_proof_plan_error_debug_contains_variant_name() {
+        let debug = format!("{:?}", EVMProofPlanError::NotSupported);
+        assert!(debug.contains("NotSupported"));
+    }
+}


### PR DESCRIPTION
Adds 32 unit tests across 4 files with 0 prior test coverage:

- `sql/evm_proof_plan/error.rs` — 9 tests: all 7 unit variants display strings + PartialEq + Debug
- `base/posql_time/error.rs` — 7 tests: InvalidTimezone, InvalidTimezoneOffset, InvalidTimeUnit, UnsupportedPrecision display; From<PoSQLTimestampError> for String; PartialEq; Debug
- `base/database/owned_column_error.rs` — 8 tests: TypeCastError, ScalarConversionError, Unsupported display strings; PartialEq equality/inequality; Debug; ColumnCoercionError Overflow, InvalidTypeCoercion, PartialEq
- `base/slice_ops/inner_product.rs` — 8 tests: empty slices, single element, 2/3 elements, longer-first-slice truncation, all-zeros, negative values, sum-as-inner-product

/attempt #560
/claim #560