### PR TITLE
test: add unit tests for scalar varint encode/decode functions

### DIFF
--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -182,3 +182,200 @@ pub fn scalar_varints_size<T: MontConfig<4>>(scals: &[MontScalar<T>]) -> usize {
 
     all_size
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        read_scalar_varint, read_scalar_varints, read_u256_varint, scalar_varint_size,
+        scalar_varints_size, u256_varint_size, write_scalar_varint, write_scalar_varints,
+        write_u256_varint,
+    };
+    use crate::base::{encode::U256, scalar::test_scalar::TestScalar};
+    use alloc::vec;
+
+    #[test]
+    fn zero_scalar_roundtrip() {
+        let scalar = TestScalar::from(0u64);
+        let mut buf = vec![0u8; 40];
+        let written = write_scalar_varint(&mut buf, &scalar);
+        let (decoded, read) = read_scalar_varint::<_>(&buf[..written]).unwrap();
+        assert_eq!(decoded, scalar);
+        assert_eq!(read, written);
+    }
+
+    #[test]
+    fn positive_scalar_roundtrip() {
+        let scalar = TestScalar::from(42u64);
+        let mut buf = vec![0u8; 40];
+        let written = write_scalar_varint(&mut buf, &scalar);
+        let (decoded, _) = read_scalar_varint::<_>(&buf[..written]).unwrap();
+        assert_eq!(decoded, scalar);
+    }
+
+    #[test]
+    fn large_scalar_roundtrip() {
+        let scalar = TestScalar::from(1000000u64);
+        let mut buf = vec![0u8; 40];
+        let written = write_scalar_varint(&mut buf, &scalar);
+        let (decoded, _) = read_scalar_varint::<_>(&buf[..written]).unwrap();
+        assert_eq!(decoded, scalar);
+    }
+
+    #[test]
+    fn negative_scalar_roundtrip() {
+        let scalar = -TestScalar::from(1u64);
+        let mut buf = vec![0u8; 40];
+        let written = write_scalar_varint(&mut buf, &scalar);
+        let (decoded, _) = read_scalar_varint::<_>(&buf[..written]).unwrap();
+        assert_eq!(decoded, scalar);
+    }
+
+    #[test]
+    fn negative_large_scalar_roundtrip() {
+        let scalar = -TestScalar::from(99999u64);
+        let mut buf = vec![0u8; 40];
+        let written = write_scalar_varint(&mut buf, &scalar);
+        let (decoded, _) = read_scalar_varint::<_>(&buf[..written]).unwrap();
+        assert_eq!(decoded, scalar);
+    }
+
+    #[test]
+    fn scalar_varint_size_for_zero_is_one() {
+        let scalar = TestScalar::from(0u64);
+        assert_eq!(scalar_varint_size(&scalar), 1);
+    }
+
+    #[test]
+    fn scalar_varint_size_for_one_is_one() {
+        let scalar = TestScalar::from(1u64);
+        assert_eq!(scalar_varint_size(&scalar), 1);
+    }
+
+    #[test]
+    fn scalar_varint_size_for_negative_one_is_one() {
+        let scalar = -TestScalar::from(1u64);
+        assert_eq!(scalar_varint_size(&scalar), 1);
+    }
+
+    #[test]
+    fn scalar_varint_size_increases_with_magnitude() {
+        let small = TestScalar::from(1u64);
+        let large = TestScalar::from(1000000u64);
+        assert!(scalar_varint_size(&large) >= scalar_varint_size(&small));
+    }
+
+    #[test]
+    fn write_bytes_equals_varint_size() {
+        let scalar = TestScalar::from(12345u64);
+        let mut buf = vec![0u8; 40];
+        let written = write_scalar_varint(&mut buf, &scalar);
+        assert_eq!(written, scalar_varint_size(&scalar));
+    }
+
+    #[test]
+    fn u256_zero_roundtrip() {
+        let val = U256::from_words(0, 0);
+        let mut buf = vec![0u8; 40];
+        let written = write_u256_varint(&mut buf, val);
+        let (decoded, read) = read_u256_varint(&buf[..written]).unwrap();
+        assert_eq!(decoded, val);
+        assert_eq!(read, written);
+    }
+
+    #[test]
+    fn u256_small_value_roundtrip() {
+        let val = U256::from_words(42, 0);
+        let mut buf = vec![0u8; 40];
+        let written = write_u256_varint(&mut buf, val);
+        let (decoded, _) = read_u256_varint(&buf[..written]).unwrap();
+        assert_eq!(decoded, val);
+    }
+
+    #[test]
+    fn u256_large_low_word_roundtrip() {
+        let val = U256::from_words(u128::MAX, 0);
+        let mut buf = vec![0u8; 40];
+        let written = write_u256_varint(&mut buf, val);
+        let (decoded, _) = read_u256_varint(&buf[..written]).unwrap();
+        assert_eq!(decoded, val);
+    }
+
+    #[test]
+    fn u256_high_word_roundtrip() {
+        let val = U256::from_words(0, 12345);
+        let mut buf = vec![0u8; 40];
+        let written = write_u256_varint(&mut buf, val);
+        let (decoded, _) = read_u256_varint(&buf[..written]).unwrap();
+        assert_eq!(decoded, val);
+    }
+
+    #[test]
+    fn u256_varint_size_for_zero_is_one() {
+        assert_eq!(u256_varint_size(U256::from_words(0, 0)), 1);
+    }
+
+    #[test]
+    fn u256_varint_size_for_128_is_two() {
+        // 128 requires 8 bits, ceil(8/7) = 2 bytes
+        assert_eq!(u256_varint_size(U256::from_words(128, 0)), 2);
+    }
+
+    #[test]
+    fn u256_varint_size_matches_written_bytes() {
+        let val = U256::from_words(9999, 0);
+        let mut buf = vec![0u8; 40];
+        let written = write_u256_varint(&mut buf, val);
+        assert_eq!(written, u256_varint_size(val));
+    }
+
+    #[test]
+    fn read_u256_varint_returns_none_on_empty_buf() {
+        assert_eq!(read_u256_varint(&[]), None);
+    }
+
+    #[test]
+    fn multiple_scalars_roundtrip() {
+        let scalars = alloc::vec![
+            TestScalar::from(1u64),
+            TestScalar::from(100u64),
+            -TestScalar::from(5u64),
+            TestScalar::from(0u64),
+        ];
+        let total_size = scalar_varints_size(&scalars);
+        let mut buf = vec![0u8; total_size];
+        let written = write_scalar_varints(&mut buf, &scalars);
+        assert_eq!(written, total_size);
+        let mut decoded = vec![TestScalar::from(0u64); 4];
+        read_scalar_varints(&mut decoded, &buf).unwrap();
+        assert_eq!(decoded, scalars);
+    }
+
+    #[test]
+    fn scalar_varints_size_empty_is_zero() {
+        let empty: alloc::vec::Vec<TestScalar> = alloc::vec![];
+        assert_eq!(scalar_varints_size(&empty), 0);
+    }
+
+    #[test]
+    fn scalar_varints_size_single() {
+        let s = TestScalar::from(42u64);
+        let scalars = alloc::vec![s];
+        assert_eq!(scalar_varints_size(&scalars), scalar_varint_size(&s));
+    }
+
+    #[test]
+    fn scalar_varints_size_sum_of_individual() {
+        let scalars = alloc::vec![TestScalar::from(1u64), TestScalar::from(1000u64)];
+        let expected: usize = scalars.iter().map(scalar_varint_size).sum();
+        assert_eq!(scalar_varints_size(&scalars), expected);
+    }
+
+    #[test]
+    fn u256_roundtrip_full_128_bit_high() {
+        let val = U256::from_words(1, u128::MAX);
+        let mut buf = vec![0u8; 40];
+        let written = write_u256_varint(&mut buf, val);
+        let (decoded, _) = read_u256_varint(&buf[..written]).unwrap();
+        assert_eq!(decoded, val);
+    }
+}


### PR DESCRIPTION
Adds 25 unit tests for scalar_varint.rs covering write_scalar_varint/read_scalar_varint roundtrips, write_u256_varint/read_u256_varint roundtrips, scalar_varint_size, u256_varint_size, and batch encode/decode with write_scalar_varints/read_scalar_varints. Contributes to bounty #560.