### PR TITLE
test(proof-of-sql): add coverage for EVMProofPlanError, EVMProofPlan, and ProvableResultColumn

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,60 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::EVMProofPlanError;
+
+    #[test]
+    fn not_supported_display() {
+        let e = EVMProofPlanError::NotSupported;
+        assert_eq!(alloc::format!("{e}"), "plan not yet supported");
+    }
+
+    #[test]
+    fn column_not_found_display() {
+        let e = EVMProofPlanError::ColumnNotFound;
+        assert_eq!(alloc::format!("{e}"), "column not found");
+    }
+
+    #[test]
+    fn table_not_found_display() {
+        let e = EVMProofPlanError::TableNotFound;
+        assert_eq!(alloc::format!("{e}"), "table not found");
+    }
+
+    #[test]
+    fn invalid_table_name_display() {
+        let e = EVMProofPlanError::InvalidTableName;
+        assert_eq!(alloc::format!("{e}"), "table name can not be parsed into TableRef");
+    }
+
+    #[test]
+    fn invalid_output_column_name_display() {
+        let e = EVMProofPlanError::InvalidOutputColumnName;
+        assert_eq!(alloc::format!("{e}"), "invalid or missing output column name");
+    }
+
+    #[test]
+    fn incorrect_scaling_factor_display() {
+        let e = EVMProofPlanError::IncorrectScalingFactor;
+        assert_eq!(alloc::format!("{e}"), "incorrect scaling factor");
+    }
+
+    #[test]
+    fn not_supported_debug() {
+        let e = EVMProofPlanError::NotSupported;
+        assert!(alloc::format!("{e:?}").contains("NotSupported"));
+    }
+
+    #[test]
+    fn not_supported_equality() {
+        assert_eq!(EVMProofPlanError::NotSupported, EVMProofPlanError::NotSupported);
+    }
+
+    #[test]
+    fn different_variants_not_equal() {
+        assert_ne!(EVMProofPlanError::NotSupported, EVMProofPlanError::ColumnNotFound);
+    }
+}

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -191,3 +191,57 @@ impl ProverEvaluate for EVMProofPlan {
             .final_round_evaluate(builder, alloc, table_map, params)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EVMProofPlan;
+    use crate::{
+        sql::proof::ProofPlan,
+        sql::proof_plans::DynProofPlan,
+    };
+
+    #[test]
+    fn new_wraps_plan() {
+        let inner = DynProofPlan::new_empty();
+        let _ = EVMProofPlan::new(inner);
+    }
+
+    #[test]
+    fn inner_returns_reference_to_plan() {
+        let inner = DynProofPlan::new_empty();
+        let plan = EVMProofPlan::new(inner);
+        assert!(matches!(plan.inner(), DynProofPlan::Empty(_)));
+    }
+
+    #[test]
+    fn into_inner_returns_plan() {
+        let inner = DynProofPlan::new_empty();
+        let plan = EVMProofPlan::new(inner);
+        let recovered = plan.into_inner();
+        assert!(matches!(recovered, DynProofPlan::Empty(_)));
+    }
+
+    #[test]
+    fn debug_formatting_contains_struct_name() {
+        let plan = EVMProofPlan::new(DynProofPlan::new_empty());
+        assert!(alloc::format!("{plan:?}").contains("EVMProofPlan") || alloc::format!("{plan:?}").contains("Empty"));
+    }
+
+    #[test]
+    fn get_column_result_fields_is_empty_for_empty_plan() {
+        let plan = EVMProofPlan::new(DynProofPlan::new_empty());
+        assert!(plan.get_column_result_fields().is_empty());
+    }
+
+    #[test]
+    fn get_column_references_is_empty_for_empty_plan() {
+        let plan = EVMProofPlan::new(DynProofPlan::new_empty());
+        assert!(plan.get_column_references().is_empty());
+    }
+
+    #[test]
+    fn get_table_references_is_empty_for_empty_plan() {
+        let plan = EVMProofPlan::new(DynProofPlan::new_empty());
+        assert!(plan.get_table_references().is_empty());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -69,3 +69,72 @@ impl<'a, T: ProvableResultElement<'a>, const N: usize> ProvableResultColumn for 
         (&self[..]).write(out, length)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProvableResultColumn;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::database::Column;
+
+    #[test]
+    fn bool_slice_num_bytes_equals_length() {
+        let data = [true, false, true];
+        assert_eq!(data.as_slice().num_bytes(3), 3);
+    }
+
+    #[test]
+    fn bool_slice_num_bytes_zero_for_empty() {
+        let data: &[bool] = &[];
+        assert_eq!(data.num_bytes(0), 0);
+    }
+
+    #[test]
+    fn bool_slice_write_encodes_true_as_one() {
+        let data = [true];
+        let mut out = alloc::vec![0u8; 1];
+        data.as_slice().write(&mut out, 1);
+        assert_eq!(out[0], 1);
+    }
+
+    #[test]
+    fn bool_slice_write_encodes_false_as_zero() {
+        let data = [false];
+        let mut out = alloc::vec![0u8; 1];
+        data.as_slice().write(&mut out, 1);
+        assert_eq!(out[0], 0);
+    }
+
+    #[test]
+    fn bool_slice_write_returns_written_count() {
+        let data = [true, false];
+        let mut out = alloc::vec![0u8; 2];
+        let written = data.as_slice().write(&mut out, 2);
+        assert_eq!(written, 2);
+    }
+
+    #[test]
+    fn bigint_column_num_bytes_is_correct() {
+        let data = alloc::vec![1i64, 2, 3];
+        let col = Column::<TestScalar>::BigInt(&data);
+        // BigInt uses VarInt encoding which is variable size
+        let nb = col.num_bytes(3);
+        assert!(nb > 0);
+    }
+
+    #[test]
+    fn boolean_column_num_bytes_equals_length() {
+        let data = alloc::vec![true, false, true];
+        let col = Column::<TestScalar>::Boolean(&data);
+        assert_eq!(col.num_bytes(3), 3);
+    }
+
+    #[test]
+    fn boolean_column_write_fills_output() {
+        let data = alloc::vec![true];
+        let col = Column::<TestScalar>::Boolean(&data);
+        let mut out = alloc::vec![0u8; 1];
+        let written = col.write(&mut out, 1);
+        assert_eq!(written, 1);
+        assert_eq!(out[0], 1);
+    }
+}


### PR DESCRIPTION
Add unit tests for previously uncovered code in `proof-of-sql`:

- `src/sql/evm_proof_plan/error.rs`: 9 tests covering all `EVMProofPlanError` variants (NotSupported, ColumnNotFound, TableNotFound, InvalidTableName, InvalidOutputColumnName, IncorrectScalingFactor) — Display format, Debug, PartialEq
- `src/sql/evm_proof_plan/proof_plan.rs`: 7 tests covering `EVMProofPlan::new()`, `inner()`, `into_inner()`, Debug formatting, `get_column_result_fields()`, `get_column_references()`, `get_table_references()`
- `src/sql/proof/provable_result_column.rs`: 8 tests covering `ProvableResultColumn` implementations for `&[bool]` slice (num_bytes, write encoding), `Column::Boolean` (num_bytes, write), and `Column::BigInt` (num_bytes)

All 24 tests pass locally.

/attempt #560