### PR TITLE
test(coverage): add tests for OffsetToBytes implementations

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -60,3 +60,70 @@ impl OffsetToBytes<32> for [u64; 4] {
         bytemuck::cast(*self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OffsetToBytes;
+
+    #[test]
+    fn u8_returns_self_as_single_byte() {
+        assert_eq!(42u8.offset_to_bytes(), [42u8]);
+    }
+
+    #[test]
+    fn i8_min_maps_to_zero() {
+        assert_eq!(i8::MIN.offset_to_bytes(), [0u8]);
+    }
+
+    #[test]
+    fn i8_zero_maps_to_128() {
+        assert_eq!(0i8.offset_to_bytes(), [128u8]);
+    }
+
+    #[test]
+    fn i8_max_maps_to_255() {
+        assert_eq!(i8::MAX.offset_to_bytes(), [255u8]);
+    }
+
+    #[test]
+    fn i16_min_maps_to_all_zeros() {
+        assert_eq!(i16::MIN.offset_to_bytes(), [0u8, 0u8]);
+    }
+
+    #[test]
+    fn i32_min_maps_to_all_zeros() {
+        assert_eq!(i32::MIN.offset_to_bytes(), [0u8, 0u8, 0u8, 0u8]);
+    }
+
+    #[test]
+    fn i64_min_maps_to_all_zeros() {
+        assert_eq!(i64::MIN.offset_to_bytes(), [0u8; 8]);
+    }
+
+    #[test]
+    fn i128_min_maps_to_all_zeros() {
+        assert_eq!(i128::MIN.offset_to_bytes(), [0u8; 16]);
+    }
+
+    #[test]
+    fn bool_false_maps_to_zero() {
+        assert_eq!(false.offset_to_bytes(), [0u8]);
+    }
+
+    #[test]
+    fn bool_true_maps_to_one() {
+        assert_eq!(true.offset_to_bytes(), [1u8]);
+    }
+
+    #[test]
+    fn u64_zero_maps_to_all_zeros() {
+        assert_eq!(0u64.offset_to_bytes(), [0u8; 8]);
+    }
+
+    #[test]
+    fn u64_one_maps_to_little_endian_one() {
+        let bytes = 1u64.offset_to_bytes();
+        assert_eq!(bytes[0], 1);
+        assert_eq!(&bytes[1..], &[0u8; 7]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 12 tests for `OffsetToBytes` trait implementations in `proof_primitive/dory/offset_to_bytes.rs`:

- `u8` returns self as single byte
- `i8::MIN` maps to `[0]` (boundary)
- `i8` zero maps to `[128]` (midpoint)
- `i8::MAX` maps to `[255]`
- `i16::MIN` maps to all zeros
- `i32::MIN` maps to all zeros
- `i64::MIN` maps to all zeros
- `i128::MIN` maps to all zeros
- `bool false` maps to `[0]`
- `bool true` maps to `[1]`
- `u64` zero maps to all zeros
- `u64` one maps to little-endian `[1, 0, 0, 0, 0, 0, 0, 0]`

All tests are `#[cfg(test)]` only — zero production impact.

Closes #560 (partial)