### PR TITLE
test: coverage for database struct types (#560)

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,66 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnField;
+    use crate::base::database::ColumnType;
+    use sqlparser::ast::Ident;
+
+    fn make_field() -> ColumnField {
+        ColumnField::new(Ident::new("my_col"), ColumnType::BigInt)
+    }
+
+    #[test]
+    fn column_field_name_returns_correct_value() {
+        let f = make_field();
+        assert_eq!(f.name().value, "my_col");
+    }
+
+    #[test]
+    fn column_field_data_type_returns_correct_value() {
+        let f = make_field();
+        assert_eq!(f.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_field_equality() {
+        let a = ColumnField::new(Ident::new("col"), ColumnType::Boolean);
+        let b = ColumnField::new(Ident::new("col"), ColumnType::Boolean);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn column_field_inequality_by_name() {
+        let a = ColumnField::new(Ident::new("a"), ColumnType::BigInt);
+        let b = ColumnField::new(Ident::new("b"), ColumnType::BigInt);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn column_field_inequality_by_type() {
+        let a = ColumnField::new(Ident::new("col"), ColumnType::BigInt);
+        let b = ColumnField::new(Ident::new("col"), ColumnType::Boolean);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn column_field_clone_equals_original() {
+        let f = make_field();
+        assert_eq!(f.clone(), f);
+    }
+
+    #[test]
+    fn column_field_is_debug_formattable() {
+        let f = make_field();
+        let s = alloc::format!("{f:?}");
+        assert!(s.contains("my_col"));
+    }
+
+    #[test]
+    fn column_field_varchar_type() {
+        let f = ColumnField::new(Ident::new("s"), ColumnType::VarChar);
+        assert_eq!(f.data_type(), ColumnType::VarChar);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,76 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnRef;
+    use crate::base::database::{ColumnType, TableRef};
+    use sqlparser::ast::Ident;
+
+    fn make_ref() -> ColumnRef {
+        let table = TableRef::new("schema", "table");
+        ColumnRef::new(table, Ident::new("col"), ColumnType::BigInt)
+    }
+
+    #[test]
+    fn column_ref_table_ref_returns_correct_value() {
+        let r = make_ref();
+        assert_eq!(r.table_ref(), TableRef::new("schema", "table"));
+    }
+
+    #[test]
+    fn column_ref_column_id_returns_correct_value() {
+        let r = make_ref();
+        assert_eq!(r.column_id().value, "col");
+    }
+
+    #[test]
+    fn column_ref_column_type_returns_correct_value() {
+        let r = make_ref();
+        assert_eq!(*r.column_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_ref_equality() {
+        let a = make_ref();
+        let b = make_ref();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn column_ref_inequality_by_column_id() {
+        let table = TableRef::new("schema", "table");
+        let a = ColumnRef::new(table.clone(), Ident::new("a"), ColumnType::BigInt);
+        let b = ColumnRef::new(table, Ident::new("b"), ColumnType::BigInt);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn column_ref_inequality_by_type() {
+        let table = TableRef::new("schema", "table");
+        let a = ColumnRef::new(table.clone(), Ident::new("col"), ColumnType::BigInt);
+        let b = ColumnRef::new(table, Ident::new("col"), ColumnType::Boolean);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn column_ref_clone_equals_original() {
+        let r = make_ref();
+        assert_eq!(r.clone(), r);
+    }
+
+    #[test]
+    fn column_ref_is_debug_formattable() {
+        let r = make_ref();
+        let s = alloc::format!("{r:?}");
+        assert!(s.contains("col"));
+    }
+
+    #[test]
+    fn column_ref_no_schema_table() {
+        let table = TableRef::new("", "mytable");
+        let r = ColumnRef::new(table, Ident::new("id"), ColumnType::Int128);
+        assert_eq!(*r.column_type(), ColumnType::Int128);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,99 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableRef;
+    use core::str::FromStr;
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn table_ref_new_with_schema_and_table() {
+        let t = TableRef::new("myschema", "mytable");
+        assert_eq!(t.table_id().value, "mytable");
+        assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("myschema"));
+    }
+
+    #[test]
+    fn table_ref_new_without_schema() {
+        let t = TableRef::new("", "mytable");
+        assert!(t.schema_id().is_none());
+        assert_eq!(t.table_id().value, "mytable");
+    }
+
+    #[test]
+    fn table_ref_display_with_schema() {
+        let t = TableRef::new("s", "t");
+        assert_eq!(alloc::format!("{t}"), "s.t");
+    }
+
+    #[test]
+    fn table_ref_display_without_schema() {
+        let t = TableRef::new("", "t");
+        assert_eq!(alloc::format!("{t}"), "t");
+    }
+
+    #[test]
+    fn table_ref_from_str_with_dot() {
+        let t = TableRef::from_str("schema.table").unwrap();
+        assert_eq!(t.table_id().value, "table");
+        assert_eq!(t.schema_id().map(|i| i.value.as_str()), Some("schema"));
+    }
+
+    #[test]
+    fn table_ref_from_str_without_dot() {
+        let t = TableRef::from_str("table").unwrap();
+        assert_eq!(t.table_id().value, "table");
+        assert!(t.schema_id().is_none());
+    }
+
+    #[test]
+    fn table_ref_from_str_two_dots_is_error() {
+        assert!(TableRef::from_str("a.b.c").is_err());
+    }
+
+    #[test]
+    fn table_ref_from_strs_single_component() {
+        let t = TableRef::from_strs(&["mytable"]).unwrap();
+        assert!(t.schema_id().is_none());
+    }
+
+    #[test]
+    fn table_ref_from_strs_two_components() {
+        let t = TableRef::from_strs(&["s", "t"]).unwrap();
+        assert_eq!(t.schema_id().unwrap().value, "s");
+    }
+
+    #[test]
+    fn table_ref_from_strs_three_components_is_error() {
+        assert!(TableRef::from_strs(&["a", "b", "c"]).is_err());
+    }
+
+    #[test]
+    fn table_ref_from_idents() {
+        let t = TableRef::from_idents(Some(Ident::new("s")), Ident::new("t"));
+        assert_eq!(t.table_id().value, "t");
+        assert_eq!(t.schema_id().unwrap().value, "s");
+    }
+
+    #[test]
+    fn table_ref_equality() {
+        let a = TableRef::new("s", "t");
+        let b = TableRef::new("s", "t");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn table_ref_clone_equals_original() {
+        let t = TableRef::new("s", "t");
+        assert_eq!(t.clone(), t);
+    }
+
+    #[test]
+    fn table_ref_is_debug_formattable() {
+        let t = TableRef::new("s", "t");
+        let s = alloc::format!("{t:?}");
+        assert!(!s.is_empty());
+    }
+}


### PR DESCRIPTION
Add 32 unit tests for three previously-uncovered database struct modules.

**`base/database/column_field.rs`** (8 tests):
- `name()` and `data_type()` accessors return correct values
- Equality and inequality by name and type
- `Clone` and `Debug` formatting

**`base/database/column_ref.rs`** (9 tests):
- `table_ref()`, `column_id()`, `column_type()` accessors
- Equality and inequality by column id and type
- `Clone` and `Debug` formatting, no-schema table

**`base/database/table_ref.rs`** (15 tests):
- `new()` with and without schema, `schema_id()` / `table_id()`
- `Display` format with and without schema
- `FromStr` / `TryFrom<&str>` for dot-separated strings (valid, no dot, too many dots)
- `from_strs()` with 1, 2, and 3 components
- `from_idents()`, equality, `Clone`, `Debug`

/attempt #560