### PR TITLE
test: cover filter exec with naive proof

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_naive_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_naive_test.rs
@@ -1,0 +1,50 @@
+use super::test_utility::{filter, table_exec};
+use crate::{
+    base::{
+        commitment::naive_evaluation_proof::NaiveEvaluationProof,
+        database::{
+            owned_table_utility::{bigint, owned_table},
+            table_utility::{borrowed_bigint, table},
+            ColumnField, ColumnType, TableRef, TableTestAccessor, TestAccessor,
+        },
+    },
+    sql::{
+        proof::VerifiableQueryResult,
+        proof_exprs::test_utility::{aliased_plan, column, const_int128, equal},
+    },
+};
+use bumpalo::Bump;
+
+#[test]
+fn we_can_filter_data_with_naive_evaluation_proof() {
+    let alloc = Bump::new();
+    let data = table([
+        borrowed_bigint("a", [1, 4, 5, 2, 5], &alloc),
+        borrowed_bigint("b", [1, 2, 3, 4, 5], &alloc),
+    ]);
+    let table_ref = TableRef::new("sxt", "t");
+    let mut accessor = TableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
+    accessor.add_table(table_ref.clone(), data, 0);
+
+    let input = table_exec(
+        table_ref.clone(),
+        vec![
+            ColumnField::new("a".into(), ColumnType::BigInt),
+            ColumnField::new("b".into(), ColumnType::BigInt),
+        ],
+    );
+    let plan = filter(
+        vec![aliased_plan(column(&table_ref, "b", &accessor), "b")],
+        input,
+        equal(column(&table_ref, "a", &accessor), const_int128(5_i128)),
+    );
+
+    let verifiable_result =
+        VerifiableQueryResult::<NaiveEvaluationProof>::new(&plan, &accessor, &(), &[]).unwrap();
+    let result = verifiable_result
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
+
+    assert_eq!(result, owned_table([bigint("b", [3_i64, 5])]));
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -38,6 +38,8 @@ mod group_by_exec_test;
 mod filter_exec;
 pub(crate) use filter_exec::FilterExec;
 
+#[cfg(test)]
+mod filter_exec_naive_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod filter_exec_test;
 


### PR DESCRIPTION
/claim #560

## Summary
- add a no-default `NaiveEvaluationProof` coverage test for `FilterExec`
- exercise a real filter query through `VerifiableQueryResult::new` and `verify`
- keep the existing Blitzar-gated integration tests unchanged

## Coverage
Local `cargo llvm-cov` comparison for `crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs`:
- before: 34 / 179 covered, 145 uncovered
- after: 178 / 179 covered, 1 uncovered
- newly covered production lines: 144

Deconfliction: I checked the #560 discussion for `filter_exec.rs` / `FilterExec`. Existing historical references I found were for legacy filter/no-Blitzar work, not this `FilterExec` naive-proof path.

## Validation
- `cargo test -p proof-of-sql --lib --no-default-features --features test filter_exec_naive -- --nocapture`
- `cargo llvm-cov -p proof-of-sql --lib --no-default-features --features test --lcov --output-path /tmp/sxt-proof-of-sql-after-filter.lcov` — 962 passed
- `cargo fmt --all -- --check`
- `git diff --check`
