### PR TITLE
test: cover serialization and proof errors

### DIFF
--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -90,3 +90,126 @@ pub enum PlaceholderError {
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn displays_top_level_proof_errors() {
+        assert_eq!(
+            ProofError::VerificationError {
+                error: "bad transcript"
+            }
+            .to_string(),
+            "Verification error: bad transcript"
+        );
+        assert_eq!(
+            ProofError::UnsupportedQueryPlan {
+                error: "window function"
+            }
+            .to_string(),
+            "Unsupported query plan: window function"
+        );
+        assert_eq!(
+            ProofError::InvalidTypeCoercion.to_string(),
+            "Result does not match query: type mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldNamesMismatch.to_string(),
+            "Result does not match query: field names mismatch"
+        );
+        assert_eq!(
+            ProofError::FieldCountMismatch.to_string(),
+            "Result does not match query: field count mismatch"
+        );
+    }
+
+    #[test]
+    fn displays_proof_size_mismatch_errors() {
+        assert_eq!(
+            ProofSizeMismatch::SumcheckProofTooSmall.to_string(),
+            "Sumcheck proof is too small"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewMLEEvaluations.to_string(),
+            "Proof has too few MLE evaluations"
+        );
+        assert_eq!(
+            ProofSizeMismatch::PostResultCountMismatch.to_string(),
+            "Post result challenge count mismatch"
+        );
+        assert_eq!(
+            ProofSizeMismatch::ConstraintCountMismatch.to_string(),
+            "Constraint count mismatch"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewBitDistributions.to_string(),
+            "Proof has too few bit distributions"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewChiLengths.to_string(),
+            "Proof has too few one lengths"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewRhoLengths.to_string(),
+            "Proof has too few rho lengths"
+        );
+        assert_eq!(
+            ProofSizeMismatch::TooFewSumcheckVariables.to_string(),
+            "Proof has too few sumcheck variables"
+        );
+        assert_eq!(
+            ProofSizeMismatch::ChiLengthNotFound.to_string(),
+            "Proof doesn't have requested one length"
+        );
+        assert_eq!(
+            ProofSizeMismatch::RhoLengthNotFound.to_string(),
+            "Proof doesn't have requested rho length"
+        );
+    }
+
+    #[test]
+    fn displays_transparent_proof_error_sources() {
+        assert_eq!(
+            ProofError::ProofSizeMismatch {
+                source: ProofSizeMismatch::TooFewMLEEvaluations,
+            }
+            .to_string(),
+            "Proof has too few MLE evaluations"
+        );
+        assert_eq!(
+            ProofError::PlaceholderError {
+                source: PlaceholderError::ZeroPlaceholderId,
+            }
+            .to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn displays_placeholder_errors() {
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderIndex {
+                index: 3,
+                num_params: 2,
+            }
+            .to_string(),
+            "Invalid placeholder index: 3, number of params: 2"
+        );
+        assert_eq!(
+            PlaceholderError::InvalidPlaceholderType {
+                index: 1,
+                expected: ColumnType::BigInt,
+                actual: ColumnType::VarChar,
+            }
+            .to_string(),
+            "Invalid placeholder type: 1, expected: BIGINT, actual: VARCHAR"
+        );
+        assert_eq!(
+            PlaceholderError::ZeroPlaceholderId.to_string(),
+            "Placeholder id must be greater than 0"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -11,3 +11,21 @@ pub enum ScalarConversionError {
         error: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn displays_scalar_conversion_overflow_error() {
+        let error = ScalarConversionError::Overflow {
+            error: "value does not fit in i128".to_string(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Overflow error: value does not fit in i128"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/limbs.rs
@@ -13,3 +13,49 @@ pub(crate) fn deserialize_to_limbs<'de, D: Deserializer<'de>>(
     let limbs = <[u64; 4]>::deserialize(deserializer)?;
     Ok([limbs[3], limbs[2], limbs[1], limbs[0]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct LimbWrapper {
+        #[serde(
+            serialize_with = "serialize_limbs",
+            deserialize_with = "deserialize_to_limbs"
+        )]
+        limbs: [u64; 4],
+    }
+
+    #[test]
+    fn serialize_limbs_reverses_limb_order() {
+        let value = LimbWrapper {
+            limbs: [1, 2, 3, 4],
+        };
+
+        assert_eq!(
+            serde_json::to_string(&value).unwrap(),
+            r#"{"limbs":[4,3,2,1]}"#
+        );
+    }
+
+    #[test]
+    fn deserialize_to_limbs_reverses_limb_order() {
+        let value: LimbWrapper = serde_json::from_str(r#"{"limbs":[4,3,2,1]}"#).unwrap();
+
+        assert_eq!(
+            value,
+            LimbWrapper {
+                limbs: [1, 2, 3, 4]
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_to_limbs_rejects_wrong_limb_count() {
+        let error = serde_json::from_str::<LimbWrapper>(r#"{"limbs":[1,2,3]}"#).unwrap_err();
+
+        assert!(error.to_string().contains("invalid length 3"));
+    }
+}


### PR DESCRIPTION
## Summary
- cover standard limb serde helper ordering and invalid limb counts
- cover scalar conversion overflow display
- cover proof, proof-size, and placeholder error display paths
- keep this test-only and separate from the current #560 coverage slices

/claim #560

## Validation
- cargo fmt --check
- git diff --check
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test limbs -- --nocapture
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test scalar_conversion -- --nocapture
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test proof_error -- --nocapture
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test proof_size_mismatch -- --nocapture
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test placeholder_errors -- --nocapture

Note: this environment does not have clang; repo config points at it, so targeted cargo commands override the linker to cc and clear the repo-level lld rustflag.