### PR TITLE
test: add unit tests for TableExec, AndExpr, MultiplyExpr, InequalityExpr, lagrange basis, interpolate

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/interpolate.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate.rs
@@ -127,3 +127,53 @@ where
         })
         .unwrap_or(vec![])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{interpolate_evaluations_to_reverse_coefficients, interpolate_uni_poly};
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn empty_polynomial_evaluates_to_zero() {
+        let result = interpolate_uni_poly::<TestScalar>(&[], ts(5));
+        assert_eq!(result, ts(0));
+    }
+
+    #[test]
+    fn constant_polynomial_evaluates_to_constant() {
+        // f(x) = 3 at x=0, so f(7) = 3
+        let result = interpolate_uni_poly::<TestScalar>(&[ts(3)], ts(7));
+        assert_eq!(result, ts(3));
+    }
+
+    #[test]
+    fn linear_polynomial_evaluates_correctly() {
+        // f(0)=0, f(1)=1 => f(x) = x => f(2) = 2
+        let result = interpolate_uni_poly::<TestScalar>(&[ts(0), ts(1)], ts(2));
+        assert_eq!(result, ts(2));
+    }
+
+    #[test]
+    fn evaluating_at_known_point_returns_exact_value() {
+        // f(0)=5, f(1)=7 => f(0) = 5 exactly (short-circuit)
+        let result = interpolate_uni_poly::<TestScalar>(&[ts(5), ts(7)], ts(0));
+        assert_eq!(result, ts(5));
+    }
+
+    #[test]
+    fn reverse_coefficients_empty_returns_empty() {
+        let result = interpolate_evaluations_to_reverse_coefficients::<TestScalar>(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn reverse_coefficients_single_element_constant() {
+        // f(x) = c => coefficients [c]
+        let result = interpolate_evaluations_to_reverse_coefficients::<TestScalar>(&[ts(4)]);
+        assert_eq!(result, alloc::vec![ts(4)]);
+    }
+}

--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
@@ -174,3 +174,65 @@ where
         rho
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{compute_rho_eval, compute_truncated_lagrange_basis_inner_product, compute_truncated_lagrange_basis_sum};
+
+    type F = f64;
+
+    #[test]
+    fn inner_product_empty_point_length_one_returns_one() {
+        let result = compute_truncated_lagrange_basis_inner_product::<F>(1, &[], &[]);
+        assert!((result - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn inner_product_empty_point_length_zero_returns_zero() {
+        let result = compute_truncated_lagrange_basis_inner_product::<F>(0, &[], &[]);
+        assert!((result - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn inner_product_single_var_full_length_equals_dot_product() {
+        // a=[0.3], b=[0.7], length=2: (1-0.3)(1-0.7) + 0.3*0.7 = 0.7*0.3 + 0.21 = 0.21 + 0.21
+        let result = compute_truncated_lagrange_basis_inner_product::<F>(2, &[0.3], &[0.7]);
+        let expected = (1.0 - 0.3) * (1.0 - 0.7) + 0.3 * 0.7;
+        assert!((result - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn inner_product_truncated_at_one_is_first_basis_product() {
+        // length=1 means only the first basis function: (1-a[0])*(1-b[0])
+        let result = compute_truncated_lagrange_basis_inner_product::<F>(1, &[0.4], &[0.6]);
+        let expected = (1.0 - 0.4) * (1.0 - 0.6);
+        assert!((result - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn basis_sum_empty_point_length_one_returns_one() {
+        let result = compute_truncated_lagrange_basis_sum::<F>(1, &[]);
+        assert!((result - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn basis_sum_full_length_returns_one() {
+        // When length >= 2^nu, the sum of all basis functions = 1
+        let result = compute_truncated_lagrange_basis_sum::<F>(4, &[0.5, 0.3]);
+        assert!((result - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn rho_eval_single_var_at_zero_is_zero() {
+        // rho is sum of i * basis_i — at point [0], only index 0 has weight, so rho = 0
+        let result = compute_rho_eval::<F>(2, &[0.0]);
+        assert!((result - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn rho_eval_single_var_at_one_is_one() {
+        // At point [1.0], only index 1 has weight 1, so rho = 1
+        let result = compute_rho_eval::<F>(2, &[1.0]);
+        assert!((result - 1.0).abs() < 1e-10);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -147,3 +147,82 @@ impl ProofExpr for AndExpr {
         self.rhs.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests_and {
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{AndExpr, DynProofExpr, ProofExpr},
+    };
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(1))
+    }
+
+    #[test]
+    fn try_new_with_booleans_returns_ok() {
+        assert!(AndExpr::try_new(
+            alloc::boxed::Box::new(bool_expr()),
+            alloc::boxed::Box::new(bool_expr())
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn try_new_with_non_booleans_returns_err() {
+        assert!(AndExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr()),
+            alloc::boxed::Box::new(bigint_expr())
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let e = AndExpr::try_new(
+            alloc::boxed::Box::new(bool_expr()),
+            alloc::boxed::Box::new(bool_expr()),
+        )
+        .unwrap();
+        assert_eq!(e.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn lhs_and_rhs_return_correct_types() {
+        let e = AndExpr::try_new(
+            alloc::boxed::Box::new(bool_expr()),
+            alloc::boxed::Box::new(bool_expr()),
+        )
+        .unwrap();
+        assert_eq!(e.lhs().data_type(), ColumnType::Boolean);
+        assert_eq!(e.rhs().data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a = AndExpr::try_new(
+            alloc::boxed::Box::new(bool_expr()),
+            alloc::boxed::Box::new(bool_expr()),
+        )
+        .unwrap();
+        let b = AndExpr::try_new(
+            alloc::boxed::Box::new(bool_expr()),
+            alloc::boxed::Box::new(bool_expr()),
+        )
+        .unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = AndExpr::try_new(
+            alloc::boxed::Box::new(bool_expr()),
+            alloc::boxed::Box::new(bool_expr()),
+        )
+        .unwrap();
+        assert!(alloc::format!("{e:?}").contains("AndExpr"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -158,3 +158,106 @@ impl ProofExpr for InequalityExpr {
         self.rhs.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests_inequality {
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, InequalityExpr, ProofExpr},
+    };
+
+    fn bigint_expr(n: i64) -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(n))
+    }
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+
+    #[test]
+    fn try_new_with_numerics_returns_ok() {
+        assert!(InequalityExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr(1)),
+            alloc::boxed::Box::new(bigint_expr(2)),
+            true,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn try_new_with_incompatible_types_returns_err() {
+        assert!(InequalityExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr(1)),
+            alloc::boxed::Box::new(bool_expr()),
+            false,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let e = InequalityExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr(0)),
+            alloc::boxed::Box::new(bigint_expr(1)),
+            true,
+        )
+        .unwrap();
+        assert_eq!(e.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn is_lt_stores_flag_correctly() {
+        let lt = InequalityExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr(0)),
+            alloc::boxed::Box::new(bigint_expr(1)),
+            true,
+        )
+        .unwrap();
+        let lte = InequalityExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr(0)),
+            alloc::boxed::Box::new(bigint_expr(1)),
+            false,
+        )
+        .unwrap();
+        assert!(lt.is_lt());
+        assert!(!lte.is_lt());
+    }
+
+    #[test]
+    fn lhs_has_correct_type() {
+        let e = InequalityExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr(3)),
+            alloc::boxed::Box::new(bigint_expr(5)),
+            true,
+        )
+        .unwrap();
+        assert_eq!(e.lhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn equality_holds_for_same_values() {
+        let a = InequalityExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr(1)),
+            alloc::boxed::Box::new(bigint_expr(2)),
+            true,
+        )
+        .unwrap();
+        let b = InequalityExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr(1)),
+            alloc::boxed::Box::new(bigint_expr(2)),
+            true,
+        )
+        .unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = InequalityExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr(0)),
+            alloc::boxed::Box::new(bigint_expr(1)),
+            false,
+        )
+        .unwrap();
+        assert!(alloc::format!("{e:?}").contains("InequalityExpr"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -138,3 +138,81 @@ impl ProofExpr for MultiplyExpr {
 }
 
 impl DecimalProofExpr for MultiplyExpr {}
+
+#[cfg(test)]
+mod tests_multiply {
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, MultiplyExpr, ProofExpr},
+    };
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(2))
+    }
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(false))
+    }
+
+    #[test]
+    fn try_new_with_numerics_returns_ok() {
+        assert!(MultiplyExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr()),
+            alloc::boxed::Box::new(bigint_expr())
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn try_new_with_non_numerics_returns_err() {
+        assert!(MultiplyExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr()),
+            alloc::boxed::Box::new(bool_expr())
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn lhs_has_correct_type() {
+        let e = MultiplyExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr()),
+            alloc::boxed::Box::new(bigint_expr()),
+        )
+        .unwrap();
+        assert_eq!(e.lhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn rhs_has_correct_type() {
+        let e = MultiplyExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr()),
+            alloc::boxed::Box::new(bigint_expr()),
+        )
+        .unwrap();
+        assert_eq!(e.rhs().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a = MultiplyExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr()),
+            alloc::boxed::Box::new(bigint_expr()),
+        )
+        .unwrap();
+        let b = MultiplyExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr()),
+            alloc::boxed::Box::new(bigint_expr()),
+        )
+        .unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = MultiplyExpr::try_new(
+            alloc::boxed::Box::new(bigint_expr()),
+            alloc::boxed::Box::new(bigint_expr()),
+        )
+        .unwrap();
+        assert!(alloc::format!("{e:?}").contains("MultiplyExpr"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -130,3 +130,63 @@ impl ProverEvaluate for TableExec {
         Ok(final_round_table)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TableExec;
+    use crate::{
+        base::database::{ColumnField, ColumnType, TableRef},
+        sql::proof::ProofPlan,
+    };
+    use sqlparser::ast::Ident;
+
+    fn make_exec() -> TableExec {
+        TableExec::new(
+            TableRef::new("s", "t"),
+            alloc::vec![ColumnField::new(Ident::new("col"), ColumnType::BigInt)],
+        )
+    }
+
+    #[test]
+    fn table_ref_returns_correct_ref() {
+        let e = make_exec();
+        assert_eq!(e.table_ref().table_id().value.as_str(), "t");
+    }
+
+    #[test]
+    fn schema_returns_columns() {
+        let e = make_exec();
+        assert_eq!(e.schema().len(), 1);
+    }
+
+    #[test]
+    fn empty_schema_creates_zero_columns() {
+        let e = TableExec::new(TableRef::new("", "t"), alloc::vec![]);
+        assert!(e.schema().is_empty());
+    }
+
+    #[test]
+    fn get_column_result_fields_matches_schema() {
+        let e = make_exec();
+        assert_eq!(e.get_column_result_fields().len(), 1);
+    }
+
+    #[test]
+    fn get_table_references_contains_the_table() {
+        let e = make_exec();
+        assert_eq!(e.get_table_references().len(), 1);
+    }
+
+    #[test]
+    fn equality_holds_for_same_values() {
+        let a = make_exec();
+        let b = make_exec();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = make_exec();
+        assert!(alloc::format!("{e:?}").contains("TableExec"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for six previously untested modules:

- `sql/proof_plans/table_exec.rs` — 7 tests (TableExec constructor, accessors, ProofPlan trait, debug/eq)
- `sql/proof_exprs/and_expr.rs` — 6 tests (try_new ok/err, data_type, lhs/rhs, equality, debug)
- `sql/proof_exprs/multiply_expr.rs` — 6 tests (try_new ok/err, lhs/rhs types, equality, debug)
- `sql/proof_exprs/inequality_expr.rs` — 7 tests (try_new ok/err, data_type boolean, is_lt flag, lhs type, equality, debug)
- `base/polynomial/lagrange_basis_evaluation.rs` — 8 tests (inner product, basis sum, rho eval with edge cases)
- `base/polynomial/interpolate.rs` — 6 tests (empty, constant, linear polynomial; known-point short-circuit; reverse coefficients)

All 40 tests pass (`cargo test -p proof-of-sql --lib`).

/attempt #560