### PR TITLE
test(coverage): add tests for DynProofPlan constructors

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -184,3 +184,68 @@ impl DynProofPlan {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DynProofPlan;
+    use crate::base::database::TableRef;
+
+    fn empty_plan() -> DynProofPlan {
+        DynProofPlan::new_empty()
+    }
+
+    #[test]
+    fn new_empty_creates_empty_variant() {
+        assert!(matches!(DynProofPlan::new_empty(), DynProofPlan::Empty(_)));
+    }
+
+    #[test]
+    fn new_table_creates_table_variant() {
+        let plan = DynProofPlan::new_table(TableRef::new("", "t"), alloc::vec![]);
+        assert!(matches!(plan, DynProofPlan::Table(_)));
+    }
+
+    #[test]
+    fn new_slice_creates_slice_variant() {
+        assert!(matches!(
+            DynProofPlan::new_slice(empty_plan(), 0, None),
+            DynProofPlan::Slice(_)
+        ));
+    }
+
+    #[test]
+    fn new_slice_with_skip_and_fetch_creates_slice_variant() {
+        assert!(matches!(
+            DynProofPlan::new_slice(empty_plan(), 3, Some(5)),
+            DynProofPlan::Slice(_)
+        ));
+    }
+
+    #[test]
+    fn try_new_union_with_one_input_is_error() {
+        assert!(DynProofPlan::try_new_union(alloc::vec![empty_plan()]).is_err());
+    }
+
+    #[test]
+    fn try_new_union_with_no_inputs_is_error() {
+        assert!(DynProofPlan::try_new_union(alloc::vec![]).is_err());
+    }
+
+    #[test]
+    fn clone_creates_equal_plan() {
+        let plan = empty_plan();
+        assert_eq!(plan.clone(), plan);
+    }
+
+    #[test]
+    fn two_empty_plans_are_equal() {
+        assert_eq!(DynProofPlan::new_empty(), DynProofPlan::new_empty());
+    }
+
+    #[test]
+    fn debug_output_of_empty_plan_contains_empty() {
+        let plan = empty_plan();
+        let debug = alloc::format!("{:?}", plan);
+        assert!(debug.contains("Empty"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds 9 tests for `DynProofPlan` factory methods in `sql/proof_plans/dyn_proof_plan.rs`:

- `new_empty()` creates the `Empty` enum variant
- `new_table(ref, schema)` creates the `Table` variant
- `new_slice(input, 0, None)` creates the `Slice` variant
- `new_slice(input, 3, Some(5))` creates the `Slice` variant with skip and fetch
- `try_new_union([one_plan])` → error (needs ≥ 2 inputs)
- `try_new_union([])` → error (needs ≥ 2 inputs)
- `clone` preserves equality
- Two `new_empty()` plans are equal (PartialEq)
- `Debug` output of empty plan contains "Empty"

All tests are `#[cfg(test)]` only — zero production impact.

Closes #560 (partial)