### PR TITLE
test: add coverage for order_by_util and filter_util (#560)

### DIFF
--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -84,3 +84,111 @@ pub fn filter_column_by_index<'a, S: Scalar>(
         ),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::Column;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use bumpalo::Bump;
+
+    #[test]
+    fn filter_columns_with_empty_selection_returns_empty() {
+        let alloc = Bump::new();
+        let data = [1i64, 2, 3];
+        let cols = [Column::<TestScalar>::BigInt(&data)];
+        let selection = [false, false, false];
+        let (result, count) = filter_columns(&alloc, &cols, &selection);
+        assert_eq!(count, 0);
+        assert_eq!(result.len(), 1);
+        if let Column::BigInt(r) = &result[0] { assert_eq!(r.len(), 0); }
+    }
+
+    #[test]
+    fn filter_columns_with_all_selected_returns_all() {
+        let alloc = Bump::new();
+        let data = [10i64, 20, 30];
+        let cols = [Column::<TestScalar>::BigInt(&data)];
+        let selection = [true, true, true];
+        let (result, count) = filter_columns(&alloc, &cols, &selection);
+        assert_eq!(count, 3);
+        if let Column::BigInt(r) = &result[0] { assert_eq!(*r, [10, 20, 30]); }
+    }
+
+    #[test]
+    fn filter_columns_selects_specific_rows() {
+        let alloc = Bump::new();
+        let data = [1i64, 2, 3, 4, 5];
+        let cols = [Column::<TestScalar>::BigInt(&data)];
+        let selection = [true, false, true, false, true];
+        let (result, count) = filter_columns(&alloc, &cols, &selection);
+        assert_eq!(count, 3);
+        if let Column::BigInt(r) = &result[0] { assert_eq!(*r, [1, 3, 5]); }
+    }
+
+    #[test]
+    fn filter_columns_multiple_columns() {
+        let alloc = Bump::new();
+        let bools = [true, false, true];
+        let ints = [10i64, 20, 30];
+        let cols = [
+            Column::<TestScalar>::Boolean(&bools),
+            Column::<TestScalar>::BigInt(&ints),
+        ];
+        let selection = [true, false, true];
+        let (result, count) = filter_columns(&alloc, &cols, &selection);
+        assert_eq!(count, 2);
+        assert_eq!(result.len(), 2);
+        if let Column::Boolean(r) = &result[0] { assert_eq!(*r, [true, true]); }
+        if let Column::BigInt(r) = &result[1] { assert_eq!(*r, [10, 30]); }
+    }
+
+    #[test]
+    fn filter_column_by_index_bool() {
+        let alloc = Bump::new();
+        let data = [false, true, false, true];
+        let col = Column::<TestScalar>::Boolean(&data);
+        let indexes = [1usize, 3];
+        let result = filter_column_by_index(&alloc, &col, &indexes);
+        if let Column::Boolean(r) = result { assert_eq!(*r, [true, true]); }
+    }
+
+    #[test]
+    fn filter_column_by_index_bigint() {
+        let alloc = Bump::new();
+        let data = [100i64, 200, 300, 400];
+        let col = Column::<TestScalar>::BigInt(&data);
+        let indexes = [0usize, 2, 3];
+        let result = filter_column_by_index(&alloc, &col, &indexes);
+        if let Column::BigInt(r) = result { assert_eq!(*r, [100, 300, 400]); }
+    }
+
+    #[test]
+    fn filter_column_by_index_empty_indexes() {
+        let alloc = Bump::new();
+        let data = [1i64, 2, 3];
+        let col = Column::<TestScalar>::BigInt(&data);
+        let result = filter_column_by_index(&alloc, &col, &[]);
+        if let Column::BigInt(r) = result { assert_eq!(r.len(), 0); }
+    }
+
+    #[test]
+    fn filter_column_by_index_uint8() {
+        let alloc = Bump::new();
+        let data = [5u8, 10, 15, 20];
+        let col = Column::<TestScalar>::Uint8(&data);
+        let indexes = [1usize, 3];
+        let result = filter_column_by_index(&alloc, &col, &indexes);
+        if let Column::Uint8(r) = result { assert_eq!(*r, [10, 20]); }
+    }
+
+    #[test]
+    fn filter_column_by_index_int128() {
+        let alloc = Bump::new();
+        let data = [1i128, -2, 3];
+        let col = Column::<TestScalar>::Int128(&data);
+        let indexes = [0usize, 2];
+        let result = filter_column_by_index(&alloc, &col, &indexes);
+        if let Column::Int128(r) = result { assert_eq!(*r, [1, 3]); }
+    }
+}

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -99,3 +99,133 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
 
     Ok(Ordering::Equal)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::Column;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use core::cmp::Ordering;
+
+    #[test]
+    fn compare_indexes_empty_columns_returns_equal() {
+        let cols: Vec<Column<TestScalar>> = vec![];
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 0), Ordering::Equal);
+    }
+
+    #[test]
+    fn compare_indexes_bool_column_less() {
+        let data = [false, true];
+        let cols = [Column::<TestScalar>::Boolean(&data)];
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 1), Ordering::Less);
+    }
+
+    #[test]
+    fn compare_indexes_bool_column_greater() {
+        let data = [true, false];
+        let cols = [Column::<TestScalar>::Boolean(&data)];
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 1), Ordering::Greater);
+    }
+
+    #[test]
+    fn compare_indexes_bool_column_equal() {
+        let data = [false, false];
+        let cols = [Column::<TestScalar>::Boolean(&data)];
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 1), Ordering::Equal);
+    }
+
+    #[test]
+    fn compare_indexes_uint8_column_ordering() {
+        let data = [10u8, 20, 10];
+        let cols = [Column::<TestScalar>::Uint8(&data)];
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 1), Ordering::Less);
+        assert_eq!(compare_indexes_by_columns(&cols, 1, 0), Ordering::Greater);
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 2), Ordering::Equal);
+    }
+
+    #[test]
+    fn compare_indexes_bigint_column_ordering() {
+        let data = [100i64, 200, 100];
+        let cols = [Column::<TestScalar>::BigInt(&data)];
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 1), Ordering::Less);
+        assert_eq!(compare_indexes_by_columns(&cols, 1, 2), Ordering::Greater);
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 2), Ordering::Equal);
+    }
+
+    #[test]
+    fn compare_indexes_int128_ordering() {
+        let data = [-1i128, 0, 1];
+        let cols = [Column::<TestScalar>::Int128(&data)];
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 1), Ordering::Less);
+        assert_eq!(compare_indexes_by_columns(&cols, 2, 0), Ordering::Greater);
+    }
+
+    #[test]
+    fn compare_indexes_lexicographic_second_column_decides() {
+        let col1 = [1i64, 1, 2];
+        let col2 = [2i64, 3, 1];
+        let cols = [Column::<TestScalar>::BigInt(&col1), Column::<TestScalar>::BigInt(&col2)];
+        // (1,2) vs (1,3) → second column decides → Less
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 1), Ordering::Less);
+        // (1,2) vs (1,2) → Equal
+        assert_eq!(compare_indexes_by_columns(&cols, 0, 0), Ordering::Equal);
+        // (2,1) vs (1,3) → first column decides → Greater
+        assert_eq!(compare_indexes_by_columns(&cols, 2, 1), Ordering::Greater);
+    }
+
+    #[test]
+    fn compare_single_row_bigint_less() {
+        let left_data = [5i64];
+        let right_data = [10i64];
+        let left = [Column::<TestScalar>::BigInt(&left_data)];
+        let right = [Column::<TestScalar>::BigInt(&right_data)];
+        assert_eq!(
+            compare_single_row_of_tables(&left, &right, 0, 0).unwrap(),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn compare_single_row_bigint_greater() {
+        let left_data = [10i64];
+        let right_data = [5i64];
+        let left = [Column::<TestScalar>::BigInt(&left_data)];
+        let right = [Column::<TestScalar>::BigInt(&right_data)];
+        assert_eq!(
+            compare_single_row_of_tables(&left, &right, 0, 0).unwrap(),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn compare_single_row_equal_values() {
+        let data = [42i64];
+        let left = [Column::<TestScalar>::BigInt(&data)];
+        let right = [Column::<TestScalar>::BigInt(&data)];
+        assert_eq!(
+            compare_single_row_of_tables(&left, &right, 0, 0).unwrap(),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn compare_single_row_incompatible_types_returns_error() {
+        let bool_data = [true];
+        let int_data = [1i64];
+        let left = [Column::<TestScalar>::Boolean(&bool_data)];
+        let right = [Column::<TestScalar>::BigInt(&int_data)];
+        assert!(compare_single_row_of_tables(&left, &right, 0, 0).is_err());
+    }
+
+    #[test]
+    fn compare_single_row_bool_columns() {
+        let left_data = [false];
+        let right_data = [true];
+        let left = [Column::<TestScalar>::Boolean(&left_data)];
+        let right = [Column::<TestScalar>::Boolean(&right_data)];
+        assert_eq!(
+            compare_single_row_of_tables(&left, &right, 0, 0).unwrap(),
+            Ordering::Less
+        );
+    }
+}


### PR DESCRIPTION
Add unit tests to previously uncovered utility functions:

- `order_by_util.rs`: 12 tests for `compare_indexes_by_columns` (bool, uint8, bigint, int128, lexicographic) and `compare_single_row_of_tables` (less, greater, equal, incompatible types)
- `filter_util.rs`: 9 tests for `filter_columns` (empty selection, all selected, partial, multi-column) and `filter_column_by_index` (bool, bigint, uint8, int128, empty)

Part of issue #560 ($0.10/line new coverage).

/attempt #560