### PR TITLE
refactor: remove hardcoded setup file path for hyperkzg testing

### DIFF
--- a/crates/proof-of-sql-planner/tests/evm_tests.rs
+++ b/crates/proof-of-sql-planner/tests/evm_tests.rs
@@ -30,6 +30,8 @@ use proof_of_sql::{
 use proof_of_sql_planner::sql_to_proof_plans;
 use sqlparser::{ast::Ident, dialect::GenericDialect, parser::Parser};
 
+const TEST_SETUP_FILE: &str = "test_assets/ppot_0080_10.bin";
+
 #[expect(clippy::missing_panics_doc)]
 fn evm_verifier_with_extra_args(
     plan: &DynProofPlan,
@@ -137,7 +139,7 @@ fn aliased_plan(expr: DynProofExpr, alias: &str) -> AliasedDynProofExpr {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_query_with_all_supported_types_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -221,7 +223,7 @@ fn we_can_verify_a_query_with_all_supported_types_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_simple_filter_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -258,7 +260,7 @@ fn we_can_verify_a_simple_filter_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_simple_filter_with_a_parameter_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -301,7 +303,7 @@ fn we_can_verify_a_simple_filter_with_a_parameter_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_simple_filter_with_negative_literal_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -338,7 +340,7 @@ fn we_can_verify_a_simple_filter_with_negative_literal_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_filter_with_arithmetic_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -376,7 +378,7 @@ fn we_can_verify_a_filter_with_arithmetic_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_filter_with_arithmetic_with_scaling_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -414,7 +416,7 @@ fn we_can_verify_a_filter_with_arithmetic_with_scaling_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_filter_with_cast_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -472,7 +474,7 @@ fn we_can_verify_a_filter_with_cast_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_filter_with_int_to_decimal_cast_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -530,7 +532,7 @@ fn we_can_verify_a_filter_with_int_to_decimal_cast_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_complex_filter_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -569,7 +571,7 @@ fn we_can_verify_a_complex_filter_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_simple_projection_exec_and_table_exec_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -608,7 +610,7 @@ fn we_can_verify_a_simple_projection_exec_and_table_exec_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_simple_inequality_filter_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -642,7 +644,7 @@ fn we_can_verify_simple_inequality_filter_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_empty_exec_using_the_evm() {
-    let (ps, _vk) = load_small_setup_for_testing();
+    let (ps, _vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::default();
     let plan = &DynProofPlan::new_empty();
@@ -661,7 +663,7 @@ fn we_can_verify_a_empty_exec_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_groupby_query_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -705,7 +707,7 @@ fn we_can_verify_a_groupby_query_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_zero_column_groupby_query_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -747,7 +749,7 @@ fn we_can_verify_a_zero_column_groupby_query_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_simple_slice_exec_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -781,7 +783,7 @@ fn we_can_verify_simple_slice_exec_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_slice_exec_using_the_evm() {
-    let (ps, _) = load_small_setup_for_testing();
+    let (ps, _) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -812,7 +814,7 @@ fn we_can_verify_a_slice_exec_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_union_exec_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let mut accessor =
         OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_empty_with_setup(&ps[..]);
@@ -858,7 +860,7 @@ fn we_can_verify_a_union_exec_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_a_sort_merge_join_exec_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let mut accessor =
         OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_empty_with_setup(&ps[..]);
@@ -898,7 +900,7 @@ fn we_can_verify_a_sort_merge_join_exec_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc)]
 fn we_can_verify_nested_filter_using_the_evm() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
 
     let accessor = OwnedTableTestAccessor::<HyperKZGCommitmentEvaluationProof>::new_from_table(
         TableRef::new("namespace", "table"),
@@ -936,7 +938,7 @@ fn we_can_verify_nested_filter_using_the_evm() {
 #[test]
 #[expect(clippy::missing_panics_doc, clippy::too_many_lines)]
 fn we_can_have_projection_as_input_plan_for_filter() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing(TEST_SETUP_FILE);
     let data = owned_table([
         bigint("a", [1, 4, 5, 2, 5]),
         bigint("b", [1, 2, 3, 4, 5]),

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment_evaluation_proof.rs
@@ -162,7 +162,7 @@ mod tests {
         },
         proof_primitive::hyperkzg::{
             nova_commitment_key_to_hyperkzg_public_setup,
-            public_setup::load_small_setup_for_testing,
+            public_setup::load_small_setup_for_testing_internal,
         },
     };
     use nova_snark::{
@@ -269,7 +269,7 @@ mod tests {
 
     #[test]
     fn we_create_hyperkzg_proof_using_setup_from_file() {
-        let (pk, vk) = load_small_setup_for_testing();
+        let (pk, vk) = load_small_setup_for_testing_internal();
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             23,
             0,

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/evm_tests.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/evm_tests.rs
@@ -8,7 +8,8 @@ use crate::{
         scalar::MontScalar,
     },
     proof_primitive::hyperkzg::{
-        public_setup::load_small_setup_for_testing, BNScalar, HyperKZGCommitmentEvaluationProof,
+        public_setup::load_small_setup_for_testing_internal, BNScalar,
+        HyperKZGCommitmentEvaluationProof,
     },
 };
 use ark_ff::{PrimeField, UniformRand};
@@ -81,7 +82,7 @@ fn run_evm_verify_hyperkzg_with_extra_args(
 #[ignore = "foundry must be installed in order to run this test"]
 #[test]
 fn we_can_create_small_valid_proof_for_use_in_solidity_tests() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing_internal();
 
     let a = [
         BNScalar::from(0),
@@ -112,7 +113,7 @@ fn we_can_create_small_valid_proof_for_use_in_solidity_tests() {
 #[ignore = "foundry must be installed in order to run this test"]
 #[test]
 fn we_can_generate_and_verify_random_hyperkzg_proofs() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing_internal();
 
     let mut rng = ark_std::test_rng();
 
@@ -148,7 +149,7 @@ fn we_can_generate_and_verify_random_hyperkzg_proofs() {
 #[ignore = "foundry must be installed in order to run this test"]
 #[test]
 fn we_can_generate_and_verify_random_hyperkzg_proofs_with_random_length() {
-    let (ps, vk) = load_small_setup_for_testing();
+    let (ps, vk) = load_small_setup_for_testing_internal();
 
     let mut rng = ark_std::test_rng();
 

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
@@ -1,6 +1,8 @@
 use alloc::vec::Vec;
 use ark_bn254::G1Affine;
 use ark_serialize::{CanonicalDeserialize, Compress, SerializationError, Validate};
+#[cfg(feature = "hyperkzg_proof")]
+use std::path::Path;
 
 /// When borrowed, `PublicSetup` type associated with the `HyperKZG` commitment scheme.
 ///
@@ -56,12 +58,28 @@ pub fn deserialize_flat_compressed_hyperkzg_public_setup_from_slice(
 }
 
 #[cfg(feature = "hyperkzg_proof")]
+#[cfg(test)]
 #[must_use]
 /// Load a small setup for testing.
 /// This returns a public setup and a verifier key.
 /// # Panics
 /// Panics if bin file not found
-pub fn load_small_setup_for_testing() -> (
+pub(crate) fn load_small_setup_for_testing_internal() -> (
+    HyperKZGPublicSetupOwned,
+    nova_snark::provider::hyperkzg::VerifierKey<super::HyperKZGEngine>,
+) {
+    load_small_setup_for_testing("test_assets/ppot_0080_10.bin")
+}
+
+#[cfg(feature = "hyperkzg_proof")]
+#[must_use]
+/// Load a small setup for testing.
+/// This returns a public setup and a verifier key.
+/// # Panics
+/// Panics if bin file not found
+pub fn load_small_setup_for_testing(
+    setup_file: impl AsRef<Path>,
+) -> (
     HyperKZGPublicSetupOwned,
     nova_snark::provider::hyperkzg::VerifierKey<super::HyperKZGEngine>,
 ) {
@@ -108,7 +126,7 @@ pub fn load_small_setup_for_testing() -> (
     ));
 
     let mut ps = super::deserialize_flat_compressed_hyperkzg_public_setup_from_reader(
-        &std::fs::File::open("test_assets/ppot_0080_10.bin").unwrap(),
+        &std::fs::File::open(setup_file).unwrap(),
         ark_serialize::Validate::Yes,
     )
     .unwrap();


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

It's not good to have a file path hardcoded in a publicly exported function.

# What changes are included in this PR?

Make the file path for the load setup function configurable

# Are these changes tested?
Not relevant
