### PR TITLE
test: cover byte matrix edge cases

### DIFF
--- a/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
+++ b/crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs
@@ -39,6 +39,34 @@ mod tests {
     use bumpalo::Bump;
 
     #[test]
+    fn we_can_compute_varying_byte_matrix_for_empty_column() {
+        let alloc = Bump::new();
+        let scalars: Vec<TestScalar> = vec![];
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(
+            byte_distribution,
+            ByteDistribution::new::<TestScalar, TestScalar>(&[])
+        );
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
+    fn we_can_compute_varying_byte_matrix_for_constant_column() {
+        let alloc = Bump::new();
+        let scalars = vec![TestScalar::from(257u64); 4];
+        let (varying_columns, byte_distribution) =
+            compute_varying_byte_matrix::<TestScalar>(&scalars, &alloc);
+
+        assert_eq!(
+            byte_distribution,
+            ByteDistribution::new::<TestScalar, TestScalar>(&scalars)
+        );
+        assert!(varying_columns.is_empty());
+    }
+
+    #[test]
     fn we_can_compute_varying_byte_matrix_for_small_scalars() {
         let alloc = Bump::new();
         let scalars: Vec<TestScalar> = [1, 2, 3, 255, 256, 257]


### PR DESCRIPTION
/claim #560

## Summary
- add regression coverage for `compute_varying_byte_matrix` on empty input
- add regression coverage for all-constant scalar columns, where no varying byte matrix columns should be allocated
- keep the existing small and large varying-column coverage unchanged

## Non-overlap
I refreshed the current open PR file map before this slice and found no open PR touching `crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs`. This is separate from #2643, which only touches `utils/parse.rs`.

## Validation
- `cargo +stable test -p proof-of-sql base::byte::byte_matrix_utils::tests --no-default-features --features test` — 4 passed
- `rustfmt +stable --check crates/proof-of-sql/src/base/byte/byte_matrix_utils.rs`
- `git diff --check`