### PR TITLE
test(coverage): add tests for EVMProofPlan wrapper

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -191,3 +191,48 @@ impl ProverEvaluate for EVMProofPlan {
             .final_round_evaluate(builder, alloc, table_map, params)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EVMProofPlan;
+    use crate::sql::proof_plans::DynProofPlan;
+
+    fn empty_plan() -> DynProofPlan {
+        DynProofPlan::new_empty()
+    }
+
+    #[test]
+    fn new_wraps_provided_plan() {
+        let evm = EVMProofPlan::new(empty_plan());
+        // inner() should return the wrapped plan
+        assert_eq!(*evm.inner(), empty_plan());
+    }
+
+    #[test]
+    fn inner_returns_reference_to_wrapped_plan() {
+        let evm = EVMProofPlan::new(empty_plan());
+        assert_eq!(*evm.inner(), empty_plan());
+    }
+
+    #[test]
+    fn into_inner_recovers_original_plan() {
+        let plan = empty_plan();
+        let evm = EVMProofPlan::new(plan.clone());
+        assert_eq!(evm.into_inner(), plan);
+    }
+
+    #[test]
+    fn debug_output_contains_plan_info() {
+        let evm = EVMProofPlan::new(empty_plan());
+        let debug = alloc::format!("{:?}", evm);
+        assert!(!debug.is_empty());
+    }
+
+    #[test]
+    fn table_plan_wraps_correctly() {
+        use crate::base::database::TableRef;
+        let plan = DynProofPlan::new_table(TableRef::new("", "t"), alloc::vec![]);
+        let evm = EVMProofPlan::new(plan.clone());
+        assert_eq!(*evm.inner(), plan);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 5 tests for `EVMProofPlan` in `sql/evm_proof_plan/proof_plan.rs`:

- `new(plan)` wraps the plan correctly (checked via `inner()`)
- `inner()` returns a reference equal to the original plan
- `into_inner()` recovers the original `DynProofPlan`
- `Debug` output is non-empty
- Wrapping a `Table` plan preserves equality via `inner()`

All tests are `#[cfg(test)]` only — zero production impact.

Closes #560 (partial)