### PR TITLE
refactor: loosen data accessor construction constraints

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -333,6 +333,33 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::TimestampTZ(_, _, col) => slice_cast_with(col, |i| S::from(i)),
         }
     }
+
+    pub(crate) fn alloc_column(self, alloc: &Bump) -> Column<'_, S> {
+        match self {
+            Column::Boolean(col) => Column::Boolean(alloc.alloc_slice_copy(col)),
+            Column::Uint8(col) => Column::Uint8(alloc.alloc_slice_copy(col)),
+            Column::TinyInt(col) => Column::TinyInt(alloc.alloc_slice_copy(col)),
+            Column::SmallInt(col) => Column::SmallInt(alloc.alloc_slice_copy(col)),
+            Column::Int(col) => Column::Int(alloc.alloc_slice_copy(col)),
+            Column::BigInt(col) => Column::BigInt(alloc.alloc_slice_copy(col)),
+            Column::Int128(col) => Column::Int128(alloc.alloc_slice_copy(col)),
+            Column::Decimal75(precision, scale, col) => {
+                Column::Decimal75(precision, scale, alloc.alloc_slice_copy(col))
+            }
+            Column::Scalar(col) => Column::Scalar(alloc.alloc_slice_copy(col)),
+            Column::TimestampTZ(tu, tz, col) => {
+                Column::TimestampTZ(tu, tz, alloc.alloc_slice_copy(col))
+            }
+            Column::VarBinary((bytes, scalars)) => Column::VarBinary((
+                alloc.alloc_slice_fill_iter(bytes.iter().map(|b| &*alloc.alloc_slice_copy(b))),
+                alloc.alloc_slice_copy(scalars),
+            )),
+            Column::VarChar((strings, scalars)) => Column::VarChar((
+                alloc.alloc_slice_fill_iter(strings.iter().map(|s| &*alloc.alloc_str(s))),
+                alloc.alloc_slice_copy(scalars),
+            )),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -577,5 +604,67 @@ mod tests {
 
         let round_trip_owned: OwnedColumn<TestScalar> = (&column).into();
         assert_eq!(owned_varbinary, round_trip_owned);
+    }
+
+    #[test]
+    fn we_can_alloc_columns() {
+        let alloc = Bump::new();
+        let column = Column::<TestScalar>::Boolean(&[true, false, true]);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let column = Column::<TestScalar>::Uint8(&[1, 2, 3, 4]);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let column = Column::<TestScalar>::TinyInt(&[1, 2, 3, 4]);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let column = Column::<TestScalar>::SmallInt(&[1, 2, 3, 4]);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let column = Column::<TestScalar>::Int(&[1, 2, 3]);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let column = Column::<TestScalar>::BigInt(&[1]);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let column = Column::<DoryScalar>::Int128(&[1, 2]);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let scalar_values = [
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+        ];
+
+        let column = Column::VarChar((&["a", "b", "c", "d", "e"], &scalar_values));
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let column = Column::Scalar(&scalar_values);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let precision = 10;
+        let scale = 2;
+        let decimal_data = [
+            TestScalar::from(1),
+            TestScalar::from(2),
+            TestScalar::from(3),
+        ];
+
+        let precision = Precision::new(precision).unwrap();
+        let column = Column::Decimal75(precision, scale, &decimal_data);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let column: Column<'_, DoryScalar> =
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1, 2, 3]);
+        assert_eq!(column, column.alloc_column(&alloc));
+
+        let raw_bytes: &[&[u8]] = &[b"foo", b"bar", b""];
+        let scalars: Vec<TestScalar> = raw_bytes
+            .iter()
+            .map(|b| TestScalar::from_le_bytes_mod_order(b))
+            .collect();
+
+        let column = Column::VarBinary((raw_bytes, &scalars));
+        assert_eq!(column, column.alloc_column(&alloc));
     }
 }

--- a/crates/proof-of-sql/src/base/database/data_accessor_impl.rs
+++ b/crates/proof-of-sql/src/base/database/data_accessor_impl.rs
@@ -39,10 +39,11 @@ impl<'a, S: Scalar> TableDataAccessor<'a, S> {
     /// Creates a new instance of `TableDataAccessor` using a `RecordBatch`
     #[cfg(feature = "arrow")]
     pub fn try_from_record_batch(
-        record_batch: &'a RecordBatch,
+        record_batch: &RecordBatch,
         offset: usize,
         alloc: &'a Bump,
     ) -> Result<Self, ArrowArrayToColumnConversionError> {
+        let inner_alloc = Bump::new();
         let range = 0..record_batch.num_rows();
         let columns = record_batch
             .schema()
@@ -50,8 +51,8 @@ impl<'a, S: Scalar> TableDataAccessor<'a, S> {
             .iter()
             .zip(record_batch.columns())
             .map(|(f, col)| {
-                col.to_column::<S>(alloc, &range, None)
-                    .map(|col| (f.name().as_str().into(), col))
+                col.to_column::<S>(&inner_alloc, &range, None)
+                    .map(|col| (f.name().as_str().into(), col.alloc_column(alloc)))
             })
             // Use collect to transform Iterator<Result<T, E>> into Result<Collection<T>, E>
             .collect::<Result<IndexMap<_, _>, _>>()?;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This should make it easier to construct a `DataAccessorImpl`, without the need to tie a `RecordBatch` to a specific lifetime.

# What changes are included in this PR?

New `alloc_column` function. Changing the signature of `DataAccessorImpl::try_from_record_batch`.

# Are these changes tested?
Yes
