### PR TITLE
build!: upgrade blitzar to 5.0.1, nova-snark to 0.53.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ arrow = { version = "51.0.0" }
 bincode = { version = "2.0.0-rc.3", default-features = false }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
-blitzar = { version = "4.3.0" }
+blitzar = { version = "5.0.1" }
 bnum = { version = "0.3.0" }
 bumpalo = { version = "3.11.0" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
@@ -42,13 +42,13 @@ derive_more = { version = "0.99" }
 enum_dispatch = { version = "0.3.13" }
 getrandom = { version = "0.2.15", default-features = false }
 ff = { version = "0.13.0"}
-halo2curves = { version = "0.8.0", default-features = false }
+halo2curves = { version = "0.9.0", default-features = false }
 hex = { version = "0.4.3" }
 indexmap = { version = "2.8", default-features = false }
 indicatif = { version = "0.17.8", default-features = false }
 itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }
 merlin = { version = "2" }
-nova-snark = { version = "0.41.0", default-features = false }
+nova-snark = { version = "0.53.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4.4", default-features = false }
 opentelemetry = { version = "0.23.0" }

--- a/crates/proof-of-sql-benches/Cargo.toml
+++ b/crates/proof-of-sql-benches/Cargo.toml
@@ -9,7 +9,7 @@ license-file.workspace = true
 [dependencies]
 ark-serialize = { version = "0.5.0" }
 ark-std = { version = "0.5.0", default-features = false }
-blitzar = { version = "4.3.0" }
+blitzar.workspace = true
 bumpalo = { version = "3.11.0" }
 clap = { version = "4.5.4", features = ["derive", "env"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -17,9 +17,9 @@ csv = { version = "1.3.1" }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
 datafusion = { version = '38.0.0', default-features = false }
 ff = { version = "0.13.0"}
-halo2curves = { version = "0.8.0", default-features = false }
+halo2curves = { workspace = true, default-features = false }
 indexmap = { version = "2.8", default-features = false }
-nova-snark = { version = "0.41.0", default-features = false }
+nova-snark = { workspace = true, default-features = false }
 opentelemetry = { version = "0.23.0" }
 opentelemetry-jaeger = { version = "0.20.0" }
 proof-of-sql = { path = "../proof-of-sql", features = ["hyperkzg_proof"] }

--- a/crates/proof-of-sql-benches/src/main.rs
+++ b/crates/proof-of-sql-benches/src/main.rs
@@ -440,12 +440,15 @@ fn bench_hyperkzg(cli: &Cli, queries: &[QueryEntry]) {
             Affine::default(),
             G2Affine::default(),
         );
-        let (_, vk) = EvaluationEngine::setup(&ck);
+        let (_, vk) = EvaluationEngine::setup(&ck).expect("HyperKZG setup is infallible");
 
         (prover_setup, vk)
     } else {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"bench", cli.table_size);
-        let (_, vk) = EvaluationEngine::setup(&ck);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"bench", cli.table_size)
+            .expect(
+                "HyperKZG CommitmentKey setup is infallible if nova-snark/test-utils is enabled",
+            );
+        let (_, vk) = EvaluationEngine::setup(&ck).expect("HyperKZG setup is infallible");
         let prover_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
         (prover_setup, vk)
     };

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment.rs
@@ -248,7 +248,7 @@ mod tests {
     proptest! {
         #[test]
         fn blitzar_and_non_blitzar_commitments_are_equal(owned_column: OwnedColumn<BNScalar>) {
-            let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", owned_column.len());
+            let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", owned_column.len()).unwrap();
 
             let public_setup = nova_commitment_key_to_hyperkzg_public_setup(&ck);
 

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/commitment_evaluation_proof.rs
@@ -92,7 +92,9 @@ impl CommitmentEvaluationProof for HyperKZGCommitmentEvaluationProof {
                 let span = span!(Level::DEBUG, "EvaluationEngine::prove").entered();
                 let eval_eng = EvaluationEngine::prove(
                     &nova_ck,
-                    &EvaluationEngine::setup(&nova_ck).0, // This parameter is unused
+                    &EvaluationEngine::setup(&nova_ck)
+                        .expect("HyperKZG setup is infallible")
+                        .0, // This parameter is unused
                     keccak_transcript,
                     &NovaCommitment::default(), // This parameter is unused
                     &nova_a,
@@ -171,8 +173,8 @@ mod tests {
 
     #[test]
     fn we_can_create_small_hyperkzg_evaluation_proofs() {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32);
-        let (_, vk) = EvaluationEngine::setup(&ck);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32).unwrap();
+        let (_, vk) = EvaluationEngine::setup(&ck).unwrap();
         test_simple_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             &&nova_commitment_key_to_hyperkzg_public_setup(&ck)[..],
             &&vk,
@@ -185,8 +187,8 @@ mod tests {
 
     #[test]
     fn we_can_create_hyperkzg_evaluation_proofs_with_various_lengths() {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128);
-        let (_, vk) = EvaluationEngine::setup(&ck);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128).unwrap();
+        let (_, vk) = EvaluationEngine::setup(&ck).unwrap();
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             2,
             0,

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/nova_commitment.rs
@@ -52,7 +52,7 @@ mod tests {
 
     #[test]
     fn we_can_compute_commitment_with_hyperkzg_repo_for_testing() {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6).unwrap();
 
         let result = compute_commitment_with_hyperkzg_repo(&ck, 0, &[0]);
 
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn we_can_compute_expected_commitments_for_testing() {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6).unwrap();
 
         let committable_columns = vec![CommittableColumn::BigInt(&[0; 0])];
 
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn we_can_compute_a_commitment_with_only_one_column() {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6).unwrap();
 
         let committable_columns = vec![CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7])];
 
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn we_can_compute_commitments_with_a_single_empty_column() {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32).unwrap();
 
         let committable_columns = vec![CommittableColumn::BigInt(&[0; 0])];
 
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn we_can_compute_commitments_with_a_multiple_mixed_empty_columns() {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32).unwrap();
 
         let committable_columns = vec![
             CommittableColumn::TinyInt(&[0; 0]),
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn we_can_compute_a_commitment_with_mixed_columns_of_different_sizes_and_offsets() {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128).unwrap();
 
         let committable_columns = vec![
             CommittableColumn::BigInt(&[0, 1]),
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn we_can_compute_a_commitment_with_mixed_signed_columns_of_different_sizes_and_offsets() {
-        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128);
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128).unwrap();
 
         let committable_columns = vec![
             CommittableColumn::BigInt(&[-1, -2, -3]),

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
@@ -105,7 +105,8 @@ pub fn load_small_setup_for_testing() -> (
         vec![],
         G1Affine::generator(),
         tau_h,
-    ));
+    ))
+    .expect("HyperKZG setup is infallible");
 
     let mut ps = super::deserialize_flat_compressed_hyperkzg_public_setup_from_reader(
         &std::fs::File::open("test_assets/ppot_0080_10.bin").unwrap(),


### PR DESCRIPTION

# Rationale for this change
Blitzar-sys released a patch that upgrades to CUDA 12.8. This means that proof-of-sql doesn't require a single particular CUDA version as we speak, dependents may need CUDA 12.6 or CUDA 12.8 depending on their blitzar-sys version. Upgrading to blitzar 5.0.1 requires the blitzar-sys version to be after the CUDA 12.8 patch, making proof-of-sql dependencies simpler again. Nova-snark also depends on blitzar and needs to be upgraded to a 5.0.1 compatible version as well.

# What changes are included in this PR?
Blitzar and nova-snark depenencies have been upgraded and code changes have been made where necessary. ptau-util has been kept the same.

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
