### PR TITLE
test: cover Arrow schema utility

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -7,7 +7,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 /// Converts an Arrow schema to a PoSQL-compatible schema.
 ///
 /// This function takes an Arrow `SchemaRef` and returns a new `SchemaRef` where
-/// floating-point data types (Float16, Float32, Float64) are converted to Decimal256(75, 30).
+/// floating-point data types (Float16, Float32, Float64) are converted to Decimal256(20, 10).
 /// Other data types remain unchanged.
 ///
 /// # Arguments

--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility_test.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility_test.rs
@@ -1,0 +1,61 @@
+use super::arrow_schema_utility::get_posql_compatible_schema;
+use alloc::sync::Arc;
+use arrow::datatypes::{DataType, Field, Schema};
+
+#[test]
+fn get_posql_compatible_schema_converts_float_fields_to_decimal256() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("float16", DataType::Float16, false),
+        Field::new("float32", DataType::Float32, true),
+        Field::new("float64", DataType::Float64, false),
+    ]));
+
+    let converted = get_posql_compatible_schema(&schema);
+
+    assert_eq!(
+        converted.field(0).data_type(),
+        &DataType::Decimal256(20, 10)
+    );
+    assert_eq!(
+        converted.field(1).data_type(),
+        &DataType::Decimal256(20, 10)
+    );
+    assert_eq!(
+        converted.field(2).data_type(),
+        &DataType::Decimal256(20, 10)
+    );
+}
+
+#[test]
+fn get_posql_compatible_schema_preserves_non_float_field_types_and_nullability() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, true),
+        Field::new("amount", DataType::Decimal128(12, 2), false),
+        Field::new("active", DataType::Boolean, true),
+    ]));
+
+    let converted = get_posql_compatible_schema(&schema);
+
+    assert_eq!(converted.fields().len(), schema.fields().len());
+    for (actual, expected) in converted.fields().iter().zip(schema.fields().iter()) {
+        assert_eq!(actual.name(), expected.name());
+        assert_eq!(actual.data_type(), expected.data_type());
+        assert_eq!(actual.is_nullable(), expected.is_nullable());
+    }
+}
+
+#[test]
+fn get_posql_compatible_schema_preserves_float_field_names_and_nullability() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("nullable_ratio", DataType::Float32, true),
+        Field::new("required_score", DataType::Float64, false),
+    ]));
+
+    let converted = get_posql_compatible_schema(&schema);
+
+    assert_eq!(converted.field(0).name(), "nullable_ratio");
+    assert!(converted.field(0).is_nullable());
+    assert_eq!(converted.field(1).name(), "required_score");
+    assert!(!converted.field(1).is_nullable());
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -73,6 +73,8 @@ pub use table_ref::TableRef;
 
 #[cfg(feature = "arrow")]
 pub mod arrow_schema_utility;
+#[cfg(all(test, feature = "arrow"))]
+mod arrow_schema_utility_test;
 
 mod owned_column;
 pub use owned_column::OwnedColumn;


### PR DESCRIPTION
/claim #560

## Summary

Adds a focused test-only coverage slice for `base::database::arrow_schema_utility`.

This PR verifies that `get_posql_compatible_schema`:

- converts `Float16`, `Float32`, and `Float64` fields to `Decimal256(20, 10)`
- preserves non-float Arrow field data types
- preserves field names and nullability for both converted and unchanged fields

It also corrects the function doc comment so it matches the current implementation’s `Decimal256(20, 10)` behavior.

## Non-overlap

This slice is limited to:

- `crates/proof-of-sql/src/base/database/arrow_schema_utility.rs`
- `crates/proof-of-sql/src/base/database/arrow_schema_utility_test.rs`
- the sibling test-module registration in `crates/proof-of-sql/src/base/database/mod.rs`

Before choosing this slice, I checked the visible #560 attempts and avoided the recently claimed areas around `zigzag`, `sql/proof/proof_plan.rs`, `sql/evm_proof_plan/proof_plan.rs`, `sql/proof_exprs/table_expr.rs`, and `sql/proof_plans/test_utility.rs`.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features arrow arrow_schema_utility -- --nocapture` — 3 passed

Note: the default feature set enables an x86_64-only `halo2curves/asm` path that fails on Apple Silicon, so the focused validation uses `--no-default-features --features arrow`, matching the narrow target of this Arrow utility coverage slice.