### PR TITLE
test: coverage for OrExpr and EqualsExpr constructors and accessors (#560)

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -213,3 +213,76 @@ pub fn verifier_evaluate_equals_zero<S: Scalar>(
 
     Ok(selection_eval)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EqualsExpr;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, ProofExpr},
+    };
+
+    fn bool_dyn() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_literal(LiteralValue::Boolean(true)))
+    }
+
+    fn bigint_dyn() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(1)))
+    }
+
+    fn int128_dyn() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_literal(LiteralValue::Int128(42)))
+    }
+
+    #[test]
+    fn equals_expr_try_new_succeeds_with_two_bigints() {
+        assert!(EqualsExpr::try_new(bigint_dyn(), bigint_dyn()).is_ok());
+    }
+
+    #[test]
+    fn equals_expr_try_new_succeeds_with_two_booleans() {
+        assert!(EqualsExpr::try_new(bool_dyn(), bool_dyn()).is_ok());
+    }
+
+    #[test]
+    fn equals_expr_try_new_fails_with_boolean_and_bigint() {
+        assert!(EqualsExpr::try_new(bool_dyn(), bigint_dyn()).is_err());
+    }
+
+    #[test]
+    fn equals_expr_try_new_succeeds_with_bigint_and_int128() {
+        assert!(EqualsExpr::try_new(bigint_dyn(), int128_dyn()).is_ok());
+    }
+
+    #[test]
+    fn equals_expr_data_type_is_boolean() {
+        let expr = EqualsExpr::try_new(bigint_dyn(), bigint_dyn()).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn equals_expr_lhs_is_accessible() {
+        let expr = EqualsExpr::try_new(bigint_dyn(), bigint_dyn()).unwrap();
+        // lhs returns a DynProofExpr reference; just verify it doesn't panic
+        let _ = expr.lhs();
+    }
+
+    #[test]
+    fn equals_expr_rhs_is_accessible() {
+        let expr = EqualsExpr::try_new(bigint_dyn(), bigint_dyn()).unwrap();
+        let _ = expr.rhs();
+    }
+
+    #[test]
+    fn equals_expr_clone_equals_original() {
+        let a = EqualsExpr::try_new(bigint_dyn(), bigint_dyn()).unwrap();
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn equals_expr_debug_contains_struct_name() {
+        let expr = EqualsExpr::try_new(bigint_dyn(), bigint_dyn()).unwrap();
+        assert!(format!("{expr:?}").contains("EqualsExpr"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -184,3 +184,66 @@ pub fn verifier_evaluate_or<S: Scalar>(
     // selection
     Ok(*lhs + *rhs - lhs_and_rhs)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OrExpr;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, ProofExpr},
+    };
+
+    fn bool_dyn() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_literal(LiteralValue::Boolean(true)))
+    }
+
+    fn bigint_dyn() -> Box<DynProofExpr> {
+        Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(1)))
+    }
+
+    #[test]
+    fn or_expr_try_new_succeeds_with_two_booleans() {
+        assert!(OrExpr::try_new(bool_dyn(), bool_dyn()).is_ok());
+    }
+
+    #[test]
+    fn or_expr_try_new_fails_with_boolean_and_bigint() {
+        assert!(OrExpr::try_new(bool_dyn(), bigint_dyn()).is_err());
+    }
+
+    #[test]
+    fn or_expr_try_new_fails_with_two_bigints() {
+        assert!(OrExpr::try_new(bigint_dyn(), bigint_dyn()).is_err());
+    }
+
+    #[test]
+    fn or_expr_data_type_is_boolean() {
+        let expr = OrExpr::try_new(bool_dyn(), bool_dyn()).unwrap();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn or_expr_lhs_is_accessible() {
+        let expr = OrExpr::try_new(bool_dyn(), bool_dyn()).unwrap();
+        let _ = expr.lhs();
+    }
+
+    #[test]
+    fn or_expr_rhs_is_accessible() {
+        let expr = OrExpr::try_new(bool_dyn(), bool_dyn()).unwrap();
+        let _ = expr.rhs();
+    }
+
+    #[test]
+    fn or_expr_clone_equals_original() {
+        let a = OrExpr::try_new(bool_dyn(), bool_dyn()).unwrap();
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn or_expr_debug_contains_struct_name() {
+        let expr = OrExpr::try_new(bool_dyn(), bool_dyn()).unwrap();
+        assert!(format!("{expr:?}").contains("OrExpr"));
+    }
+}


### PR DESCRIPTION
Add 17 unit tests across two previously uncovered proof expression modules.

**`sql/proof_exprs/or_expr.rs`** (8 tests):
- `try_new` succeeds with two Boolean operands
- `try_new` fails with Boolean + BigInt (type mismatch)
- `try_new` fails with two BigInts (neither is Boolean)
- `data_type()` always returns `Boolean`
- `lhs()`/`rhs()` accessors are accessible without panic
- `Clone` produces equal value
- `Debug` format contains struct name

**`sql/proof_exprs/equals_expr.rs`** (9 tests):
- `try_new` succeeds with two identical BigInt types
- `try_new` succeeds with two Boolean types
- `try_new` succeeds with BigInt + Int128 (compatible numeric types)
- `try_new` fails with Boolean + BigInt (type mismatch)
- `data_type()` always returns `Boolean`
- `lhs()`/`rhs()` accessors are accessible without panic
- `Clone` produces equal value
- `Debug` format contains struct name

/attempt #560