### PR TITLE
test: coverage for DoryPublicSetup, TableExpr, limbs serialization, Curve25519Scalar×RistrettoPoint

### DIFF
--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,70 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{deserialize_to_limbs, serialize_limbs};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct LimbsWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn roundtrip_preserves_all_limb_values() {
+        let w = LimbsWrapper { limbs: [1, 2, 3, 4] };
+        let json = serde_json::to_string(&w).unwrap();
+        let back: LimbsWrapper = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, w);
+    }
+
+    #[test]
+    fn serialize_reverses_limb_order() {
+        let w = LimbsWrapper { limbs: [1, 2, 3, 4] };
+        let json = serde_json::to_string(&w).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = v["limbs"].as_array().unwrap();
+        assert_eq!(arr[0].as_u64().unwrap(), 4);
+        assert_eq!(arr[1].as_u64().unwrap(), 3);
+        assert_eq!(arr[2].as_u64().unwrap(), 2);
+        assert_eq!(arr[3].as_u64().unwrap(), 1);
+    }
+
+    #[test]
+    fn roundtrip_with_all_zeros() {
+        let w = LimbsWrapper { limbs: [0, 0, 0, 0] };
+        let json = serde_json::to_string(&w).unwrap();
+        let back: LimbsWrapper = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, w);
+    }
+
+    #[test]
+    fn roundtrip_with_max_values() {
+        let w = LimbsWrapper { limbs: [u64::MAX, u64::MAX, u64::MAX, u64::MAX] };
+        let json = serde_json::to_string(&w).unwrap();
+        let back: LimbsWrapper = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, w);
+    }
+
+    #[test]
+    fn deserialize_reverses_encoded_order() {
+        // Wire format: [4,3,2,1] → decoded limbs: [1,2,3,4]
+        let json = r#"{"limbs":[4,3,2,1]}"#;
+        let back: LimbsWrapper = serde_json::from_str(json).unwrap();
+        assert_eq!(back.limbs, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn roundtrip_with_distinct_values_per_limb() {
+        let w = LimbsWrapper { limbs: [0xAABB_CCDD_0011_2233, 0x4455_6677_8899_AABB, 0xCCDD_EEFF_0102_0304, 0x0506_0708_090A_0B0C] };
+        let json = serde_json::to_string(&w).unwrap();
+        let back: LimbsWrapper = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, w);
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
@@ -57,3 +57,71 @@ impl<'a> DoryVerifierPublicSetup<'a> {
         self.verifier_setup
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{DoryProverPublicSetup, DoryVerifierPublicSetup};
+    use crate::proof_primitive::dory::{test_params_nu_4, test_verifier_setup_nu_4, ProverSetup};
+
+    #[test]
+    fn dory_verifier_setup_sigma_returns_configured_value() {
+        let vs = test_verifier_setup_nu_4();
+        let setup = DoryVerifierPublicSetup::new(vs, 3);
+        assert_eq!(setup.sigma(), 3);
+    }
+
+    #[test]
+    fn dory_verifier_setup_sigma_zero() {
+        let vs = test_verifier_setup_nu_4();
+        let setup = DoryVerifierPublicSetup::new(vs, 0);
+        assert_eq!(setup.sigma(), 0);
+    }
+
+    #[test]
+    fn dory_verifier_setup_returns_same_setup_reference() {
+        let vs = test_verifier_setup_nu_4();
+        let setup = DoryVerifierPublicSetup::new(vs, 2);
+        assert!(core::ptr::eq(setup.verifier_setup(), vs));
+    }
+
+    #[test]
+    fn dory_verifier_setup_is_copy() {
+        let vs = test_verifier_setup_nu_4();
+        let setup = DoryVerifierPublicSetup::new(vs, 5);
+        let copied = setup;
+        assert_eq!(copied.sigma(), 5);
+    }
+
+    #[test]
+    fn dory_prover_setup_sigma_returns_configured_value() {
+        let pp = test_params_nu_4();
+        let prover_setup = ProverSetup::from(pp);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 4);
+        assert_eq!(setup.sigma(), 4);
+    }
+
+    #[test]
+    fn dory_prover_setup_sigma_zero() {
+        let pp = test_params_nu_4();
+        let prover_setup = ProverSetup::from(pp);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 0);
+        assert_eq!(setup.sigma(), 0);
+    }
+
+    #[test]
+    fn dory_prover_setup_returns_same_prover_setup_reference() {
+        let pp = test_params_nu_4();
+        let prover_setup = ProverSetup::from(pp);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+        assert!(core::ptr::eq(setup.prover_setup(), &prover_setup));
+    }
+
+    #[test]
+    fn dory_prover_setup_is_copy() {
+        let pp = test_params_nu_4();
+        let prover_setup = ProverSetup::from(pp);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 7);
+        let copied = setup;
+        assert_eq!(copied.sigma(), 7);
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_scalar.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_scalar.rs
@@ -50,3 +50,94 @@ impl core::ops::Mul<Curve25519Scalar> for &curve25519_dalek::ristretto::Ristrett
         self * curve25519_dalek::scalar::Scalar::from(rhs)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Curve25519Scalar;
+    use crate::base::scalar::Scalar;
+    use curve25519_dalek::{
+        constants::RISTRETTO_BASEPOINT_POINT,
+        scalar::Scalar as DalekScalar,
+    };
+
+    #[test]
+    fn scalar_mul_ristretto_point_zero_gives_identity() {
+        let s = Curve25519Scalar::ZERO;
+        let g = RISTRETTO_BASEPOINT_POINT;
+        let result = s * g;
+        let expected = DalekScalar::ZERO * g;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn scalar_mul_ristretto_ref_zero_gives_identity() {
+        let s = Curve25519Scalar::ZERO;
+        let g = RISTRETTO_BASEPOINT_POINT;
+        let result = s * &g;
+        let expected = DalekScalar::ZERO * g;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn ristretto_point_mul_scalar_zero_gives_identity() {
+        let s = Curve25519Scalar::ZERO;
+        let g = RISTRETTO_BASEPOINT_POINT;
+        let result = g * s;
+        let expected = g * DalekScalar::ZERO;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn ristretto_point_ref_mul_scalar_zero_gives_identity() {
+        let s = Curve25519Scalar::ZERO;
+        let g = RISTRETTO_BASEPOINT_POINT;
+        let result = &g * s;
+        let expected = &g * DalekScalar::ZERO;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn scalar_mul_ristretto_point_one_gives_base_point() {
+        let s = Curve25519Scalar::ONE;
+        let g = RISTRETTO_BASEPOINT_POINT;
+        let result = s * g;
+        assert_eq!(result, g);
+    }
+
+    #[test]
+    fn scalar_mul_ristretto_ref_one_gives_base_point() {
+        let s = Curve25519Scalar::ONE;
+        let g = RISTRETTO_BASEPOINT_POINT;
+        let result = s * &g;
+        assert_eq!(result, g);
+    }
+
+    #[test]
+    fn ristretto_point_mul_scalar_one_gives_base_point() {
+        let s = Curve25519Scalar::ONE;
+        let g = RISTRETTO_BASEPOINT_POINT;
+        let result = g * s;
+        assert_eq!(result, g);
+    }
+
+    #[test]
+    fn ristretto_point_ref_mul_scalar_one_gives_base_point() {
+        let s = Curve25519Scalar::ONE;
+        let g = RISTRETTO_BASEPOINT_POINT;
+        let result = &g * s;
+        assert_eq!(result, g);
+    }
+
+    #[test]
+    fn all_four_mul_impls_are_consistent() {
+        let s = Curve25519Scalar::from(7u64);
+        let g = RISTRETTO_BASEPOINT_POINT;
+        let r1 = s * g;
+        let r2 = s * &g;
+        let r3 = g * s;
+        let r4 = &g * s;
+        assert_eq!(r1, r2);
+        assert_eq!(r2, r3);
+        assert_eq!(r3, r4);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -7,3 +7,45 @@ pub struct TableExpr {
     /// The `TableRef` for the table
     pub table_ref: TableRef,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableExpr;
+    use crate::base::database::TableRef;
+
+    #[test]
+    fn table_expr_construction_stores_table_ref() {
+        let table_ref = TableRef::new("my_schema", "my_table");
+        let expr = TableExpr { table_ref: table_ref.clone() };
+        assert_eq!(expr.table_ref, table_ref);
+    }
+
+    #[test]
+    fn table_expr_implements_partial_eq_equal() {
+        let tr = TableRef::new("schema", "table");
+        let a = TableExpr { table_ref: tr.clone() };
+        let b = TableExpr { table_ref: tr };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn table_expr_implements_partial_eq_not_equal() {
+        let a = TableExpr { table_ref: TableRef::new("schema", "table_a") };
+        let b = TableExpr { table_ref: TableRef::new("schema", "table_b") };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn table_expr_debug_output_contains_struct_name() {
+        let expr = TableExpr { table_ref: TableRef::new("s", "t") };
+        let debug = format!("{:?}", expr);
+        assert!(debug.contains("TableExpr"));
+    }
+
+    #[test]
+    fn table_expr_clone_equals_original() {
+        let expr = TableExpr { table_ref: TableRef::new("schema", "table") };
+        let cloned = expr.clone();
+        assert_eq!(expr, cloned);
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit tests to four files that had no existing test coverage:

### `dory_public_setup.rs` — 8 tests
- `DoryProverPublicSetup::new` + `sigma()` + `prover_setup()` getters
- `DoryVerifierPublicSetup::new` + `sigma()` + `verifier_setup()` getters
- Copy semantics verified

### `table_expr.rs` — 5 tests
- `TableExpr` construction, `PartialEq`, `Debug`, `Clone`

### `standard_serializations/limbs.rs` — 6 tests
- `serialize_limbs` reverses limb order on the wire
- `deserialize_to_limbs` inverts the reversal
- Roundtrip identity across JSON for various values

### `inner_product/curve_25519_scalar.rs` — 9 tests
- All four `Mul` implementations between `Curve25519Scalar` and `RistrettoPoint`/`&RistrettoPoint`
- Tests with scalar zero (identity result) and scalar one (base point result)
- Cross-impl consistency check

/attempt #560
/claim #560
