### PR TITLE
test: add display coverage for AnalyzeError and PlannerError

### DIFF
--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -105,3 +105,86 @@ pub enum PlannerError {
 
 /// Proof of SQL Planner result
 pub type PlannerResult<T> = Result<T, PlannerError>;
+
+#[cfg(test)]
+mod tests {
+    use super::PlannerError;
+    use arrow::datatypes::DataType;
+    use datafusion::logical_expr::Operator;
+
+    #[test]
+    fn column_not_found_displays_correctly() {
+        assert_eq!(PlannerError::ColumnNotFound.to_string(), "Column not found");
+    }
+
+    #[test]
+    fn table_not_found_displays_table_name() {
+        let err = PlannerError::TableNotFound {
+            table_name: "my_table".to_string(),
+        };
+        assert_eq!(err.to_string(), "Table not found: my_table");
+    }
+
+    #[test]
+    fn invalid_placeholder_id_displays_id_in_message() {
+        let err = PlannerError::InvalidPlaceholderId { id: "$abc".to_string() };
+        let msg = err.to_string();
+        assert!(msg.contains("$abc"), "expected id in: {msg}");
+        assert!(msg.contains("invalid"), "expected 'invalid' in: {msg}");
+    }
+
+    #[test]
+    fn unsupported_data_type_displays_type_name() {
+        let err = PlannerError::UnsupportedDataType { data_type: DataType::Boolean };
+        let msg = err.to_string();
+        assert!(msg.contains("Unsupported"), "expected Unsupported in: {msg}");
+    }
+
+    #[test]
+    fn unsupported_binary_operator_displays_not_supported() {
+        let err = PlannerError::UnsupportedBinaryOperator { op: Operator::Plus };
+        let msg = err.to_string();
+        assert!(msg.contains("not supported"), "expected 'not supported' in: {msg}");
+    }
+
+    #[test]
+    fn catalog_not_supported_displays_correctly() {
+        assert_eq!(
+            PlannerError::CatalogNotSupported.to_string(),
+            "Catalog is not supported"
+        );
+    }
+
+    #[test]
+    fn unresolved_logical_plan_displays_correctly() {
+        assert_eq!(
+            PlannerError::UnresolvedLogicalPlan.to_string(),
+            "LogicalPlan is not resolved"
+        );
+    }
+
+    #[test]
+    fn planner_error_debug_includes_variant_name() {
+        let debug = format!("{:?}", PlannerError::ColumnNotFound);
+        assert!(debug.contains("ColumnNotFound"));
+    }
+
+    #[test]
+    fn table_not_found_with_schema_qualified_name() {
+        let err = PlannerError::TableNotFound {
+            table_name: "public.users".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("public.users"), "expected table name in: {msg}");
+        assert!(msg.contains("Table not found"), "expected prefix in: {msg}");
+    }
+
+    #[test]
+    fn column_not_found_and_catalog_not_supported_are_not_equal() {
+        // PlannerError does not derive PartialEq but we test debug output differs
+        assert_ne!(
+            format!("{:?}", PlannerError::ColumnNotFound),
+            format!("{:?}", PlannerError::CatalogNotSupported)
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,82 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::AnalyzeError;
+    use crate::base::database::ColumnType;
+    use alloc::string::ToString;
+
+    #[test]
+    fn invalid_data_type_displays_expr_type() {
+        let err = AnalyzeError::InvalidDataType { expr_type: ColumnType::BigInt };
+        let msg = err.to_string();
+        assert!(msg.contains("BigInt"), "expected BigInt in: {msg}");
+        assert!(msg.contains("not valid"), "expected 'not valid' in: {msg}");
+    }
+
+    #[test]
+    fn data_type_mismatch_displays_both_sides() {
+        let err = AnalyzeError::DataTypeMismatch {
+            left_type: "BigInt".to_string(),
+            right_type: "Boolean".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("BigInt"), "expected BigInt in: {msg}");
+        assert!(msg.contains("Boolean"), "expected Boolean in: {msg}");
+    }
+
+    #[test]
+    fn different_column_length_displays_both_lengths() {
+        let err = AnalyzeError::DifferentColumnLength { len_a: 3, len_b: 7 };
+        assert_eq!(err.to_string(), "Columns have different lengths: 3 != 7");
+    }
+
+    #[test]
+    fn not_enough_input_plans_displays_correctly() {
+        assert_eq!(
+            AnalyzeError::NotEnoughInputPlans.to_string(),
+            "Not enough input plans"
+        );
+    }
+
+    #[test]
+    fn analyze_error_converts_to_string_via_from_impl() {
+        let err = AnalyzeError::NotEnoughInputPlans;
+        let s: alloc::string::String = err.into();
+        assert_eq!(s, "Not enough input plans");
+    }
+
+    #[test]
+    fn analyze_error_implements_partial_eq() {
+        assert_eq!(AnalyzeError::NotEnoughInputPlans, AnalyzeError::NotEnoughInputPlans);
+        assert_ne!(
+            AnalyzeError::NotEnoughInputPlans,
+            AnalyzeError::DifferentColumnLength { len_a: 1, len_b: 2 }
+        );
+    }
+
+    #[test]
+    fn analyze_error_debug_includes_variant_name() {
+        let debug = format!("{:?}", AnalyzeError::NotEnoughInputPlans);
+        assert!(debug.contains("NotEnoughInputPlans"));
+    }
+
+    #[test]
+    fn invalid_data_type_with_boolean_contains_boolean() {
+        let err = AnalyzeError::InvalidDataType { expr_type: ColumnType::Boolean };
+        let msg = err.to_string();
+        assert!(msg.contains("Boolean"), "expected Boolean in: {msg}");
+    }
+
+    #[test]
+    fn data_type_mismatch_different_column_length_are_not_equal() {
+        let mismatch = AnalyzeError::DataTypeMismatch {
+            left_type: "Int".to_string(),
+            right_type: "BigInt".to_string(),
+        };
+        let length = AnalyzeError::DifferentColumnLength { len_a: 5, len_b: 10 };
+        assert_ne!(mismatch, length);
+    }
+}


### PR DESCRIPTION
/attempt #560

Add unit tests for all error display variants in two previously-untested files:

- `crates/proof-of-sql/src/sql/error.rs` — `AnalyzeError` (9 tests):
  - `InvalidDataType`, `DataTypeMismatch`, `DifferentColumnLength`, `NotEnoughInputPlans`
  - `From<AnalyzeError> for String` impl
  - `PartialEq` and `Debug` impls

- `crates/proof-of-sql-planner/src/error.rs` — `PlannerError` (10 tests):
  - `ColumnNotFound`, `TableNotFound`, `InvalidPlaceholderId`
  - `UnsupportedDataType`, `UnsupportedBinaryOperator`
  - `CatalogNotSupported`, `UnresolvedLogicalPlan`, `Debug` output

Total: 19 new tests across 2 files with 0 prior test coverage.