### PR TITLE
test: coverage for slice_ops functions (#560)

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/add_const.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/add_const.rs
@@ -17,3 +17,58 @@ where
         *res_i += to_add.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::add_const;
+
+    #[test]
+    fn add_const_empty_slice_is_noop() {
+        let mut result: Vec<i32> = vec![];
+        add_const(&mut result, 5i32);
+        assert_eq!(result, Vec::<i32>::new());
+    }
+
+    #[test]
+    fn add_const_adds_to_every_element() {
+        let mut result = vec![1i32, 2, 3, 4];
+        add_const(&mut result, 10i32);
+        assert_eq!(result, vec![11, 12, 13, 14]);
+    }
+
+    #[test]
+    fn add_const_zero_is_identity() {
+        let mut result = vec![5i32, 10, 15];
+        add_const(&mut result, 0i32);
+        assert_eq!(result, vec![5, 10, 15]);
+    }
+
+    #[test]
+    fn add_const_negative_value_decrements() {
+        let mut result = vec![10i32, 20, 30];
+        add_const(&mut result, -5i32);
+        assert_eq!(result, vec![5, 15, 25]);
+    }
+
+    #[test]
+    fn add_const_single_element() {
+        let mut result = vec![42i32];
+        add_const(&mut result, 1i32);
+        assert_eq!(result, vec![43]);
+    }
+
+    #[test]
+    fn add_const_with_u64() {
+        let mut result = vec![100u64, 200, 300];
+        add_const(&mut result, 50u64);
+        assert_eq!(result, vec![150, 250, 350]);
+    }
+
+    #[test]
+    fn add_const_accumulates_over_multiple_calls() {
+        let mut result = vec![0i32; 3];
+        add_const(&mut result, 5i32);
+        add_const(&mut result, 3i32);
+        assert_eq!(result, vec![8, 8, 8]);
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
@@ -24,3 +24,68 @@ where
         *res_i += multiplier * data_i.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::mul_add_assign;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn mul_add_assign_empty_to_mul_add_is_noop() {
+        let mut result = alloc::vec![TestScalar::from(1), TestScalar::from(2)];
+        mul_add_assign(&mut result, TestScalar::from(5), &[] as &[TestScalar]);
+        assert_eq!(result, alloc::vec![TestScalar::from(1), TestScalar::from(2)]);
+    }
+
+    #[test]
+    fn mul_add_assign_basic_multiply_and_add() {
+        let mut result = alloc::vec![TestScalar::from(0); 3];
+        let to_add = alloc::vec![TestScalar::from(1), TestScalar::from(2), TestScalar::from(3)];
+        mul_add_assign(&mut result, TestScalar::from(2), &to_add);
+        assert_eq!(result, alloc::vec![TestScalar::from(2), TestScalar::from(4), TestScalar::from(6)]);
+    }
+
+    #[test]
+    fn mul_add_assign_accumulates_into_existing_values() {
+        let mut result = alloc::vec![TestScalar::from(10), TestScalar::from(20), TestScalar::from(30)];
+        let to_add = alloc::vec![TestScalar::from(1), TestScalar::from(2), TestScalar::from(3)];
+        mul_add_assign(&mut result, TestScalar::from(3), &to_add);
+        assert_eq!(result, alloc::vec![TestScalar::from(13), TestScalar::from(26), TestScalar::from(39)]);
+    }
+
+    #[test]
+    fn mul_add_assign_zero_multiplier_leaves_result_unchanged() {
+        let mut result = alloc::vec![TestScalar::from(5), TestScalar::from(10), TestScalar::from(15)];
+        let to_add = alloc::vec![TestScalar::from(100), TestScalar::from(200), TestScalar::from(300)];
+        mul_add_assign(&mut result, TestScalar::from(0), &to_add);
+        assert_eq!(result, alloc::vec![TestScalar::from(5), TestScalar::from(10), TestScalar::from(15)]);
+    }
+
+    #[test]
+    fn mul_add_assign_result_longer_than_to_mul_add_only_affects_prefix() {
+        let mut result = alloc::vec![
+            TestScalar::from(1), TestScalar::from(2), TestScalar::from(3),
+            TestScalar::from(4), TestScalar::from(5),
+        ];
+        let to_add = alloc::vec![TestScalar::from(10), TestScalar::from(20)];
+        mul_add_assign(&mut result, TestScalar::from(1), &to_add);
+        assert_eq!(result[0], TestScalar::from(11));
+        assert_eq!(result[1], TestScalar::from(22));
+        assert_eq!(result[2], TestScalar::from(3));
+    }
+
+    #[test]
+    #[should_panic(expected = "The length of result must be greater than or equal to")]
+    fn mul_add_assign_panics_if_result_shorter_than_to_mul_add() {
+        let mut result = alloc::vec![TestScalar::from(1), TestScalar::from(2)];
+        let to_add = alloc::vec![TestScalar::from(10), TestScalar::from(20), TestScalar::from(30)];
+        mul_add_assign(&mut result, TestScalar::from(1), &to_add);
+    }
+
+    #[test]
+    fn mul_add_assign_single_element() {
+        let mut result = alloc::vec![TestScalar::from(5)];
+        mul_add_assign(&mut result, TestScalar::from(3), &[TestScalar::from(4)]);
+        assert_eq!(result[0], TestScalar::from(17));
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
@@ -53,3 +53,62 @@ where
 {
     slice_cast_mut_with(value, result, Into::into);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{slice_cast_mut_with, slice_cast_with};
+    use alloc::{string::String, vec};
+
+    #[test]
+    fn slice_cast_with_empty_slice_returns_empty_vec() {
+        let result: Vec<i64> = slice_cast_with(&[] as &[i32], |&x| x as i64);
+        assert_eq!(result, Vec::<i64>::new());
+    }
+
+    #[test]
+    fn slice_cast_with_converts_i32_to_i64() {
+        let result: Vec<i64> = slice_cast_with(&[1i32, 2, 3], |&x| x as i64);
+        assert_eq!(result, vec![1i64, 2, 3]);
+    }
+
+    #[test]
+    fn slice_cast_with_applies_transformation() {
+        let result: Vec<i32> = slice_cast_with(&[1i32, 2, 3, 4], |&x| x * x);
+        assert_eq!(result, vec![1, 4, 9, 16]);
+    }
+
+    #[test]
+    fn slice_cast_with_converts_to_string() {
+        let result: Vec<String> = slice_cast_with(&[1i32, 2, 3], |&x| x.to_string());
+        assert_eq!(result, vec!["1", "2", "3"]);
+    }
+
+    #[test]
+    fn slice_cast_mut_with_empty_slices_is_noop() {
+        let mut result: Vec<i64> = vec![];
+        slice_cast_mut_with(&[] as &[i32], &mut result, |&x| x as i64);
+        assert_eq!(result, Vec::<i64>::new());
+    }
+
+    #[test]
+    fn slice_cast_mut_with_writes_to_result() {
+        let mut result = vec![0i64; 3];
+        slice_cast_mut_with(&[10i32, 20, 30], &mut result, |&x| x as i64 * 2);
+        assert_eq!(result, vec![20i64, 40, 60]);
+    }
+
+    #[test]
+    fn slice_cast_mut_with_partial_write() {
+        let mut result = vec![0i64; 5];
+        slice_cast_mut_with(&[1i32, 2], &mut result, |&x| x as i64);
+        assert_eq!(result[0], 1);
+        assert_eq!(result[1], 2);
+        assert_eq!(result[2], 0); // untouched
+    }
+
+    #[test]
+    fn slice_cast_with_single_element() {
+        let result: Vec<i64> = slice_cast_with(&[42i32], |&x| x as i64);
+        assert_eq!(result, vec![42i64]);
+    }
+}


### PR DESCRIPTION
Add 22 unit tests across three previously-uncovered slice operation modules.

**`base/slice_ops/add_const.rs`** (7 tests):
- Empty slice is a no-op
- Adds constant to every element
- Zero constant is identity
- Negative constant decrements values
- Single-element slice
- Works with `u64` type
- Accumulates over multiple calls

**`base/slice_ops/mul_add_assign.rs`** (7 tests):
- Uses `TestScalar` (satisfies the `&'a S: Into<T>` bound)
- Empty `to_mul_add` is a no-op
- Basic multiply-and-accumulate
- Accumulates into existing values
- Zero multiplier leaves result unchanged
- Result longer than input — only prefix affected
- Panics when result is shorter than input (with exact message match)
- Single-element case

**`base/slice_ops/slice_cast.rs`** (8 tests):
- `slice_cast_with`: empty → empty, `i32` to `i64`, square transformation, to `String`, single element
- `slice_cast_mut_with`: empty slices, writes to result, partial write leaves tail unchanged

/attempt #560