### PR TITLE
test: coverage for RefInto blanket impl and SumcheckTermOptimizer

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,72 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+
+    struct Wrapper(i32);
+
+    impl<'a> From<&'a Wrapper> for i64 {
+        fn from(w: &'a Wrapper) -> i64 {
+            i64::from(w.0)
+        }
+    }
+
+    impl<'a> From<&'a Wrapper> for i128 {
+        fn from(w: &'a Wrapper) -> i128 {
+            i128::from(w.0)
+        }
+    }
+
+    #[test]
+    fn ref_into_delegates_to_from_impl() {
+        let w = Wrapper(42);
+        let result: i64 = w.ref_into();
+        assert_eq!(result, 42i64);
+    }
+
+    #[test]
+    fn ref_into_works_with_negative_value() {
+        let w = Wrapper(-100);
+        let result: i64 = w.ref_into();
+        assert_eq!(result, -100i64);
+    }
+
+    #[test]
+    fn ref_into_does_not_consume_the_value() {
+        let w = Wrapper(7);
+        let r1: i64 = w.ref_into();
+        let r2: i64 = w.ref_into();
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn ref_into_zero_value() {
+        let w = Wrapper(0);
+        let result: i64 = w.ref_into();
+        assert_eq!(result, 0i64);
+    }
+
+    #[test]
+    fn ref_into_works_with_different_target_type() {
+        let w = Wrapper(99);
+        let result: i128 = w.ref_into();
+        assert_eq!(result, 99i128);
+    }
+
+    #[test]
+    fn ref_into_preserves_max_i32() {
+        let w = Wrapper(i32::MAX);
+        let result: i64 = w.ref_into();
+        assert_eq!(result, i64::from(i32::MAX));
+    }
+
+    #[test]
+    fn ref_into_preserves_min_i32() {
+        let w = Wrapper(i32::MIN);
+        let result: i64 = w.ref_into();
+        assert_eq!(result, i64::from(i32::MIN));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
@@ -141,3 +141,45 @@ impl<'a, S: Scalar + 'a> IntoIterator for &'a OptimizedSumcheckTerms<'a, S> {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{OptimizedSumcheckTerms, SumcheckTermOptimizer};
+    use crate::sql::proof::SumcheckSubpolynomialType;
+
+    #[test]
+    fn optimizer_with_empty_terms_produces_no_iterations() {
+        let optimizer =
+            SumcheckTermOptimizer::<crate::base::scalar::test_scalar::TestScalar>::new(
+                core::iter::empty(),
+                4,
+            );
+        let terms = optimizer.terms();
+        let count = (&terms).into_iter().count();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn zero_sum_and_identity_subpolynomial_types_are_distinct() {
+        assert_ne!(
+            SumcheckSubpolynomialType::ZeroSum,
+            SumcheckSubpolynomialType::Identity
+        );
+    }
+
+    #[test]
+    fn zero_sum_type_equals_itself() {
+        assert_eq!(
+            SumcheckSubpolynomialType::ZeroSum,
+            SumcheckSubpolynomialType::ZeroSum
+        );
+    }
+
+    #[test]
+    fn identity_type_equals_itself() {
+        assert_eq!(
+            SumcheckSubpolynomialType::Identity,
+            SumcheckSubpolynomialType::Identity
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit tests to two files with no prior coverage:

### `base/ref_into.rs` — 7 tests
- Verifies the `RefInto<T>` blanket implementation delegates to `&S: Into<T>`
- Tests zero, negative, max/min i32, multiple target types
- Verifies the method does not consume the value (callable multiple times)

### `sql/proof/sumcheck_term_optimizer.rs` — 4 tests
- Empty term iterator produces zero optimized terms
- `SumcheckSubpolynomialType` equality reflexivity (ZeroSum == ZeroSum, Identity == Identity)
- Inequality between the two subpolynomial type variants

/attempt #560
/claim #560
