### PR TITLE
test: add coverage for ColumnExpr and AliasedDynProofExpr (#560)

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -10,3 +10,51 @@ pub struct AliasedDynProofExpr {
     /// The alias for the expression.
     pub alias: Ident,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AliasedDynProofExpr;
+    use crate::sql::proof_exprs::{DynProofExpr, LiteralExpr};
+    use crate::base::database::LiteralValue;
+    use sqlparser::ast::Ident;
+
+    fn make_aliased(alias: &str) -> AliasedDynProofExpr {
+        AliasedDynProofExpr {
+            expr: DynProofExpr::from(LiteralExpr::new(LiteralValue::Boolean(true))),
+            alias: Ident::new(alias),
+        }
+    }
+
+    #[test]
+    fn aliased_expr_stores_alias() {
+        let a = make_aliased("my_col");
+        assert_eq!(a.alias, Ident::new("my_col"));
+    }
+
+    #[test]
+    fn two_equal_aliased_exprs_are_eq() {
+        let a = make_aliased("col");
+        let b = make_aliased("col");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn two_different_aliases_are_not_eq() {
+        let a = make_aliased("col1");
+        let b = make_aliased("col2");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn clone_aliased_expr_is_equal() {
+        let a = make_aliased("test");
+        assert_eq!(a.clone(), a);
+    }
+
+    #[test]
+    fn debug_output_contains_struct_name() {
+        let a = make_aliased("debug_test");
+        let debug = format!("{:?}", a);
+        assert!(debug.contains("AliasedDynProofExpr"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -116,3 +116,92 @@ impl ProofExpr for ColumnExpr {
         columns.insert(self.column_ref.clone());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnExpr;
+    use crate::base::database::{ColumnRef, ColumnType, TableRef};
+    use crate::sql::proof_exprs::ProofExpr;
+    use sqlparser::ast::Ident;
+
+    fn make_col_ref(col: &str, col_type: ColumnType) -> ColumnRef {
+        ColumnRef::new(
+            TableRef::new(Ident::new("myschema"), Ident::new("mytable")),
+            Ident::new(col),
+            col_type,
+        )
+    }
+
+    #[test]
+    fn new_column_expr_stores_column_ref() {
+        let col_ref = make_col_ref("age", ColumnType::BigInt);
+        let expr = ColumnExpr::new(col_ref.clone());
+        assert_eq!(expr.get_column_reference(), col_ref);
+    }
+
+    #[test]
+    fn column_ref_getter_returns_reference() {
+        let col_ref = make_col_ref("name", ColumnType::Boolean);
+        let expr = ColumnExpr::new(col_ref.clone());
+        assert_eq!(expr.column_ref(), &col_ref);
+    }
+
+    #[test]
+    fn data_type_matches_column_type_bigint() {
+        let expr = ColumnExpr::new(make_col_ref("val", ColumnType::BigInt));
+        assert_eq!(expr.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn data_type_matches_column_type_boolean() {
+        let expr = ColumnExpr::new(make_col_ref("flag", ColumnType::Boolean));
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn data_type_matches_column_type_int128() {
+        let expr = ColumnExpr::new(make_col_ref("big", ColumnType::Int128));
+        assert_eq!(expr.data_type(), ColumnType::Int128);
+    }
+
+    #[test]
+    fn column_id_returns_column_identifier() {
+        let expr = ColumnExpr::new(make_col_ref("mycolumn", ColumnType::BigInt));
+        assert_eq!(expr.column_id(), Ident::new("mycolumn"));
+    }
+
+    #[test]
+    fn get_column_field_has_correct_name_and_type() {
+        let expr = ColumnExpr::new(make_col_ref("score", ColumnType::Int));
+        let field = expr.get_column_field();
+        assert_eq!(field.name(), Ident::new("score"));
+        assert_eq!(field.data_type(), ColumnType::Int);
+    }
+
+    #[test]
+    fn two_equal_column_exprs_are_eq() {
+        let expr_a = ColumnExpr::new(make_col_ref("x", ColumnType::BigInt));
+        let expr_b = ColumnExpr::new(make_col_ref("x", ColumnType::BigInt));
+        assert_eq!(expr_a, expr_b);
+    }
+
+    #[test]
+    fn two_different_column_exprs_are_not_eq() {
+        let expr_a = ColumnExpr::new(make_col_ref("x", ColumnType::BigInt));
+        let expr_b = ColumnExpr::new(make_col_ref("y", ColumnType::BigInt));
+        assert_ne!(expr_a, expr_b);
+    }
+
+    #[test]
+    fn column_expr_clone_equals_original() {
+        let expr = ColumnExpr::new(make_col_ref("foo", ColumnType::Boolean));
+        assert_eq!(expr.clone(), expr);
+    }
+
+    #[test]
+    fn column_expr_debug_output_contains_struct_name() {
+        let expr = ColumnExpr::new(make_col_ref("bar", ColumnType::BigInt));
+        let debug = format!("{:?}", expr);
+        assert!(debug.contains("ColumnExpr"));
+    }
+}


### PR DESCRIPTION
Add unit tests to previously uncovered proof expression types:

- `sql/proof_exprs/column_expr.rs`: 11 tests for `ColumnExpr::new`, `get_column_reference`, `column_ref`, `data_type` (BigInt/Boolean/Int128), `column_id`, `get_column_field`, `PartialEq`, `Clone`, `Debug`
- `sql/proof_exprs/aliased_dyn_proof_expr.rs`: 5 tests for struct field access, `PartialEq`, `Clone`, `Debug`

Part of issue #560 ($0.10/line new coverage).

/attempt #560