### PR TITLE
test(planner): add coverage for PlannerError variants and df_util helpers

### DIFF
--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -25,3 +25,45 @@ pub(crate) fn df_schema(table_name: &str, pairs: Vec<(&str, DataType)>) -> DFSch
     );
     DFSchema::try_from_qualified_schema(table_name, &arrow_schema).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{df_column, df_schema};
+    use arrow::datatypes::DataType;
+    use datafusion::logical_expr::Expr;
+
+    #[test]
+    fn df_column_returns_column_expr() {
+        let expr = df_column("schema.table", "col");
+        assert!(matches!(expr, Expr::Column(_)));
+    }
+
+    #[test]
+    fn df_column_contains_column_name() {
+        let expr = df_column("myschema.mytable", "mycolumn");
+        if let Expr::Column(col) = expr {
+            assert_eq!(col.name, "mycolumn");
+        } else {
+            panic!("expected Expr::Column");
+        }
+    }
+
+    #[test]
+    fn df_schema_creates_schema_with_correct_column_count() {
+        let schema = df_schema("t", vec![("a", DataType::Int64), ("b", DataType::Boolean)]);
+        assert_eq!(schema.fields().len(), 2);
+    }
+
+    #[test]
+    fn df_schema_preserves_column_names() {
+        let schema = df_schema("t", vec![("myfield", DataType::Utf8)]);
+        let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(field_names.iter().any(|n| n.contains("myfield")));
+    }
+
+    #[test]
+    fn df_schema_empty_pairs_creates_empty_schema() {
+        let schema = df_schema("t", vec![]);
+        assert_eq!(schema.fields().len(), 0);
+    }
+}

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -105,3 +105,88 @@ pub enum PlannerError {
 
 /// Proof of SQL Planner result
 pub type PlannerResult<T> = Result<T, PlannerError>;
+
+#[cfg(test)]
+mod tests {
+    use super::PlannerError;
+    use arrow::datatypes::DataType;
+    use datafusion::{
+        logical_expr::{expr::Placeholder, Operator},
+        physical_plan,
+    };
+
+    #[test]
+    fn column_not_found_display() {
+        let e = PlannerError::ColumnNotFound;
+        assert_eq!(format!("{e}"), "Column not found");
+    }
+
+    #[test]
+    fn table_not_found_display_contains_table_name() {
+        let e = PlannerError::TableNotFound { table_name: "mytable".to_string() };
+        assert!(format!("{e}").contains("mytable"));
+    }
+
+    #[test]
+    fn invalid_placeholder_id_display_contains_id() {
+        let e = PlannerError::InvalidPlaceholderId { id: "bad_id".to_string() };
+        assert!(format!("{e}").contains("bad_id"));
+    }
+
+    #[test]
+    fn unsupported_datatype_display_contains_type() {
+        let e = PlannerError::UnsupportedDataType { data_type: DataType::Float64 };
+        assert!(format!("{e}").contains("Float64") || format!("{e}").contains("datatype"));
+    }
+
+    #[test]
+    fn unsupported_binary_operator_display() {
+        let e = PlannerError::UnsupportedBinaryOperator { op: Operator::Plus };
+        assert!(format!("{e}").contains("not supported"));
+    }
+
+    #[test]
+    fn unresolved_logical_plan_display() {
+        let e = PlannerError::UnresolvedLogicalPlan;
+        assert_eq!(format!("{e}"), "LogicalPlan is not resolved");
+    }
+
+    #[test]
+    fn catalog_not_supported_display() {
+        let e = PlannerError::CatalogNotSupported;
+        assert_eq!(format!("{e}"), "Catalog is not supported");
+    }
+
+    #[test]
+    fn untyped_placeholder_display_contains_id() {
+        let placeholder = Placeholder { id: "$1".to_string(), data_type: None };
+        let e = PlannerError::UntypedPlaceholder { placeholder };
+        assert!(format!("{e}").contains("$1") || format!("{e}").contains("untyped"));
+    }
+
+    #[test]
+    fn unsupported_aggregate_operation_display() {
+        let e = PlannerError::UnsupportedAggregateOperation {
+            op: physical_plan::aggregates::AggregateFunction::Sum,
+        };
+        assert!(format!("{e}").contains("not supported") || format!("{e}").contains("Sum"));
+    }
+
+    #[test]
+    fn column_not_found_debug_contains_variant_name() {
+        let e = PlannerError::ColumnNotFound;
+        assert!(format!("{e:?}").contains("ColumnNotFound"));
+    }
+
+    #[test]
+    fn table_not_found_debug() {
+        let e = PlannerError::TableNotFound { table_name: "t".to_string() };
+        assert!(format!("{e:?}").contains("TableNotFound"));
+    }
+
+    #[test]
+    fn unresolved_logical_plan_debug() {
+        let e = PlannerError::UnresolvedLogicalPlan;
+        assert!(format!("{e:?}").contains("UnresolvedLogicalPlan"));
+    }
+}


### PR DESCRIPTION
Add unit tests for previously uncovered code in `proof-of-sql-planner`:

- `src/error.rs`: 12 tests covering all simple `PlannerError` variants (`ColumnNotFound`, `TableNotFound`, `InvalidPlaceholderId`, `UnsupportedDataType`, `UnsupportedBinaryOperator`, `UnresolvedLogicalPlan`, `CatalogNotSupported`, `UntypedPlaceholder`, `UnsupportedAggregateOperation`) — Display format and Debug formatting
- `src/df_util.rs`: 5 tests covering `df_column()` and `df_schema()` helper functions

All tests pass locally on the full test suite.

/attempt #560