### PR TITLE
feat: Changes to support BETWEEN operator using naive approach

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -3,7 +3,7 @@ use super::{
     PlannerError, PlannerResult,
 };
 use datafusion::logical_expr::{
-    expr::{Alias, Cast, InList, Placeholder},
+    expr::{Alias, Between, Cast, InList, Placeholder},
     BinaryExpr, Expr, Operator,
 };
 use indexmap::IndexSet;
@@ -45,15 +45,19 @@ pub(crate) fn get_column_idents_from_expr(expr: &Expr) -> IndexSet<Ident> {
             .iter()
             .flat_map(get_column_idents_from_expr)
             .collect(),
+        Expr::Between(Between {
+            expr, low, high, ..
+        }) => {
+            let mut idents = get_column_idents_from_expr(expr);
+            idents.extend(get_column_idents_from_expr(low));
+            idents.extend(get_column_idents_from_expr(high));
+            idents
+        }
         _ => IndexSet::new(),
     }
 }
 
 /// Convert a [`BinaryExpr`] to [`DynProofExpr`]
-#[expect(
-    clippy::missing_panics_doc,
-    reason = "Output of comparisons is always boolean"
-)]
 fn binary_expr_to_proof_expr(
     left: &Expr,
     right: &Expr,
@@ -62,7 +66,22 @@ fn binary_expr_to_proof_expr(
 ) -> PlannerResult<DynProofExpr> {
     let left_proof_expr = expr_to_proof_expr(left, schema)?;
     let right_proof_expr = expr_to_proof_expr(right, schema)?;
+    binary_proof_exprs_to_proof_expr(left_proof_expr, right_proof_expr, op)
+}
 
+/// Apply a binary [`Operator`] to two already-converted [`DynProofExpr`]s.
+///
+/// Scale-casting is performed here for operators that require it, so callers
+/// that already hold `DynProofExpr`s can skip the `Expr` conversion step.
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "Output of comparisons is always boolean"
+)]
+fn binary_proof_exprs_to_proof_expr(
+    left_proof_expr: DynProofExpr,
+    right_proof_expr: DynProofExpr,
+    op: Operator,
+) -> PlannerResult<DynProofExpr> {
     let (left_proof_expr, right_proof_expr) = match op {
         Operator::Eq
         | Operator::NotEq
@@ -124,7 +143,6 @@ fn binary_expr_to_proof_expr(
             left_proof_expr,
             right_proof_expr,
         )?),
-        // Any other operator is unsupported
         _ => Err(PlannerError::UnsupportedBinaryOperator { op }),
     }
 }
@@ -238,9 +256,39 @@ pub fn expr_to_proof_expr(
                 }
             }
         }
+        Expr::Between(Between {
+            expr,
+            negated,
+            low,
+            high,
+        }) => between_to_proof_expr(expr, *negated, low, high, schema),
         _ => Err(PlannerError::UnsupportedLogicalExpression {
             expr: Box::new(expr.clone()),
         }),
+    }
+}
+
+/// Convert a [`Between`] expression to [`DynProofExpr`]
+fn between_to_proof_expr(
+    expr: &Expr,
+    negated: bool,
+    low: &Expr,
+    high: &Expr,
+    schema: &[(Ident, ColumnType)],
+) -> PlannerResult<DynProofExpr> {
+    let expr_proof = expr_to_proof_expr(expr, schema)?;
+    let low_proof = expr_to_proof_expr(low, schema)?;
+    let high_proof = expr_to_proof_expr(high, schema)?;
+    // expr < low OR expr > high
+    let out_of_range = binary_proof_exprs_to_proof_expr(
+        binary_proof_exprs_to_proof_expr(expr_proof.clone(), low_proof, Operator::Lt)?,
+        binary_proof_exprs_to_proof_expr(expr_proof, high_proof, Operator::Gt)?,
+        Operator::Or,
+    )?;
+    if negated {
+        Ok(out_of_range)
+    } else {
+        Ok(DynProofExpr::try_new_not(out_of_range)?)
     }
 }
 
@@ -888,6 +936,73 @@ mod tests {
             expr_to_proof_expr(&expr, &Vec::new()),
             Err(PlannerError::UnsupportedLogicalExpression { .. })
         ));
+    }
+
+    // Between
+    #[test]
+    fn we_can_convert_between_expr_to_proof_expr() {
+        let schema = vec![("column1".into(), ColumnType::BigInt)];
+
+        let col = df_column("namespace.table_name", "column1");
+        let low = Expr::Literal(ScalarValue::Int64(Some(10)));
+        let high = Expr::Literal(ScalarValue::Int64(Some(20)));
+        let expr = col.between(low, high);
+
+        let col_expr = DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::BigInt,
+        ));
+        let low_expr = DynProofExpr::new_literal(LiteralValue::BigInt(10));
+        let high_expr = DynProofExpr::new_literal(LiteralValue::BigInt(20));
+
+        let expected = DynProofExpr::try_new_not(
+            DynProofExpr::try_new_or(
+                DynProofExpr::try_new_inequality(col_expr.clone(), low_expr, true).unwrap(),
+                DynProofExpr::try_new_inequality(col_expr, high_expr, false).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), expected);
+    }
+
+    #[test]
+    fn we_can_convert_not_between_expr_to_proof_expr() {
+        let schema = vec![("column1".into(), ColumnType::BigInt)];
+
+        let col = df_column("namespace.table_name", "column1");
+        let low = Expr::Literal(ScalarValue::Int64(Some(10)));
+        let high = Expr::Literal(ScalarValue::Int64(Some(20)));
+        let expr = col.not_between(low, high);
+
+        let col_expr = DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::BigInt,
+        ));
+        let low_expr = DynProofExpr::new_literal(LiteralValue::BigInt(10));
+        let high_expr = DynProofExpr::new_literal(LiteralValue::BigInt(20));
+
+        let expected = DynProofExpr::try_new_or(
+            DynProofExpr::try_new_inequality(col_expr.clone(), low_expr, true).unwrap(),
+            DynProofExpr::try_new_inequality(col_expr, high_expr, false).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), expected);
+    }
+
+    #[test]
+    fn we_can_extract_column_idents_from_between_expr() {
+        let col = df_column("table", "val");
+        let low = Expr::Literal(ScalarValue::Int64(Some(1)));
+        let high = Expr::Literal(ScalarValue::Int64(Some(100)));
+        let expr = col.between(low, high);
+        let result = get_column_idents_from_expr(&expr);
+        let expected: IndexSet<Ident> = ["val".into()].into_iter().collect();
+        assert_eq!(result, expected);
     }
 
     #[test]

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -839,3 +839,87 @@ fn test_in_list_long_numeric_list() {
         &[],
     );
 }
+
+/// Test BETWEEN and NOT BETWEEN operators, including inclusive boundary behaviour
+#[test]
+fn test_between_operator() {
+    let alloc = Bump::new();
+    let sql = "SELECT id, score FROM students WHERE score BETWEEN 60 AND 90;
+    SELECT id, score FROM students WHERE score NOT BETWEEN 60 AND 90;
+    SELECT id, score FROM students WHERE score BETWEEN 90 AND 90;";
+
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "students") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4, 5], &alloc),
+                borrowed_bigint("score", [45_i64, 60, 75, 90, 95], &alloc),
+            ]
+        )
+    };
+
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        // score >= 60 AND score <= 90  →  rows 2, 3, 4
+        owned_table([int("id", [2, 3, 4]), bigint("score", [60_i64, 75, 90])]),
+        // score < 60 OR score > 90  →  rows 1, 5
+        owned_table([int("id", [1, 5]), bigint("score", [45_i64, 95])]),
+        // exact single-value range  →  row 4 only
+        owned_table([int("id", [4]), bigint("score", [90_i64])]),
+    ];
+
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}
+
+/// Test BETWEEN combined with AND / OR filters
+#[test]
+fn test_between_combined_with_other_filters() {
+    let alloc = Bump::new();
+    let sql =
+        "SELECT id, name FROM employees WHERE salary BETWEEN 50000 AND 80000 AND department = 'Engineering';
+    SELECT id, name FROM employees WHERE salary BETWEEN 50000 AND 80000 OR age < 25;";
+
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "employees") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4, 5], &alloc),
+                borrowed_varchar("name", ["Alice", "Bob", "Carol", "Dave", "Eve"], &alloc),
+                borrowed_bigint("salary", [45_000_i64, 60_000, 75_000, 90_000, 55_000], &alloc),
+                borrowed_varchar("department", ["HR", "Engineering", "Engineering", "Engineering", "HR"], &alloc),
+                borrowed_tinyint("age", [30_i8, 24, 35, 28, 22], &alloc),
+            ]
+        )
+    };
+
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        // salary in [50000,80000]: ids 2,3,5  AND  department='Engineering': ids 2,3
+        owned_table([int("id", [2, 3]), varchar("name", ["Bob", "Carol"])]),
+        // salary in [50000,80000]: ids 2,3,5  OR  age < 25 (ids 2,5)  →  union: ids 2,3,5
+        owned_table([
+            int("id", [2, 3, 5]),
+            varchar("name", ["Bob", "Carol", "Eve"]),
+        ]),
+    ];
+
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}


### PR DESCRIPTION
  # Rationale for this change

  SQL `BETWEEN` was not supported by the planner. This adds them by lowering `Expr::Between` into expressions we already have (inequality, `OR`, `NOT`), so there's no new proof expr.

  # What changes are included in this PR?

  `a BETWEEN low AND high` is lowered to `NOT (a < low OR a > high)` (and `a NOT BETWEEN low AND high` to `a < low OR a > high`, without the outer `NOT`):
  - Added an `Expr::Between` arm to `expr_to_proof_expr`, handled by a new `between_to_proof_expr` helper.
  - Extracted the scale-casting binary-op logic out of `binary_expr_to_proof_expr` into a new `binary_proof_exprs_to_proof_expr`, so `between_to_proof_expr` can build the `<`/`>`/`OR` chain from already-lowered
  `DynProofExpr`s without going back through `Expr`.
  - Added a `Between` case to `get_column_idents_from_expr` so columns referenced in the expr, low, and high bounds are all picked up.

  # Are these changes tested?

  Yes — planner unit tests (`BETWEEN`, `NOT BETWEEN`, column-ident extraction) and end-to-end prove/verify tests covering inclusive boundaries and `BETWEEN` combined with `AND`/`OR` filters.