### PR TITLE
test: add coverage for ColumnRef and U256 (19 tests)

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,76 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnRef;
+    use crate::base::database::{ColumnType, TableRef};
+    use sqlparser::ast::Ident;
+
+    fn make_table_ref() -> TableRef {
+        TableRef::new("myschema", "mytable")
+    }
+
+    #[test]
+    fn new_stores_all_fields() {
+        let tr = make_table_ref();
+        let col = ColumnRef::new(tr.clone(), Ident::new("my_col"), ColumnType::BigInt);
+        assert_eq!(col.table_ref(), tr);
+        assert_eq!(col.column_id(), Ident::new("my_col"));
+        assert_eq!(col.column_type(), &ColumnType::BigInt);
+    }
+
+    #[test]
+    fn table_ref_returns_correct_value() {
+        let tr = TableRef::new("s", "t");
+        let col = ColumnRef::new(tr.clone(), Ident::new("x"), ColumnType::Int);
+        assert_eq!(col.table_ref(), tr);
+    }
+
+    #[test]
+    fn column_id_returns_correct_identifier() {
+        let col = ColumnRef::new(make_table_ref(), Ident::new("salary"), ColumnType::BigInt);
+        assert_eq!(col.column_id().value, "salary");
+    }
+
+    #[test]
+    fn column_type_returns_correct_type() {
+        let col = ColumnRef::new(make_table_ref(), Ident::new("flag"), ColumnType::Boolean);
+        assert_eq!(col.column_type(), &ColumnType::Boolean);
+    }
+
+    #[test]
+    fn column_ref_equality() {
+        let c1 = ColumnRef::new(make_table_ref(), Ident::new("col"), ColumnType::VarChar);
+        let c2 = ColumnRef::new(make_table_ref(), Ident::new("col"), ColumnType::VarChar);
+        assert_eq!(c1, c2);
+    }
+
+    #[test]
+    fn column_ref_inequality_different_column_id() {
+        let c1 = ColumnRef::new(make_table_ref(), Ident::new("col_a"), ColumnType::BigInt);
+        let c2 = ColumnRef::new(make_table_ref(), Ident::new("col_b"), ColumnType::BigInt);
+        assert_ne!(c1, c2);
+    }
+
+    #[test]
+    fn column_ref_inequality_different_type() {
+        let c1 = ColumnRef::new(make_table_ref(), Ident::new("col"), ColumnType::BigInt);
+        let c2 = ColumnRef::new(make_table_ref(), Ident::new("col"), ColumnType::Int);
+        assert_ne!(c1, c2);
+    }
+
+    #[test]
+    fn column_ref_clone_equals_original() {
+        let c = ColumnRef::new(make_table_ref(), Ident::new("x"), ColumnType::Boolean);
+        assert_eq!(c.clone(), c);
+    }
+
+    #[test]
+    fn column_ref_debug_contains_column_name() {
+        let c = ColumnRef::new(make_table_ref(), Ident::new("myfield"), ColumnType::BigInt);
+        let debug = format!("{c:?}");
+        assert!(debug.contains("myfield"));
+    }
+}

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -35,3 +35,81 @@ impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
         MontScalar::<T>::from_le_bytes_mod_order(&bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::U256;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn from_words_stores_low_and_high() {
+        let u = U256::from_words(42, 100);
+        assert_eq!(u.low, 42);
+        assert_eq!(u.high, 100);
+    }
+
+    #[test]
+    fn from_words_zero_both_parts() {
+        let u = U256::from_words(0, 0);
+        assert_eq!(u.low, 0);
+        assert_eq!(u.high, 0);
+    }
+
+    #[test]
+    fn from_words_max_values() {
+        let u = U256::from_words(u128::MAX, u128::MAX);
+        assert_eq!(u.low, u128::MAX);
+        assert_eq!(u.high, u128::MAX);
+    }
+
+    #[test]
+    fn u256_equality() {
+        let a = U256::from_words(1, 2);
+        let b = U256::from_words(1, 2);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn u256_inequality_different_low() {
+        let a = U256::from_words(1, 0);
+        let b = U256::from_words(2, 0);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn u256_inequality_different_high() {
+        let a = U256::from_words(0, 1);
+        let b = U256::from_words(0, 2);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn u256_copy_trait_works() {
+        let a = U256::from_words(5, 10);
+        let b = a;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn scalar_zero_converts_to_zero_u256() {
+        let scalar = TestScalar::from(0);
+        let u: U256 = (&scalar).into();
+        assert_eq!(u.low, 0);
+        assert_eq!(u.high, 0);
+    }
+
+    #[test]
+    fn small_scalar_converts_to_u256_with_correct_low() {
+        let scalar = TestScalar::from(255);
+        let u: U256 = (&scalar).into();
+        assert_eq!(u.low, 255);
+        assert_eq!(u.high, 0);
+    }
+
+    #[test]
+    fn u256_zero_roundtrip_via_scalar() {
+        let u = U256::from_words(0, 0);
+        let scalar: TestScalar = (&u).into();
+        assert_eq!(scalar, TestScalar::from(0));
+    }
+}


### PR DESCRIPTION
Adds 19 unit tests across 2 files with 0 prior test coverage:

- `base/database/column_ref.rs` — 9 tests: new/table_ref/column_id/column_type accessors; equality; inequality on column_id and type; clone; debug output
- `base/encode/u256.rs` — 10 tests: from_words stores low/high; zero values; max values; equality; inequality on low and high; copy trait; scalar zero → U256 zero; small scalar low bits; zero U256 roundtrip via scalar

/attempt #560
/claim #560