### PR TITLE
test(proof-of-sql): add coverage for AddExpr, SubtractExpr, and DynProofExpr

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -117,3 +117,94 @@ impl ProofExpr for AddExpr {
 }
 
 impl DecimalProofExpr for AddExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::AddExpr;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, ProofExpr},
+    };
+
+    fn bigint_literal() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(1))
+    }
+
+    fn boolean_literal() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+
+    #[test]
+    fn try_new_with_compatible_numeric_types_returns_ok() {
+        let result = AddExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_with_incompatible_types_returns_err() {
+        let result = AddExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(boolean_literal()),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn lhs_returns_left_expr() {
+        let lhs = bigint_literal();
+        let expr = AddExpr::try_new(
+            alloc::boxed::Box::new(lhs),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert_eq!(expr.lhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn rhs_returns_right_expr() {
+        let expr = AddExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert_eq!(expr.rhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn debug_formatting_contains_struct_name() {
+        let expr = AddExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert!(alloc::format!("{expr:?}").contains("AddExpr"));
+    }
+
+    #[test]
+    fn equality_holds_for_equal_expressions() {
+        let a = AddExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        let b = AddExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_produces_equal_value() {
+        let expr = AddExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert_eq!(expr.clone(), expr);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -122,3 +122,105 @@ impl DynProofExpr {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DynProofExpr;
+    use crate::{
+        base::database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+        sql::proof_exprs::ProofExpr,
+    };
+    use sqlparser::ast::Ident;
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(42))
+    }
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+
+    #[test]
+    fn new_literal_creates_literal_variant() {
+        let expr = DynProofExpr::new_literal(LiteralValue::BigInt(1));
+        assert!(matches!(expr, DynProofExpr::Literal(_)));
+    }
+
+    #[test]
+    fn new_literal_bigint_has_correct_data_type() {
+        let expr = bigint_expr();
+        assert_eq!(expr.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn new_literal_boolean_has_correct_data_type() {
+        let expr = bool_expr();
+        assert_eq!(expr.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn new_column_creates_column_variant() {
+        let col_ref = ColumnRef::new(TableRef::new("s", "t"), Ident::new("col"), ColumnType::BigInt);
+        let expr = DynProofExpr::new_column(col_ref);
+        assert!(matches!(expr, DynProofExpr::Column(_)));
+    }
+
+    #[test]
+    fn try_new_and_with_booleans_returns_ok() {
+        let result = DynProofExpr::try_new_and(bool_expr(), bool_expr());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_and_creates_and_variant() {
+        let expr = DynProofExpr::try_new_and(bool_expr(), bool_expr()).unwrap();
+        assert!(matches!(expr, DynProofExpr::And(_)));
+    }
+
+    #[test]
+    fn try_new_not_with_boolean_returns_ok() {
+        let result = DynProofExpr::try_new_not(bool_expr());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_equals_with_same_types_returns_ok() {
+        let result = DynProofExpr::try_new_equals(bigint_expr(), bigint_expr());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_add_with_bigints_returns_ok() {
+        let result = DynProofExpr::try_new_add(bigint_expr(), bigint_expr());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_subtract_with_bigints_returns_ok() {
+        let result = DynProofExpr::try_new_subtract(bigint_expr(), bigint_expr());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_multiply_with_bigints_returns_ok() {
+        let result = DynProofExpr::try_new_multiply(bigint_expr(), bigint_expr());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn debug_formatting_contains_expr_type() {
+        let expr = bigint_expr();
+        assert!(alloc::format!("{expr:?}").contains("Literal") || alloc::format!("{expr:?}").contains("BigInt"));
+    }
+
+    #[test]
+    fn equality_holds_for_same_literals() {
+        assert_eq!(bigint_expr(), bigint_expr());
+    }
+
+    #[test]
+    fn clone_produces_equal_value() {
+        let expr = bigint_expr();
+        assert_eq!(expr.clone(), expr);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
@@ -118,3 +118,93 @@ impl ProofExpr for SubtractExpr {
 }
 
 impl DecimalProofExpr for SubtractExpr {}
+
+#[cfg(test)]
+mod tests {
+    use super::SubtractExpr;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, ProofExpr},
+    };
+
+    fn bigint_literal() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(1))
+    }
+
+    fn boolean_literal() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(false))
+    }
+
+    #[test]
+    fn try_new_with_compatible_types_returns_ok() {
+        let result = SubtractExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_new_with_incompatible_types_returns_err() {
+        let result = SubtractExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(boolean_literal()),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn lhs_returns_left_expr_type() {
+        let expr = SubtractExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert_eq!(expr.lhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn rhs_returns_right_expr_type() {
+        let expr = SubtractExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert_eq!(expr.rhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn debug_formatting_contains_struct_name() {
+        let expr = SubtractExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert!(alloc::format!("{expr:?}").contains("SubtractExpr"));
+    }
+
+    #[test]
+    fn equality_holds_for_equal_expressions() {
+        let a = SubtractExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        let b = SubtractExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_produces_equal_value() {
+        let expr = SubtractExpr::try_new(
+            alloc::boxed::Box::new(bigint_literal()),
+            alloc::boxed::Box::new(bigint_literal()),
+        )
+        .unwrap();
+        assert_eq!(expr.clone(), expr);
+    }
+}


### PR DESCRIPTION
Add unit tests for previously uncovered arithmetic expression types in `proof-of-sql`:

- `src/sql/proof_exprs/add_expr.rs`: 7 tests covering `AddExpr::try_new()` (compatible types → Ok, incompatible → Err), `lhs()`, `rhs()`, `data_type()`, Debug, PartialEq, Clone
- `src/sql/proof_exprs/subtract_expr.rs`: 7 tests covering `SubtractExpr::try_new()` (compatible → Ok, incompatible → Err), `lhs()`, `rhs()`, `data_type()`, Debug, PartialEq, Clone
- `src/sql/proof_exprs/dyn_proof_expr.rs`: 14 tests covering `new_literal()`, `new_column()`, `try_new_and()`, `try_new_not()`, `try_new_equals()`, `try_new_add()`, `try_new_subtract()`, `try_new_multiply()` — variant matching, data type checks, Debug, PartialEq, Clone

All 28 tests pass locally.

/attempt #560