### PR TITLE
test(coverage): add tests for compute_evaluation_vector

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -67,3 +67,73 @@ where
 
     log::log_memory_usage("End");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_evaluation_vector;
+
+    #[test]
+    fn empty_v_with_empty_point_remains_empty() {
+        let mut v: Vec<f64> = vec![];
+        compute_evaluation_vector(&mut v, &[]);
+        assert_eq!(v, Vec::<f64>::new());
+    }
+
+    #[test]
+    fn single_element_v_with_empty_point_is_one() {
+        let mut v = vec![0.0f64];
+        compute_evaluation_vector(&mut v, &[]);
+        assert_eq!(v, vec![1.0]);
+    }
+
+    #[test]
+    fn two_element_v_with_single_point_zero_gives_one_zero() {
+        // point = [0.0]: v = [1-0, 0] = [1, 0]
+        let mut v = vec![0.0f64; 2];
+        compute_evaluation_vector(&mut v, &[0.0]);
+        assert_eq!(v, vec![1.0, 0.0]);
+    }
+
+    #[test]
+    fn two_element_v_with_single_point_one_gives_zero_one() {
+        // point = [1.0]: v = [1-1, 1] = [0, 1]
+        let mut v = vec![0.0f64; 2];
+        compute_evaluation_vector(&mut v, &[1.0]);
+        assert_eq!(v, vec![0.0, 1.0]);
+    }
+
+    #[test]
+    fn four_element_v_with_two_point_half_gives_quarter_each() {
+        // point = [0.5, 0.5]: v = [0.25, 0.25, 0.25, 0.25]
+        let mut v = vec![0.0f64; 4];
+        compute_evaluation_vector(&mut v, &[0.5, 0.5]);
+        let expected = vec![0.25, 0.25, 0.25, 0.25];
+        for (a, b) in v.iter().zip(expected.iter()) {
+            assert!((a - b).abs() < 1e-10, "expected {b} got {a}");
+        }
+    }
+
+    #[test]
+    fn evaluation_vector_sums_to_one() {
+        let mut v = vec![0.0f64; 8];
+        compute_evaluation_vector(&mut v, &[0.3, 0.7, 0.5]);
+        let sum: f64 = v.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-10, "sum = {sum}");
+    }
+
+    #[test]
+    fn four_element_v_with_point_zero_zero_gives_one_zero_zero_zero() {
+        // point = [0, 0]: v = [1, 0, 0, 0]
+        let mut v = vec![0.0f64; 4];
+        compute_evaluation_vector(&mut v, &[0.0, 0.0]);
+        assert_eq!(v, vec![1.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn four_element_v_with_point_one_one_gives_zero_zero_zero_one() {
+        // point = [1, 1]: v = [0, 0, 0, 1]
+        let mut v = vec![0.0f64; 4];
+        compute_evaluation_vector(&mut v, &[1.0, 1.0]);
+        assert_eq!(v, vec![0.0, 0.0, 0.0, 1.0]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 8 tests for `compute_evaluation_vector` in `base/polynomial/evaluation_vector.rs`:

- Empty v with empty point stays empty
- Single element v with empty point gets filled with 1
- Two-element v with point [0] gives [1, 0]
- Two-element v with point [1] gives [0, 1]
- Four-element v with point [0.5, 0.5] gives [0.25, 0.25, 0.25, 0.25]
- Evaluation vector sums to 1 (probability property)
- Four-element v with point [0, 0] gives [1, 0, 0, 0]
- Four-element v with point [1, 1] gives [0, 0, 0, 1]

All tests are `#[cfg(test)]` only — zero production impact.

Closes #560 (partial)