### PR TITLE
test: cover binary serialization utilities

### DIFF
--- a/crates/proof-of-sql/src/base/rayon_cfg.rs
+++ b/crates/proof-of-sql/src/base/rayon_cfg.rs
@@ -11,3 +11,12 @@ macro_rules! if_rayon {
     }};
 }
 pub(crate) use if_rayon;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(not(feature = "rayon"))]
+    fn if_rayon_selects_fallback_without_rayon_feature() {
+        assert_eq!(super::if_rayon!("rayon", "fallback"), "fallback");
+    }
+}

--- a/crates/proof-of-sql/src/base/standard_serializations/binary.rs
+++ b/crates/proof-of-sql/src/base/standard_serializations/binary.rs
@@ -51,4 +51,36 @@ mod tests {
         let reserialized = try_standard_binary_serialization(deserialized).unwrap();
         assert_eq!(serialized, reserialized);
     }
+
+    #[test]
+    fn integers_are_serialized_with_fixed_width_big_endian_encoding() {
+        let serialized = try_standard_binary_serialization((0x1234_u16, 0x89AB_CDEF_u32))
+            .expect("tuple serialization should succeed");
+
+        assert_eq!(serialized, [0x12, 0x34, 0x89, 0xAB, 0xCD, 0xEF]);
+    }
+
+    #[test]
+    fn deserialization_reports_consumed_bytes() {
+        let mut bytes = try_standard_binary_serialization((7_u16, true))
+            .expect("tuple serialization should succeed");
+        bytes.extend_from_slice(&[0xAA, 0xBB]);
+
+        let (deserialized, consumed): ((u16, bool), _) =
+            try_standard_binary_deserialization(&bytes).expect("tuple deserialization should pass");
+
+        assert_eq!(deserialized, (7, true));
+        assert_eq!(consumed, bytes.len() - 2);
+    }
+
+    #[test]
+    fn deserialization_rejects_invalid_binary_data() {
+        let error = try_standard_binary_deserialization::<(u16, bool)>(&[0x00, 0x01])
+            .expect_err("truncated tuple should fail to deserialize");
+
+        assert!(matches!(
+            error,
+            bincode::error::DecodeError::UnexpectedEnd { .. }
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- cover standard binary serialization using fixed-width big-endian integer encoding
- cover deserialization consumed-byte reporting with trailing bytes
- cover truncated binary decode failure
- cover the non-rayon `if_rayon!` fallback branch

/claim #560

## Validation
- cargo fmt --check
- git diff --check
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test standard_serializations::binary -- --nocapture
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo test -p proof-of-sql --lib --no-default-features --features test if_rayon -- --nocapture
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS="" cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --no-report -- standard_serializations::binary

Note: this environment does not have clang; repo config points at it, so targeted cargo commands override the linker to cc and clear the repo-level lld rustflag.