### PR TITLE
test: cover PoSQL timestamp errors

### DIFF
--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -38,3 +38,46 @@ impl From<PoSQLTimestampError> for String {
         error.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PoSQLTimestampError;
+    use alloc::{string::String, vec};
+
+    #[test]
+    fn we_display_invalid_timezone_with_the_original_input() {
+        let error = PoSQLTimestampError::InvalidTimezone {
+            timezone: "Mars/Olympus".into(),
+        };
+
+        assert_eq!(error.to_string(), "invalid timezone string: Mars/Olympus");
+    }
+
+    #[test]
+    fn we_convert_timestamp_errors_into_their_display_strings() {
+        let converted =
+            String::from(PoSQLTimestampError::UnsupportedPrecision { error: "7".into() });
+
+        assert_eq!(converted, "Unsupported precision for timestamp: 7");
+    }
+
+    #[test]
+    fn timestamp_error_variants_round_trip_through_json() {
+        let errors = vec![
+            PoSQLTimestampError::InvalidTimezone {
+                timezone: "Local/WallClock".into(),
+            },
+            PoSQLTimestampError::InvalidTimezoneOffset,
+            PoSQLTimestampError::InvalidTimeUnit {
+                error: "fortnight".into(),
+            },
+            PoSQLTimestampError::UnsupportedPrecision { error: "12".into() },
+        ];
+
+        for error in errors {
+            let serialized = serde_json::to_string(&error).unwrap();
+            let deserialized: PoSQLTimestampError = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized, error);
+        }
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary

Adds a focused coverage slice for `base::posql_time::PoSQLTimestampError`.

This PR verifies that timestamp errors:

- display the original invalid timezone input in the user-facing error string
- convert into `String` through the existing `From<PoSQLTimestampError> for String` implementation
- round-trip through `serde_json` for every enum variant, including the payload-carrying variants

## Non-overlap

This slice is limited to `crates/proof-of-sql/src/base/posql_time/error.rs`.

Before choosing it, I avoided the visible recent #560 attempt areas around `zigzag`, `sql/proof/proof_plan.rs`, `sql/evm_proof_plan/proof_plan.rs`, `sql/proof_exprs/table_expr.rs`, `sql/proof_plans/test_utility.rs`, and my separate Arrow schema utility PR #2622.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features std posql_time::error -- --nocapture` — 3 passed

Note: the focused command uses `--features std` because this crate has existing tests and modules that require `std` when running the library test harness without default features.