### PR TITLE
test: split slow Dory evaluation proof cases

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof_test.rs
@@ -51,21 +51,32 @@ fn test_random_ipa_with_length_1() {
 }
 
 #[test]
-fn test_random_ipa_with_various_lengths() {
+fn test_random_ipa_with_various_lengths_sigma_4() {
+    test_random_ipa_with_various_lengths_for_setup(4, 4);
+}
+
+#[test]
+fn test_random_ipa_with_various_lengths_sigma_3() {
+    test_random_ipa_with_various_lengths_for_setup(4, 3);
+}
+
+#[test]
+fn test_random_ipa_with_various_lengths_sigma_2() {
+    test_random_ipa_with_various_lengths_for_setup(6, 2);
+}
+
+fn test_random_ipa_with_various_lengths_for_setup(setup_nu: usize, sigma: usize) {
     let lengths = [128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2];
-    let setup_setup = [(4, 4), (4, 3), (6, 2)];
-    for setup_p in setup_setup {
-        let public_parameters = PublicParameters::test_rand(setup_p.0, &mut test_rng());
-        let prover_setup = ProverSetup::from(&public_parameters);
-        let verifier_setup = VerifierSetup::from(&public_parameters);
-        for length in lengths {
-            test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
-                length,
-                0,
-                &DoryProverPublicSetup::new(&prover_setup, setup_p.1),
-                &DoryVerifierPublicSetup::new(&verifier_setup, setup_p.1),
-            );
-        }
+    let public_parameters = PublicParameters::test_rand(setup_nu, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    for length in lengths {
+        test_random_commitment_evaluation_proof::<DoryEvaluationProof>(
+            length,
+            0,
+            &DoryProverPublicSetup::new(&prover_setup, sigma),
+            &DoryVerifierPublicSetup::new(&verifier_setup, sigma),
+        );
     }
 }
 


### PR DESCRIPTION
Part of #557

## Summary

- Split `test_random_ipa_with_various_lengths` into separate Dory evaluation proof tests for `sigma = 4`, `sigma = 3`, and `sigma = 2`
- Keep the same length coverage for each setup: `128, 100, 64, 50, 32, 20, 16, 10, 8, 5, 4, 3, 2`
- Preserve the same setup sizes used before: `(setup_nu, sigma) = (4, 4), (4, 3), (6, 2)`
- Allow `cargo test`/CI test runners to schedule the three expensive groups independently instead of running all groups inside one serial test function

## Local Measurement

On Windows with `proof-of-sql --no-default-features --features="std"`:

- Before: original single test body reported `finished in 299.51s`
- After: filtered `test_random_ipa_with_various_lengths` run completed in `184.91s` wall-clock via `Measure-Command`

This keeps the same test cases but improves wall-clock time for parallel test runners by exposing independent work as separate tests.

## Tests

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p proof-of-sql --lib --no-default-features --features="std"`
- `cargo test -p proof-of-sql --lib --no-default-features --features="std" proof_primitive::dory::dory_commitment_evaluation_proof_test::test_random_ipa_with_various_lengths`
- `cargo test -p proof-of-sql --lib --no-default-features --features="std" proof_primitive::dory::dory_commitment_evaluation_proof_test::test_random_ipa_with_various_lengths -- --list`

Note: local Windows runs used `CARGO_HTTP_CHECK_REVOKE=false` to work around a crates.io TLS revocation check issue.