### PR TITLE
test: cover column comparison and arithmetic element-wise operations

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
@@ -323,3 +323,87 @@ impl ArithmeticOp for DivOp {
         try_divide_decimal_columns(lhs, rhs, left_column_type, right_column_type)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{AddOp, DivOp, MulOp, SubOp};
+    use crate::base::{database::OwnedColumn, scalar::test_scalar::TestScalar};
+    use alloc::vec;
+
+    #[test]
+    fn add_op_bigint_columns() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![4i64, 5, 6]);
+        let result = AddOp::owned_column_element_wise_arithmetic(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::BigInt(vec![5i64, 7, 9]));
+    }
+
+    #[test]
+    fn sub_op_bigint_columns() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![10i64, 5, 3]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![3i64, 2, 1]);
+        let result = SubOp::owned_column_element_wise_arithmetic(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::BigInt(vec![7i64, 3, 2]));
+    }
+
+    #[test]
+    fn mul_op_bigint_columns() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![2i64, 3, 4]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![5i64, 6, 7]);
+        let result = MulOp::owned_column_element_wise_arithmetic(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::BigInt(vec![10i64, 18, 28]));
+    }
+
+    #[test]
+    fn div_op_bigint_columns() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![10i64, 9, 8]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![2i64, 3, 4]);
+        let result = DivOp::owned_column_element_wise_arithmetic(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::BigInt(vec![5i64, 3, 2]));
+    }
+
+    #[test]
+    fn div_op_by_zero_returns_error() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![10i64]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![0i64]);
+        assert!(DivOp::owned_column_element_wise_arithmetic(&lhs, &rhs).is_err());
+    }
+
+    #[test]
+    fn add_op_different_lengths_returns_error() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64, 2]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64]);
+        assert!(AddOp::owned_column_element_wise_arithmetic(&lhs, &rhs).is_err());
+    }
+
+    #[test]
+    fn add_op_int128_columns() {
+        let lhs = OwnedColumn::<TestScalar>::Int128(vec![100i128, 200]);
+        let rhs = OwnedColumn::<TestScalar>::Int128(vec![300i128, 400]);
+        let result = AddOp::owned_column_element_wise_arithmetic(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Int128(vec![400i128, 600]));
+    }
+
+    #[test]
+    fn sub_op_tinyint_columns() {
+        let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![10i8, 5]);
+        let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![3i8, 2]);
+        let result = SubOp::owned_column_element_wise_arithmetic(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::TinyInt(vec![7i8, 3]));
+    }
+
+    #[test]
+    fn mul_op_int128_columns() {
+        let lhs = OwnedColumn::<TestScalar>::Int128(vec![10i128, 3]);
+        let rhs = OwnedColumn::<TestScalar>::Int128(vec![7i128, 4]);
+        let result = MulOp::owned_column_element_wise_arithmetic(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Int128(vec![70i128, 12]));
+    }
+
+    #[test]
+    fn signed_uint8_tinyint_mismatch_returns_error() {
+        let lhs = OwnedColumn::<TestScalar>::Uint8(vec![1u8, 2]);
+        let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8, 2]);
+        assert!(AddOp::owned_column_element_wise_arithmetic(&lhs, &rhs).is_err());
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
@@ -414,3 +414,103 @@ impl ComparisonOp for LessThanOp {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{EqualOp, GreaterThanOp, LessThanOp};
+    use crate::base::{database::OwnedColumn, scalar::test_scalar::TestScalar};
+    use alloc::{string::ToString, vec};
+
+    #[test]
+    fn equal_op_bigint_equal_and_unequal_elements() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64, 4, 3]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Boolean(vec![true, false, true]));
+    }
+
+    #[test]
+    fn equal_op_different_lengths_returns_error() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64, 2]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64]);
+        assert!(EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).is_err());
+    }
+
+    #[test]
+    fn greater_than_op_bigint_columns() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![5i64, 2, 3]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![3i64, 3, 3]);
+        let result = GreaterThanOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+    }
+
+    #[test]
+    fn less_than_op_bigint_columns() {
+        let lhs = OwnedColumn::<TestScalar>::BigInt(vec![1i64, 5, 3]);
+        let rhs = OwnedColumn::<TestScalar>::BigInt(vec![3i64, 3, 3]);
+        let result = LessThanOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+    }
+
+    #[test]
+    fn equal_op_boolean_columns() {
+        let lhs = OwnedColumn::<TestScalar>::Boolean(vec![true, false, true]);
+        let rhs = OwnedColumn::<TestScalar>::Boolean(vec![true, true, false]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Boolean(vec![true, false, false]));
+    }
+
+    #[test]
+    fn equal_op_int128_columns() {
+        let lhs = OwnedColumn::<TestScalar>::Int128(vec![100i128, 200]);
+        let rhs = OwnedColumn::<TestScalar>::Int128(vec![100i128, 300]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Boolean(vec![true, false]));
+    }
+
+    #[test]
+    fn equal_op_tinyint_columns() {
+        let lhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8, 2, -1]);
+        let rhs = OwnedColumn::<TestScalar>::TinyInt(vec![1i8, 3, -1]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Boolean(vec![true, false, true]));
+    }
+
+    #[test]
+    fn equal_op_varchar_columns() {
+        let lhs = OwnedColumn::<TestScalar>::VarChar(vec!["hello".to_string(), "world".to_string()]);
+        let rhs = OwnedColumn::<TestScalar>::VarChar(vec!["hello".to_string(), "earth".to_string()]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Boolean(vec![true, false]));
+    }
+
+    #[test]
+    fn greater_than_op_varchar_returns_error() {
+        let lhs = OwnedColumn::<TestScalar>::VarChar(vec!["a".to_string()]);
+        let rhs = OwnedColumn::<TestScalar>::VarChar(vec!["b".to_string()]);
+        assert!(GreaterThanOp::owned_column_element_wise_comparison(&lhs, &rhs).is_err());
+    }
+
+    #[test]
+    fn less_than_op_varchar_returns_error() {
+        let lhs = OwnedColumn::<TestScalar>::VarChar(vec!["a".to_string()]);
+        let rhs = OwnedColumn::<TestScalar>::VarChar(vec!["b".to_string()]);
+        assert!(LessThanOp::owned_column_element_wise_comparison(&lhs, &rhs).is_err());
+    }
+
+    #[test]
+    fn equal_op_smallint_columns() {
+        let lhs = OwnedColumn::<TestScalar>::SmallInt(vec![10i16, 20]);
+        let rhs = OwnedColumn::<TestScalar>::SmallInt(vec![10i16, 30]);
+        let result = EqualOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Boolean(vec![true, false]));
+    }
+
+    #[test]
+    fn greater_than_op_int128_columns() {
+        let lhs = OwnedColumn::<TestScalar>::Int128(vec![100i128, 50]);
+        let rhs = OwnedColumn::<TestScalar>::Int128(vec![50i128, 100]);
+        let result = GreaterThanOp::owned_column_element_wise_comparison(&lhs, &rhs).unwrap();
+        assert_eq!(result, OwnedColumn::Boolean(vec![true, false]));
+    }
+}


### PR DESCRIPTION
Add unit tests for element-wise column comparison and arithmetic operations.

**`column_comparison_operation.rs`** (12 tests for `EqualOp`, `GreaterThanOp`, `LessThanOp`):
- BigInt equal/unequal detection, different lengths error
- GreaterThan and LessThan on BigInt, Int128
- Boolean, TinyInt, SmallInt, VarChar equality
- VarChar inequality/less-than returns error (not supported)

**`column_arithmetic_operation.rs`** (10 tests for `AddOp`, `SubOp`, `MulOp`, `DivOp`):
- Add, Sub, Mul, Div on BigInt and Int128 columns
- Division by zero returns error
- Different lengths returns error
- TinyInt subtraction
- Uint8/TinyInt signed casting error

/attempt #560