### PR TITLE
fix: derive traits for `EVMProofPlan`

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -25,7 +25,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize, Serializer};
 use sqlparser::ast::Ident;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 /// An implementation of `ProofPlan` that allows for EVM compatible serialization.
 /// Serialization should be done using bincode with fixint, big-endian encoding in order to be compatible with EVM.
 ///


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

There's no reason not to derive `Clone` and `PartialEq`.

# What changes are included in this PR?

Derive a couple more traits on `EVMProofPlan`.

# Are these changes tested?
Not relevant
