### PR TITLE
test: add coverage for error types and ZigZag encoding (35 tests)

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,76 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::TableOperationError;
+    use crate::base::database::ColumnType;
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn union_not_enough_tables_displays_correctly() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+    }
+
+    #[test]
+    fn join_with_different_column_counts_displays_counts() {
+        let err = TableOperationError::JoinWithDifferentNumberOfColumns {
+            left_num_columns: 3,
+            right_num_columns: 5,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("3"));
+        assert!(msg.contains("5"));
+        assert!(msg.contains("Cannot join tables with different numbers of columns"));
+    }
+
+    #[test]
+    fn join_incompatible_types_displays_types() {
+        let err = TableOperationError::JoinIncompatibleTypes {
+            left_type: ColumnType::BigInt,
+            right_type: ColumnType::Boolean,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("BigInt"));
+        assert!(msg.contains("Boolean"));
+    }
+
+    #[test]
+    fn column_does_not_exist_displays_column_name() {
+        let err = TableOperationError::ColumnDoesNotExist {
+            column_ident: Ident::new("my_col"),
+        };
+        assert!(err.to_string().contains("my_col"));
+        assert!(err.to_string().contains("does not exist in table"));
+    }
+
+    #[test]
+    fn duplicate_column_displays_correctly() {
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+    }
+
+    #[test]
+    fn column_index_out_of_bounds_displays_index() {
+        let err = TableOperationError::ColumnIndexOutOfBounds { column_index: 42 };
+        assert_eq!(err.to_string(), "Column index out of bounds: 42");
+    }
+
+    #[test]
+    fn table_operation_errors_implement_partial_eq() {
+        assert_eq!(TableOperationError::UnionNotEnoughTables, TableOperationError::UnionNotEnoughTables);
+        assert_ne!(TableOperationError::UnionNotEnoughTables, TableOperationError::DuplicateColumn);
+    }
+
+    #[test]
+    fn table_operation_error_debug_contains_variant_name() {
+        let debug = format!("{:?}", TableOperationError::UnionNotEnoughTables);
+        assert!(debug.contains("UnionNotEnoughTables"));
+    }
+}

--- a/crates/proof-of-sql/src/base/encode/zigzag.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag.rs
@@ -109,3 +109,75 @@ impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ZigZag;
+    use crate::base::{encode::U256, scalar::test_scalar::TestScalar};
+
+    #[test]
+    fn zero_scalar_encodes_to_zero_u256() {
+        let encoded: U256 = TestScalar::from(0).zigzag();
+        assert_eq!(encoded, U256::from_words(0, 0));
+    }
+
+    #[test]
+    fn positive_one_encodes_to_even_u256() {
+        // 1 → 2 (positive zigzag: 2*x)
+        let encoded: U256 = TestScalar::from(1).zigzag();
+        assert_eq!(encoded, U256::from_words(2, 0));
+    }
+
+    #[test]
+    fn positive_two_encodes_to_four() {
+        // 2 → 4
+        let encoded: U256 = TestScalar::from(2).zigzag();
+        assert_eq!(encoded, U256::from_words(4, 0));
+    }
+
+    #[test]
+    fn negative_one_encodes_to_odd_u256() {
+        // -1 → 1 (negative zigzag: 2*y+1 where y=|-1|=1; 2*1-1=1)
+        let encoded: U256 = (-TestScalar::from(1)).zigzag();
+        assert_eq!(encoded, U256::from_words(1, 0));
+    }
+
+    #[test]
+    fn negative_two_encodes_to_three() {
+        // -2 → 3
+        let encoded: U256 = (-TestScalar::from(2)).zigzag();
+        assert_eq!(encoded, U256::from_words(3, 0));
+    }
+
+    #[test]
+    fn positive_roundtrip_via_u256() {
+        let original = TestScalar::from(42);
+        let encoded: U256 = original.zigzag();
+        let decoded: TestScalar = encoded.zigzag();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn negative_roundtrip_via_u256() {
+        let original = -TestScalar::from(17);
+        let encoded: U256 = original.zigzag();
+        let decoded: TestScalar = encoded.zigzag();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn even_encoded_u256_decodes_to_positive_scalar() {
+        // even u256 → positive scalar: 4 → 2
+        let encoded = U256::from_words(4, 0);
+        let decoded: TestScalar = encoded.zigzag();
+        assert_eq!(decoded, TestScalar::from(2));
+    }
+
+    #[test]
+    fn odd_encoded_u256_decodes_to_negative_scalar() {
+        // odd u256 → negative scalar: 1 → -1
+        let encoded = U256::from_words(1, 0);
+        let decoded: TestScalar = encoded.zigzag();
+        assert_eq!(decoded, -TestScalar::from(1));
+    }
+}

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,97 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{PlaceholderError, ProofError, ProofSizeMismatch};
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn proof_error_verification_error_displays_message() {
+        let err = ProofError::VerificationError { error: "bad proof" };
+        assert_eq!(err.to_string(), "Verification error: bad proof");
+    }
+
+    #[test]
+    fn proof_error_invalid_type_coercion_displays_correctly() {
+        assert_eq!(
+            ProofError::InvalidTypeCoercion.to_string(),
+            "Result does not match query: type mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_error_field_names_mismatch_displays_correctly() {
+        assert_eq!(
+            ProofError::FieldNamesMismatch.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_error_field_count_mismatch_displays_correctly() {
+        assert_eq!(
+            ProofError::FieldCountMismatch.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+
+    #[test]
+    fn proof_size_mismatch_sumcheck_too_small_displays_correctly() {
+        assert_eq!(
+            ProofSizeMismatch::SumcheckProofTooSmall.to_string(),
+            "Sumcheck proof is too small"
+        );
+    }
+
+    #[test]
+    fn proof_size_mismatch_too_few_mle_evaluations_displays_correctly() {
+        assert_eq!(
+            ProofSizeMismatch::TooFewMLEEvaluations.to_string(),
+            "Proof has too few MLE evaluations"
+        );
+    }
+
+    #[test]
+    fn proof_size_mismatch_chi_length_not_found_displays_correctly() {
+        assert_eq!(
+            ProofSizeMismatch::ChiLengthNotFound.to_string(),
+            "Proof doesn't have requested one length"
+        );
+    }
+
+    #[test]
+    fn placeholder_error_zero_id_displays_correctly() {
+        assert_eq!(
+            PlaceholderError::ZeroPlaceholderId.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn placeholder_error_invalid_index_displays_index_and_params() {
+        let err = PlaceholderError::InvalidPlaceholderIndex { index: 5, num_params: 3 };
+        let msg = err.to_string();
+        assert!(msg.contains("5"));
+        assert!(msg.contains("3"));
+    }
+
+    #[test]
+    fn placeholder_error_invalid_type_displays_types() {
+        let err = PlaceholderError::InvalidPlaceholderType {
+            index: 1,
+            expected: ColumnType::BigInt,
+            actual: ColumnType::Boolean,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("BigInt"));
+        assert!(msg.contains("Boolean"));
+    }
+
+    #[test]
+    fn placeholder_errors_implement_partial_eq() {
+        assert_eq!(PlaceholderError::ZeroPlaceholderId, PlaceholderError::ZeroPlaceholderId);
+        assert_ne!(PlaceholderError::ZeroPlaceholderId, PlaceholderError::InvalidPlaceholderIndex { index: 0, num_params: 0 });
+    }
+}

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,61 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::AnalyzeError;
+    use crate::base::database::ColumnType;
+    use alloc::string::String;
+
+    #[test]
+    fn invalid_data_type_displays_type() {
+        let err = AnalyzeError::InvalidDataType { expr_type: ColumnType::BigInt };
+        let msg = err.to_string();
+        assert!(msg.contains("BigInt"));
+        assert!(msg.contains("was not valid"));
+    }
+
+    #[test]
+    fn data_type_mismatch_displays_both_types() {
+        let err = AnalyzeError::DataTypeMismatch {
+            left_type: "Int".to_string(),
+            right_type: "Boolean".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Int"));
+        assert!(msg.contains("Boolean"));
+    }
+
+    #[test]
+    fn different_column_length_displays_lengths() {
+        let err = AnalyzeError::DifferentColumnLength { len_a: 5, len_b: 10 };
+        assert_eq!(err.to_string(), "Columns have different lengths: 5 != 10");
+    }
+
+    #[test]
+    fn not_enough_input_plans_displays_correctly() {
+        assert_eq!(AnalyzeError::NotEnoughInputPlans.to_string(), "Not enough input plans");
+    }
+
+    #[test]
+    fn from_impl_converts_to_string_via_display() {
+        let err = AnalyzeError::NotEnoughInputPlans;
+        let s: String = err.into();
+        assert_eq!(s, "Not enough input plans");
+    }
+
+    #[test]
+    fn analyze_errors_implement_partial_eq() {
+        assert_eq!(AnalyzeError::NotEnoughInputPlans, AnalyzeError::NotEnoughInputPlans);
+        let e1 = AnalyzeError::DifferentColumnLength { len_a: 1, len_b: 2 };
+        let e2 = AnalyzeError::DifferentColumnLength { len_a: 1, len_b: 2 };
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn analyze_error_debug_contains_variant_name() {
+        let debug = format!("{:?}", AnalyzeError::NotEnoughInputPlans);
+        assert!(debug.contains("NotEnoughInputPlans"));
+    }
+}


### PR DESCRIPTION
Adds 35 unit tests across 4 files with 0 prior test coverage:

- `base/database/table_operation_error.rs` — 8 tests: UnionNotEnoughTables, JoinWithDifferentNumberOfColumns, JoinIncompatibleTypes, ColumnDoesNotExist, DuplicateColumn, ColumnIndexOutOfBounds display strings; PartialEq; Debug
- `sql/error.rs` — 7 tests: InvalidDataType, DataTypeMismatch, DifferentColumnLength, NotEnoughInputPlans display; From<AnalyzeError> for String; PartialEq; Debug
- `base/proof/error.rs` — 11 tests: ProofError VerificationError/InvalidTypeCoercion/FieldNamesMismatch/FieldCountMismatch; ProofSizeMismatch SumcheckProofTooSmall/TooFewMLEEvaluations/ChiLengthNotFound; PlaceholderError ZeroPlaceholderId/InvalidPlaceholderIndex/InvalidPlaceholderType/PartialEq
- `base/encode/zigzag.rs` — 9 tests: zero encodes to zero; positive 1→2, 2→4; negative -1→1, -2→3; positive roundtrip; negative roundtrip; even U256→positive scalar; odd U256→negative scalar

/attempt #560
/claim #560