### PR TITLE
test: cover sql utility errors

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -69,6 +69,31 @@ mod time_unit_tests {
     }
 
     #[test]
+    fn test_precision_numeric_conversion() {
+        assert_eq!(u64::from(PoSQLTimeUnit::Second), 0);
+        assert_eq!(u64::from(PoSQLTimeUnit::Millisecond), 3);
+        assert_eq!(u64::from(PoSQLTimeUnit::Microsecond), 6);
+        assert_eq!(u64::from(PoSQLTimeUnit::Nanosecond), 9);
+    }
+
+    #[test]
+    fn test_time_unit_display() {
+        assert_eq!(PoSQLTimeUnit::Second.to_string(), "seconds (precision: 0)");
+        assert_eq!(
+            PoSQLTimeUnit::Millisecond.to_string(),
+            "milliseconds (precision: 3)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Microsecond.to_string(),
+            "microseconds (precision: 6)"
+        );
+        assert_eq!(
+            PoSQLTimeUnit::Nanosecond.to_string(),
+            "nanoseconds (precision: 9)"
+        );
+    }
+
+    #[test]
     fn test_invalid_precision() {
         let invalid_precisions = [
             "1", "2", "4", "5", "7", "8", "10", "zero", "three", "cat", "-1", "-2",

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -71,3 +71,57 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::math::decimal::IntermediateDecimalError;
+
+    #[test]
+    fn displays_analyze_error_variants() {
+        assert_eq!(
+            AnalyzeError::InvalidDataType {
+                expr_type: ColumnType::Boolean,
+            }
+            .to_string(),
+            "Expression has datatype BOOLEAN, which was not valid"
+        );
+        assert_eq!(
+            AnalyzeError::DataTypeMismatch {
+                left_type: "BIGINT".into(),
+                right_type: "VARCHAR".into(),
+            }
+            .to_string(),
+            "Left side has 'BIGINT' type but right side has 'VARCHAR' type"
+        );
+        assert_eq!(
+            AnalyzeError::DifferentColumnLength { len_a: 2, len_b: 3 }.to_string(),
+            "Columns have different lengths: 2 != 3"
+        );
+        assert_eq!(
+            AnalyzeError::NotEnoughInputPlans.to_string(),
+            "Not enough input plans"
+        );
+    }
+
+    #[test]
+    fn converts_analyze_errors_to_string() {
+        let message: String = AnalyzeError::DataTypeMismatch {
+            left_type: "INT".into(),
+            right_type: "BIGINT".into(),
+        }
+        .into();
+
+        assert_eq!(
+            message,
+            "Left side has 'INT' type but right side has 'BIGINT' type"
+        );
+    }
+
+    #[test]
+    fn converts_intermediate_decimal_errors_to_analyze_errors() {
+        let error = AnalyzeError::from(IntermediateDecimalError::LossyCast);
+
+        assert_eq!(error.to_string(), "Fractional part of decimal is non-zero");
+    }
+}

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -35,3 +35,50 @@ pub(crate) enum EVMProofPlanError {
 
 /// Result type for EVM proof plan operations.
 pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn displays_evm_proof_plan_errors() {
+        assert_eq!(
+            EVMProofPlanError::NotSupported.to_string(),
+            "plan not yet supported"
+        );
+        assert_eq!(
+            EVMProofPlanError::ColumnNotFound.to_string(),
+            "column not found"
+        );
+        assert_eq!(
+            EVMProofPlanError::TableNotFound.to_string(),
+            "table not found"
+        );
+        assert_eq!(
+            EVMProofPlanError::InvalidTableName.to_string(),
+            "table name can not be parsed into TableRef"
+        );
+        assert_eq!(
+            EVMProofPlanError::InvalidOutputColumnName.to_string(),
+            "invalid or missing output column name"
+        );
+        assert_eq!(
+            EVMProofPlanError::InconsistentGroupByColumnCounts.to_string(),
+            "column counts in group by plans are inconsistent"
+        );
+        assert_eq!(
+            EVMProofPlanError::IncorrectScalingFactor.to_string(),
+            "incorrect scaling factor"
+        );
+    }
+
+    #[test]
+    fn displays_transparent_analyze_error_source() {
+        let error = EVMProofPlanError::AnalyzeError {
+            source: AnalyzeError::NotEnoughInputPlans,
+        };
+
+        assert_eq!(error.to_string(), "Not enough input plans");
+    }
+}


### PR DESCRIPTION
## Summary
- cover `AnalyzeError` display and conversion paths
- cover EVM proof-plan error display and transparent AnalyzeError source behavior
- cover PoSQL time-unit display and numeric precision conversion
- keep this test-only and separate from the current #560 coverage slices

/claim #560

## Validation
- cargo fmt --check
- git diff --check
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test analyze_error -- --nocapture
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test evm_proof_plan_errors -- --nocapture
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test time_unit -- --nocapture

Note: this environment does not have clang; repo config points at it, so targeted cargo commands override the linker to cc and clear the repo-level lld rustflag.