### PR TITLE
test: coverage for TableExpr, SumcheckRandomScalars, TableEvaluation (#560)

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,74 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableEvaluation;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    fn make_eval() -> TableEvaluation<TestScalar> {
+        TableEvaluation::new(alloc::vec![ts(1), ts(2), ts(3)], (ts(10), 4))
+    }
+
+    #[test]
+    fn column_evals_returns_correct_values() {
+        let e = make_eval();
+        assert_eq!(e.column_evals(), &[ts(1), ts(2), ts(3)]);
+    }
+
+    #[test]
+    fn chi_eval_returns_scalar_part() {
+        let e = make_eval();
+        assert_eq!(e.chi_eval(), ts(10));
+    }
+
+    #[test]
+    fn chi_returns_both_parts() {
+        let e = make_eval();
+        assert_eq!(e.chi(), (ts(10), 4));
+    }
+
+    #[test]
+    fn equality_on_identical_values() {
+        assert_eq!(make_eval(), make_eval());
+    }
+
+    #[test]
+    fn inequality_on_different_column_evals() {
+        let a = TableEvaluation::new(alloc::vec![ts(1)], (ts(5), 1));
+        let b = TableEvaluation::new(alloc::vec![ts(2)], (ts(5), 1));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn inequality_on_different_chi() {
+        let a = TableEvaluation::new(alloc::vec![ts(1)], (ts(5), 1));
+        let b = TableEvaluation::new(alloc::vec![ts(1)], (ts(6), 1));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn clone_produces_equal_value() {
+        let e = make_eval();
+        assert_eq!(e.clone(), e);
+    }
+
+    #[test]
+    fn debug_formatting_works() {
+        let e = make_eval();
+        let s = alloc::format!("{e:?}");
+        assert!(s.contains("TableEvaluation"));
+    }
+
+    #[test]
+    fn empty_column_evals_is_valid() {
+        let e = TableEvaluation::<TestScalar>::new(alloc::vec![], (ts(0), 0));
+        assert_eq!(e.column_evals(), &[]);
+        assert_eq!(e.chi_eval(), ts(0));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
@@ -27,3 +27,58 @@ impl<'a, S: Scalar> SumcheckRandomScalars<'a, S> {
         v
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SumcheckRandomScalars;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn new_splits_scalars_correctly() {
+        let scalars = alloc::vec![ts(1), ts(2), ts(3)];
+        let sr = SumcheckRandomScalars::new(&scalars, 4, 2);
+        assert_eq!(sr.subpolynomial_multipliers, &scalars[..1]);
+        assert_eq!(sr.entrywise_point, &scalars[1..]);
+        assert_eq!(sr.table_length, 4);
+    }
+
+    #[test]
+    fn new_all_scalars_as_entrywise_point() {
+        let scalars = alloc::vec![ts(5), ts(6)];
+        let sr = SumcheckRandomScalars::new(&scalars, 2, 2);
+        assert_eq!(sr.subpolynomial_multipliers.len(), 0);
+        assert_eq!(sr.entrywise_point.len(), 2);
+    }
+
+    #[test]
+    fn compute_entrywise_multipliers_length_equals_table_length() {
+        let scalars = alloc::vec![ts(1), ts(0)];
+        let sr = SumcheckRandomScalars::new(&scalars, 2, 1);
+        let mult = sr.compute_entrywise_multipliers();
+        assert_eq!(mult.len(), 2);
+    }
+
+    #[test]
+    fn compute_entrywise_multipliers_with_zero_point_is_all_ones() {
+        let scalars = alloc::vec![ts(99), ts(0)];
+        let sr = SumcheckRandomScalars::new(&scalars, 2, 1);
+        let mult = sr.compute_entrywise_multipliers();
+        // With point=[0]: evaluation vector = [1-0, 0] = [1, 0]
+        assert_eq!(mult[0], ts(1));
+        assert_eq!(mult[1], ts(0));
+    }
+
+    #[test]
+    fn compute_entrywise_multipliers_with_one_point() {
+        let scalars = alloc::vec![ts(99), ts(1)];
+        let sr = SumcheckRandomScalars::new(&scalars, 2, 1);
+        let mult = sr.compute_entrywise_multipliers();
+        // With point=[1]: evaluation vector = [1-1, 1] = [0, 1]
+        assert_eq!(mult[0], ts(0));
+        assert_eq!(mult[1], ts(1));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -7,3 +7,50 @@ pub struct TableExpr {
     /// The `TableRef` for the table
     pub table_ref: TableRef,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableExpr;
+    use crate::base::database::TableRef;
+
+    fn make_expr() -> TableExpr {
+        TableExpr { table_ref: TableRef::new("schema", "table") }
+    }
+
+    #[test]
+    fn table_expr_stores_table_ref() {
+        let e = make_expr();
+        assert_eq!(e.table_ref, TableRef::new("schema", "table"));
+    }
+
+    #[test]
+    fn table_expr_equality() {
+        assert_eq!(make_expr(), make_expr());
+    }
+
+    #[test]
+    fn table_expr_inequality() {
+        let a = TableExpr { table_ref: TableRef::new("s", "t1") };
+        let b = TableExpr { table_ref: TableRef::new("s", "t2") };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn table_expr_clone_equals_original() {
+        let e = make_expr();
+        assert_eq!(e.clone(), e);
+    }
+
+    #[test]
+    fn table_expr_is_debug_formattable() {
+        let e = make_expr();
+        let s = alloc::format!("{e:?}");
+        assert!(s.contains("TableExpr"));
+    }
+
+    #[test]
+    fn table_expr_without_schema() {
+        let e = TableExpr { table_ref: TableRef::new("", "mytable") };
+        assert_eq!(alloc::format!("{}", e.table_ref), "mytable");
+    }
+}


### PR DESCRIPTION
Add 20 unit tests across three previously-uncovered struct modules.

**`sql/proof_exprs/table_expr.rs`** (6 tests):
- `table_ref` field stores the correct `TableRef`
- Equality on identical tables, inequality on different table names
- `Clone` and `Debug` formatting
- Construction without schema prefix

**`sql/proof/sumcheck_random_scalars.rs`** (5 tests):
- `new()` splits the scalar slice correctly into `subpolynomial_multipliers` and `entrywise_point`
- When `num_sumcheck_variables == scalars.len()`, all scalars are in `entrywise_point`
- `compute_entrywise_multipliers()` produces a vector of length `table_length`
- With evaluation point `[0]`, output is `[1, 0]` (MLE evaluation at zero)
- With evaluation point `[1]`, output is `[0, 1]` (MLE evaluation at one)

**`base/database/table_evaluation.rs`** (9 tests):
- `column_evals()` returns the correct slice
- `chi_eval()` returns the scalar part of the chi tuple
- `chi()` returns the full `(S, usize)` pair
- Equality and inequality by column values and by chi
- `Clone` and `Debug`
- Empty `column_evals` is valid

/attempt #560