### PR TITLE
test: add unit tests for ColumnExpr, NotExpr, CastExpr, and batch_inversion

### DIFF
--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
@@ -106,3 +106,60 @@ where
         tmp = new_tmp;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{batch_inversion, batch_inversion_and_mul};
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn batch_inversion_empty_slice_does_not_panic() {
+        let mut v: Vec<TestScalar> = alloc::vec![];
+        batch_inversion(&mut v);
+    }
+
+    #[test]
+    fn batch_inversion_single_element_inverts() {
+        // inv(2) * 2 == 1
+        let mut v = alloc::vec![ts(2)];
+        batch_inversion(&mut v);
+        assert_eq!(v[0] * ts(2), ts(1));
+    }
+
+    #[test]
+    fn batch_inversion_skips_zeros_leaving_them_unchanged() {
+        let mut v = alloc::vec![ts(0), ts(2)];
+        batch_inversion(&mut v);
+        assert_eq!(v[0], ts(0)); // zero unchanged
+        assert_eq!(v[1] * ts(2), ts(1)); // inv(2) correct
+    }
+
+    #[test]
+    fn batch_inversion_and_mul_multiplies_by_coeff() {
+        // inv(2) * coeff=3 => 3 * inv(2) 
+        // check: result * 2 == 3
+        let mut v = alloc::vec![ts(2)];
+        batch_inversion_and_mul(&mut v, ts(3));
+        assert_eq!(v[0] * ts(2), ts(3));
+    }
+
+    #[test]
+    fn batch_inversion_and_mul_empty_does_not_panic() {
+        let mut v: Vec<TestScalar> = alloc::vec![];
+        batch_inversion_and_mul(&mut v, ts(5));
+    }
+
+    #[test]
+    fn batch_inversion_multiple_elements_all_correct() {
+        let mut v = alloc::vec![ts(2), ts(3)];
+        batch_inversion(&mut v);
+        // inv(2) * 2 = 1
+        assert_eq!(v[0] * ts(2), ts(1));
+        // inv(3) * 3 = 1
+        assert_eq!(v[1] * ts(3), ts(1));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -99,3 +99,73 @@ impl ProofExpr for CastExpr {
         self.from_expr.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests_cast {
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{CastExpr, DynProofExpr, ProofExpr},
+    };
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+    fn tinyint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::TinyInt(1))
+    }
+
+    #[test]
+    fn try_new_bool_to_bigint_returns_ok() {
+        assert!(
+            CastExpr::try_new(alloc::boxed::Box::new(bool_expr()), ColumnType::BigInt).is_ok()
+        );
+    }
+
+    #[test]
+    fn try_new_bigint_to_boolean_returns_err() {
+        assert!(
+            CastExpr::try_new(
+                alloc::boxed::Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(1))),
+                ColumnType::Boolean
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn data_type_returns_to_type() {
+        let e =
+            CastExpr::try_new(alloc::boxed::Box::new(bool_expr()), ColumnType::BigInt).unwrap();
+        assert_eq!(e.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn to_type_accessor() {
+        let e =
+            CastExpr::try_new(alloc::boxed::Box::new(bool_expr()), ColumnType::Int128).unwrap();
+        assert_eq!(*e.to_type(), ColumnType::Int128);
+    }
+
+    #[test]
+    fn from_expr_has_correct_type() {
+        let e =
+            CastExpr::try_new(alloc::boxed::Box::new(bool_expr()), ColumnType::BigInt).unwrap();
+        assert_eq!(e.get_from_expr().data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a =
+            CastExpr::try_new(alloc::boxed::Box::new(bool_expr()), ColumnType::BigInt).unwrap();
+        let b =
+            CastExpr::try_new(alloc::boxed::Box::new(bool_expr()), ColumnType::BigInt).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e =
+            CastExpr::try_new(alloc::boxed::Box::new(bool_expr()), ColumnType::BigInt).unwrap();
+        assert!(alloc::format!("{e:?}").contains("CastExpr"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -116,3 +116,51 @@ impl ProofExpr for ColumnExpr {
         columns.insert(self.column_ref.clone());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnExpr;
+    use crate::base::database::{ColumnRef, ColumnType, TableRef};
+    use sqlparser::ast::Ident;
+
+    fn make_col_ref() -> ColumnRef {
+        ColumnRef::new(TableRef::new("s", "t"), Ident::new("col"), ColumnType::BigInt)
+    }
+
+    #[test]
+    fn new_stores_column_ref() {
+        let e = ColumnExpr::new(make_col_ref());
+        assert_eq!(e.column_ref(), &make_col_ref());
+    }
+
+    #[test]
+    fn get_column_reference_returns_clone() {
+        let e = ColumnExpr::new(make_col_ref());
+        assert_eq!(e.get_column_reference(), make_col_ref());
+    }
+
+    #[test]
+    fn column_id_returns_ident() {
+        let e = ColumnExpr::new(make_col_ref());
+        assert_eq!(e.column_id().value.as_str(), "col");
+    }
+
+    #[test]
+    fn get_column_field_has_correct_type() {
+        let e = ColumnExpr::new(make_col_ref());
+        assert_eq!(e.get_column_field().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a = ColumnExpr::new(make_col_ref());
+        let b = ColumnExpr::new(make_col_ref());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = ColumnExpr::new(make_col_ref());
+        assert!(alloc::format!("{e:?}").contains("ColumnExpr"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -99,3 +99,53 @@ impl ProofExpr for NotExpr {
         self.expr.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests_not {
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::{DynProofExpr, NotExpr, ProofExpr},
+    };
+
+    fn bool_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::Boolean(true))
+    }
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(1))
+    }
+
+    #[test]
+    fn try_new_with_boolean_returns_ok() {
+        assert!(NotExpr::try_new(alloc::boxed::Box::new(bool_expr())).is_ok());
+    }
+
+    #[test]
+    fn try_new_with_bigint_returns_err() {
+        assert!(NotExpr::try_new(alloc::boxed::Box::new(bigint_expr())).is_err());
+    }
+
+    #[test]
+    fn data_type_is_boolean() {
+        let e = NotExpr::try_new(alloc::boxed::Box::new(bool_expr())).unwrap();
+        assert_eq!(e.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn input_returns_correct_type() {
+        let e = NotExpr::try_new(alloc::boxed::Box::new(bool_expr())).unwrap();
+        assert_eq!(e.input().data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a = NotExpr::try_new(alloc::boxed::Box::new(bool_expr())).unwrap();
+        let b = NotExpr::try_new(alloc::boxed::Box::new(bool_expr())).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = NotExpr::try_new(alloc::boxed::Box::new(bool_expr())).unwrap();
+        assert!(alloc::format!("{e:?}").contains("NotExpr"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for four previously untested modules:

- `sql/proof_exprs/column_expr.rs` — 6 tests (new, get_column_reference, column_id, get_column_field data_type, equality, debug)
- `sql/proof_exprs/not_expr.rs` — 6 tests (try_new ok with Boolean, err with BigInt, data_type is Boolean, input type, equality, debug)
- `sql/proof_exprs/cast_expr.rs` — 7 tests (try_new Bool→BigInt ok, BigInt→Boolean err, data_type, to_type accessor, from_expr type, equality, debug)
- `base/slice_ops/batch_inverse.rs` — 6 tests (empty slice, single element inversion, zero skipped, mul_by_coeff, multiple elements correct)

All 25 tests pass (`cargo test -p proof-of-sql --lib`).

/attempt #560