### PR TITLE
test: coverage for U256 and OffsetToBytes (#560)

### DIFF
--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -35,3 +35,85 @@ impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
         MontScalar::<T>::from_le_bytes_mod_order(&bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::U256;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn eq(a: U256, b: U256) -> bool {
+        a.low == b.low && a.high == b.high
+    }
+
+    #[test]
+    fn from_words_stores_low_and_high() {
+        let u = U256::from_words(42, 100);
+        assert_eq!(u.low, 42);
+        assert_eq!(u.high, 100);
+    }
+
+    #[test]
+    fn from_words_zero_both_parts() {
+        let u = U256::from_words(0, 0);
+        assert_eq!(u.low, 0);
+        assert_eq!(u.high, 0);
+    }
+
+    #[test]
+    fn from_words_max_values() {
+        let u = U256::from_words(u128::MAX, u128::MAX);
+        assert_eq!(u.low, u128::MAX);
+        assert_eq!(u.high, u128::MAX);
+    }
+
+    #[test]
+    fn u256_equality() {
+        let a = U256::from_words(1, 2);
+        let b = U256::from_words(1, 2);
+        assert!(eq(a, b));
+    }
+
+    #[test]
+    fn u256_inequality_different_low() {
+        let a = U256::from_words(1, 0);
+        let b = U256::from_words(2, 0);
+        assert!(!eq(a, b));
+    }
+
+    #[test]
+    fn u256_inequality_different_high() {
+        let a = U256::from_words(0, 1);
+        let b = U256::from_words(0, 2);
+        assert!(!eq(a, b));
+    }
+
+    #[test]
+    fn u256_copy_trait_works() {
+        let a = U256::from_words(5, 10);
+        let b = a;
+        assert!(eq(a, b));
+    }
+
+    #[test]
+    fn scalar_zero_converts_to_zero_u256() {
+        let scalar = TestScalar::from(0);
+        let u: U256 = (&scalar).into();
+        assert_eq!(u.low, 0);
+        assert_eq!(u.high, 0);
+    }
+
+    #[test]
+    fn small_scalar_converts_to_u256_with_correct_low() {
+        let scalar = TestScalar::from(255);
+        let u: U256 = (&scalar).into();
+        assert_eq!(u.low, 255);
+        assert_eq!(u.high, 0);
+    }
+
+    #[test]
+    fn u256_zero_roundtrip_via_scalar() {
+        let u = U256::from_words(0, 0);
+        let scalar: TestScalar = (&u).into();
+        assert_eq!(scalar, TestScalar::from(0));
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -60,3 +60,190 @@ impl OffsetToBytes<32> for [u64; 4] {
         bytemuck::cast(*self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OffsetToBytes;
+
+    #[test]
+    fn u8_zero_maps_to_zero_byte() {
+        assert_eq!(0u8.offset_to_bytes(), [0]);
+    }
+
+    #[test]
+    fn u8_max_maps_to_255() {
+        assert_eq!(255u8.offset_to_bytes(), [255]);
+    }
+
+    #[test]
+    fn u8_midpoint_round_trips() {
+        assert_eq!(128u8.offset_to_bytes(), [128]);
+    }
+
+    #[test]
+    fn i8_min_maps_to_zero() {
+        assert_eq!(i8::MIN.offset_to_bytes(), [0]);
+    }
+
+    #[test]
+    fn i8_zero_maps_to_128() {
+        assert_eq!(0i8.offset_to_bytes(), [128]);
+    }
+
+    #[test]
+    fn i8_max_maps_to_255() {
+        assert_eq!(i8::MAX.offset_to_bytes(), [255]);
+    }
+
+    #[test]
+    fn i8_minus_one_maps_to_127() {
+        assert_eq!((-1i8).offset_to_bytes(), [127]);
+    }
+
+    #[test]
+    fn i8_preserves_sort_order() {
+        let a = (-100i8).offset_to_bytes()[0];
+        let b = 0i8.offset_to_bytes()[0];
+        let c = 100i8.offset_to_bytes()[0];
+        assert!(a < b && b < c);
+    }
+
+    #[test]
+    fn i16_min_maps_to_zero() {
+        assert_eq!(i16::MIN.offset_to_bytes(), [0, 0]);
+    }
+
+    #[test]
+    fn i16_zero_maps_to_midpoint() {
+        let expected = 32768u16.to_le_bytes();
+        assert_eq!(0i16.offset_to_bytes(), expected);
+    }
+
+    #[test]
+    fn i16_max_maps_to_all_ones() {
+        assert_eq!(i16::MAX.offset_to_bytes(), [0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn i16_minus_one_maps_correctly() {
+        let expected = 32767u16.to_le_bytes();
+        assert_eq!((-1i16).offset_to_bytes(), expected);
+    }
+
+    #[test]
+    fn i32_min_maps_to_zero() {
+        assert_eq!(i32::MIN.offset_to_bytes(), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn i32_zero_maps_to_midpoint() {
+        let expected = 2_147_483_648u32.to_le_bytes();
+        assert_eq!(0i32.offset_to_bytes(), expected);
+    }
+
+    #[test]
+    fn i32_max_maps_to_all_ones() {
+        assert_eq!(i32::MAX.offset_to_bytes(), [0xFF, 0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn i32_preserves_sort_order() {
+        let a = u32::from_le_bytes(i32::MIN.offset_to_bytes());
+        let b = u32::from_le_bytes(0i32.offset_to_bytes());
+        let c = u32::from_le_bytes(i32::MAX.offset_to_bytes());
+        assert!(a < b && b < c);
+    }
+
+    #[test]
+    fn i64_min_maps_to_zero() {
+        assert_eq!(i64::MIN.offset_to_bytes(), [0u8; 8]);
+    }
+
+    #[test]
+    fn i64_zero_maps_to_midpoint() {
+        let expected = (i64::MAX as u64 + 1).to_le_bytes();
+        assert_eq!(0i64.offset_to_bytes(), expected);
+    }
+
+    #[test]
+    fn i64_max_maps_to_all_ones() {
+        assert_eq!(i64::MAX.offset_to_bytes(), [0xFF; 8]);
+    }
+
+    #[test]
+    fn i64_minus_one_maps_correctly() {
+        let expected = i64::MAX.unsigned_abs().to_le_bytes();
+        assert_eq!((-1i64).offset_to_bytes(), expected);
+    }
+
+    #[test]
+    fn i128_min_maps_to_zero() {
+        assert_eq!(i128::MIN.offset_to_bytes(), [0u8; 16]);
+    }
+
+    #[test]
+    fn i128_zero_maps_to_midpoint() {
+        let expected = (i128::MAX as u128 + 1).to_le_bytes();
+        assert_eq!(0i128.offset_to_bytes(), expected);
+    }
+
+    #[test]
+    fn i128_max_maps_to_all_ones() {
+        assert_eq!(i128::MAX.offset_to_bytes(), [0xFF; 16]);
+    }
+
+    #[test]
+    fn bool_false_maps_to_zero() {
+        assert_eq!(false.offset_to_bytes(), [0]);
+    }
+
+    #[test]
+    fn bool_true_maps_to_one() {
+        assert_eq!(true.offset_to_bytes(), [1]);
+    }
+
+    #[test]
+    fn u64_zero_maps_to_zero_bytes() {
+        assert_eq!(0u64.offset_to_bytes(), [0u8; 8]);
+    }
+
+    #[test]
+    fn u64_max_maps_to_all_ones() {
+        assert_eq!(u64::MAX.offset_to_bytes(), [0xFF; 8]);
+    }
+
+    #[test]
+    fn u64_uses_little_endian_byte_order() {
+        assert_eq!(1u64.offset_to_bytes(), [1, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn u64_known_value_encodes_correctly() {
+        let val: u64 = 0x0102_0304_0506_0708;
+        assert_eq!(val.offset_to_bytes(), [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]);
+    }
+
+    #[test]
+    fn u64_array_all_zero_maps_to_32_zero_bytes() {
+        let arr: [u64; 4] = [0, 0, 0, 0];
+        assert_eq!(arr.offset_to_bytes(), [0u8; 32]);
+    }
+
+    #[test]
+    fn u64_array_first_element_affects_first_bytes() {
+        let arr: [u64; 4] = [1, 0, 0, 0];
+        let bytes = arr.offset_to_bytes();
+        assert_eq!(bytes[0], 1);
+        assert_eq!(bytes[1..8], [0u8; 7]);
+        assert_eq!(bytes[8..32], [0u8; 24]);
+    }
+
+    #[test]
+    fn u64_array_last_element_affects_last_bytes() {
+        let arr: [u64; 4] = [0, 0, 0, 1];
+        let bytes = arr.offset_to_bytes();
+        assert_eq!(bytes[0..24], [0u8; 24]);
+        assert_eq!(bytes[24], 1);
+        assert_eq!(bytes[25..32], [0u8; 7]);
+    }
+}


### PR DESCRIPTION
Add 42 unit tests across two previously-uncovered utility modules.

**`base/encode/u256.rs`** (10 tests):
- `from_words()` stores low/high correctly, zero case, max case
- `Copy` trait works (field-by-field equality check without `Debug`)
- Equality and inequality for different `low`/`high` combinations
- `From<&MontScalar<T>> for U256`: scalar 0 → U256 {0, 0}, scalar 255 → U256 {255, 0}
- `From<&U256> for TestScalar`: zero U256 round-trips back to scalar 0

**`proof_primitive/dory/offset_to_bytes.rs`** (32 tests):
- `u8`: zero → [0], max → [255], midpoint → [128]
- `i8`: min → [0], zero → [128], max → [255], -1 → [127], sort-order preserved
- `i16`: min → [0,0], zero → midpoint, max → [0xFF,0xFF], -1 → correct
- `i32`: min → [0,0,0,0], zero → midpoint, max → [0xFF×4], sort-order check uses `u32`
- `i64`: min → all-zero, zero → midpoint, max → all-ones, -1 → correct
- `i128`: min, zero, max
- `bool`: false → [0], true → [1]
- `u64`: zero → [0×8], max → [0xFF×8], little-endian byte order, known pattern
- `[u64; 4]`: all-zero → 32 zero bytes, first element affects first 8 bytes, last element affects last 8 bytes

/attempt #560