### PR TITLE
test: coverage for ZigZag encoding and fold_vals (#560)

### DIFF
--- a/crates/proof-of-sql/src/base/encode/zigzag.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag.rs
@@ -109,3 +109,73 @@ impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ZigZag;
+    use crate::base::{encode::U256, scalar::test_scalar::TestScalar};
+
+    fn u256_eq(a: U256, b: U256) -> bool {
+        a.low == b.low && a.high == b.high
+    }
+
+    #[test]
+    fn zero_scalar_encodes_to_zero_u256() {
+        let encoded: U256 = TestScalar::from(0).zigzag();
+        assert!(u256_eq(encoded, U256::from_words(0, 0)));
+    }
+
+    #[test]
+    fn positive_one_encodes_to_even_u256() {
+        let encoded: U256 = TestScalar::from(1).zigzag();
+        assert!(u256_eq(encoded, U256::from_words(2, 0)));
+    }
+
+    #[test]
+    fn positive_two_encodes_to_four() {
+        let encoded: U256 = TestScalar::from(2).zigzag();
+        assert!(u256_eq(encoded, U256::from_words(4, 0)));
+    }
+
+    #[test]
+    fn negative_one_encodes_to_odd_u256() {
+        let encoded: U256 = (-TestScalar::from(1)).zigzag();
+        assert!(u256_eq(encoded, U256::from_words(1, 0)));
+    }
+
+    #[test]
+    fn negative_two_encodes_to_three() {
+        let encoded: U256 = (-TestScalar::from(2)).zigzag();
+        assert!(u256_eq(encoded, U256::from_words(3, 0)));
+    }
+
+    #[test]
+    fn positive_roundtrip_via_u256() {
+        let original = TestScalar::from(42);
+        let encoded: U256 = original.zigzag();
+        let decoded: TestScalar = encoded.zigzag();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn negative_roundtrip_via_u256() {
+        let original = -TestScalar::from(17);
+        let encoded: U256 = original.zigzag();
+        let decoded: TestScalar = encoded.zigzag();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn even_encoded_u256_decodes_to_positive_scalar() {
+        let encoded = U256::from_words(4, 0);
+        let decoded: TestScalar = encoded.zigzag();
+        assert_eq!(decoded, TestScalar::from(2));
+    }
+
+    #[test]
+    fn odd_encoded_u256_decodes_to_negative_scalar() {
+        let encoded = U256::from_words(1, 0);
+        let decoded: TestScalar = encoded.zigzag();
+        assert_eq!(decoded, -TestScalar::from(1));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
@@ -32,3 +32,93 @@ pub fn fold_vals<S: Scalar>(beta: S, vals: &[S]) -> S {
 fn powers<S: Scalar>(init: S, base: S) -> impl Iterator<Item = S> {
     core::iter::successors(Some(init), move |&m| Some(m * base))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{fold_vals, powers};
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn fold_vals_empty_slice_returns_zero() {
+        let result = fold_vals::<TestScalar>(TestScalar::from(2), &[]);
+        assert_eq!(result, TestScalar::from(0));
+    }
+
+    #[test]
+    fn fold_vals_single_element_returns_element_unchanged() {
+        let result = fold_vals::<TestScalar>(TestScalar::from(5), &[TestScalar::from(7)]);
+        assert_eq!(result, TestScalar::from(7));
+    }
+
+    #[test]
+    fn fold_vals_two_elements_applies_horner_scheme() {
+        // beta=2, vals=[3, 1]: 3*2 + 1 = 7
+        let result = fold_vals::<TestScalar>(
+            TestScalar::from(2),
+            &[TestScalar::from(3), TestScalar::from(1)],
+        );
+        assert_eq!(result, TestScalar::from(7));
+    }
+
+    #[test]
+    fn fold_vals_three_elements_computes_correctly() {
+        // beta=2, vals=[1, 2, 3]: 1*4 + 2*2 + 3 = 11
+        let result = fold_vals::<TestScalar>(
+            TestScalar::from(2),
+            &[TestScalar::from(1), TestScalar::from(2), TestScalar::from(3)],
+        );
+        assert_eq!(result, TestScalar::from(11));
+    }
+
+    #[test]
+    fn fold_vals_beta_zero_returns_last_element() {
+        // beta=0, vals=[5, 99]: 5*0 + 99 = 99
+        let result = fold_vals::<TestScalar>(
+            TestScalar::from(0),
+            &[TestScalar::from(5), TestScalar::from(99)],
+        );
+        assert_eq!(result, TestScalar::from(99));
+    }
+
+    #[test]
+    fn fold_vals_beta_one_sums_all_values() {
+        // beta=1, vals=[1, 2, 3]: 1 + 2 + 3 = 6
+        let result = fold_vals::<TestScalar>(
+            TestScalar::from(1),
+            &[TestScalar::from(1), TestScalar::from(2), TestScalar::from(3)],
+        );
+        assert_eq!(result, TestScalar::from(6));
+    }
+
+    #[test]
+    fn powers_produces_geometric_sequence() {
+        let vals: Vec<TestScalar> = powers(TestScalar::from(1), TestScalar::from(3))
+            .take(4)
+            .collect();
+        assert_eq!(
+            vals,
+            vec![
+                TestScalar::from(1),
+                TestScalar::from(3),
+                TestScalar::from(9),
+                TestScalar::from(27),
+            ]
+        );
+    }
+
+    #[test]
+    fn powers_with_init_two_and_base_two() {
+        let vals: Vec<TestScalar> = powers(TestScalar::from(2), TestScalar::from(2))
+            .take(4)
+            .collect();
+        assert_eq!(
+            vals,
+            vec![
+                TestScalar::from(2),
+                TestScalar::from(4),
+                TestScalar::from(8),
+                TestScalar::from(16),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Add 17 unit tests across two previously-uncovered modules.

**`base/encode/zigzag.rs`** (9 tests):
- Zero scalar encodes to `U256 {0, 0}`
- Positive values encode as `2×x` (even U256)
- Negative values encode as `2×|y|-1` (odd U256)
- Round-trip encode→decode recovers original for both positive and negative scalars
- Even U256 decodes to positive scalar (e.g. 4 → 2)
- Odd U256 decodes to negative scalar (e.g. 1 → -1)
- Note: uses field-by-field comparison since `U256` does not implement `Debug`

**`sql/proof_plans/fold_util.rs`** (8 tests):
- `fold_vals`: empty slice returns zero, single element returns element, Horner scheme for two and three elements
- `fold_vals`: beta=0 returns last element only; beta=1 sums all values
- `powers`: produces correct geometric sequence (1, base, base², …), tested with two different (init, base) pairs

/attempt #560