### PR TITLE
test: coverage for inner_product slice operation (#560)

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -40,3 +40,68 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
         .sum()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::inner_product;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn inner_product_empty_slices_returns_zero() {
+        let result = inner_product::<TestScalar, TestScalar>(&[], &[]);
+        assert_eq!(result, ts(0));
+    }
+
+    #[test]
+    fn inner_product_single_element() {
+        let result = inner_product(&[ts(5)], &[ts(3)]);
+        assert_eq!(result, ts(15));
+    }
+
+    #[test]
+    fn inner_product_two_elements() {
+        // 1*3 + 2*4 = 3 + 8 = 11
+        let result = inner_product(&[ts(1), ts(2)], &[ts(3), ts(4)]);
+        assert_eq!(result, ts(11));
+    }
+
+    #[test]
+    fn inner_product_three_elements() {
+        // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
+        let result = inner_product(&[ts(1), ts(2), ts(3)], &[ts(4), ts(5), ts(6)]);
+        assert_eq!(result, ts(32));
+    }
+
+    #[test]
+    fn inner_product_first_slice_longer_ignores_extra() {
+        // 1*3 + 2*4 = 11; third element (100) ignored
+        let result = inner_product(&[ts(1), ts(2), ts(100)], &[ts(3), ts(4)]);
+        assert_eq!(result, ts(11));
+    }
+
+    #[test]
+    fn inner_product_with_zeros() {
+        let result = inner_product(&[ts(0), ts(0), ts(0)], &[ts(1), ts(2), ts(3)]);
+        assert_eq!(result, ts(0));
+    }
+
+    #[test]
+    fn inner_product_identity_like_operation() {
+        // a · [1,1,1,1,1] = sum(a)
+        let a = alloc::vec![ts(1), ts(2), ts(3), ts(4), ts(5)];
+        let ones = alloc::vec![ts(1); 5];
+        let result = inner_product(&a, &ones);
+        assert_eq!(result, ts(15));
+    }
+
+    #[test]
+    fn inner_product_with_negative_values() {
+        // (-1)*3 + 2*(-4) = -3 - 8 = -11
+        let result = inner_product(&[ts(-1), ts(2)], &[ts(3), ts(-4)]);
+        assert_eq!(result, ts(-11));
+    }
+}


### PR DESCRIPTION
Add 8 unit tests for the previously-uncovered `inner_product` function in `base/slice_ops/inner_product.rs`.

Tests use `TestScalar` (which satisfies the `&'a T: Into<F>` bound):
- Empty slices return zero
- Single element: 5 × 3 = 15
- Two elements: 1×3 + 2×4 = 11
- Three elements: 1×4 + 2×5 + 3×6 = 32
- When `a` is longer than `b`, the trailing elements of `a` are silently ignored
- All-zero `a` returns zero regardless of `b`
- Identity-like: inner product with all-ones vector equals sum of `a`
- Negative values: (−1)×3 + 2×(−4) = −11

/attempt #560