### PR TITLE
test: add coverage for schema utility, TableEvaluation, and slice_cast (25 tests)

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -35,3 +35,83 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
 
     Arc::new(Schema::new(new_fields))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::get_posql_compatible_schema;
+    use alloc::sync::Arc;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    fn make_schema(fields: Vec<Field>) -> Arc<Schema> {
+        Arc::new(Schema::new(fields))
+    }
+
+    #[test]
+    fn float32_is_converted_to_decimal256() {
+        let schema = make_schema(vec![Field::new("f", DataType::Float32, false)]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).data_type(), &DataType::Decimal256(20, 10));
+    }
+
+    #[test]
+    fn float64_is_converted_to_decimal256() {
+        let schema = make_schema(vec![Field::new("f", DataType::Float64, false)]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).data_type(), &DataType::Decimal256(20, 10));
+    }
+
+    #[test]
+    fn float16_is_converted_to_decimal256() {
+        let schema = make_schema(vec![Field::new("f", DataType::Float16, false)]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).data_type(), &DataType::Decimal256(20, 10));
+    }
+
+    #[test]
+    fn int64_is_unchanged() {
+        let schema = make_schema(vec![Field::new("i", DataType::Int64, false)]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).data_type(), &DataType::Int64);
+    }
+
+    #[test]
+    fn boolean_is_unchanged() {
+        let schema = make_schema(vec![Field::new("b", DataType::Boolean, false)]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).data_type(), &DataType::Boolean);
+    }
+
+    #[test]
+    fn mixed_schema_converts_only_floats() {
+        let schema = make_schema(vec![
+            Field::new("a", DataType::Float32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Float64, true),
+        ]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).data_type(), &DataType::Decimal256(20, 10));
+        assert_eq!(result.field(1).data_type(), &DataType::Int32);
+        assert_eq!(result.field(2).data_type(), &DataType::Decimal256(20, 10));
+    }
+
+    #[test]
+    fn empty_schema_returns_empty_schema() {
+        let schema = make_schema(vec![]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.fields().len(), 0);
+    }
+
+    #[test]
+    fn field_nullability_is_preserved() {
+        let schema = make_schema(vec![Field::new("f", DataType::Float32, true)]);
+        let result = get_posql_compatible_schema(&schema);
+        assert!(result.field(0).is_nullable());
+    }
+
+    #[test]
+    fn field_name_is_preserved() {
+        let schema = make_schema(vec![Field::new("my_float", DataType::Float64, false)]);
+        let result = get_posql_compatible_schema(&schema);
+        assert_eq!(result.field(0).name(), "my_float");
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,74 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableEvaluation;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn new_stores_column_evals_and_chi() {
+        let evals = vec![TestScalar::from(1), TestScalar::from(2)];
+        let chi = (TestScalar::from(3), 5);
+        let te = TableEvaluation::new(evals.clone(), chi);
+        assert_eq!(te.column_evals(), evals.as_slice());
+        assert_eq!(te.chi_eval(), TestScalar::from(3));
+        assert_eq!(te.chi(), (TestScalar::from(3), 5));
+    }
+
+    #[test]
+    fn column_evals_returns_correct_slice() {
+        let evals = vec![TestScalar::from(10), TestScalar::from(20), TestScalar::from(30)];
+        let te = TableEvaluation::new(evals.clone(), (TestScalar::from(0), 3));
+        assert_eq!(te.column_evals().len(), 3);
+        assert_eq!(te.column_evals()[1], TestScalar::from(20));
+    }
+
+    #[test]
+    fn chi_eval_returns_first_element_of_chi() {
+        let te = TableEvaluation::new(vec![], (TestScalar::from(42), 100));
+        assert_eq!(te.chi_eval(), TestScalar::from(42));
+    }
+
+    #[test]
+    fn chi_returns_full_tuple() {
+        let te = TableEvaluation::new(vec![], (TestScalar::from(7), 99));
+        assert_eq!(te.chi(), (TestScalar::from(7), 99));
+    }
+
+    #[test]
+    fn empty_column_evals_is_valid() {
+        let te = TableEvaluation::<TestScalar>::new(vec![], (TestScalar::from(0), 0));
+        assert_eq!(te.column_evals().len(), 0);
+    }
+
+    #[test]
+    fn table_evaluation_equality() {
+        let te1 = TableEvaluation::new(
+            vec![TestScalar::from(1)],
+            (TestScalar::from(2), 5),
+        );
+        let te2 = TableEvaluation::new(
+            vec![TestScalar::from(1)],
+            (TestScalar::from(2), 5),
+        );
+        assert_eq!(te1, te2);
+    }
+
+    #[test]
+    fn table_evaluation_inequality_different_evals() {
+        let te1 = TableEvaluation::new(vec![TestScalar::from(1)], (TestScalar::from(0), 1));
+        let te2 = TableEvaluation::new(vec![TestScalar::from(2)], (TestScalar::from(0), 1));
+        assert_ne!(te1, te2);
+    }
+
+    #[test]
+    fn table_evaluation_clone_equals_original() {
+        let te = TableEvaluation::new(
+            vec![TestScalar::from(5), TestScalar::from(6)],
+            (TestScalar::from(1), 2),
+        );
+        assert_eq!(te.clone(), te);
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
@@ -53,3 +53,62 @@ where
 {
     slice_cast_mut_with(value, result, Into::into);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{slice_cast_mut_with, slice_cast_with};
+    use alloc::{string::String, vec};
+
+    #[test]
+    fn slice_cast_with_empty_slice_returns_empty_vec() {
+        let result: Vec<i64> = slice_cast_with(&[] as &[i32], |&x| x as i64);
+        assert_eq!(result, Vec::<i64>::new());
+    }
+
+    #[test]
+    fn slice_cast_with_converts_i32_to_i64() {
+        let result: Vec<i64> = slice_cast_with(&[1i32, 2, 3], |&x| x as i64);
+        assert_eq!(result, vec![1i64, 2, 3]);
+    }
+
+    #[test]
+    fn slice_cast_with_applies_transformation() {
+        let result: Vec<i32> = slice_cast_with(&[1i32, 2, 3, 4], |&x| x * x);
+        assert_eq!(result, vec![1, 4, 9, 16]);
+    }
+
+    #[test]
+    fn slice_cast_with_converts_to_string() {
+        let result: Vec<String> = slice_cast_with(&[1i32, 2, 3], |&x| x.to_string());
+        assert_eq!(result, vec!["1", "2", "3"]);
+    }
+
+    #[test]
+    fn slice_cast_mut_with_empty_slices_is_noop() {
+        let mut result: Vec<i64> = vec![];
+        slice_cast_mut_with(&[] as &[i32], &mut result, |&x| x as i64);
+        assert_eq!(result, Vec::<i64>::new());
+    }
+
+    #[test]
+    fn slice_cast_mut_with_writes_to_result() {
+        let mut result = vec![0i64; 3];
+        slice_cast_mut_with(&[10i32, 20, 30], &mut result, |&x| x as i64 * 2);
+        assert_eq!(result, vec![20i64, 40, 60]);
+    }
+
+    #[test]
+    fn slice_cast_mut_with_partial_write() {
+        let mut result = vec![0i64; 5];
+        slice_cast_mut_with(&[1i32, 2], &mut result, |&x| x as i64);
+        assert_eq!(result[0], 1);
+        assert_eq!(result[1], 2);
+        assert_eq!(result[2], 0); // untouched
+    }
+
+    #[test]
+    fn slice_cast_with_single_element() {
+        let result: Vec<i64> = slice_cast_with(&[42i32], |&x| x as i64);
+        assert_eq!(result, vec![42i64]);
+    }
+}


### PR DESCRIPTION
Adds 25 unit tests across 3 files with 0 prior test coverage:

- `base/database/arrow_schema_utility.rs` — 9 tests: Float16/32/64 → Decimal256(20,10) conversion; Int64/Boolean unchanged; mixed schema; empty schema; nullability preserved; field name preserved
- `base/database/table_evaluation.rs` — 8 tests: new/column_evals/chi_eval/chi accessors; empty column evals; equality; inequality on evals; clone
- `base/slice_ops/slice_cast.rs` — 8 tests: `slice_cast_with` empty/i32→i64/transformation/to-string/single element; `slice_cast_mut_with` empty/write/partial write

/attempt #560
/claim #560