### PR TITLE
test: coverage for HonestProver, QueryError, ProvableResultColumn (#560)

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -67,3 +67,25 @@ pub trait ProverHonestyMarker: Debug + Send + Sync + PartialEq + 'static {}
 #[derive(Debug, PartialEq, Clone)]
 pub struct HonestProver;
 impl ProverHonestyMarker for HonestProver {}
+
+#[cfg(test)]
+mod tests {
+    use super::HonestProver;
+
+    #[test]
+    fn honest_prover_equality() {
+        assert_eq!(HonestProver, HonestProver);
+    }
+
+    #[test]
+    fn honest_prover_clone_equals_original() {
+        let a = HonestProver;
+        assert_eq!(a.clone(), a);
+    }
+
+    #[test]
+    fn honest_prover_is_debug_formattable() {
+        let s = alloc::format!("{:?}", HonestProver);
+        assert!(s.contains("HonestProver"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -69,3 +69,58 @@ impl<'a, T: ProvableResultElement<'a>, const N: usize> ProvableResultColumn for 
         (&self[..]).write(out, length)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProvableResultColumn;
+
+    #[test]
+    fn bool_slice_num_bytes_returns_length() {
+        let data = [true, false, true];
+        assert_eq!(data.as_slice().num_bytes(3), 3);
+    }
+
+    #[test]
+    fn bool_slice_num_bytes_empty_returns_zero() {
+        let data: &[bool] = &[];
+        assert_eq!(data.num_bytes(0), 0);
+    }
+
+    #[test]
+    fn bool_slice_write_fills_output() {
+        let data = [true, false, true];
+        let mut out = alloc::vec![0u8; 3];
+        let written = data.as_slice().write(&mut out, 3);
+        assert_eq!(written, 3);
+    }
+
+    #[test]
+    fn bool_slice_write_encodes_true_as_one() {
+        let data = [true];
+        let mut out = alloc::vec![0u8; 1];
+        data.as_slice().write(&mut out, 1);
+        assert_eq!(out[0], 1);
+    }
+
+    #[test]
+    fn bool_slice_write_encodes_false_as_zero() {
+        let data = [false];
+        let mut out = alloc::vec![0u8; 1];
+        data.as_slice().write(&mut out, 1);
+        assert_eq!(out[0], 0);
+    }
+
+    #[test]
+    fn u8_slice_num_bytes_returns_length() {
+        let data = [10u8, 20, 30];
+        assert_eq!(data.as_slice().num_bytes(3), 3);
+    }
+
+    #[test]
+    fn u8_slice_write_fills_bytes() {
+        let data = [42u8];
+        let mut out = alloc::vec![0u8; 1];
+        data.as_slice().write(&mut out, 1);
+        assert_eq!(out[0], 42);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,50 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::QueryError;
+
+    #[test]
+    fn overflow_display() {
+        let e = QueryError::Overflow;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("Overflow") || s.contains("overflow"));
+    }
+
+    #[test]
+    fn invalid_string_display() {
+        let e = QueryError::InvalidString;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("String") || s.contains("decode"));
+    }
+
+    #[test]
+    fn miscellaneous_decoding_error_display() {
+        let e = QueryError::MiscellaneousDecodingError;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("decoding") || s.contains("Miscellaneous"));
+    }
+
+    #[test]
+    fn miscellaneous_evaluation_error_display() {
+        let e = QueryError::MiscellaneousEvaluationError;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("evaluation") || s.contains("Miscellaneous"));
+    }
+
+    #[test]
+    fn invalid_column_count_display() {
+        let e = QueryError::InvalidColumnCount;
+        let s = alloc::format!("{e}");
+        assert!(s.contains("columns") || s.contains("Invalid"));
+    }
+
+    #[test]
+    fn query_error_is_debug_formattable() {
+        let e = QueryError::InvalidColumnCount;
+        let s = alloc::format!("{e:?}");
+        assert!(s.contains("InvalidColumnCount"));
+    }
+}


### PR DESCRIPTION
Add 16 unit tests across three previously-uncovered modules in the proof layer.

**`sql/proof/proof_plan.rs`** (3 tests):
- `HonestProver::PartialEq`: instances are equal to themselves
- `HonestProver::Clone`: clone equals original
- `HonestProver::Debug`: format string contains "HonestProver"

**`sql/proof/query_result.rs`** (6 tests):
- `QueryError::Overflow` display contains "Overflow"
- `QueryError::InvalidString` display contains "String" or "decode"
- `QueryError::MiscellaneousDecodingError` display is sensible
- `QueryError::MiscellaneousEvaluationError` display is sensible
- `QueryError::InvalidColumnCount` display contains "columns" or "Invalid"
- `Debug` formatting includes variant name

**`sql/proof/provable_result_column.rs`** (7 tests):
- `&[bool]`: `num_bytes` returns slice length for non-empty and empty slices
- `&[bool]`: `write` returns number of bytes written, encodes `true` as 1, `false` as 0
- `&[u8]`: `num_bytes` returns slice length, `write` encodes raw byte value

/attempt #560