### PR TITLE
test: add unit tests for evaluation_vector, ProverState, and slice_cast_with

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -67,3 +67,63 @@ where
 
     log::log_memory_usage("End");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compute_evaluation_vector;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn empty_point_fills_with_one() {
+        let mut v = alloc::vec![ts(0); 1];
+        compute_evaluation_vector(&mut v, &[]);
+        assert_eq!(v[0], ts(1));
+    }
+
+    #[test]
+    fn single_var_at_zero_gives_one_zero() {
+        let mut v = alloc::vec![ts(0), ts(0)];
+        compute_evaluation_vector(&mut v, &[ts(0)]);
+        assert_eq!(v[0], ts(1)); // 1 - 0 = 1
+        assert_eq!(v[1], ts(0)); // 0
+    }
+
+    #[test]
+    fn single_var_at_one_gives_zero_one() {
+        let mut v = alloc::vec![ts(0), ts(0)];
+        compute_evaluation_vector(&mut v, &[ts(1)]);
+        assert_eq!(v[0], ts(0)); // 1 - 1 = 0
+        assert_eq!(v[1], ts(1)); // 1
+    }
+
+    #[test]
+    fn two_vars_evaluates_to_four_basis_values() {
+        // point = [0, 0] => basis = [1, 0, 0, 0]
+        let mut v = alloc::vec![ts(0); 4];
+        compute_evaluation_vector(&mut v, &[ts(0), ts(0)]);
+        assert_eq!(v[0], ts(1));
+        assert_eq!(v[1], ts(0));
+        assert_eq!(v[2], ts(0));
+        assert_eq!(v[3], ts(0));
+    }
+
+    #[test]
+    fn basis_values_sum_to_one_for_any_point() {
+        let mut v = alloc::vec![ts(0); 4];
+        compute_evaluation_vector(&mut v, &[ts(3), ts(5)]);
+        let sum: TestScalar = v.iter().fold(ts(0), |acc, &x| acc + x);
+        assert_eq!(sum, ts(1));
+    }
+
+    #[test]
+    fn length_one_vector_fills_with_one() {
+        let mut v = alloc::vec![ts(0); 1];
+        compute_evaluation_vector(&mut v, &[ts(7)]);
+        // Only one element, just 1-p term
+        assert_eq!(v[0], ts(1) - ts(7));
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
@@ -53,3 +53,45 @@ where
 {
     slice_cast_mut_with(value, result, Into::into);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{slice_cast_mut_with, slice_cast_with};
+
+    #[test]
+    fn slice_cast_with_converts_each_element() {
+        let v = alloc::vec![1i32, 2, 3];
+        let result = slice_cast_with(&v, |&x| x as i64 * 2);
+        assert_eq!(result, alloc::vec![2i64, 4, 6]);
+    }
+
+    #[test]
+    fn slice_cast_with_empty_slice() {
+        let v: &[i32] = &[];
+        let result = slice_cast_with(v, |&x| x as i64);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn slice_cast_mut_with_writes_to_output() {
+        let v = alloc::vec![10i32, 20, 30];
+        let mut result = alloc::vec![0i64; 3];
+        slice_cast_mut_with(&v, &mut result, |&x| x as i64 + 1);
+        assert_eq!(result, alloc::vec![11i64, 21, 31]);
+    }
+
+    #[test]
+    fn slice_cast_mut_with_empty_slice() {
+        let v: &[i32] = &[];
+        let mut result: alloc::vec::Vec<i64> = alloc::vec![];
+        slice_cast_mut_with(v, &mut result, |&x| x as i64);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn slice_cast_with_negate() {
+        let v = alloc::vec![3i32, -1, 5];
+        let result = slice_cast_with(&v, |&x| -x);
+        assert_eq!(result, alloc::vec![-3i32, 1, -5]);
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -62,3 +62,54 @@ impl<S: Scalar> ProverState<S> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProverState;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn new_stores_list_of_products() {
+        let state = ProverState::new(
+            alloc::vec![(ts(1), alloc::vec![0usize])],
+            alloc::vec![alloc::vec![ts(1), ts(2)]],
+            1,
+            1,
+        );
+        assert_eq!(state.list_of_products.len(), 1);
+    }
+
+    #[test]
+    fn new_stores_flattened_extensions() {
+        let state = ProverState::new(
+            alloc::vec![],
+            alloc::vec![alloc::vec![ts(3), ts(4)]],
+            1,
+            0,
+        );
+        assert_eq!(state.flattened_ml_extensions.len(), 1);
+        assert_eq!(state.flattened_ml_extensions[0][0], ts(3));
+    }
+
+    #[test]
+    fn new_stores_num_vars() {
+        let state = ProverState::<TestScalar>::new(alloc::vec![], alloc::vec![], 3, 0);
+        assert_eq!(state.num_vars, 3);
+    }
+
+    #[test]
+    fn new_stores_max_multiplicands() {
+        let state = ProverState::<TestScalar>::new(alloc::vec![], alloc::vec![], 1, 4);
+        assert_eq!(state.max_multiplicands, 4);
+    }
+
+    #[test]
+    fn new_starts_round_at_zero() {
+        let state = ProverState::<TestScalar>::new(alloc::vec![], alloc::vec![], 1, 0);
+        assert_eq!(state.round, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for three previously untested utility modules:

- `base/polynomial/evaluation_vector.rs` — 6 tests (empty point fills with 1, single var at 0/1, two vars basis values, sum-to-one property, length-1 truncation)
- `proof_primitive/sumcheck/prover_state.rs` — 5 tests (new stores list_of_products, flattened_extensions, num_vars, max_multiplicands; round starts at 0)
- `base/slice_ops/slice_cast.rs` — 5 tests (slice_cast_with converts/empty/negate, slice_cast_mut_with writes/empty)

All 16 tests pass (`cargo test -p proof-of-sql --lib`).

/attempt #560