### PR TITLE
test: add unit tests for ScalingCastExpr, LiteralExpr, and filter_util

### DIFF
--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -84,3 +84,80 @@ pub fn filter_column_by_index<'a, S: Scalar>(
         ),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_column_by_index, filter_columns};
+    use crate::base::{database::Column, scalar::test_scalar::TestScalar};
+    use bumpalo::Bump;
+
+    type S = TestScalar;
+
+    #[test]
+    fn filter_columns_with_all_selected() {
+        let alloc = Bump::new();
+        let data = &[1i64, 2, 3];
+        let cols: &[Column<S>] = &[Column::BigInt(data)];
+        let selection = &[true, true, true];
+        let (filtered, count) = filter_columns(&alloc, cols, selection);
+        assert_eq!(count, 3);
+        assert_eq!(filtered.len(), 1);
+    }
+
+    #[test]
+    fn filter_columns_with_none_selected() {
+        let alloc = Bump::new();
+        let data = &[1i64, 2, 3];
+        let cols: &[Column<S>] = &[Column::BigInt(data)];
+        let selection = &[false, false, false];
+        let (_, count) = filter_columns(&alloc, cols, selection);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn filter_columns_selects_correct_rows() {
+        let alloc = Bump::new();
+        let data = &[10i64, 20, 30];
+        let cols: &[Column<S>] = &[Column::BigInt(data)];
+        let selection = &[false, true, false];
+        let (filtered, count) = filter_columns(&alloc, cols, selection);
+        assert_eq!(count, 1);
+        if let Column::BigInt(vals) = &filtered[0] {
+            assert_eq!(vals[0], 20);
+        } else {
+            panic!("expected BigInt column");
+        }
+    }
+
+    #[test]
+    fn filter_column_by_index_boolean_column() {
+        let alloc = Bump::new();
+        let data = &[true, false, true];
+        let col = Column::<S>::Boolean(data);
+        let filtered = filter_column_by_index(&alloc, &col, &[0, 2]);
+        if let Column::Boolean(vals) = filtered {
+            assert_eq!(vals, &[true, true]);
+        } else {
+            panic!("expected Boolean column");
+        }
+    }
+
+    #[test]
+    fn filter_column_by_index_empty_indexes() {
+        let alloc = Bump::new();
+        let data = &[1i64, 2, 3];
+        let col = Column::<S>::BigInt(data);
+        let filtered = filter_column_by_index(&alloc, &col, &[]);
+        assert_eq!(filtered.len(), 0);
+    }
+
+    #[test]
+    fn filter_columns_empty_columns_list() {
+        let alloc = Bump::new();
+        let cols: &[Column<S>] = &[];
+        let selection = &[true, false, true];
+        let (filtered, count) = filter_columns(&alloc, cols, selection);
+        assert_eq!(count, 2);
+        assert!(filtered.is_empty());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -92,3 +92,50 @@ impl ProofExpr for LiteralExpr {
 
     fn get_column_references(&self, _columns: &mut IndexSet<ColumnRef>) {}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::LiteralExpr;
+    use crate::{
+        base::database::{ColumnType, LiteralValue},
+        sql::proof_exprs::ProofExpr,
+    };
+
+    #[test]
+    fn new_bigint_literal_stores_value() {
+        let e = LiteralExpr::new(LiteralValue::BigInt(42));
+        assert_eq!(e.value(), &LiteralValue::BigInt(42));
+    }
+
+    #[test]
+    fn data_type_bigint() {
+        let e = LiteralExpr::new(LiteralValue::BigInt(1));
+        assert_eq!(e.data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn data_type_boolean() {
+        let e = LiteralExpr::new(LiteralValue::Boolean(true));
+        assert_eq!(e.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a = LiteralExpr::new(LiteralValue::BigInt(5));
+        let b = LiteralExpr::new(LiteralValue::BigInt(5));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn inequality_for_different_values() {
+        let a = LiteralExpr::new(LiteralValue::BigInt(1));
+        let b = LiteralExpr::new(LiteralValue::BigInt(2));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = LiteralExpr::new(LiteralValue::Boolean(false));
+        assert!(alloc::format!("{e:?}").contains("LiteralExpr"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
@@ -110,3 +110,70 @@ impl ProofExpr for ScalingCastExpr {
         self.from_expr.get_column_references(columns);
     }
 }
+
+#[cfg(test)]
+mod tests_scaling_cast {
+    use crate::{
+        base::{database::{ColumnType, LiteralValue}, math::decimal::Precision},
+        sql::proof_exprs::{DynProofExpr, ProofExpr, ScalingCastExpr},
+    };
+
+    fn bigint_expr() -> DynProofExpr {
+        DynProofExpr::new_literal(LiteralValue::BigInt(5))
+    }
+
+    fn decimal75_type() -> ColumnType {
+        // BigInt has precision=19, scale=0; Decimal75(75, 2) has 75-2=73 >= 19-0=19
+        ColumnType::Decimal75(Precision::new(75).unwrap(), 2)
+    }
+
+    #[test]
+    fn try_new_valid_cast_returns_ok() {
+        assert!(ScalingCastExpr::try_new(alloc::boxed::Box::new(bigint_expr()), decimal75_type()).is_ok());
+    }
+
+    #[test]
+    fn try_new_invalid_cast_returns_err() {
+        // Boolean → Decimal75 is not a valid scale cast
+        let bool_expr = DynProofExpr::new_literal(LiteralValue::Boolean(true));
+        assert!(ScalingCastExpr::try_new(alloc::boxed::Box::new(bool_expr), decimal75_type()).is_err());
+    }
+
+    #[test]
+    fn data_type_returns_to_type() {
+        let e = ScalingCastExpr::try_new(alloc::boxed::Box::new(bigint_expr()), decimal75_type()).unwrap();
+        assert_eq!(e.data_type(), decimal75_type());
+    }
+
+    #[test]
+    fn to_type_accessor() {
+        let e = ScalingCastExpr::try_new(alloc::boxed::Box::new(bigint_expr()), decimal75_type()).unwrap();
+        assert_eq!(*e.to_type(), decimal75_type());
+    }
+
+    #[test]
+    fn from_expr_has_bigint_type() {
+        let e = ScalingCastExpr::try_new(alloc::boxed::Box::new(bigint_expr()), decimal75_type()).unwrap();
+        assert_eq!(e.get_from_expr().data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn scaling_factor_is_100_for_scale_2() {
+        // 10^(2-0) = 100 as a U256 → [u64; 4] = [100, 0, 0, 0]
+        let e = ScalingCastExpr::try_new(alloc::boxed::Box::new(bigint_expr()), decimal75_type()).unwrap();
+        assert_eq!(e.scaling_factor()[0], 100);
+    }
+
+    #[test]
+    fn equality_holds() {
+        let a = ScalingCastExpr::try_new(alloc::boxed::Box::new(bigint_expr()), decimal75_type()).unwrap();
+        let b = ScalingCastExpr::try_new(alloc::boxed::Box::new(bigint_expr()), decimal75_type()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_contains_struct_name() {
+        let e = ScalingCastExpr::try_new(alloc::boxed::Box::new(bigint_expr()), decimal75_type()).unwrap();
+        assert!(alloc::format!("{e:?}").contains("ScalingCastExpr"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for three previously untested modules:

- `sql/proof_exprs/scaling_cast_expr.rs` — 8 tests (try_new valid/invalid, data_type, to_type, from_expr type, scaling_factor value, equality, debug)
- `sql/proof_exprs/literal_expr.rs` — 6 tests (new stores value, data_type BigInt/Boolean, equality, inequality, debug)
- `base/database/filter_util.rs` — 6 tests (filter_columns all/none/partial selection, filter_column_by_index boolean, empty indexes, empty columns list)

All 20 tests pass (`cargo test -p proof-of-sql --lib`).

/attempt #560