### PR TITLE
test: add unit tests for BitDistribution and QueryError

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -170,3 +170,54 @@ impl BitDistribution {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{BitDistribution, BitDistributionError};
+    use crate::{
+        base::{proof::ProofError, scalar::test_scalar::TestScalar},
+    };
+
+    #[test]
+    fn new_with_empty_slice_has_zero_varying_bits() {
+        let dist = BitDistribution::new::<TestScalar, i64>(&[]);
+        assert_eq!(dist.num_varying_bits(), 0);
+    }
+
+    #[test]
+    fn new_with_constant_data_has_zero_varying_bits() {
+        let dist = BitDistribution::new::<TestScalar, i64>(&[42, 42, 42]);
+        assert_eq!(dist.num_varying_bits(), 0);
+    }
+
+    #[test]
+    fn new_with_varying_data_has_nonzero_vary_mask() {
+        let dist = BitDistribution::new::<TestScalar, i64>(&[0, 1]);
+        assert!(dist.num_varying_bits() > 0);
+    }
+
+    #[test]
+    fn is_valid_returns_true_for_constant_data() {
+        let dist = BitDistribution::new::<TestScalar, i64>(&[5, 5, 5]);
+        assert!(dist.is_valid());
+    }
+
+    #[test]
+    fn vary_mask_is_zero_for_constant_data() {
+        use bnum::types::U256;
+        let dist = BitDistribution::new::<TestScalar, i64>(&[10, 10]);
+        assert_eq!(dist.vary_mask(), U256::ZERO);
+    }
+
+    #[test]
+    fn error_verification_converts_to_proof_error() {
+        let err: ProofError = BitDistributionError::Verification.into();
+        assert!(matches!(err, ProofError::VerificationError { .. }));
+    }
+
+    #[test]
+    fn error_debug_contains_variant_name() {
+        assert!(alloc::format!("{:?}", BitDistributionError::Verification).contains("Verification"));
+        assert!(alloc::format!("{:?}", BitDistributionError::NoLeadBit).contains("NoLeadBit"));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -69,3 +69,43 @@ pub struct QueryData<S: Scalar> {
 
 /// The result of a query -- either an error or a table.
 pub type QueryResult<S> = Result<QueryData<S>, QueryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::QueryError;
+
+    #[test]
+    fn overflow_display() {
+        let err = QueryError::Overflow;
+        assert!(alloc::format!("{err}").contains("Overflow"));
+    }
+
+    #[test]
+    fn invalid_string_display() {
+        let err = QueryError::InvalidString;
+        assert!(alloc::format!("{err}").contains("String"));
+    }
+
+    #[test]
+    fn miscellaneous_decoding_error_display() {
+        let err = QueryError::MiscellaneousDecodingError;
+        assert!(alloc::format!("{err}").contains("decoding"));
+    }
+
+    #[test]
+    fn miscellaneous_evaluation_error_display() {
+        let err = QueryError::MiscellaneousEvaluationError;
+        assert!(alloc::format!("{err}").contains("evaluation"));
+    }
+
+    #[test]
+    fn invalid_column_count_display() {
+        let err = QueryError::InvalidColumnCount;
+        assert!(alloc::format!("{err}").contains("columns"));
+    }
+
+    #[test]
+    fn overflow_debug_contains_variant_name() {
+        assert!(alloc::format!("{:?}", QueryError::Overflow).contains("Overflow"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds 13 unit tests across 2 files:

**BitDistribution** (7 tests):
- `new` with empty slice → 0 varying bits
- `new` with constant data → 0 varying bits
- `new` with varying data → nonzero vary mask
- `is_valid` returns true for constant data
- `vary_mask` is zero for constant data
- `BitDistributionError::Verification` converts to `ProofError::VerificationError`
- Debug formatting contains variant names for both error variants

**QueryError** (6 tests):
- Display formatting for Overflow, InvalidString, MiscellaneousDecodingError, MiscellaneousEvaluationError, InvalidColumnCount variants
- Debug formatting contains variant name for Overflow

All 13 tests pass locally.

/attempt #560