### PR TITLE
test(coverage): add tests for DynProofExpr, AddExpr, SubtractExpr

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -117,3 +117,62 @@ impl ProofExpr for AddExpr {
 }
 
 impl DecimalProofExpr for AddExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::AddExpr;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, ProofExpr},
+    };
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(10))
+    }
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(false))
+    }
+
+    #[test]
+    fn try_new_bigint_plus_bigint_succeeds() {
+        let add = AddExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr()));
+        assert!(add.is_ok());
+    }
+
+    #[test]
+    fn data_type_of_bigint_plus_bigint_is_decimal75() {
+        let add = AddExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        assert!(matches!(add.data_type(), ColumnType::Decimal75(..)));
+    }
+
+    #[test]
+    fn lhs_returns_correct_type() {
+        let add = AddExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        assert_eq!(add.lhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn rhs_returns_correct_type() {
+        let add = AddExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        assert_eq!(add.rhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn boolean_plus_bigint_is_error() {
+        assert!(AddExpr::try_new(Box::new(bool_expr()), Box::new(bigint_expr())).is_err());
+    }
+
+    #[test]
+    fn clone_creates_equal_instance() {
+        let add = AddExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        assert_eq!(add.clone(), add);
+    }
+
+    #[test]
+    fn equal_add_exprs_compare_equal() {
+        let a = AddExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        let b = AddExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -122,3 +122,100 @@ impl DynProofExpr {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, ProofExpr},
+    };
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(42))
+    }
+
+    #[test]
+    fn new_literal_boolean_has_boolean_type() {
+        assert_eq!(bool_expr().data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn new_literal_bigint_has_bigint_type() {
+        assert_eq!(bigint_expr().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn try_new_placeholder_valid_index_succeeds() {
+        let expr = DynProofExpr::try_new_placeholder(1, ColumnType::Boolean).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn try_new_placeholder_zero_index_is_error() {
+        assert!(DynProofExpr::try_new_placeholder(0, ColumnType::Boolean).is_err());
+    }
+
+    #[test]
+    fn try_new_not_of_boolean_has_boolean_type() {
+        let expr = DynProofExpr::try_new_not(bool_expr()).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn try_new_not_of_bigint_is_error() {
+        assert!(DynProofExpr::try_new_not(bigint_expr()).is_err());
+    }
+
+    #[test]
+    fn try_new_and_of_two_booleans_succeeds() {
+        let expr = DynProofExpr::try_new_and(bool_expr(), bool_expr()).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn try_new_or_of_two_booleans_succeeds() {
+        let expr = DynProofExpr::try_new_or(bool_expr(), bool_expr()).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn try_new_add_of_two_bigints_gives_decimal_type() {
+        let expr = DynProofExpr::try_new_add(bigint_expr(), bigint_expr()).unwrap();
+        assert!(matches!(expr.data_type(), ColumnType::Decimal75(..)));
+    }
+
+    #[test]
+    fn try_new_add_boolean_and_bigint_is_error() {
+        assert!(DynProofExpr::try_new_add(bool_expr(), bigint_expr()).is_err());
+    }
+
+    #[test]
+    fn try_new_subtract_of_two_bigints_succeeds() {
+        assert!(DynProofExpr::try_new_subtract(bigint_expr(), bigint_expr()).is_ok());
+    }
+
+    #[test]
+    fn try_new_multiply_of_two_bigints_succeeds() {
+        assert!(DynProofExpr::try_new_multiply(bigint_expr(), bigint_expr()).is_ok());
+    }
+
+    #[test]
+    fn clone_creates_equal_expression() {
+        let expr = bool_expr();
+        assert_eq!(expr.clone(), expr);
+    }
+
+    #[test]
+    fn equal_literals_compare_equal() {
+        assert_eq!(bool_expr(), bool_expr());
+    }
+
+    #[test]
+    fn different_literal_types_compare_unequal() {
+        assert_ne!(bool_expr(), bigint_expr());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
@@ -118,3 +118,54 @@ impl ProofExpr for SubtractExpr {
 }
 
 impl DecimalProofExpr for SubtractExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::SubtractExpr;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, ProofExpr},
+    };
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(5))
+    }
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+
+    #[test]
+    fn try_new_bigint_minus_bigint_succeeds() {
+        assert!(SubtractExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).is_ok());
+    }
+
+    #[test]
+    fn data_type_of_bigint_minus_bigint_is_decimal75() {
+        let sub = SubtractExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        assert!(matches!(sub.data_type(), ColumnType::Decimal75(..)));
+    }
+
+    #[test]
+    fn lhs_returns_correct_type() {
+        let sub = SubtractExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        assert_eq!(sub.lhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn rhs_returns_correct_type() {
+        let sub = SubtractExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        assert_eq!(sub.rhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn boolean_minus_bigint_is_error() {
+        assert!(SubtractExpr::try_new(Box::new(bool_expr()), Box::new(bigint_expr())).is_err());
+    }
+
+    #[test]
+    fn clone_creates_equal_instance() {
+        let sub = SubtractExpr::try_new(Box::new(bigint_expr()), Box::new(bigint_expr())).unwrap();
+        assert_eq!(sub.clone(), sub);
+    }
+}


### PR DESCRIPTION
## Summary

Adds test coverage for three uncovered proof expression types:

- `sql/proof_exprs/dyn_proof_expr.rs` — 15 tests: literal types, placeholder, Not/And/Or/Add/Subtract/Multiply constructors, type errors, Clone, PartialEq
- `sql/proof_exprs/add_expr.rs` — 7 tests: try_new success/error, lhs/rhs accessors, data_type (Decimal75), clone, equality
- `sql/proof_exprs/subtract_expr.rs` — 6 tests: try_new success/error, lhs/rhs accessors, data_type (Decimal75), clone

All tests are `#[cfg(test)]` only — zero impact on production binary.

Closes #560 (partial)