### PR TITLE
test(coverage): add tests for ProverState, EmptyExec, and QueryError

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -62,3 +62,69 @@ impl<S: Scalar> ProverState<S> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProverState;
+    use crate::base::{polynomial::CompositePolynomial, scalar::test_scalar::TestScalar};
+
+    #[test]
+    fn new_sets_round_to_zero() {
+        let state: ProverState<TestScalar> = ProverState::new(vec![], vec![], 3, 2);
+        assert_eq!(state.round, 0);
+    }
+
+    #[test]
+    fn new_stores_num_vars() {
+        let state: ProverState<TestScalar> = ProverState::new(vec![], vec![], 5, 0);
+        assert_eq!(state.num_vars, 5);
+    }
+
+    #[test]
+    fn new_stores_max_multiplicands() {
+        let state: ProverState<TestScalar> = ProverState::new(vec![], vec![], 2, 4);
+        assert_eq!(state.max_multiplicands, 4);
+    }
+
+    #[test]
+    fn new_stores_list_of_products() {
+        let products = vec![(TestScalar::from(3u64), vec![0usize, 1])];
+        let state: ProverState<TestScalar> = ProverState::new(products, vec![], 2, 2);
+        assert_eq!(state.list_of_products.len(), 1);
+    }
+
+    #[test]
+    fn new_stores_flattened_ml_extensions() {
+        let exts = vec![vec![TestScalar::from(1u64), TestScalar::from(2u64)]];
+        let state: ProverState<TestScalar> = ProverState::new(vec![], exts, 1, 0);
+        assert_eq!(state.flattened_ml_extensions.len(), 1);
+        assert_eq!(state.flattened_ml_extensions[0].len(), 2);
+    }
+
+    #[test]
+    fn create_from_empty_composite_polynomial() {
+        let poly = CompositePolynomial::<TestScalar>::new(3);
+        let state = ProverState::create(&poly);
+        assert_eq!(state.num_vars, 3);
+        assert_eq!(state.round, 0);
+        assert_eq!(state.max_multiplicands, 0);
+        assert!(state.list_of_products.is_empty());
+    }
+
+    #[test]
+    fn debug_output_contains_num_vars() {
+        let state: ProverState<TestScalar> = ProverState::new(vec![], vec![], 7, 0);
+        let debug = alloc::format!("{state:?}");
+        assert!(debug.contains("num_vars"));
+    }
+
+    #[test]
+    fn empty_prover_state_has_all_zero_fields() {
+        let state: ProverState<TestScalar> = ProverState::new(vec![], vec![], 0, 0);
+        assert!(state.list_of_products.is_empty());
+        assert!(state.flattened_ml_extensions.is_empty());
+        assert_eq!(state.num_vars, 0);
+        assert_eq!(state.max_multiplicands, 0);
+        assert_eq!(state.round, 0);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,49 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::QueryError;
+    use alloc::string::ToString;
+
+    #[test]
+    fn overflow_displays_overflow_error() {
+        assert_eq!(QueryError::Overflow.to_string(), "Overflow error");
+    }
+
+    #[test]
+    fn invalid_string_displays_string_decode_error() {
+        assert_eq!(QueryError::InvalidString.to_string(), "String decode error");
+    }
+
+    #[test]
+    fn miscellaneous_decoding_error_displays_correctly() {
+        assert_eq!(
+            QueryError::MiscellaneousDecodingError.to_string(),
+            "Miscellaneous decoding error"
+        );
+    }
+
+    #[test]
+    fn miscellaneous_evaluation_error_displays_correctly() {
+        assert_eq!(
+            QueryError::MiscellaneousEvaluationError.to_string(),
+            "Miscellaneous evaluation error"
+        );
+    }
+
+    #[test]
+    fn invalid_column_count_displays_correctly() {
+        assert_eq!(
+            QueryError::InvalidColumnCount.to_string(),
+            "Invalid number of columns"
+        );
+    }
+
+    #[test]
+    fn debug_output_contains_variant_name() {
+        let debug = alloc::format!("{:?}", QueryError::Overflow);
+        assert!(debug.contains("Overflow"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -104,3 +104,46 @@ impl ProverEvaluate for EmptyExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EmptyExec;
+    use crate::sql::proof::ProofPlan;
+
+    #[test]
+    fn new_creates_empty_exec() {
+        let _exec = EmptyExec::new();
+    }
+
+    #[test]
+    fn default_equals_new() {
+        assert_eq!(EmptyExec::default(), EmptyExec::new());
+    }
+
+    #[test]
+    fn get_column_result_fields_returns_empty() {
+        assert!(EmptyExec::new().get_column_result_fields().is_empty());
+    }
+
+    #[test]
+    fn get_column_references_returns_empty() {
+        assert!(EmptyExec::new().get_column_references().is_empty());
+    }
+
+    #[test]
+    fn get_table_references_returns_empty() {
+        assert!(EmptyExec::new().get_table_references().is_empty());
+    }
+
+    #[test]
+    fn clone_creates_equal_instance() {
+        let exec = EmptyExec::new();
+        assert_eq!(exec.clone(), exec);
+    }
+
+    #[test]
+    fn debug_output_contains_type_name() {
+        let debug = alloc::format!("{:?}", EmptyExec::new());
+        assert!(debug.contains("EmptyExec"));
+    }
+}


### PR DESCRIPTION
Closes #560

Adds unit tests to three previously untested files:

- `proof_primitive/sumcheck/prover_state.rs` (8 tests): `ProverState::new` constructor fields, `create` from `CompositePolynomial`, debug output
- `sql/proof_plans/empty_exec.rs` (7 tests): `EmptyExec::new`, `Default`, `get_column_result_fields`, `get_column_references`, `get_table_references`, clone, debug
- `sql/proof/query_result.rs` (6 tests): `QueryError` display strings for all unit variants

Total: 21 new tests