### PR TITLE
test(proof-of-sql): add coverage for TableOperationError, OwnedColumnError, ColumnRef, PoSQLTimestampError, TableEvaluation

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,58 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnRef;
+    use crate::base::database::{ColumnType, TableRef};
+    use sqlparser::ast::Ident;
+
+    fn make_ref(table: &str, col: &str, ty: ColumnType) -> ColumnRef {
+        ColumnRef::new(TableRef::new("s", table), Ident::new(col), ty)
+    }
+
+    #[test]
+    fn table_ref_returns_correct_table() {
+        let r = make_ref("t", "col", ColumnType::BigInt);
+        assert_eq!(r.table_ref().table_id().value.as_str(), "t");
+    }
+
+    #[test]
+    fn column_id_returns_correct_ident() {
+        let r = make_ref("t", "mycol", ColumnType::BigInt);
+        assert_eq!(r.column_id().value.as_str(), "mycol");
+    }
+
+    #[test]
+    fn column_type_returns_correct_type() {
+        let r = make_ref("t", "col", ColumnType::Boolean);
+        assert_eq!(*r.column_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn equality_holds_for_same_values() {
+        let a = make_ref("t", "col", ColumnType::BigInt);
+        let b = make_ref("t", "col", ColumnType::BigInt);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_types_are_not_equal() {
+        let a = make_ref("t", "col", ColumnType::BigInt);
+        let b = make_ref("t", "col", ColumnType::Boolean);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_column_ref() {
+        let r = make_ref("t", "col", ColumnType::BigInt);
+        assert!(alloc::format!("{r:?}").contains("ColumnRef"));
+    }
+
+    #[test]
+    fn clone_produces_equal_value() {
+        let r = make_ref("t", "col", ColumnType::BigInt);
+        assert_eq!(r.clone(), r);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,61 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnCoercionError, OwnedColumnError};
+    use crate::base::database::ColumnType;
+
+    #[test]
+    fn type_cast_error_display_mentions_types() {
+        let e = OwnedColumnError::TypeCastError {
+            from_type: ColumnType::BigInt,
+            to_type: ColumnType::Boolean,
+        };
+        assert!(alloc::format!("{e}").contains("type casting"));
+    }
+
+    #[test]
+    fn scalar_conversion_error_display_contains_message() {
+        let e = OwnedColumnError::ScalarConversionError { error: "bad value".into() };
+        assert!(alloc::format!("{e}").contains("bad value"));
+    }
+
+    #[test]
+    fn unsupported_display_contains_message() {
+        let e = OwnedColumnError::Unsupported { error: "operation x".into() };
+        assert!(alloc::format!("{e}").contains("operation x"));
+    }
+
+    #[test]
+    fn type_cast_error_equality() {
+        let e1 = OwnedColumnError::TypeCastError {
+            from_type: ColumnType::BigInt,
+            to_type: ColumnType::Boolean,
+        };
+        let e2 = OwnedColumnError::TypeCastError {
+            from_type: ColumnType::BigInt,
+            to_type: ColumnType::Boolean,
+        };
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn debug_contains_variant_name() {
+        let e = OwnedColumnError::Unsupported { error: "x".into() };
+        assert!(alloc::format!("{e:?}").contains("Unsupported"));
+    }
+
+    #[test]
+    fn coercion_error_overflow_display() {
+        let e = ColumnCoercionError::Overflow;
+        assert!(alloc::format!("{e}").contains("Overflow") || alloc::format!("{e}").contains("overflow"));
+    }
+
+    #[test]
+    fn coercion_error_invalid_type_display() {
+        let e = ColumnCoercionError::InvalidTypeCoercion;
+        assert!(alloc::format!("{e}").contains("Invalid") || alloc::format!("{e}").contains("coercion"));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -35,3 +35,57 @@ impl<S: Scalar> TableEvaluation<S> {
         self.chi
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableEvaluation;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn new_creates_struct_with_correct_evals() {
+        let evals = alloc::vec![ts(1), ts(2)];
+        let te = TableEvaluation::new(evals.clone(), (ts(3), 5));
+        assert_eq!(te.column_evals(), &[ts(1), ts(2)]);
+    }
+
+    #[test]
+    fn chi_eval_returns_correct_scalar() {
+        let te = TableEvaluation::<TestScalar>::new(alloc::vec![], (ts(7), 10));
+        assert_eq!(te.chi_eval(), ts(7));
+    }
+
+    #[test]
+    fn chi_returns_tuple() {
+        let te = TableEvaluation::<TestScalar>::new(alloc::vec![], (ts(4), 8));
+        assert_eq!(te.chi(), (ts(4), 8));
+    }
+
+    #[test]
+    fn column_evals_is_empty_for_empty_input() {
+        let te = TableEvaluation::<TestScalar>::new(alloc::vec![], (ts(0), 0));
+        assert!(te.column_evals().is_empty());
+    }
+
+    #[test]
+    fn equality_holds_for_same_values() {
+        let a = TableEvaluation::new(alloc::vec![ts(1)], (ts(2), 3));
+        let b = TableEvaluation::new(alloc::vec![ts(1)], (ts(2), 3));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_produces_equal_value() {
+        let te = TableEvaluation::new(alloc::vec![ts(5)], (ts(6), 7));
+        assert_eq!(te.clone(), te);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let te = TableEvaluation::<TestScalar>::new(alloc::vec![], (ts(0), 0));
+        assert!(alloc::format!("{te:?}").contains("TableEvaluation"));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,66 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::TableOperationError;
+    use crate::base::database::{ColumnType};
+    use sqlparser::ast::Ident;
+
+    #[test]
+    fn union_not_enough_tables_display() {
+        let e = TableOperationError::UnionNotEnoughTables;
+        assert_eq!(alloc::format!("{e}"), "Cannot union fewer than 2 tables");
+    }
+
+    #[test]
+    fn join_with_different_column_count_display_contains_numbers() {
+        let e = TableOperationError::JoinWithDifferentNumberOfColumns {
+            left_num_columns: 3,
+            right_num_columns: 5,
+        };
+        let s = alloc::format!("{e}");
+        assert!(s.contains("3") && s.contains("5"));
+    }
+
+    #[test]
+    fn join_incompatible_types_display() {
+        let e = TableOperationError::JoinIncompatibleTypes {
+            left_type: ColumnType::BigInt,
+            right_type: ColumnType::Boolean,
+        };
+        assert!(alloc::format!("{e}").contains("incompatible"));
+    }
+
+    #[test]
+    fn column_does_not_exist_display_contains_column_name() {
+        let e = TableOperationError::ColumnDoesNotExist {
+            column_ident: Ident::new("mycol"),
+        };
+        assert!(alloc::format!("{e}").contains("mycol"));
+    }
+
+    #[test]
+    fn duplicate_column_display() {
+        let e = TableOperationError::DuplicateColumn;
+        assert!(alloc::format!("{e}").contains("duplicated") || alloc::format!("{e}").contains("duplicate"));
+    }
+
+    #[test]
+    fn column_index_out_of_bounds_display_contains_index() {
+        let e = TableOperationError::ColumnIndexOutOfBounds { column_index: 42 };
+        assert!(alloc::format!("{e}").contains("42"));
+    }
+
+    #[test]
+    fn union_not_enough_tables_equality() {
+        assert_eq!(TableOperationError::UnionNotEnoughTables, TableOperationError::UnionNotEnoughTables);
+    }
+
+    #[test]
+    fn debug_contains_variant_name() {
+        let e = TableOperationError::DuplicateColumn;
+        assert!(alloc::format!("{e:?}").contains("DuplicateColumn"));
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,50 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PoSQLTimestampError;
+
+    #[test]
+    fn invalid_timezone_display_contains_timezone() {
+        let e = PoSQLTimestampError::InvalidTimezone { timezone: "badzone".into() };
+        assert!(alloc::format!("{e}").contains("badzone"));
+    }
+
+    #[test]
+    fn invalid_timezone_offset_display() {
+        let e = PoSQLTimestampError::InvalidTimezoneOffset;
+        assert_eq!(alloc::format!("{e}"), "invalid timezone offset");
+    }
+
+    #[test]
+    fn invalid_time_unit_display_contains_error() {
+        let e = PoSQLTimestampError::InvalidTimeUnit { error: "bad unit".into() };
+        assert!(alloc::format!("{e}").contains("time unit") || alloc::format!("{e}").contains("Invalid"));
+    }
+
+    #[test]
+    fn unsupported_precision_display_contains_error() {
+        let e = PoSQLTimestampError::UnsupportedPrecision { error: "nanoseconds".into() };
+        assert!(alloc::format!("{e}").contains("nanoseconds") || alloc::format!("{e}").contains("precision"));
+    }
+
+    #[test]
+    fn error_can_be_converted_to_string() {
+        let e = PoSQLTimestampError::InvalidTimezoneOffset;
+        let s: alloc::string::String = e.into();
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn debug_contains_variant_name() {
+        let e = PoSQLTimestampError::InvalidTimezoneOffset;
+        assert!(alloc::format!("{e:?}").contains("InvalidTimezoneOffset"));
+    }
+
+    #[test]
+    fn equality_holds_for_same_variant() {
+        assert_eq!(PoSQLTimestampError::InvalidTimezoneOffset, PoSQLTimestampError::InvalidTimezoneOffset);
+    }
+}


### PR DESCRIPTION
Add unit tests for previously uncovered types in `proof-of-sql`:

- `src/base/database/table_operation_error.rs`: 8 tests covering `TableOperationError` variants — `UnionNotEnoughTables`, `JoinWithDifferentNumberOfColumns`, `JoinIncompatibleTypes`, `ColumnDoesNotExist`, `DuplicateColumn`, `ColumnIndexOutOfBounds` — Display format, Debug, PartialEq
- `src/base/database/owned_column_error.rs`: 7 tests covering `OwnedColumnError` (TypeCastError, ScalarConversionError, Unsupported) and `ColumnCoercionError` (Overflow, InvalidTypeCoercion) — Display, Debug, PartialEq
- `src/base/database/column_ref.rs`: 7 tests covering `ColumnRef::new()`, `table_ref()`, `column_id()`, `column_type()` accessors, PartialEq, Clone, Debug
- `src/base/posql_time/error.rs`: 7 tests covering `PoSQLTimestampError` variants — `InvalidTimezone`, `InvalidTimezoneOffset`, `InvalidTimeUnit`, `UnsupportedPrecision` — Display, Debug, PartialEq, `From<PoSQLTimestampError> for String`
- `src/base/database/table_evaluation.rs`: 7 tests covering `TableEvaluation::new()`, `column_evals()`, `chi_eval()`, `chi()` accessors, PartialEq, Clone, Debug

All 36 tests pass locally.

/attempt #560