### PR TITLE
test: cover database metadata and error displays

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -31,3 +31,24 @@ impl ColumnField {
         self.data_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructor_stores_name_and_type_metadata() {
+        let field = ColumnField::new(Ident::new("is_active"), ColumnType::Boolean);
+
+        assert_eq!(field.name(), Ident::new("is_active"));
+        assert_eq!(field.data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn column_fields_round_trip_through_serde() {
+        let field = ColumnField::new(Ident::new("payload"), ColumnType::VarBinary);
+        let json = serde_json::to_string(&field).unwrap();
+
+        assert_eq!(serde_json::from_str::<ColumnField>(&json).unwrap(), field);
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -108,3 +108,93 @@ pub enum ColumnOperationError {
 
 /// Result type for column operations
 pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn displays_column_length_and_index_errors() {
+        assert_eq!(
+            ColumnOperationError::DifferentColumnLength { len_a: 2, len_b: 3 }.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+        assert_eq!(
+            ColumnOperationError::IndexOutOfBounds { index: 5, len: 5 }.to_string(),
+            "Index out of bounds: 5 >= 5"
+        );
+    }
+
+    #[test]
+    fn displays_invalid_operation_type_errors() {
+        assert_eq!(
+            ColumnOperationError::BinaryOperationInvalidColumnType {
+                operator: "add".to_string(),
+                left_type: ColumnType::Int,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            r#""add"(lhs: Int, rhs: VarChar) is not supported"#
+        );
+        assert_eq!(
+            ColumnOperationError::UnaryOperationInvalidColumnType {
+                operator: "not".to_string(),
+                operand_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            r#""not"(operand: BigInt) is not supported"#
+        );
+    }
+
+    #[test]
+    fn displays_casting_and_union_errors() {
+        assert_eq!(
+            ColumnOperationError::UnionDifferentTypes {
+                correct_type: ColumnType::Boolean,
+                actual_type: ColumnType::Int,
+            }
+            .to_string(),
+            "Cannot union columns of different types: Boolean and Int"
+        );
+        assert_eq!(
+            ColumnOperationError::SignedCastingError {
+                left_type: ColumnType::TinyInt,
+                right_type: ColumnType::Uint8,
+            }
+            .to_string(),
+            "Cannot fit TINYINT into UINT8 without losing data"
+        );
+        assert_eq!(
+            ColumnOperationError::CastingError {
+                left_type: ColumnType::VarChar,
+                right_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Cannot fit VARCHAR into BIGINT without losing data"
+        );
+        assert_eq!(
+            ColumnOperationError::ScaleCastingError {
+                left_type: ColumnType::Int128,
+                right_type: ColumnType::SmallInt,
+            }
+            .to_string(),
+            "Cannot fit DECIMAL into SMALLINT without losing data"
+        );
+    }
+
+    #[test]
+    fn displays_arithmetic_errors() {
+        assert_eq!(
+            ColumnOperationError::IntegerOverflow {
+                error: "i64 overflow".to_string(),
+            }
+            .to_string(),
+            "Overflow in integer operation: i64 overflow"
+        );
+        assert_eq!(
+            ColumnOperationError::DivisionByZero.to_string(),
+            "Division by zero"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_ref.rs
+++ b/crates/proof-of-sql/src/base/database/column_ref.rs
@@ -39,3 +39,35 @@ impl ColumnRef {
         &self.column_type
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::TableRef;
+
+    #[test]
+    fn constructor_stores_table_column_and_type_metadata() {
+        let table_ref = TableRef::from_names(Some("public"), "orders");
+        let column_ref =
+            ColumnRef::new(table_ref.clone(), Ident::new("amount"), ColumnType::BigInt);
+
+        assert_eq!(column_ref.table_ref(), table_ref);
+        assert_eq!(column_ref.column_id(), Ident::new("amount"));
+        assert_eq!(*column_ref.column_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn column_refs_round_trip_through_serde() {
+        let column_ref = ColumnRef::new(
+            TableRef::from_names(Some("analytics"), "orders"),
+            Ident::new("customer_id"),
+            ColumnType::VarChar,
+        );
+
+        let json = serde_json::to_string(&column_ref).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ColumnRef>(&json).unwrap(),
+            column_ref
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -40,3 +40,47 @@ pub(crate) enum ColumnCoercionError {
 
 /// Result type for operations related to `OwnedColumn`s.
 pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn displays_owned_column_errors() {
+        assert_eq!(
+            OwnedColumnError::TypeCastError {
+                from_type: ColumnType::VarChar,
+                to_type: ColumnType::BigInt,
+            }
+            .to_string(),
+            "Can not perform type casting from VarChar to BigInt"
+        );
+        assert_eq!(
+            OwnedColumnError::ScalarConversionError {
+                error: "bad scalar".to_string(),
+            }
+            .to_string(),
+            "Error in converting scalars to a given column type: bad scalar"
+        );
+        assert_eq!(
+            OwnedColumnError::Unsupported {
+                error: "windowed varbinary".to_string(),
+            }
+            .to_string(),
+            "Unsupported operation: windowed varbinary"
+        );
+    }
+
+    #[test]
+    fn displays_column_coercion_errors() {
+        assert_eq!(
+            ColumnCoercionError::Overflow.to_string(),
+            "Overflow when coercing a column"
+        );
+        assert_eq!(
+            ColumnCoercionError::InvalidTypeCoercion.to_string(),
+            "Invalid type coercion"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -65,3 +65,75 @@ pub enum TableOperationError {
 
 /// Result type for table operations
 pub type TableOperationResult<T> = Result<T, TableOperationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{string::ToString, vec};
+
+    #[test]
+    fn displays_table_union_and_join_errors() {
+        assert_eq!(
+            TableOperationError::UnionNotEnoughTables.to_string(),
+            "Cannot union fewer than 2 tables"
+        );
+        assert_eq!(
+            TableOperationError::JoinWithDifferentNumberOfColumns {
+                left_num_columns: 2,
+                right_num_columns: 3,
+            }
+            .to_string(),
+            "Cannot join tables with different numbers of columns: 2 and 3"
+        );
+        assert_eq!(
+            TableOperationError::JoinIncompatibleTypes {
+                left_type: ColumnType::Int,
+                right_type: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Cannot join tables on columns with incompatible types: Int and VarChar"
+        );
+    }
+
+    #[test]
+    fn displays_missing_duplicate_and_index_errors() {
+        assert_eq!(
+            TableOperationError::ColumnDoesNotExist {
+                column_ident: Ident::new("missing_col"),
+            }
+            .to_string(),
+            r#"Column Ident { value: "missing_col", quote_style: None } does not exist in table"#
+        );
+        assert_eq!(
+            TableOperationError::DuplicateColumn.to_string(),
+            "Some column is duplicated in table"
+        );
+        assert_eq!(
+            TableOperationError::ColumnIndexOutOfBounds { column_index: 4 }.to_string(),
+            "Column index out of bounds: 4"
+        );
+    }
+
+    #[test]
+    fn displays_incompatible_schema_and_transparent_column_error() {
+        let correct_schema = vec![ColumnField::new(Ident::new("id"), ColumnType::BigInt)];
+        let actual_schema = vec![ColumnField::new(Ident::new("id"), ColumnType::VarChar)];
+        let schema_error = TableOperationError::UnionIncompatibleSchemas {
+            correct_schema,
+            actual_schema,
+        }
+        .to_string();
+
+        assert!(schema_error.starts_with("Cannot union tables with incompatible schemas:"));
+        assert!(schema_error.contains("BigInt"));
+        assert!(schema_error.contains("VarChar"));
+
+        assert_eq!(
+            TableOperationError::ColumnOperationError {
+                source: ColumnOperationError::DivisionByZero,
+            }
+            .to_string(),
+            "Division by zero"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -142,3 +142,97 @@ impl<'d> Deserialize<'d> for TableRef {
         TableRef::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn constructors_normalize_empty_schema_and_preserve_idents() {
+        let table = TableRef::new("", "orders");
+        assert_eq!(table.schema_id(), None);
+        assert_eq!(table.table_id().value, "orders");
+        assert_eq!(table.to_string(), "orders");
+
+        let table = TableRef::from_names(Some("analytics"), "orders");
+        assert_eq!(table.schema_id().unwrap().value, "analytics");
+        assert_eq!(table.table_id().value, "orders");
+        assert_eq!(table.to_string(), "analytics.orders");
+
+        let table = TableRef::from_idents(Some(Ident::new("public")), Ident::new("lineitem"));
+        assert_eq!(table.schema_id().unwrap().value, "public");
+        assert_eq!(table.table_id().value, "lineitem");
+        assert_eq!(table.to_string(), "public.lineitem");
+    }
+
+    #[test]
+    fn parses_from_component_slices_and_dot_separated_strings() {
+        assert_eq!(
+            TableRef::from_strs(&["orders"]).unwrap(),
+            TableRef::from_names(None, "orders")
+        );
+        assert_eq!(
+            TableRef::from_strs(&["public", "orders"]).unwrap(),
+            TableRef::from_names(Some("public"), "orders")
+        );
+        assert_eq!(
+            TableRef::try_from("public.orders").unwrap(),
+            TableRef::from_names(Some("public"), "orders")
+        );
+        assert_eq!(
+            TableRef::from_str("orders").unwrap(),
+            TableRef::from_names(None, "orders")
+        );
+    }
+
+    #[test]
+    fn rejects_table_references_with_too_many_components() {
+        assert_eq!(
+            TableRef::from_strs(&["catalog", "schema", "orders"]).unwrap_err(),
+            ParseError::InvalidTableReference {
+                table_reference: "catalog,schema,orders".to_string()
+            }
+        );
+        assert_eq!(
+            TableRef::try_from("catalog.schema.orders").unwrap_err(),
+            ParseError::InvalidTableReference {
+                table_reference: "catalog.schema.orders".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn serializes_as_display_string_and_deserializes_back() {
+        let table = TableRef::from_names(Some("public"), "orders");
+        let json = serde_json::to_string(&table).unwrap();
+        assert_eq!(json, r#""public.orders""#);
+        assert_eq!(serde_json::from_str::<TableRef>(&json).unwrap(), table);
+
+        let invalid = serde_json::from_str::<TableRef>(r#""a.b.c""#).unwrap_err();
+        assert!(invalid.to_string().contains("Invalid table reference"));
+    }
+
+    #[test]
+    fn borrowed_table_refs_are_equivalent_to_matching_keys() {
+        let key = TableRef::from_names(Some("public"), "orders");
+        let same = TableRef::from_names(Some("public"), "orders");
+        let different_schema = TableRef::from_names(Some("private"), "orders");
+        let different_table = TableRef::from_names(Some("public"), "lineitem");
+
+        assert!(Equivalent::<TableRef>::equivalent(&&same, &key));
+        assert!(!Equivalent::<TableRef>::equivalent(
+            &&different_schema,
+            &key
+        ));
+        assert!(!Equivalent::<TableRef>::equivalent(&&different_table, &key));
+    }
+
+    #[test]
+    fn parse_error_display_includes_bad_reference() {
+        let error = ParseError::InvalidTableReference {
+            table_reference: "a.b.c".to_string(),
+        };
+        assert_eq!(error.to_string(), "Invalid table reference: a.b.c");
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,57 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn displays_timestamp_errors() {
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezone {
+                timezone: "Mars/Base".to_string(),
+            }
+            .to_string(),
+            "invalid timezone string: Mars/Base"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimezoneOffset.to_string(),
+            "invalid timezone offset"
+        );
+        assert_eq!(
+            PoSQLTimestampError::InvalidTimeUnit {
+                error: "weeks".to_string(),
+            }
+            .to_string(),
+            "Invalid time unit"
+        );
+        assert_eq!(
+            PoSQLTimestampError::UnsupportedPrecision {
+                error: "picoseconds".to_string(),
+            }
+            .to_string(),
+            "Unsupported precision for timestamp: picoseconds"
+        );
+    }
+
+    #[test]
+    fn converts_timestamp_errors_to_strings() {
+        let message: String = PoSQLTimestampError::InvalidTimezoneOffset.into();
+        assert_eq!(message, "invalid timezone offset");
+    }
+
+    #[test]
+    fn timestamp_errors_round_trip_through_serde() {
+        let error = PoSQLTimestampError::InvalidTimezone {
+            timezone: "bad zone".to_string(),
+        };
+        let json = serde_json::to_string(&error).unwrap();
+
+        assert_eq!(
+            serde_json::from_str::<PoSQLTimestampError>(&json).unwrap(),
+            error
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/posql_time/timezone.rs
+++ b/crates/proof-of-sql/src/base/posql_time/timezone.rs
@@ -104,6 +104,25 @@ mod timezone_parsing_tests {
     }
 
     #[test]
+    fn we_can_parse_utc_aliases() {
+        for value in ["Z", "z", "UTC", "utc", "00:00", "+00:00", "0:00", "+0:00"] {
+            let timezone_as_str: Option<Arc<str>> = Some(value.into());
+            assert_eq!(
+                PoSQLTimeZone::try_from(&timezone_as_str).unwrap(),
+                PoSQLTimeZone::utc()
+            );
+        }
+    }
+
+    #[test]
+    fn we_can_parse_positive_time_zone() {
+        let timezone_as_str: Option<Arc<str>> = Some("+05:45".into());
+        let timezone = PoSQLTimeZone::try_from(&timezone_as_str).unwrap();
+        assert_eq!(timezone, PoSQLTimeZone::new(20_700));
+        assert_eq!(format!("{timezone}"), "+05:45");
+    }
+
+    #[test]
     fn we_can_parse_none_time_zone() {
         let timezone = PoSQLTimeZone::try_from(&None).unwrap();
         let expected_time_zone = PoSQLTimeZone::utc();
@@ -118,5 +137,16 @@ mod timezone_parsing_tests {
             timezone_err,
             PoSQLTimestampError::InvalidTimezone { timezone: _ }
         ));
+    }
+
+    #[test]
+    fn we_cannot_parse_malformed_numeric_offsets() {
+        for value in ["+aa:00", "+01:bb", "-zz:30"] {
+            let timezone_as_str: Option<Arc<str>> = Some(value.into());
+            assert_eq!(
+                PoSQLTimeZone::try_from(&timezone_as_str),
+                Err(PoSQLTimestampError::InvalidTimezoneOffset)
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add direct `TableRef` coverage for constructors, parsing, display, serde, equivalence, and invalid references
- cover `ColumnRef` and `ColumnField` constructor/accessor behavior plus serde round trips
- cover database error display behavior for `ColumnOperationError`, `OwnedColumnError`, `ColumnCoercionError`, and `TableOperationError`
- cover `PoSQLTimestampError` display, string conversion, and serde round trips
- cover `PoSQLTimeZone` UTC aliases, positive offsets, and malformed numeric offsets
- keep the change test-only and separate from the existing open #560 coverage slices

/claim #560

## Validation
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test table_ref -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test timezone_parsing_tests -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test column_ref -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test column_field -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test column_operation_error -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test owned_column_error -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test table_operation_error -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test timestamp_errors -- --nocapture`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --summary-only -- table_ref`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --summary-only -- timezone_parsing_tests`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --summary-only -- column_ref` (`column_ref.rs`: 33/33 lines, 6/6 functions)
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --summary-only -- column_field` (`column_field.rs`: 19/19 lines, 5/5 functions)

Note: this environment does not have `clang`, while the repo config points at it, so the targeted cargo commands above override the linker to `cc` and clear the repo-level `-fuse-ld=lld` rustflag.