### PR TITLE
test: add unit tests for U256 struct and scalar conversions

### DIFF
--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -35,3 +35,105 @@ impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
         MontScalar::<T>::from_le_bytes_mod_order(&bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::U256;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn from_words_sets_low_and_high() {
+        let u = U256::from_words(42, 99);
+        assert_eq!(u.low, 42);
+        assert_eq!(u.high, 99);
+    }
+
+    #[test]
+    fn from_words_zero_is_zero() {
+        let u = U256::from_words(0, 0);
+        assert_eq!(u.low, 0);
+        assert_eq!(u.high, 0);
+    }
+
+    #[test]
+    fn equality_same_words() {
+        let a = U256::from_words(1, 2);
+        let b = U256::from_words(1, 2);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn inequality_different_low() {
+        let a = U256::from_words(1, 0);
+        let b = U256::from_words(2, 0);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn inequality_different_high() {
+        let a = U256::from_words(0, 1);
+        let b = U256::from_words(0, 2);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn scalar_zero_converts_to_u256_zero() {
+        let scalar = TestScalar::from(0u64);
+        let u: U256 = (&scalar).into();
+        assert_eq!(u, U256::from_words(0, 0));
+    }
+
+    #[test]
+    fn scalar_one_converts_to_u256_one() {
+        let scalar = TestScalar::from(1u64);
+        let u: U256 = (&scalar).into();
+        assert_eq!(u.low, 1);
+        assert_eq!(u.high, 0);
+    }
+
+    #[test]
+    fn scalar_large_value_converts_to_u256() {
+        let scalar = TestScalar::from(u64::MAX);
+        let u: U256 = (&scalar).into();
+        // u64::MAX should be in the low 128 bits
+        assert_eq!(u.high, 0);
+        assert_eq!(u.low, u128::from(u64::MAX));
+    }
+
+    #[test]
+    fn u256_zero_converts_to_scalar_zero() {
+        let u = U256::from_words(0, 0);
+        let scalar: TestScalar = (&u).into();
+        assert_eq!(scalar, TestScalar::from(0u64));
+    }
+
+    #[test]
+    fn u256_one_converts_to_scalar_one() {
+        let u = U256::from_words(1, 0);
+        let scalar: TestScalar = (&u).into();
+        assert_eq!(scalar, TestScalar::from(1u64));
+    }
+
+    #[test]
+    fn scalar_to_u256_to_scalar_roundtrip_zero() {
+        let original = TestScalar::from(0u64);
+        let u: U256 = (&original).into();
+        let recovered: TestScalar = (&u).into();
+        assert_eq!(recovered, original);
+    }
+
+    #[test]
+    fn scalar_to_u256_to_scalar_roundtrip_small_positive() {
+        let original = TestScalar::from(42u64);
+        let u: U256 = (&original).into();
+        let recovered: TestScalar = (&u).into();
+        assert_eq!(recovered, original);
+    }
+
+    #[test]
+    fn u256_copy_is_identical() {
+        let u = U256::from_words(100, 200);
+        let v = u;
+        assert_eq!(u, v);
+    }
+}


### PR DESCRIPTION
Adds 13 unit tests for u256.rs covering U256::from_words, equality, and From conversions between U256 and MontScalar. Contributes to bounty #560.