### PR TITLE
test: cover benchmark CSV result appends

### DIFF
--- a/crates/proof-of-sql-benches/src/utils/results_io.rs
+++ b/crates/proof-of-sql-benches/src/utils/results_io.rs
@@ -56,3 +56,85 @@ pub fn append_to_csv(file_path: &Path, new_row: &[String]) {
 
     writer.flush().expect("Failed to flush CSV writer.");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::append_to_csv;
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_csv_path(test_name: &str) -> PathBuf {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after Unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "proof_of_sql_benches_{test_name}_{unique_suffix}"
+        ));
+        fs::create_dir_all(&dir).expect("failed to create temporary test directory");
+        dir.join("results.csv")
+    }
+
+    #[test]
+    fn append_to_csv_writes_header_for_new_file() {
+        let file_path = temp_csv_path("writes_header");
+        let row = [
+            "dory".to_string(),
+            "Filter".to_string(),
+            "128".to_string(),
+            "10".to_string(),
+            "2".to_string(),
+            "1".to_string(),
+        ];
+
+        append_to_csv(&file_path, &row);
+
+        let contents = fs::read_to_string(&file_path).expect("failed to read CSV file");
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(
+            lines[0],
+            "commitment_scheme,query,table_size,generate_proof (ms),verify_proof (ms),iteration"
+        );
+        assert_eq!(lines[1], "dory,Filter,128,10,2,1");
+    }
+
+    #[test]
+    fn append_to_csv_does_not_repeat_header_for_existing_file() {
+        let file_path = temp_csv_path("does_not_repeat_header");
+        let first_row = [
+            "dory".to_string(),
+            "Filter".to_string(),
+            "128".to_string(),
+            "10".to_string(),
+            "2".to_string(),
+            "1".to_string(),
+        ];
+        let second_row = [
+            "hyperkzg".to_string(),
+            "Aggregate".to_string(),
+            "256".to_string(),
+            "20".to_string(),
+            "4".to_string(),
+            "2".to_string(),
+        ];
+
+        append_to_csv(&file_path, &first_row);
+        append_to_csv(&file_path, &second_row);
+
+        let contents = fs::read_to_string(&file_path).expect("failed to read CSV file");
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(
+            lines
+                .iter()
+                .filter(|line| line.starts_with("commitment_scheme,query"))
+                .count(),
+            1
+        );
+        assert_eq!(lines[1], "dory,Filter,128,10,2,1");
+        assert_eq!(lines[2], "hyperkzg,Aggregate,256,20,4,2");
+    }
+}


### PR DESCRIPTION
/claim #560

## Summary
- add focused tests for proof-of-sql-benches CSV result appending
- verify a new CSV receives the benchmark header before its first row
- verify appending a second row does not duplicate the header

## Verification
- git diff --check
- Could not run cargo test locally because this Windows environment does not have cargo/rustc installed. CI should provide the Rust toolchain.