### PR TITLE
test: add coverage for bit_mask_utils and LiteralExpr (#560)

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_mask_utils.rs
@@ -19,3 +19,45 @@ pub fn make_bit_mask<S: ScalarExt>(x: S) -> U256 {
 pub fn is_bit_mask_negative_representation(bit_mask: U256) -> bool {
     bit_mask & MSB_MASK == U256::ZERO
 }
+
+#[cfg(test)]
+mod tests {
+    use super::is_bit_mask_negative_representation;
+    use bnum::types::U256;
+
+    fn msb_mask() -> U256 {
+        U256::ONE << 255u32
+    }
+
+    #[test]
+    fn zero_has_no_msb_so_is_negative_representation() {
+        assert!(is_bit_mask_negative_representation(U256::ZERO));
+    }
+
+    #[test]
+    fn one_has_no_msb_so_is_negative_representation() {
+        assert!(is_bit_mask_negative_representation(U256::ONE));
+    }
+
+    #[test]
+    fn msb_set_alone_is_not_negative_representation() {
+        assert!(!is_bit_mask_negative_representation(msb_mask()));
+    }
+
+    #[test]
+    fn max_u256_has_msb_set_so_not_negative_representation() {
+        assert!(!is_bit_mask_negative_representation(U256::MAX));
+    }
+
+    #[test]
+    fn msb_plus_lower_bits_is_not_negative_representation() {
+        let val = msb_mask() | U256::ONE;
+        assert!(!is_bit_mask_negative_representation(val));
+    }
+
+    #[test]
+    fn large_value_without_msb_is_negative_representation() {
+        let val = msb_mask() - U256::ONE;
+        assert!(is_bit_mask_negative_representation(val));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -92,3 +92,70 @@ impl ProofExpr for LiteralExpr {
 
     fn get_column_references(&self, _columns: &mut IndexSet<ColumnRef>) {}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::LiteralExpr;
+    use crate::base::database::{ColumnType, LiteralValue};
+
+    #[test]
+    fn new_boolean_literal_has_correct_value() {
+        let expr = LiteralExpr::new(LiteralValue::Boolean(true));
+        assert_eq!(expr.value(), &LiteralValue::Boolean(true));
+    }
+
+    #[test]
+    fn new_bigint_literal_has_correct_value() {
+        let expr = LiteralExpr::new(LiteralValue::BigInt(42));
+        assert_eq!(expr.value(), &LiteralValue::BigInt(42));
+    }
+
+    #[test]
+    fn boolean_literal_data_type_is_boolean() {
+        use crate::sql::proof_exprs::ProofExpr;
+        let expr = LiteralExpr::new(LiteralValue::Boolean(false));
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn bigint_literal_data_type_is_bigint() {
+        use crate::sql::proof_exprs::ProofExpr;
+        let expr = LiteralExpr::new(LiteralValue::BigInt(0));
+        assert_eq!(expr.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn int128_literal_data_type_is_int128() {
+        use crate::sql::proof_exprs::ProofExpr;
+        let expr = LiteralExpr::new(LiteralValue::Int128(i128::MAX));
+        assert_eq!(expr.data_type(), ColumnType::Int128);
+    }
+
+    #[test]
+    fn two_equal_literals_are_eq() {
+        let a = LiteralExpr::new(LiteralValue::Boolean(true));
+        let b = LiteralExpr::new(LiteralValue::Boolean(true));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn two_different_literals_are_not_eq() {
+        let a = LiteralExpr::new(LiteralValue::Boolean(true));
+        let b = LiteralExpr::new(LiteralValue::Boolean(false));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn literal_expr_clone_is_equal() {
+        let expr = LiteralExpr::new(LiteralValue::BigInt(99));
+        let cloned = expr.clone();
+        assert_eq!(expr, cloned);
+    }
+
+    #[test]
+    fn literal_expr_debug_contains_value() {
+        let expr = LiteralExpr::new(LiteralValue::BigInt(7));
+        let debug = format!("{:?}", expr);
+        assert!(debug.contains("LiteralExpr"));
+    }
+}


### PR DESCRIPTION
Add unit tests to previously uncovered functions:

- `base/bit/bit_mask_utils.rs`: 6 tests for `is_bit_mask_negative_representation` (zero, one, MSB set, MAX, MSB+lower bits, large without MSB)
- `sql/proof_exprs/literal_expr.rs`: 9 tests for `LiteralExpr::new`, `value()`, `data_type()` for boolean/bigint/int128, PartialEq, Clone, Debug

Part of issue #560 ($0.10/line new coverage).

/attempt #560