### PR TITLE
test: add unit tests for ProverState, prove_round, and EmptyExec

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
@@ -124,3 +124,83 @@ fn in_place_fix_variable<S: Scalar>(multiplicand: &mut [S], r_as_field: S, num_v
 fn vec_elementwise_add<S: Scalar>(a: Vec<S>, b: Vec<S>) -> Vec<S> {
     a.into_iter().zip(b).map(|(x, y)| x + y).collect::<Vec<S>>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::prove_round;
+    use crate::{
+        base::scalar::test_scalar::TestScalar,
+        proof_primitive::sumcheck::ProverState,
+    };
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn first_round_constant_polynomial_returns_same_value_at_both_points() {
+        // f = constant 3: extension = [1, 1], coeff = 3
+        let mut state = ProverState::new(
+            alloc::vec![(ts(3), alloc::vec![0usize])],
+            alloc::vec![alloc::vec![ts(1), ts(1)]],
+            1,
+            1,
+        );
+        let result = prove_round(&mut state, &None);
+        assert_eq!(result[0], ts(3));
+        assert_eq!(result[1], ts(3));
+    }
+
+    #[test]
+    fn first_round_result_has_degree_plus_one_entries() {
+        let mut state = ProverState::new(
+            alloc::vec![(ts(1), alloc::vec![0usize])],
+            alloc::vec![alloc::vec![ts(0), ts(2)]],
+            1,
+            1,
+        );
+        let result = prove_round(&mut state, &None);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn prove_round_increments_round_counter() {
+        let mut state = ProverState::new(
+            alloc::vec![(ts(1), alloc::vec![0usize])],
+            alloc::vec![alloc::vec![ts(1), ts(1)]],
+            1,
+            1,
+        );
+        assert_eq!(state.round, 0);
+        prove_round(&mut state, &None);
+        assert_eq!(state.round, 1);
+    }
+
+    #[test]
+    fn first_round_linear_polynomial_evaluations_correct() {
+        // extension = [0, 4], coeff = 1 → at t=0: 0, at t=1: 4
+        let mut state = ProverState::new(
+            alloc::vec![(ts(1), alloc::vec![0usize])],
+            alloc::vec![alloc::vec![ts(0), ts(4)]],
+            1,
+            1,
+        );
+        let result = prove_round(&mut state, &None);
+        assert_eq!(result[0], ts(0));
+        assert_eq!(result[1], ts(4));
+    }
+
+    #[test]
+    fn first_round_with_scalar_coefficient() {
+        // coeff=2, extension=[1,3] → at t=0: 2, at t=1: 6
+        let mut state = ProverState::new(
+            alloc::vec![(ts(2), alloc::vec![0usize])],
+            alloc::vec![alloc::vec![ts(1), ts(3)]],
+            1,
+            1,
+        );
+        let result = prove_round(&mut state, &None);
+        assert_eq!(result[0], ts(2));
+        assert_eq!(result[1], ts(6));
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -62,3 +62,62 @@ impl<S: Scalar> ProverState<S> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProverState;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn new_creates_state_with_round_zero() {
+        let state = ProverState::<TestScalar>::new(alloc::vec![], alloc::vec![], 3, 2);
+        assert_eq!(state.round, 0);
+    }
+
+    #[test]
+    fn new_stores_num_vars() {
+        let state = ProverState::<TestScalar>::new(alloc::vec![], alloc::vec![], 5, 1);
+        assert_eq!(state.num_vars, 5);
+    }
+
+    #[test]
+    fn new_stores_max_multiplicands() {
+        let state = ProverState::<TestScalar>::new(alloc::vec![], alloc::vec![], 2, 3);
+        assert_eq!(state.max_multiplicands, 3);
+    }
+
+    #[test]
+    fn new_stores_list_of_products_length() {
+        let products = alloc::vec![(ts(2), alloc::vec![0usize, 1])];
+        let state = ProverState::new(products, alloc::vec![], 2, 1);
+        assert_eq!(state.list_of_products.len(), 1);
+        assert_eq!(state.list_of_products[0].0, ts(2));
+    }
+
+    #[test]
+    fn new_stores_flattened_extensions() {
+        let exts = alloc::vec![alloc::vec![ts(1), ts(2), ts(3), ts(4)]];
+        let state = ProverState::new(alloc::vec![], exts, 2, 1);
+        assert_eq!(state.flattened_ml_extensions.len(), 1);
+        assert_eq!(state.flattened_ml_extensions[0][0], ts(1));
+    }
+
+    #[test]
+    fn debug_formatting_works() {
+        let state = ProverState::<TestScalar>::new(alloc::vec![], alloc::vec![], 1, 1);
+        let s = alloc::format!("{state:?}");
+        assert!(s.contains("ProverState"));
+    }
+
+    #[test]
+    fn empty_state_has_zero_products_and_extensions() {
+        let state = ProverState::<TestScalar>::new(alloc::vec![], alloc::vec![], 0, 0);
+        assert_eq!(state.round, 0);
+        assert_eq!(state.list_of_products.len(), 0);
+        assert_eq!(state.flattened_ml_extensions.len(), 0);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -104,3 +104,51 @@ impl ProverEvaluate for EmptyExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EmptyExec;
+    use crate::sql::proof::ProofPlan;
+
+    #[test]
+    fn new_creates_unit_struct() {
+        let _ = EmptyExec::new();
+    }
+
+    #[test]
+    fn default_equals_new() {
+        assert_eq!(EmptyExec::default(), EmptyExec::new());
+    }
+
+    #[test]
+    fn clone_equals_original() {
+        let a = EmptyExec::new();
+        assert_eq!(a.clone(), a);
+    }
+
+    #[test]
+    fn equality_holds_between_two_instances() {
+        assert_eq!(EmptyExec::new(), EmptyExec::new());
+    }
+
+    #[test]
+    fn debug_formatting_contains_struct_name() {
+        let s = alloc::format!("{:?}", EmptyExec::new());
+        assert!(s.contains("EmptyExec"));
+    }
+
+    #[test]
+    fn get_column_result_fields_is_empty() {
+        assert!(EmptyExec::new().get_column_result_fields().is_empty());
+    }
+
+    #[test]
+    fn get_column_references_is_empty() {
+        assert!(EmptyExec::new().get_column_references().is_empty());
+    }
+
+    #[test]
+    fn get_table_references_is_empty() {
+        assert!(EmptyExec::new().get_table_references().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Adds 19 new unit tests covering previously untested code paths:

- **`proof_primitive/sumcheck/prover_state.rs`** (7 tests): `ProverState::new()` field storage, initial round counter, Debug formatting
- **`proof_primitive/sumcheck/prover_round.rs`** (5 tests): `prove_round()` evaluations at both endpoints of a linear polynomial, round counter increment, scalar coefficient handling
- **`sql/proof_plans/empty_exec.rs`** (8 tests): `EmptyExec::new()`, `Default`, `Clone`, `PartialEq`, `Debug`, `get_column_result_fields()`, `get_column_references()`, `get_table_references()`

All tests pass locally with `cargo test --lib`.

/attempt #560