### PR TITLE
test(coverage): add tests for ColumnRef

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,62 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnRef;
+    use crate::base::database::{ColumnType, TableRef};
+    use sqlparser::ast::Ident;
+
+    fn make_table_ref() -> TableRef {
+        TableRef::new("", "orders")
+    }
+
+    #[test]
+    fn new_stores_all_fields() {
+        let col_id = Ident::new("amount");
+        let cr = ColumnRef::new(make_table_ref(), col_id.clone(), ColumnType::BigInt);
+        assert_eq!(cr.column_id(), col_id);
+        assert_eq!(cr.column_type(), &ColumnType::BigInt);
+    }
+
+    #[test]
+    fn table_ref_returns_stored_table() {
+        let tr = make_table_ref();
+        let cr = ColumnRef::new(tr.clone(), Ident::new("col"), ColumnType::Boolean);
+        assert_eq!(cr.table_ref(), tr);
+    }
+
+    #[test]
+    fn column_id_returns_identifier() {
+        let id = Ident::new("my_col");
+        let cr = ColumnRef::new(make_table_ref(), id.clone(), ColumnType::BigInt);
+        assert_eq!(cr.column_id(), id);
+    }
+
+    #[test]
+    fn column_type_returns_reference_to_type() {
+        let cr = ColumnRef::new(make_table_ref(), Ident::new("x"), ColumnType::TinyInt);
+        assert_eq!(*cr.column_type(), ColumnType::TinyInt);
+    }
+
+    #[test]
+    fn clone_creates_equal_column_ref() {
+        let cr = ColumnRef::new(make_table_ref(), Ident::new("col"), ColumnType::BigInt);
+        assert_eq!(cr.clone(), cr);
+    }
+
+    #[test]
+    fn two_column_refs_with_same_fields_are_equal() {
+        let a = ColumnRef::new(make_table_ref(), Ident::new("x"), ColumnType::BigInt);
+        let b = ColumnRef::new(make_table_ref(), Ident::new("x"), ColumnType::BigInt);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn two_column_refs_with_different_type_are_not_equal() {
+        let a = ColumnRef::new(make_table_ref(), Ident::new("x"), ColumnType::BigInt);
+        let b = ColumnRef::new(make_table_ref(), Ident::new("x"), ColumnType::Boolean);
+        assert_ne!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 7 tests for `ColumnRef` in `base/database/column_ref.rs`:

- `new` stores all three fields
- `table_ref()` returns stored table reference
- `column_id()` returns stored identifier
- `column_type()` returns reference to stored type
- `clone` creates equal instance
- Two instances with same fields are equal (PartialEq)
- Two instances with different type are not equal

All tests are `#[cfg(test)]` only — zero production impact.

Closes #560 (partial)