### PR TITLE
test: cover multi-row bit matrix layout

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
@@ -33,6 +33,24 @@ fn we_can_compute_the_bit_matrix_for_data_with_a_single_varying_bit() {
 }
 
 #[test]
+fn we_can_compute_the_bit_matrix_for_multiple_rows_and_varying_bits() {
+    let data: Vec<TestScalar> = vec![
+        TestScalar::zero(),
+        TestScalar::one(),
+        TestScalar::from(2),
+        TestScalar::from(3),
+    ];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
+    let alloc = Bump::new();
+    let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
+    assert_eq!(matrix.len(), 2);
+    let least_significant_bit = vec![false, true, false, true];
+    let second_least_significant_bit = vec![false, false, true, true];
+    assert_eq!(matrix[0], least_significant_bit);
+    assert_eq!(matrix[1], second_least_significant_bit);
+}
+
+#[test]
 fn we_can_compute_the_bit_matrix_for_data_with_a_varying_sign_bit() {
     let data: Vec<TestScalar> = vec![TestScalar::one(), -TestScalar::one()];
     let dist = BitDistribution::new::<TestScalar, _>(&data);


### PR DESCRIPTION
/claim #560

## Summary

Adds a focused test-only coverage slice for `compute_varying_bit_matrix` in `base::bit::bit_matrix`.

The new test verifies a multi-row input with two varying bit positions: `[0, 1, 2, 3]`. This exercises the column-major output layout across more than two rows and guards against accidentally mixing scalar indexes with varying-bit indexes.

## Non-overlap

This slice is limited to `crates/proof-of-sql/src/base/bit/bit_matrix_test.rs` and targets `crates/proof-of-sql/src/base/bit/bit_matrix.rs` behavior.

Before choosing it, I checked #560 comments for exact `bit_matrix.rs` / `BitMatrix` overlap. I found related byte-matrix and broad planning comments, but no active exact claim for this bit-matrix multi-row layout case.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p proof-of-sql --lib --no-default-features --features test bit_matrix -- --nocapture` — 8 passed