### PR TITLE
test: add unit tests for RefInto, ScalarConversionError, and log_memory_usage

### DIFF
--- a/crates/proof-of-sql/src/base/ref_into.rs
+++ b/crates/proof-of-sql/src/base/ref_into.rs
@@ -23,3 +23,38 @@ where
         self.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RefInto;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn test_scalar_ref_into_u64_4_does_not_panic() {
+        let s = TestScalar::from(0i32);
+        let _: [u64; 4] = s.ref_into();
+    }
+
+    #[test]
+    fn zero_scalar_ref_into_is_all_zeros() {
+        let s = TestScalar::from(0i32);
+        let limbs: [u64; 4] = s.ref_into();
+        assert_eq!(limbs, [0u64; 4]);
+    }
+
+    #[test]
+    fn nonzero_scalar_ref_into_is_nonzero() {
+        let s = TestScalar::from(1i32);
+        let limbs: [u64; 4] = s.ref_into();
+        assert_ne!(limbs, [0u64; 4]);
+    }
+
+    #[test]
+    fn distinct_scalars_produce_distinct_limbs() {
+        let a = TestScalar::from(1i32);
+        let b = TestScalar::from(2i32);
+        let limbs_a: [u64; 4] = a.ref_into();
+        let limbs_b: [u64; 4] = b.ref_into();
+        assert_ne!(limbs_a, limbs_b);
+    }
+}

--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,44 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ScalarConversionError;
+
+    #[test]
+    fn overflow_display_contains_message() {
+        let e = ScalarConversionError::Overflow {
+            error: "value too large".into(),
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("value too large"));
+    }
+
+    #[test]
+    fn overflow_display_contains_overflow() {
+        let e = ScalarConversionError::Overflow {
+            error: "abc".into(),
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("Overflow") || s.contains("overflow"));
+    }
+
+    #[test]
+    fn overflow_debug_contains_overflow() {
+        let e = ScalarConversionError::Overflow {
+            error: "abc".into(),
+        };
+        let s = alloc::format!("{e:?}");
+        assert!(s.contains("Overflow"));
+    }
+
+    #[test]
+    fn overflow_error_message_is_preserved() {
+        let e = ScalarConversionError::Overflow {
+            error: "specific error text".into(),
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("specific error text"));
+    }
+}

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -30,3 +30,18 @@ pub fn log_memory_usage(name: &str) {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::log_memory_usage;
+
+    #[test]
+    fn log_memory_usage_does_not_panic_with_empty_name() {
+        log_memory_usage("");
+    }
+
+    #[test]
+    fn log_memory_usage_does_not_panic_with_name() {
+        log_memory_usage("test");
+    }
+}


### PR DESCRIPTION
## Summary

Adds 10 new unit tests covering three previously untested files:

- **`base/ref_into.rs`** (4 tests): `RefInto<[u64; 4]>` trait — zero scalar maps to all-zero limbs, nonzero scalar maps to nonzero limbs, distinct scalars produce distinct limb representations
- **`base/scalar/error.rs`** (4 tests): `ScalarConversionError::Overflow` Display contains the error message, Display contains "overflow" keyword, Debug contains "Overflow"
- **`utils/log.rs`** (2 tests): `log_memory_usage()` smoke tests — does not panic with empty or non-empty name

All tests pass locally with `cargo test --lib`.

/attempt #560