### PR TITLE
Define nullable presence-column schema contract

### DIFF
--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -137,9 +137,12 @@ pub fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
         column_fields
             .into_iter()
             .map(|column_field| {
-                //TODO: Make columns nullable
                 let data_type = (&column_field.data_type()).into();
-                Field::new(column_field.name().value.as_str(), data_type, false)
+                Field::new(
+                    column_field.name().value.as_str(),
+                    data_type,
+                    column_field.is_nullable(),
+                )
             })
             .collect::<Vec<_>>(),
     )

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -77,7 +77,7 @@ impl From<&ColumnField> for Field {
         Field::new(
             column_field.name().value.as_str(),
             (&column_field.data_type()).into(),
-            false,
+            column_field.is_nullable(),
         )
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_field.rs
+++ b/crates/proof-of-sql/src/base/database/column_field.rs
@@ -10,13 +10,37 @@ use sqlparser::ast::Ident;
 pub struct ColumnField {
     name: Ident,
     data_type: ColumnType,
+    #[serde(default, skip_serializing_if = "is_false")]
+    nullable: bool,
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if requires a by-reference predicate"
+)]
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 impl ColumnField {
     /// Create a new `ColumnField` from a name and a type
     #[must_use]
     pub fn new(name: Ident, data_type: ColumnType) -> ColumnField {
-        ColumnField { name, data_type }
+        ColumnField {
+            name,
+            data_type,
+            nullable: false,
+        }
+    }
+
+    /// Create a new nullable `ColumnField` from a name and a type.
+    #[must_use]
+    pub fn new_nullable(name: Ident, data_type: ColumnType) -> ColumnField {
+        ColumnField {
+            name,
+            data_type,
+            nullable: true,
+        }
     }
 
     /// Returns the name of the column
@@ -29,5 +53,42 @@ impl ColumnField {
     #[must_use]
     pub fn data_type(&self) -> ColumnType {
         self.data_type
+    }
+
+    /// Returns true when the column is nullable.
+    #[must_use]
+    pub fn is_nullable(&self) -> bool {
+        self.nullable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn non_nullable_column_fields_do_not_serialize_nullable_false() {
+        let field = ColumnField::new("score".into(), ColumnType::BigInt);
+
+        let json = serde_json::to_value(&field).unwrap();
+
+        assert!(json.get("nullable").is_none());
+    }
+
+    #[test]
+    fn column_fields_without_nullable_metadata_deserialize_as_non_nullable() {
+        let field = ColumnField::new("score".into(), ColumnType::BigInt);
+        let mut json = serde_json::to_value(&field).unwrap();
+        let Value::Object(ref mut object) = json else {
+            panic!("ColumnField should serialize as an object");
+        };
+        object.remove("nullable");
+
+        let field_without_nullable: ColumnField = serde_json::from_value(json).unwrap();
+
+        assert!(!field_without_nullable.is_nullable());
+        assert_eq!(field_without_nullable.name(), "score".into());
+        assert_eq!(field_without_nullable.data_type(), ColumnType::BigInt);
     }
 }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -18,6 +18,13 @@ pub use column_ref::ColumnRef;
 mod column_field;
 pub use column_field::ColumnField;
 
+mod nullable_schema;
+pub use nullable_schema::{
+    is_generated_presence_field, logical_column_fields_from_physical_schema,
+    physical_column_fields_from_logical_schema, presence_column_id, value_column_id_from_presence,
+    NullableSchemaError, NullableSchemaResult, PRESENCE_COLUMN_SUFFIX,
+};
+
 mod data_accessor_impl;
 pub use data_accessor_impl::{DataAccessorImpl, TableDataAccessor};
 

--- a/crates/proof-of-sql/src/base/database/nullable_schema.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_schema.rs
@@ -1,0 +1,199 @@
+use super::{ColumnField, ColumnType};
+use alloc::{format, vec::Vec};
+use snafu::Snafu;
+use sqlparser::ast::Ident;
+
+/// Suffix reserved for generated nullable-column presence fields.
+pub const PRESENCE_COLUMN_SUFFIX: &str = "__presence";
+
+/// Errors from converting between logical nullable schemas and physical proof schemas.
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum NullableSchemaError {
+    /// A logical user column collides with the generated presence column name.
+    #[snafu(display(
+        "nullable column {column_id} collides with generated presence column {presence_column_id}"
+    ))]
+    PresenceColumnCollision {
+        /// The nullable logical value column.
+        column_id: Ident,
+        /// The generated physical presence column.
+        presence_column_id: Ident,
+    },
+}
+
+/// Result type for nullable schema contract conversions.
+pub type NullableSchemaResult<T> = Result<T, NullableSchemaError>;
+
+/// Return the generated physical presence-column identifier for a nullable logical column.
+#[must_use]
+pub fn presence_column_id(column_id: &Ident) -> Ident {
+    Ident::new(format!("{}{}", column_id.value, PRESENCE_COLUMN_SUFFIX))
+}
+
+/// Return the value-column identifier if `column_id` uses the generated presence suffix.
+#[must_use]
+pub fn value_column_id_from_presence(column_id: &Ident) -> Option<Ident> {
+    column_id
+        .value
+        .strip_suffix(PRESENCE_COLUMN_SUFFIX)
+        .filter(|value_id| !value_id.is_empty())
+        .map(Ident::new)
+}
+
+/// Return true when `field` is a generated presence field for a nullable value field.
+#[must_use]
+pub fn is_generated_presence_field(field: &ColumnField, fields: &[ColumnField]) -> bool {
+    if field.data_type() != ColumnType::Boolean {
+        return false;
+    }
+    let Some(value_column_id) = value_column_id_from_presence(&field.name()) else {
+        return false;
+    };
+    fields.iter().any(|candidate| {
+        candidate.name() == value_column_id && presence_column_id(&candidate.name()) == field.name()
+    })
+}
+
+/// Convert a logical nullable schema into the physical value/presence schema used by proofs.
+pub fn physical_column_fields_from_logical_schema(
+    logical_fields: &[ColumnField],
+) -> NullableSchemaResult<Vec<ColumnField>> {
+    let mut physical_fields = Vec::new();
+    for field in logical_fields {
+        if field.is_nullable() {
+            let presence_id = presence_column_id(&field.name());
+            if logical_fields
+                .iter()
+                .any(|candidate| candidate.name() == presence_id)
+            {
+                return Err(NullableSchemaError::PresenceColumnCollision {
+                    column_id: field.name(),
+                    presence_column_id: presence_id,
+                });
+            }
+            physical_fields.push(ColumnField::new(field.name(), field.data_type()));
+            physical_fields.push(ColumnField::new(presence_id, ColumnType::Boolean));
+        } else {
+            physical_fields.push(field.clone());
+        }
+    }
+    Ok(physical_fields)
+}
+
+/// Convert a physical value/presence schema back into its logical nullable schema.
+#[must_use]
+pub fn logical_column_fields_from_physical_schema(
+    physical_fields: &[ColumnField],
+) -> Vec<ColumnField> {
+    physical_fields
+        .iter()
+        .filter_map(|field| {
+            if is_generated_presence_field(field, physical_fields) {
+                None
+            } else {
+                let presence_id = presence_column_id(&field.name());
+                let has_presence = physical_fields.iter().any(|candidate| {
+                    candidate.name() == presence_id && candidate.data_type() == ColumnType::Boolean
+                });
+                if has_presence {
+                    Some(ColumnField::new_nullable(field.name(), field.data_type()))
+                } else {
+                    Some(field.clone())
+                }
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(fields: &[ColumnField]) -> Vec<Ident> {
+        fields.iter().map(ColumnField::name).collect()
+    }
+
+    #[test]
+    fn nullable_logical_fields_expand_to_value_and_presence_fields() {
+        let logical_fields = vec![ColumnField::new_nullable(
+            "score".into(),
+            ColumnType::BigInt,
+        )];
+
+        let physical_fields = physical_column_fields_from_logical_schema(&logical_fields).unwrap();
+
+        assert_eq!(
+            names(&physical_fields),
+            vec!["score".into(), "score__presence".into()]
+        );
+        assert!(!physical_fields[0].is_nullable());
+        assert_eq!(physical_fields[1].data_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn user_presence_suffix_fields_are_preserved_without_matching_nullable_value() {
+        let physical_fields = vec![
+            ColumnField::new("score__presence".into(), ColumnType::Boolean),
+            ColumnField::new("other".into(), ColumnType::BigInt),
+        ];
+
+        let logical_fields = logical_column_fields_from_physical_schema(&physical_fields);
+
+        assert_eq!(
+            names(&logical_fields),
+            vec!["score__presence".into(), "other".into()]
+        );
+        assert!(logical_fields.iter().all(|field| !field.is_nullable()));
+    }
+
+    #[test]
+    fn logical_schemas_reject_generated_presence_name_collisions() {
+        let logical_fields = vec![
+            ColumnField::new_nullable("score".into(), ColumnType::BigInt),
+            ColumnField::new("score__presence".into(), ColumnType::Boolean),
+        ];
+
+        let err = physical_column_fields_from_logical_schema(&logical_fields).unwrap_err();
+
+        assert_eq!(
+            err,
+            NullableSchemaError::PresenceColumnCollision {
+                column_id: "score".into(),
+                presence_column_id: "score__presence".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn physical_value_and_boolean_presence_round_trip_to_logical_nullable_field() {
+        let physical_fields =
+            physical_column_fields_from_logical_schema(&[ColumnField::new_nullable(
+                "score".into(),
+                ColumnType::BigInt,
+            )])
+            .unwrap();
+
+        let logical_fields = logical_column_fields_from_physical_schema(&physical_fields);
+
+        assert_eq!(names(&logical_fields), vec!["score".into()]);
+        assert!(logical_fields[0].is_nullable());
+        assert_eq!(logical_fields[0].data_type(), ColumnType::BigInt);
+    }
+
+    #[test]
+    fn non_boolean_suffix_fields_are_not_generated_presence_fields() {
+        let physical_fields = vec![
+            ColumnField::new_nullable("score".into(), ColumnType::BigInt),
+            ColumnField::new("score__presence".into(), ColumnType::BigInt),
+        ];
+
+        let logical_fields = logical_column_fields_from_physical_schema(&physical_fields);
+
+        assert_eq!(
+            names(&logical_fields),
+            vec!["score".into(), "score__presence".into()]
+        );
+        assert!(logical_fields[0].is_nullable());
+        assert!(!logical_fields[1].is_nullable());
+    }
+}


### PR DESCRIPTION
/claim #183

## Summary

Defines a small nullable-column schema contract for the value-column + generated presence-column design.

This PR adds focused helpers and tests for:

- generated `__presence` column naming
- logical nullable schema -> physical value/presence schema expansion
- physical value/presence schema -> logical nullable schema round-trip
- collision rejection when a real user column conflicts with generated presence metadata
- preservation of user-owned orphan `__presence` columns
- ignoring non-boolean suffix fields as generated presence columns
- backward-compatible nullable metadata on `ColumnField`

## Why this is not another full nullable implementation

This PR does not implement full nullable query execution, nullable expression evaluation, filtering, joins, aggregates, Arrow nullable-array ingestion, or SQL three-valued logic.

The `ColumnField` nullable metadata is only the minimal schema foundation needed to express and test the contract. The main purpose is the logical/physical schema boundary and collision behavior required by larger nullable-column implementations.

This is intended as a small, reviewable contract slice for #183 rather than a competing full nullable engine implementation.

## Contract covered

A nullable logical column `score` expands to physical fields:

- `score`
- `score__presence: boolean`

A real user column named `score__presence` is rejected when it would collide with generated presence metadata for nullable `score`.

A user-owned suffix column without a matching generated nullable value column remains visible as a normal logical column.

A suffix column that is not boolean is not treated as generated presence metadata.

## Tests

Added focused tests for:

- nullable logical field expansion
- collision rejection
- physical/logical round-trip
- orphan `__presence` preservation
- non-boolean suffix preservation
- backward-compatible `ColumnField` serialization/deserialization

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p proof-of-sql --no-default-features --features "arrow std"`
- `cargo test -p proof-of-sql --no-default-features --features "arrow std" nullable_schema --lib`
- `cargo test -p proof-of-sql --no-default-features --features "arrow std" column_field --lib`
- `cargo test -p proof-of-sql-planner we_can_convert_column_fields_to_schema`

`cargo clippy -p proof-of-sql --no-default-features --features "arrow std" --lib -- -D warnings` currently fails on existing Dory/CPU unused/dead-code and style warnings unrelated to this change.

## Scope / Not included

Not included:

- full nullable query execution
- nullable arithmetic
- three-valued boolean logic
- `IS NULL` / `IS NOT NULL`
- nullable Arrow array ingestion
- proof verification changes

Refs #183.