### PR TITLE
Handle precision-only bigdecimal columns

### DIFF
--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -34,6 +34,11 @@ pub fn find_bigdecimals(queries: &str) -> IndexMap<String, Vec<(String, u8, i8)>
                         {
                             Some((column_def.name.to_string(), precision as u8, scale as i8))
                         }
+                        DataType::Decimal(ExactNumberInfo::Precision(precision))
+                            if precision > 38 =>
+                        {
+                            Some((column_def.name.to_string(), precision as u8, 0))
+                        }
                         _ => None,
                     })
                     .collect();
@@ -90,6 +95,42 @@ mod tests {
         assert_eq!(
             bigdecimals.get("ETHEREUM.BLOCK_DETAILS").unwrap(),
             &empty_vec
+        );
+    }
+
+    #[test]
+    fn we_ignore_non_create_table_statements() {
+        let sql = "
+            CREATE VIEW ETHEREUM.REWARDS AS SELECT REWARD FROM ETHEREUM.BLOCKS;
+            CREATE INDEX BLOCKS_REWARD_IDX ON ETHEREUM.BLOCKS(REWARD);
+        ";
+
+        assert!(find_bigdecimals(sql).is_empty());
+    }
+
+    #[test]
+    fn we_ignore_decimal_precision_at_or_below_38() {
+        let sql = "CREATE TABLE ETHEREUM.TRANSFERS(
+            VALUE DECIMAL(38, 0),
+            FEE DECIMAL(37, 2)
+        );";
+
+        assert_eq!(
+            find_bigdecimals(sql).get("ETHEREUM.TRANSFERS").unwrap(),
+            &Vec::<(String, u8, i8)>::new()
+        );
+    }
+
+    #[test]
+    fn we_find_bigdecimal_columns_without_explicit_scale() {
+        let sql = "CREATE TABLE ETHEREUM.BALANCES(
+            ADDRESS VARCHAR,
+            BALANCE DECIMAL(39)
+        );";
+
+        assert_eq!(
+            find_bigdecimals(sql).get("ETHEREUM.BALANCES").unwrap(),
+            &[("BALANCE".to_string(), 39, 0)]
         );
     }
 }


### PR DESCRIPTION
/claim #560

## Summary
- handle `DECIMAL(precision)` declarations above the bigdecimal threshold as scale `0`
- add regression coverage for non-table statements, precision-at-threshold decimals, and precision-only bigdecimal columns

## Why
`find_bigdecimals` already captures `DECIMAL(precision, scale)` columns with precision greater than 38. SQL parsers also represent `DECIMAL(39)` as a precision-only decimal, which should be treated as a bigdecimal column with implicit scale `0`.

## Validation
- `cargo +stable test -p proof-of-sql utils::parse::tests --no-default-features --features test`
- `rustfmt +stable --check crates/proof-of-sql/src/utils/parse.rs`
- `git diff --check`

Note: `cargo +stable fmt --check` currently reports an unrelated import-order diff in `crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs`; this PR only touches `crates/proof-of-sql/src/utils/parse.rs`.