### PR TITLE
test: add display and conversion coverage for QueryError

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,87 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::QueryError;
+    use crate::base::{
+        database::{ColumnCoercionError, TableCoercionError},
+        proof::ProofError,
+    };
+
+    #[test]
+    fn overflow_display() {
+        let e = QueryError::Overflow;
+        assert_eq!(alloc::format!("{e}"), "Overflow error");
+    }
+
+    #[test]
+    fn invalid_string_display() {
+        let e = QueryError::InvalidString;
+        assert_eq!(alloc::format!("{e}"), "String decode error");
+    }
+
+    #[test]
+    fn miscellaneous_decoding_error_display() {
+        let e = QueryError::MiscellaneousDecodingError;
+        assert_eq!(alloc::format!("{e}"), "Miscellaneous decoding error");
+    }
+
+    #[test]
+    fn miscellaneous_evaluation_error_display() {
+        let e = QueryError::MiscellaneousEvaluationError;
+        assert_eq!(alloc::format!("{e}"), "Miscellaneous evaluation error");
+    }
+
+    #[test]
+    fn invalid_column_count_display() {
+        let e = QueryError::InvalidColumnCount;
+        assert_eq!(alloc::format!("{e}"), "Invalid number of columns");
+    }
+
+    #[test]
+    fn debug_overflow_contains_variant_name() {
+        let e = QueryError::Overflow;
+        assert!(alloc::format!("{e:?}").contains("Overflow"));
+    }
+
+    #[test]
+    fn from_table_coercion_overflow_produces_query_overflow() {
+        let tc = TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::Overflow,
+        };
+        let qe: QueryError = tc.into();
+        assert!(matches!(qe, QueryError::Overflow));
+    }
+
+    #[test]
+    fn from_table_coercion_invalid_type_produces_proof_error() {
+        let tc = TableCoercionError::ColumnCoercionError {
+            source: ColumnCoercionError::InvalidTypeCoercion,
+        };
+        let qe: QueryError = tc.into();
+        assert!(matches!(qe, QueryError::ProofError { .. }));
+    }
+
+    #[test]
+    fn from_table_coercion_name_mismatch_produces_proof_error() {
+        let tc = TableCoercionError::NameMismatch;
+        let qe: QueryError = tc.into();
+        assert!(matches!(qe, QueryError::ProofError { .. }));
+    }
+
+    #[test]
+    fn from_table_coercion_count_mismatch_produces_proof_error() {
+        let tc = TableCoercionError::ColumnCountMismatch;
+        let qe: QueryError = tc.into();
+        assert!(matches!(qe, QueryError::ProofError { .. }));
+    }
+
+    #[test]
+    fn from_proof_error_transparent() {
+        let pe = ProofError::InvalidTypeCoercion;
+        let qe: QueryError = pe.into();
+        assert!(matches!(qe, QueryError::ProofError { .. }));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -184,3 +184,83 @@ impl DynProofPlan {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DynProofPlan;
+    use crate::{
+        base::database::{ColumnField, ColumnType, TableRef},
+        sql::proof::ProofPlan,
+    };
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn new_empty_creates_empty_variant() {
+        let plan = DynProofPlan::new_empty();
+        assert!(matches!(plan, DynProofPlan::Empty(_)));
+    }
+
+    #[test]
+    fn new_empty_get_column_result_fields_is_empty() {
+        let plan = DynProofPlan::new_empty();
+        assert!(plan.get_column_result_fields().is_empty());
+    }
+
+    #[test]
+    fn new_empty_get_column_references_is_empty() {
+        let plan = DynProofPlan::new_empty();
+        assert!(plan.get_column_references().is_empty());
+    }
+
+    #[test]
+    fn new_empty_get_table_references_is_empty() {
+        let plan = DynProofPlan::new_empty();
+        assert!(plan.get_table_references().is_empty());
+    }
+
+    #[test]
+    fn new_empty_equality() {
+        assert_eq!(DynProofPlan::new_empty(), DynProofPlan::new_empty());
+    }
+
+    #[test]
+    fn new_empty_clone_equals_original() {
+        let plan = DynProofPlan::new_empty();
+        assert_eq!(plan.clone(), plan);
+    }
+
+    #[test]
+    fn new_empty_debug_contains_variant() {
+        let plan = DynProofPlan::new_empty();
+        assert!(alloc::format!("{plan:?}").contains("Empty") || alloc::format!("{plan:?}").contains("EmptyExec"));
+    }
+
+    #[test]
+    fn new_table_creates_table_variant() {
+        let tref = TableRef::new("s", "t");
+        let schema = alloc::vec![ColumnField::new(Ident::new("col"), ColumnType::BigInt)];
+        let plan = DynProofPlan::new_table(tref, schema);
+        assert!(matches!(plan, DynProofPlan::Table(_)));
+    }
+
+    #[test]
+    fn new_table_with_no_columns_creates_table_variant() {
+        let tref = TableRef::new("", "t");
+        let plan = DynProofPlan::new_table(tref, alloc::vec![]);
+        assert!(matches!(plan, DynProofPlan::Table(_)));
+    }
+
+    #[test]
+    fn new_slice_creates_slice_variant() {
+        let input = DynProofPlan::new_empty();
+        let plan = DynProofPlan::new_slice(input, 0, None);
+        assert!(matches!(plan, DynProofPlan::Slice(_)));
+    }
+
+    #[test]
+    fn new_slice_with_fetch_creates_slice_variant() {
+        let input = DynProofPlan::new_empty();
+        let plan = DynProofPlan::new_slice(input, 5, Some(10));
+        assert!(matches!(plan, DynProofPlan::Slice(_)));
+    }
+}


### PR DESCRIPTION
/attempt #560

Add unit tests for `crates/proof-of-sql/src/sql/proof/query_result.rs` which had 0 prior test coverage.

`QueryError` (10 tests):
- Display assertions for all simple variants: `Overflow`, `InvalidString`, `MiscellaneousDecodingError`, `MiscellaneousEvaluationError`, `InvalidColumnCount`
- `Debug` output verification
- `From<TableCoercionError>` conversion for all 4 mapping cases (`Overflow`, `NameMismatch`, `ColumnCountMismatch`, `InvalidTypeCoercion`)