### PR TITLE
test(coverage): add tests for df_column and df_schema utilities

### DIFF
--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -25,3 +25,47 @@ pub(crate) fn df_schema(table_name: &str, pairs: Vec<(&str, DataType)>) -> DFSch
     );
     DFSchema::try_from_qualified_schema(table_name, &arrow_schema).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{df_column, df_schema};
+    use arrow::datatypes::DataType;
+    use datafusion::logical_expr::Expr;
+
+    #[test]
+    fn df_column_creates_column_expr() {
+        let expr = df_column("my_table", "my_col");
+        assert!(matches!(expr, Expr::Column(_)));
+    }
+
+    #[test]
+    fn df_column_stores_column_name() {
+        let expr = df_column("t", "age");
+        if let Expr::Column(col) = expr {
+            assert_eq!(col.name, "age");
+        } else {
+            panic!("Expected Expr::Column");
+        }
+    }
+
+    #[test]
+    fn df_schema_with_empty_pairs_creates_empty_schema() {
+        let schema = df_schema("t", vec![]);
+        assert_eq!(schema.fields().len(), 0);
+    }
+
+    #[test]
+    fn df_schema_with_one_field_has_one_field() {
+        let schema = df_schema("t", vec![("col1", DataType::Int64)]);
+        assert_eq!(schema.fields().len(), 1);
+    }
+
+    #[test]
+    fn df_schema_with_two_fields_has_two_fields() {
+        let schema = df_schema("orders", vec![
+            ("id", DataType::Int64),
+            ("active", DataType::Boolean),
+        ]);
+        assert_eq!(schema.fields().len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 5 tests for utility functions in `crates/proof-of-sql-planner/src/df_util.rs`:

- `df_column` creates an `Expr::Column` variant
- `df_column` stores the column name correctly
- `df_schema` with empty pairs creates a schema with 0 fields
- `df_schema` with 1 pair creates a schema with 1 field
- `df_schema` with 2 pairs creates a schema with 2 fields

All tests are `#[cfg(test)]` only — zero production impact.

Closes #560 (partial)