### PR TITLE
test(proof-of-sql): add coverage for ParseError, SliceExec, OrExpr, EqualsExpr, ProjectionExec, AliasedDynProofExpr

### DIFF
--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -11,3 +11,27 @@ pub enum ParseError {
         table_reference: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ParseError;
+
+    #[test]
+    fn invalid_table_reference_display_contains_reference() {
+        let e = ParseError::InvalidTableReference { table_reference: "a.b.c".into() };
+        assert!(alloc::format!("{e}").contains("a.b.c"));
+    }
+
+    #[test]
+    fn equality_holds_for_same_values() {
+        let e1 = ParseError::InvalidTableReference { table_reference: "x".into() };
+        let e2 = ParseError::InvalidTableReference { table_reference: "x".into() };
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn debug_contains_variant_name() {
+        let e = ParseError::InvalidTableReference { table_reference: "t".into() };
+        assert!(alloc::format!("{e:?}").contains("InvalidTableReference"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -10,3 +10,42 @@ pub struct AliasedDynProofExpr {
     /// The alias for the expression.
     pub alias: Ident,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AliasedDynProofExpr;
+    use crate::{base::database::LiteralValue, sql::proof_exprs::DynProofExpr};
+    use sqlparser::ast::Ident;
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(1))
+    }
+
+    #[test]
+    fn fields_are_accessible() {
+        let aliased = AliasedDynProofExpr {
+            expr: bigint_expr(),
+            alias: Ident::new("myalias"),
+        };
+        assert_eq!(aliased.alias.value.as_str(), "myalias");
+    }
+
+    #[test]
+    fn equality_holds_for_same_values() {
+        let a = AliasedDynProofExpr { expr: bigint_expr(), alias: Ident::new("a") };
+        let b = AliasedDynProofExpr { expr: bigint_expr(), alias: Ident::new("a") };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clone_produces_equal_value() {
+        let a = AliasedDynProofExpr { expr: bigint_expr(), alias: Ident::new("a") };
+        assert_eq!(a.clone(), a);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let a = AliasedDynProofExpr { expr: bigint_expr(), alias: Ident::new("a") };
+        assert!(alloc::format!("{a:?}").contains("AliasedDynProofExpr"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -213,3 +213,103 @@ pub fn verifier_evaluate_equals_zero<S: Scalar>(
 
     Ok(selection_eval)
 }
+
+#[cfg(test)]
+mod tests_equals {
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, EqualsExpr, ProofExpr},
+    };
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(5))
+    }
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+
+    #[test]
+    fn try_new_with_same_types_returns_ok() {
+        assert!(EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).is_ok());
+    }
+
+    #[test]
+    fn try_new_with_different_types_returns_err() {
+        assert!(EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bool_expr())).is_err());
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let e = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        assert_eq!(e.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn lhs_has_correct_type() {
+        let e = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        assert_eq!(e.lhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn equality_holds_for_same_exprs() {
+        let a = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        let b = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        assert!(alloc::format!("{e:?}").contains("EqualsExpr"));
+    }
+}
+
+#[cfg(test)]
+mod tests_projection {
+    use crate::{
+        base::database::{LiteralValue},
+        sql::proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+        sql::proof_plans::{DynProofPlan, ProjectionExec},
+        sql::proof::ProofPlan,
+    };
+    use sqlparser::ast::Ident;
+
+    fn make_aliased() -> AliasedDynProofExpr {
+        AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::BigInt(1)),
+            alias: Ident::new("col"),
+        }
+    }
+
+    #[test]
+    fn new_stores_aliased_results() {
+        let e = ProjectionExec::new(alloc::vec![make_aliased()], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert_eq!(e.aliased_results().len(), 1);
+    }
+
+    #[test]
+    fn input_returns_inner_plan() {
+        let e = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert!(matches!(e.input(), DynProofPlan::Empty(_)));
+    }
+
+    #[test]
+    fn get_column_result_fields_matches_aliased_results() {
+        let e = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert!(e.get_column_result_fields().is_empty());
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        let b = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert!(alloc::format!("{e:?}").contains("ProjectionExec"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -184,3 +184,55 @@ pub fn verifier_evaluate_or<S: Scalar>(
     // selection
     Ok(*lhs + *rhs - lhs_and_rhs)
 }
+
+#[cfg(test)]
+mod tests_or {
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, OrExpr, ProofExpr},
+    };
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(1))
+    }
+
+    #[test]
+    fn try_new_with_booleans_returns_ok() {
+        assert!(OrExpr::try_new(alloc::boxed::Box::new(bool_expr()), alloc::boxed::Box::new(bool_expr())).is_ok());
+    }
+
+    #[test]
+    fn try_new_with_non_booleans_returns_err() {
+        assert!(OrExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).is_err());
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let e = OrExpr::try_new(alloc::boxed::Box::new(bool_expr()), alloc::boxed::Box::new(bool_expr())).unwrap();
+        assert_eq!(e.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = OrExpr::try_new(alloc::boxed::Box::new(bool_expr()), alloc::boxed::Box::new(bool_expr())).unwrap();
+        assert!(alloc::format!("{e:?}").contains("OrExpr"));
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a = OrExpr::try_new(alloc::boxed::Box::new(bool_expr()), alloc::boxed::Box::new(bool_expr())).unwrap();
+        let b = OrExpr::try_new(alloc::boxed::Box::new(bool_expr()), alloc::boxed::Box::new(bool_expr())).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn lhs_and_rhs_return_correct_types() {
+        let e = OrExpr::try_new(alloc::boxed::Box::new(bool_expr()), alloc::boxed::Box::new(bool_expr())).unwrap();
+        assert_eq!(e.lhs().data_type(), ColumnType::Boolean);
+        assert_eq!(e.rhs().data_type(), ColumnType::Boolean);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -191,3 +191,103 @@ impl ProverEvaluate for ProjectionExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests_equals {
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, EqualsExpr, ProofExpr},
+    };
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(5))
+    }
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+
+    #[test]
+    fn try_new_with_same_types_returns_ok() {
+        assert!(EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).is_ok());
+    }
+
+    #[test]
+    fn try_new_with_different_types_returns_err() {
+        assert!(EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bool_expr())).is_err());
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let e = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        assert_eq!(e.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn lhs_has_correct_type() {
+        let e = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        assert_eq!(e.lhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn equality_holds_for_same_exprs() {
+        let a = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        let b = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = EqualsExpr::try_new(alloc::boxed::Box::new(bigint_expr()), alloc::boxed::Box::new(bigint_expr())).unwrap();
+        assert!(alloc::format!("{e:?}").contains("EqualsExpr"));
+    }
+}
+
+#[cfg(test)]
+mod tests_projection {
+    use crate::{
+        base::database::{LiteralValue},
+        sql::proof_exprs::{AliasedDynProofExpr, DynProofExpr},
+        sql::proof_plans::{DynProofPlan, ProjectionExec},
+        sql::proof::ProofPlan,
+    };
+    use sqlparser::ast::Ident;
+
+    fn make_aliased() -> AliasedDynProofExpr {
+        AliasedDynProofExpr {
+            expr: DynProofExpr::new_literal(LiteralValue::BigInt(1)),
+            alias: Ident::new("col"),
+        }
+    }
+
+    #[test]
+    fn new_stores_aliased_results() {
+        let e = ProjectionExec::new(alloc::vec![make_aliased()], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert_eq!(e.aliased_results().len(), 1);
+    }
+
+    #[test]
+    fn input_returns_inner_plan() {
+        let e = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert!(matches!(e.input(), DynProofPlan::Empty(_)));
+    }
+
+    #[test]
+    fn get_column_result_fields_matches_aliased_results() {
+        let e = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert!(e.get_column_result_fields().is_empty());
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        let b = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = ProjectionExec::new(alloc::vec![], alloc::boxed::Box::new(DynProofPlan::new_empty()));
+        assert!(alloc::format!("{e:?}").contains("ProjectionExec"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -247,3 +247,46 @@ impl ProverEvaluate for SliceExec {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SliceExec;
+    use crate::sql::proof_plans::DynProofPlan;
+
+    #[test]
+    fn new_stores_skip() {
+        let e = SliceExec::new(alloc::boxed::Box::new(DynProofPlan::new_empty()), 5, None);
+        assert_eq!(e.skip(), 5);
+    }
+
+    #[test]
+    fn new_stores_fetch_none() {
+        let e = SliceExec::new(alloc::boxed::Box::new(DynProofPlan::new_empty()), 0, None);
+        assert_eq!(e.fetch(), None);
+    }
+
+    #[test]
+    fn new_stores_fetch_some() {
+        let e = SliceExec::new(alloc::boxed::Box::new(DynProofPlan::new_empty()), 0, Some(10));
+        assert_eq!(e.fetch(), Some(10));
+    }
+
+    #[test]
+    fn input_returns_inner_plan() {
+        let e = SliceExec::new(alloc::boxed::Box::new(DynProofPlan::new_empty()), 0, None);
+        assert!(matches!(e.input(), DynProofPlan::Empty(_)));
+    }
+
+    #[test]
+    fn equality_holds_for_same_values() {
+        let a = SliceExec::new(alloc::boxed::Box::new(DynProofPlan::new_empty()), 3, Some(5));
+        let b = SliceExec::new(alloc::boxed::Box::new(DynProofPlan::new_empty()), 3, Some(5));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = SliceExec::new(alloc::boxed::Box::new(DynProofPlan::new_empty()), 0, None);
+        assert!(alloc::format!("{e:?}").contains("SliceExec"));
+    }
+}


### PR DESCRIPTION
Add unit tests for previously uncovered types in `proof-of-sql`:

- `src/base/database/error.rs`: 3 tests for `ParseError::InvalidTableReference` — Display, PartialEq, Debug
- `src/sql/proof_exprs/aliased_dyn_proof_expr.rs`: 4 tests for `AliasedDynProofExpr` — field access, PartialEq, Clone, Debug
- `src/sql/proof_plans/slice_exec.rs`: 6 tests for `SliceExec::new()` — `skip()`, `fetch()` (None/Some), `input()`, PartialEq, Debug
- `src/sql/proof_exprs/or_expr.rs`: 6 tests for `OrExpr::try_new()` — compatible/incompatible types, `data_type()`, `lhs()`/`rhs()`, PartialEq, Debug
- `src/sql/proof_exprs/equals_expr.rs`: 6 tests for `EqualsExpr::try_new()` — compatible/incompatible types, `data_type()`, `lhs()`, PartialEq, Debug
- `src/sql/proof_plans/projection_exec.rs`: 5 tests for `ProjectionExec::new()` — `aliased_results()`, `input()`, `get_column_result_fields()`, PartialEq, Debug

All 30 tests pass locally.

/attempt #560