### PR TITLE
test: add unit tests for fold_vals, RecordBatchToColumnsError, and mul_add_assign

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -29,3 +29,34 @@ pub enum AppendRecordBatchTableCommitmentError {
         source: RecordBatchToColumnsError,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RecordBatchToColumnsError;
+    use crate::base::arrow::arrow_array_to_column_conversion::ArrowArrayToColumnConversionError;
+    use arrow::datatypes::DataType;
+
+    #[test]
+    fn record_batch_to_columns_error_debug() {
+        let inner = ArrowArrayToColumnConversionError::ArrayContainsNulls;
+        let err = RecordBatchToColumnsError::ArrowArrayToColumnConversionError { source: inner };
+        let msg = alloc::format!("{err:?}");
+        assert!(msg.contains("ArrowArrayToColumnConversionError") || msg.contains("ArrayContainsNulls"));
+    }
+
+    #[test]
+    fn unsupported_type_error_propagates_through_record_batch_error() {
+        let inner = ArrowArrayToColumnConversionError::UnsupportedType { datatype: DataType::Float64 };
+        let err = RecordBatchToColumnsError::ArrowArrayToColumnConversionError { source: inner };
+        let msg = alloc::format!("{err}");
+        assert!(msg.contains("Float64") || msg.contains("unsupported"));
+    }
+
+    #[test]
+    fn array_contains_nulls_error_display() {
+        let inner = ArrowArrayToColumnConversionError::ArrayContainsNulls;
+        let err = RecordBatchToColumnsError::ArrowArrayToColumnConversionError { source: inner };
+        let msg = alloc::format!("{err}");
+        assert!(msg.contains("null") || msg.contains("null"));
+    }
+}

--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign.rs
@@ -24,3 +24,63 @@ where
         *res_i += multiplier * data_i.into();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::mul_add_assign;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn mul_add_assign_basic() {
+        // result[i] += mul * to_mul_add[i]
+        // [0, 0] += 2 * [3, 4] => [6, 8]
+        let mut result = alloc::vec![ts(0), ts(0)];
+        let to_mul = alloc::vec![ts(3), ts(4)];
+        mul_add_assign(&mut result, ts(2), &to_mul);
+        assert_eq!(result[0], ts(6));
+        assert_eq!(result[1], ts(8));
+    }
+
+    #[test]
+    fn mul_add_assign_adds_to_existing() {
+        // result = [10, 20], += 1 * [5, 5] => [15, 25]
+        let mut result = alloc::vec![ts(10), ts(20)];
+        let to_mul = alloc::vec![ts(5), ts(5)];
+        mul_add_assign(&mut result, ts(1), &to_mul);
+        assert_eq!(result[0], ts(15));
+        assert_eq!(result[1], ts(25));
+    }
+
+    #[test]
+    fn mul_add_assign_with_zero_multiplier() {
+        // mul=0 => result unchanged
+        let mut result = alloc::vec![ts(7), ts(8)];
+        let to_mul = alloc::vec![ts(100), ts(200)];
+        mul_add_assign(&mut result, ts(0), &to_mul);
+        assert_eq!(result[0], ts(7));
+        assert_eq!(result[1], ts(8));
+    }
+
+    #[test]
+    fn mul_add_assign_empty_to_mul() {
+        let mut result = alloc::vec![ts(5), ts(6)];
+        let to_mul: alloc::vec::Vec<TestScalar> = alloc::vec![];
+        mul_add_assign(&mut result, ts(3), &to_mul);
+        assert_eq!(result[0], ts(5)); // unchanged
+    }
+
+    #[test]
+    fn mul_add_assign_partial_update() {
+        // result has 3 elements, to_mul has 2 → only first 2 updated
+        let mut result = alloc::vec![ts(0), ts(0), ts(99)];
+        let to_mul = alloc::vec![ts(1), ts(2)];
+        mul_add_assign(&mut result, ts(3), &to_mul);
+        assert_eq!(result[0], ts(3));
+        assert_eq!(result[1], ts(6));
+        assert_eq!(result[2], ts(99)); // unchanged
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
@@ -32,3 +32,53 @@ pub fn fold_vals<S: Scalar>(beta: S, vals: &[S]) -> S {
 fn powers<S: Scalar>(init: S, base: S) -> impl Iterator<Item = S> {
     core::iter::successors(Some(init), move |&m| Some(m * base))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::fold_vals;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    fn ts(n: i32) -> TestScalar {
+        TestScalar::from(n)
+    }
+
+    #[test]
+    fn fold_vals_empty_returns_zero() {
+        let result = fold_vals(ts(3), &[]);
+        assert_eq!(result, ts(0));
+    }
+
+    #[test]
+    fn fold_vals_single_element_is_that_element() {
+        let result = fold_vals(ts(2), &[ts(7)]);
+        assert_eq!(result, ts(7));
+    }
+
+    #[test]
+    fn fold_vals_two_elements_with_beta_one() {
+        // beta=1, vals=[a, b] => result = a*1 + b = a + b
+        let result = fold_vals(ts(1), &[ts(3), ts(4)]);
+        assert_eq!(result, ts(7));
+    }
+
+    #[test]
+    fn fold_vals_two_elements_with_beta_two() {
+        // beta=2, vals=[3, 4] => 3*2 + 4 = 10
+        let result = fold_vals(ts(2), &[ts(3), ts(4)]);
+        assert_eq!(result, ts(10));
+    }
+
+    #[test]
+    fn fold_vals_three_elements_with_beta_10() {
+        // beta=10, vals=[1, 2, 3] => 1*100 + 2*10 + 3 = 123
+        let result = fold_vals(ts(10), &[ts(1), ts(2), ts(3)]);
+        assert_eq!(result, ts(123));
+    }
+
+    #[test]
+    fn fold_vals_with_beta_zero_returns_last_element() {
+        // beta=0, vals=[a, b] => 0*a + b = b
+        let result = fold_vals(ts(0), &[ts(5), ts(9)]);
+        assert_eq!(result, ts(9));
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for three previously untested utility modules:

- `sql/proof_plans/fold_util.rs` — 6 tests (fold_vals: empty returns zero, single element, beta=1/2/10, beta=0 returns last)
- `base/arrow/record_batch_errors.rs` — 3 tests (RecordBatchToColumnsError: debug, null display, unsupported type propagation)
- `base/slice_ops/mul_add_assign.rs` — 5 tests (basic mul_add, adds to existing, zero multiplier, empty to_mul, partial update)

All 14 tests pass (`cargo test -p proof-of-sql --lib`).

/attempt #560