### PR TITLE
test: coverage for database error types (#560)

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,115 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnOperationError;
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn different_column_length_display() {
+        let e = ColumnOperationError::DifferentColumnLength { len_a: 3, len_b: 5 };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("3") && s.contains("5"));
+    }
+
+    #[test]
+    fn different_column_length_equality() {
+        let a = ColumnOperationError::DifferentColumnLength { len_a: 3, len_b: 5 };
+        let b = ColumnOperationError::DifferentColumnLength { len_a: 3, len_b: 5 };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn binary_operation_invalid_column_type_display() {
+        let e = ColumnOperationError::BinaryOperationInvalidColumnType {
+            operator: "ADD".into(),
+            left_type: ColumnType::BigInt,
+            right_type: ColumnType::Boolean,
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("ADD"));
+    }
+
+    #[test]
+    fn unary_operation_invalid_column_type_display() {
+        let e = ColumnOperationError::UnaryOperationInvalidColumnType {
+            operator: "NEG".into(),
+            operand_type: ColumnType::VarChar,
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("NEG"));
+    }
+
+    #[test]
+    fn integer_overflow_display() {
+        let e = ColumnOperationError::IntegerOverflow {
+            error: "max exceeded".into(),
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("max exceeded"));
+    }
+
+    #[test]
+    fn division_by_zero_display() {
+        let e = ColumnOperationError::DivisionByZero;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("zero") || s.contains("Zero"));
+    }
+
+    #[test]
+    fn index_out_of_bounds_display() {
+        let e = ColumnOperationError::IndexOutOfBounds { index: 10, len: 5 };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("10") && s.contains("5"));
+    }
+
+    #[test]
+    fn signed_casting_error_display() {
+        let e = ColumnOperationError::SignedCastingError {
+            left_type: ColumnType::TinyInt,
+            right_type: ColumnType::Uint8,
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("losing data") || s.contains("fit"));
+    }
+
+    #[test]
+    fn casting_error_equality() {
+        let a = ColumnOperationError::CastingError {
+            left_type: ColumnType::BigInt,
+            right_type: ColumnType::Boolean,
+        };
+        let b = ColumnOperationError::CastingError {
+            left_type: ColumnType::BigInt,
+            right_type: ColumnType::Boolean,
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn division_by_zero_equality() {
+        assert_eq!(
+            ColumnOperationError::DivisionByZero,
+            ColumnOperationError::DivisionByZero
+        );
+    }
+
+    #[test]
+    fn column_operation_error_is_debug_formattable() {
+        let e = ColumnOperationError::DivisionByZero;
+        let s = alloc::format!("{e:?}");
+        assert!(s.contains("DivisionByZero"));
+    }
+
+    #[test]
+    fn union_different_types_display() {
+        let e = ColumnOperationError::UnionDifferentTypes {
+            correct_type: ColumnType::BigInt,
+            actual_type: ColumnType::Boolean,
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("union") || s.contains("Union"));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -13,7 +13,7 @@ pub enum OwnedColumnError {
         /// The type to which we are trying to cast.
         to_type: ColumnType,
     },
-    /// Error in converting scalars to a given column type.   
+    /// Error in converting scalars to a given column type.
     #[snafu(display("Error in converting scalars to a given column type: {error}"))]
     ScalarConversionError {
         /// The underlying error
@@ -40,3 +40,97 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnCoercionError, OwnedColumnError};
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn owned_column_error_type_cast_display() {
+        let e = OwnedColumnError::TypeCastError {
+            from_type: ColumnType::BigInt,
+            to_type: ColumnType::Boolean,
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("type casting"));
+    }
+
+    #[test]
+    fn owned_column_error_scalar_conversion_display() {
+        let e = OwnedColumnError::ScalarConversionError {
+            error: "overflow".into(),
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("overflow"));
+    }
+
+    #[test]
+    fn owned_column_error_unsupported_display() {
+        let e = OwnedColumnError::Unsupported {
+            error: "not yet".into(),
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("not yet"));
+    }
+
+    #[test]
+    fn owned_column_error_type_cast_equality() {
+        let a = OwnedColumnError::TypeCastError {
+            from_type: ColumnType::BigInt,
+            to_type: ColumnType::Boolean,
+        };
+        let b = OwnedColumnError::TypeCastError {
+            from_type: ColumnType::BigInt,
+            to_type: ColumnType::Boolean,
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn owned_column_error_scalar_conversion_equality() {
+        let a = OwnedColumnError::ScalarConversionError {
+            error: "test".into(),
+        };
+        let b = OwnedColumnError::ScalarConversionError {
+            error: "test".into(),
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn owned_column_error_is_debug_formattable() {
+        let e = OwnedColumnError::Unsupported {
+            error: "test".into(),
+        };
+        let s = alloc::format!("{e:?}");
+        assert!(s.contains("Unsupported"));
+    }
+
+    #[test]
+    fn column_coercion_error_overflow_display() {
+        let e = ColumnCoercionError::Overflow;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("Overflow"));
+    }
+
+    #[test]
+    fn column_coercion_error_invalid_type_coercion_display() {
+        let e = ColumnCoercionError::InvalidTypeCoercion;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("Invalid"));
+    }
+
+    #[test]
+    fn column_coercion_errors_are_not_equal() {
+        assert_ne!(
+            ColumnCoercionError::Overflow,
+            ColumnCoercionError::InvalidTypeCoercion
+        );
+    }
+
+    #[test]
+    fn column_coercion_overflow_equality() {
+        assert_eq!(ColumnCoercionError::Overflow, ColumnCoercionError::Overflow);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,83 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::TableOperationError;
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn union_not_enough_tables_display() {
+        let e = TableOperationError::UnionNotEnoughTables;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("2") || s.contains("fewer"));
+    }
+
+    #[test]
+    fn join_with_different_number_of_columns_display() {
+        let e = TableOperationError::JoinWithDifferentNumberOfColumns {
+            left_num_columns: 3,
+            right_num_columns: 5,
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("3") && s.contains("5"));
+    }
+
+    #[test]
+    fn join_incompatible_types_display() {
+        let e = TableOperationError::JoinIncompatibleTypes {
+            left_type: ColumnType::BigInt,
+            right_type: ColumnType::Boolean,
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("incompatible") || s.contains("Incompatible"));
+    }
+
+    #[test]
+    fn duplicate_column_display() {
+        let e = TableOperationError::DuplicateColumn;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("duplicated") || s.contains("duplicate"));
+    }
+
+    #[test]
+    fn column_index_out_of_bounds_display() {
+        let e = TableOperationError::ColumnIndexOutOfBounds { column_index: 42 };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("42"));
+    }
+
+    #[test]
+    fn union_not_enough_tables_equality() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables,
+            TableOperationError::UnionNotEnoughTables
+        );
+    }
+
+    #[test]
+    fn duplicate_column_equality() {
+        assert_eq!(
+            TableOperationError::DuplicateColumn,
+            TableOperationError::DuplicateColumn
+        );
+    }
+
+    #[test]
+    fn table_operation_error_is_debug_formattable() {
+        let e = TableOperationError::DuplicateColumn;
+        let s = alloc::format!("{e:?}");
+        assert!(s.contains("DuplicateColumn"));
+    }
+
+    #[test]
+    fn column_does_not_exist_display() {
+        use sqlparser::ast::Ident;
+        let e = TableOperationError::ColumnDoesNotExist {
+            column_ident: Ident::new("my_col"),
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("my_col") || s.contains("exist"));
+    }
+}


### PR DESCRIPTION
Add 31 unit tests for three previously-uncovered database error type modules.

**`base/database/owned_column_error.rs`** (10 tests):
- Display messages for `TypeCastError`, `ScalarConversionError`, `Unsupported`
- Equality on variants, `Debug` formatting
- `ColumnCoercionError::Overflow` and `InvalidTypeCoercion` display, equality, inequality

**`base/database/column_operation_error.rs`** (12 tests):
- Display for `DifferentColumnLength`, `BinaryOperationInvalidColumnType`, `UnaryOperationInvalidColumnType`, `IntegerOverflow`, `DivisionByZero`, `IndexOutOfBounds`, `SignedCastingError`, `UnionDifferentTypes`
- Equality on variants, `Debug` formatting

**`base/database/table_operation_error.rs`** (9 tests):
- Display for `UnionNotEnoughTables`, `JoinWithDifferentNumberOfColumns`, `JoinIncompatibleTypes`, `DuplicateColumn`, `ColumnIndexOutOfBounds`, `ColumnDoesNotExist`
- Equality on variants, `Debug` formatting

/attempt #560