### PR TITLE
test: add coverage for ColumnOperationError and compute_evaluation_vector (18 tests)

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,94 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnOperationError;
+    use crate::base::database::ColumnType;
+    use alloc::string::ToString;
+
+    #[test]
+    fn different_column_length_displays_both_lengths() {
+        let err = ColumnOperationError::DifferentColumnLength { len_a: 3, len_b: 5 };
+        assert_eq!(err.to_string(), "Columns have different lengths: 3 != 5");
+    }
+
+    #[test]
+    fn binary_operation_invalid_type_displays_operator_and_types() {
+        let err = ColumnOperationError::BinaryOperationInvalidColumnType {
+            operator: "Add".to_string(),
+            left_type: ColumnType::BigInt,
+            right_type: ColumnType::Boolean,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Add"));
+        assert!(msg.contains("BigInt"));
+        assert!(msg.contains("Boolean"));
+        assert!(msg.contains("not supported"));
+    }
+
+    #[test]
+    fn unary_operation_invalid_type_displays_operator_and_operand() {
+        let err = ColumnOperationError::UnaryOperationInvalidColumnType {
+            operator: "Not".to_string(),
+            operand_type: ColumnType::BigInt,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Not"));
+        assert!(msg.contains("BigInt"));
+    }
+
+    #[test]
+    fn integer_overflow_displays_error_message() {
+        let err = ColumnOperationError::IntegerOverflow { error: "value too large".to_string() };
+        assert_eq!(err.to_string(), "Overflow in integer operation: value too large");
+    }
+
+    #[test]
+    fn division_by_zero_displays_correctly() {
+        assert_eq!(ColumnOperationError::DivisionByZero.to_string(), "Division by zero");
+    }
+
+    #[test]
+    fn union_different_types_displays_both_types() {
+        let err = ColumnOperationError::UnionDifferentTypes {
+            correct_type: ColumnType::BigInt,
+            actual_type: ColumnType::Boolean,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("BigInt"));
+        assert!(msg.contains("Boolean"));
+        assert!(msg.contains("Cannot union columns of different types"));
+    }
+
+    #[test]
+    fn index_out_of_bounds_displays_index_and_len() {
+        let err = ColumnOperationError::IndexOutOfBounds { index: 10, len: 5 };
+        assert_eq!(err.to_string(), "Index out of bounds: 10 >= 5");
+    }
+
+    #[test]
+    fn signed_casting_error_displays_types() {
+        let err = ColumnOperationError::SignedCastingError {
+            left_type: ColumnType::Int,
+            right_type: ColumnType::TinyInt,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Cannot fit"));
+        assert!(msg.contains("without losing data"));
+    }
+
+    #[test]
+    fn column_operation_errors_implement_partial_eq() {
+        assert_eq!(ColumnOperationError::DivisionByZero, ColumnOperationError::DivisionByZero);
+        assert_ne!(ColumnOperationError::DivisionByZero,
+            ColumnOperationError::DifferentColumnLength { len_a: 1, len_b: 2 });
+    }
+
+    #[test]
+    fn column_operation_error_debug_contains_variant_name() {
+        let debug = format!("{:?}", ColumnOperationError::DivisionByZero);
+        assert!(debug.contains("DivisionByZero"));
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -67,3 +67,73 @@ where
 
     log::log_memory_usage("End");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_evaluation_vector;
+
+    #[test]
+    fn empty_v_with_empty_point_remains_empty() {
+        let mut v: Vec<f64> = vec![];
+        compute_evaluation_vector(&mut v, &[]);
+        assert_eq!(v, Vec::<f64>::new());
+    }
+
+    #[test]
+    fn single_element_v_with_empty_point_is_one() {
+        let mut v = vec![0.0f64];
+        compute_evaluation_vector(&mut v, &[]);
+        assert_eq!(v, vec![1.0]);
+    }
+
+    #[test]
+    fn two_element_v_with_single_point_zero_gives_one_zero() {
+        // point = [0.0]: v = [1-0, 0] = [1, 0]
+        let mut v = vec![0.0f64; 2];
+        compute_evaluation_vector(&mut v, &[0.0]);
+        assert_eq!(v, vec![1.0, 0.0]);
+    }
+
+    #[test]
+    fn two_element_v_with_single_point_one_gives_zero_one() {
+        // point = [1.0]: v = [1-1, 1] = [0, 1]
+        let mut v = vec![0.0f64; 2];
+        compute_evaluation_vector(&mut v, &[1.0]);
+        assert_eq!(v, vec![0.0, 1.0]);
+    }
+
+    #[test]
+    fn four_element_v_with_two_point_half_gives_quarter_each() {
+        // point = [0.5, 0.5]: v = [0.25, 0.25, 0.25, 0.25]
+        let mut v = vec![0.0f64; 4];
+        compute_evaluation_vector(&mut v, &[0.5, 0.5]);
+        let expected = vec![0.25, 0.25, 0.25, 0.25];
+        for (a, b) in v.iter().zip(expected.iter()) {
+            assert!((a - b).abs() < 1e-10, "expected {b} got {a}");
+        }
+    }
+
+    #[test]
+    fn evaluation_vector_sums_to_one() {
+        let mut v = vec![0.0f64; 8];
+        compute_evaluation_vector(&mut v, &[0.3, 0.7, 0.5]);
+        let sum: f64 = v.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-10, "sum = {sum}");
+    }
+
+    #[test]
+    fn four_element_v_with_point_zero_zero_gives_one_zero_zero_zero() {
+        // point = [0, 0]: v = [1, 0, 0, 0]
+        let mut v = vec![0.0f64; 4];
+        compute_evaluation_vector(&mut v, &[0.0, 0.0]);
+        assert_eq!(v, vec![1.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn four_element_v_with_point_one_one_gives_zero_zero_zero_one() {
+        // point = [1, 1]: v = [0, 0, 0, 1]
+        let mut v = vec![0.0f64; 4];
+        compute_evaluation_vector(&mut v, &[1.0, 1.0]);
+        assert_eq!(v, vec![0.0, 0.0, 0.0, 1.0]);
+    }
+}


### PR DESCRIPTION
Adds 18 unit tests across 2 files with 0 prior test coverage:

- `base/database/column_operation_error.rs` — 10 tests: DifferentColumnLength, BinaryOperationInvalidColumnType, UnaryOperationInvalidColumnType, IntegerOverflow, DivisionByZero, UnionDifferentTypes, IndexOutOfBounds, SignedCastingError display strings; PartialEq; Debug
- `base/polynomial/evaluation_vector.rs` — 8 tests: empty v with empty point; single element with empty point = 1; [0.0] → [1,0]; [1.0] → [0,1]; [0.5,0.5] → [0.25,0.25,0.25,0.25]; sum-to-one invariant; point=[0,0] → [1,0,0,0]; point=[1,1] → [0,0,0,1]

/attempt #560
/claim #560