### PR TITLE
feat: support `CASE WHEN` by composing existing proof expressions

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -3,14 +3,14 @@ use super::{
     PlannerError, PlannerResult,
 };
 use datafusion::logical_expr::{
-    expr::{Alias, Between, Cast, InList, Placeholder},
+    expr::{Alias, Between, Case, Cast, InList, Placeholder},
     BinaryExpr, Expr, Operator,
 };
 use indexmap::IndexSet;
 use proof_of_sql::{
     base::database::{ColumnType, LiteralValue},
     sql::{
-        proof_exprs::{DynProofExpr, ProofExpr},
+        proof_exprs::{try_new_case, DynProofExpr, ProofExpr},
         scale_cast_binary_op,
     },
 };
@@ -51,6 +51,24 @@ pub(crate) fn get_column_idents_from_expr(expr: &Expr) -> IndexSet<Ident> {
             let mut idents = get_column_idents_from_expr(expr);
             idents.extend(get_column_idents_from_expr(low));
             idents.extend(get_column_idents_from_expr(high));
+            idents
+        }
+        Expr::Case(Case {
+            expr,
+            when_then_expr,
+            else_expr,
+        }) => {
+            let mut idents = expr
+                .as_deref()
+                .map(get_column_idents_from_expr)
+                .unwrap_or_default();
+            for (when, then) in when_then_expr {
+                idents.extend(get_column_idents_from_expr(when));
+                idents.extend(get_column_idents_from_expr(then));
+            }
+            if let Some(else_expr) = else_expr {
+                idents.extend(get_column_idents_from_expr(else_expr));
+            }
             idents
         }
         _ => IndexSet::new(),
@@ -262,10 +280,56 @@ pub fn expr_to_proof_expr(
             low,
             high,
         }) => between_to_proof_expr(expr, *negated, low, high, schema),
+        Expr::Case(case) => case_to_proof_expr(case, expr, schema),
         _ => Err(PlannerError::UnsupportedLogicalExpression {
             expr: Box::new(expr.clone()),
         }),
     }
+}
+
+/// Convert a [`Case`] expression to [`DynProofExpr`]
+///
+/// `CASE WHEN c THEN v ... ELSE e END` lowers to a composite proof expression
+/// (a first-match-wins masked sum, see `DynProofExpr::try_new_case`). A missing
+/// ELSE would make unmatched rows NULL, which has no representation here, so it
+/// is rejected; users can write an explicit `ELSE <value>`.
+fn case_to_proof_expr(
+    case: &Case,
+    original_expr: &Expr,
+    schema: &[(Ident, ColumnType)],
+) -> PlannerResult<DynProofExpr> {
+    let Case {
+        expr: base,
+        when_then_expr,
+        else_expr,
+    } = case;
+    let else_expr =
+        else_expr
+            .as_ref()
+            .ok_or_else(|| PlannerError::UnsupportedLogicalExpression {
+                expr: Box::new(original_expr.clone()),
+            })?;
+    let when_thens = when_then_expr
+        .iter()
+        .map(|(when, then)| -> PlannerResult<_> {
+            // The simple form `CASE x WHEN v THEN ...` compares x to each v.
+            let condition = match base {
+                Some(base) => {
+                    let (lhs, rhs) = scale_cast_binary_op(
+                        expr_to_proof_expr(base, schema)?,
+                        expr_to_proof_expr(when, schema)?,
+                    )?;
+                    DynProofExpr::try_new_equals(lhs, rhs)?
+                }
+                None => expr_to_proof_expr(when, schema)?,
+            };
+            Ok((condition, expr_to_proof_expr(then, schema)?))
+        })
+        .collect::<PlannerResult<Vec<_>>>()?;
+    Ok(try_new_case(
+        when_thens,
+        expr_to_proof_expr(else_expr, schema)?,
+    )?)
 }
 
 /// Convert a [`Between`] expression to [`DynProofExpr`]

--- a/crates/proof-of-sql-planner/tests/case_when_matrix_tests.rs
+++ b/crates/proof-of-sql-planner/tests/case_when_matrix_tests.rs
@@ -1,0 +1,251 @@
+//! Support-matrix probe for `CASE WHEN` queries.
+use ark_std::test_rng;
+use bumpalo::Bump;
+use datafusion::config::ConfigOptions;
+use indexmap::{indexmap, IndexMap};
+use proof_of_sql::{
+    base::database::{table_utility::*, Table, TableRef, TableTestAccessor, TestAccessor},
+    proof_primitive::dory::{
+        DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
+    },
+};
+use proof_of_sql_planner::sql_to_proof_plans;
+use sqlparser::{dialect::GenericDialect, parser::Parser};
+
+fn cats_table<'a>(alloc: &'a Bump) -> IndexMap<TableRef, Table<'a, DoryScalar>> {
+    indexmap! {
+        TableRef::from_names(None, "cats") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4, 5], alloc),
+                borrowed_varchar("name", ["Chloe", "Margaret", "Katy", "Lucy", "Prudence"], alloc),
+                borrowed_int("human_id", [1, 1, 1, 2, 2], alloc),
+                borrowed_decimal75("weight", 3, 1, [145, 75, 20, 45, 55], alloc),
+                borrowed_boolean("adopted", [true, true, false, false, true], alloc),
+            ]
+        )
+    }
+}
+
+/// A boolean-valued CASE inside WHERE works today: DataFusion rewrites it into
+/// boolean algebra, e.g. `CASE WHEN c THEN a ELSE true END` -> `(c AND a) OR NOT c`,
+/// before the planner lowers it. Prove + verify to pin this.
+#[test]
+fn test_boolean_case_in_where_clause_proves() {
+    use proof_of_sql::{
+        base::database::{owned_table_utility::*, OwnedTable},
+        proof_primitive::dory::VerifierSetup,
+        sql::proof::VerifiableQueryResult,
+    };
+    let alloc = Bump::new();
+    let tables = cats_table(&alloc);
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let mut accessor =
+        TableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
+    for (table_ref, table) in &tables {
+        accessor.add_table(table_ref.clone(), table.clone(), 0);
+    }
+    let config = ConfigOptions::default();
+    let statements = Parser::parse_sql(
+        &GenericDialect {},
+        // human 1's cats only if adopted; human 2's cats unconditionally
+        "SELECT id FROM cats WHERE CASE WHEN human_id = 1 THEN adopted ELSE true END",
+    )
+    .unwrap();
+    let plans = sql_to_proof_plans(&statements, &accessor, &config).unwrap();
+    let res = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
+        &plans[0],
+        &accessor,
+        &&prover_setup,
+        &[],
+    )
+    .unwrap();
+    let res = res
+        .verify(&plans[0], &accessor, &&verifier_setup, &[])
+        .unwrap()
+        .table;
+    // adopted: [t, t, f, f, t]; human_id: [1, 1, 1, 2, 2] -> ids 1, 2 (adopted, human 1), 4, 5 (human 2)
+    let expected: OwnedTable<DoryScalar> = owned_table([int("id", [1, 2, 4, 5])]);
+    assert_eq!(res, expected);
+}
+
+/// Convert, prove and verify each query against the cats table, asserting results.
+fn assert_case_queries_prove_and_verify(
+    sql: &str,
+    expected_results: &[proof_of_sql::base::database::OwnedTable<DoryScalar>],
+) {
+    use proof_of_sql::{proof_primitive::dory::VerifierSetup, sql::proof::VerifiableQueryResult};
+    let alloc = Bump::new();
+    let tables = cats_table(&alloc);
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let mut accessor =
+        TableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
+    for (table_ref, table) in &tables {
+        accessor.add_table(table_ref.clone(), table.clone(), 0);
+    }
+    let config = ConfigOptions::default();
+    let statements = Parser::parse_sql(&GenericDialect {}, sql).unwrap();
+    let plans = sql_to_proof_plans(&statements, &accessor, &config).unwrap();
+    assert_eq!(plans.len(), expected_results.len());
+    for (plan, expected) in plans.iter().zip(expected_results.iter()) {
+        let res = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
+            plan,
+            &accessor,
+            &&prover_setup,
+            &[],
+        )
+        .unwrap();
+        let res = res
+            .verify(plan, &accessor, &&verifier_setup, &[])
+            .unwrap()
+            .table;
+        assert_eq!(res, expected.clone());
+    }
+}
+
+/// Searched CASE with numeric branches proves and verifies.
+#[test]
+fn test_case_when_numeric_branches() {
+    use proof_of_sql::base::database::owned_table_utility::*;
+    let sql = "SELECT CASE WHEN adopted THEN 1 ELSE 0 END AS flag FROM cats;
+    SELECT CASE WHEN weight > 5.0 THEN 1 ELSE 0 END AS is_big FROM cats;
+    SELECT CASE WHEN weight > 5.0 THEN id ELSE human_id END AS pick FROM cats;
+    SELECT CASE WHEN id = 1 THEN 10 WHEN id = 2 THEN 20 ELSE 0 END AS v FROM cats;
+    SELECT CASE human_id WHEN 1 THEN 10 ELSE 20 END AS v FROM cats;
+    SELECT CASE WHEN adopted THEN CASE WHEN weight > 5.0 THEN 2 ELSE 1 END ELSE 0 END AS v FROM cats;";
+    let expected_results = vec![
+        owned_table([bigint("flag", [1_i64, 1, 0, 0, 1])]),
+        // weights: 14.5, 7.5, 2.0, 4.5, 5.5
+        owned_table([bigint("is_big", [1_i64, 1, 0, 0, 1])]),
+        owned_table([int("pick", [1, 2, 1, 2, 5])]),
+        // multiple arms with first-match-wins guards
+        owned_table([bigint("v", [10_i64, 20, 0, 0, 0])]),
+        // simple form CASE x WHEN v THEN ...
+        owned_table([bigint("v", [10_i64, 10, 10, 20, 20])]),
+        // nested CASE
+        owned_table([bigint("v", [2_i64, 2, 0, 0, 2])]),
+    ];
+    assert_case_queries_prove_and_verify(sql, &expected_results);
+}
+
+/// Conditional aggregation - the highest-value CASE pattern.
+#[test]
+fn test_case_when_conditional_aggregation() {
+    use proof_of_sql::base::database::owned_table_utility::*;
+    let sql = "SELECT SUM(CASE WHEN adopted THEN 1 ELSE 0 END) AS adopted_count FROM cats;
+    SELECT human_id, SUM(CASE WHEN adopted THEN weight ELSE 0.0 END) AS adopted_weight FROM cats GROUP BY human_id;";
+    let expected_results = vec![
+        owned_table([bigint("adopted_count", [3_i64])]),
+        // human 1: 14.5 + 7.5 = 22.0; human 2: 5.5 (branches coerced to decimal(30,15))
+        owned_table([
+            int("human_id", [1, 2]),
+            decimal75(
+                "adopted_weight",
+                30,
+                15,
+                [22_000_000_000_000_000_i128, 5_500_000_000_000_000],
+            ),
+        ]),
+    ];
+    assert_case_queries_prove_and_verify(sql, &expected_results);
+}
+
+/// CASE flavors that cannot be represented are rejected at planning time.
+#[test]
+fn test_unsupported_case_when_variants() {
+    use proof_of_sql_planner::PlannerError;
+    let alloc = Bump::new();
+    let tables = cats_table(&alloc);
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let mut accessor =
+        TableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
+    for (table_ref, table) in &tables {
+        accessor.add_table(table_ref.clone(), table.clone(), 0);
+    }
+    let config = ConfigOptions::default();
+
+    // Varchar branches: strings cannot be rebuilt from the masked hash sum.
+    let statements = Parser::parse_sql(
+        &GenericDialect {},
+        "SELECT CASE WHEN weight > 5.0 THEN 'big' ELSE 'small' END FROM cats",
+    )
+    .unwrap();
+    assert!(matches!(
+        sql_to_proof_plans(&statements, &accessor, &config),
+        Err(PlannerError::AnalyzeError { .. })
+    ));
+
+    // Missing ELSE: unmatched rows would be NULL, which has no representation.
+    let statements = Parser::parse_sql(
+        &GenericDialect {},
+        "SELECT CASE WHEN adopted THEN 1 END FROM cats",
+    )
+    .unwrap();
+    assert!(matches!(
+        sql_to_proof_plans(&statements, &accessor, &config),
+        Err(PlannerError::UnsupportedLogicalExpression { .. })
+    ));
+}
+
+/// Probe which CASE WHEN flavors convert to proof plans today.
+/// Run with: cargo test -p proof-of-sql-planner --test case_when_matrix_tests probe -- --nocapture --ignored
+#[test]
+#[ignore = "diagnostic probe, prints plans; not a regression test"]
+fn probe_case_when_feasibility() {
+    let alloc = Bump::new();
+    let tables = cats_table(&alloc);
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let mut accessor =
+        TableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
+    for (table_ref, table) in &tables {
+        accessor.add_table(table_ref.clone(), table.clone(), 0);
+    }
+    let config = ConfigOptions::default();
+
+    let queries = [
+        // searched CASE, numeric branches
+        "SELECT CASE WHEN adopted THEN 1 ELSE 0 END FROM cats",
+        "SELECT CASE WHEN weight > 5.0 THEN 1 ELSE 0 END FROM cats",
+        "SELECT CASE WHEN weight > 5.0 THEN id ELSE human_id END FROM cats",
+        // multiple WHEN arms
+        "SELECT CASE WHEN id = 1 THEN 10 WHEN id = 2 THEN 20 ELSE 0 END FROM cats",
+        // varchar branches
+        "SELECT CASE WHEN weight > 5.0 THEN 'big' ELSE 'small' END FROM cats",
+        // simple CASE form (CASE expr WHEN value ...)
+        "SELECT CASE human_id WHEN 1 THEN 10 ELSE 20 END FROM cats",
+        // no ELSE (implicit NULL)
+        "SELECT CASE WHEN adopted THEN 1 END FROM cats",
+        // CASE in WHERE
+        "SELECT id FROM cats WHERE CASE WHEN human_id = 1 THEN adopted ELSE true END",
+        // conditional aggregation
+        "SELECT SUM(CASE WHEN adopted THEN 1 ELSE 0 END) FROM cats",
+        "SELECT human_id, SUM(CASE WHEN adopted THEN weight ELSE 0.0 END) FROM cats GROUP BY human_id",
+        // nested CASE
+        "SELECT CASE WHEN adopted THEN CASE WHEN weight > 5.0 THEN 2 ELSE 1 END ELSE 0 END FROM cats",
+        // constant-foldable CASE
+        "SELECT CASE WHEN 1 = 1 THEN id ELSE human_id END FROM cats",
+    ];
+    for sql in queries {
+        let statements = match Parser::parse_sql(&GenericDialect {}, sql) {
+            Ok(s) => s,
+            Err(e) => {
+                println!("=== PARSE-FAIL: {sql}\n--- error: {e}");
+                continue;
+            }
+        };
+        match sql_to_proof_plans(&statements, &accessor, &config) {
+            Ok(plans) => {
+                println!("=== OK: {sql}");
+                println!("--- plan:\n{:#?}", plans[0]);
+            }
+            Err(e) => {
+                println!("=== UNSUPPORTED: {sql}\n--- error: {e}");
+            }
+        }
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -235,6 +235,29 @@ pub fn try_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult
     })
 }
 
+/// Verifies that a value's raw scalar encoding may be relabeled from `from` to `to`
+/// without any conversion or constraint. This is deliberately more permissive than
+/// [`try_cast_types`] but still bounded:
+/// - anything may be relabeled *into* `Scalar`, since `Scalar` is exactly the raw
+///   encoding every column type already lives in (this is what allows a boolean
+///   guard to be multiplied with a value of any type);
+/// - `Scalar` may be relabeled back *out* to any type that can be materialized from
+///   raw scalars (everything except `VarChar`/`VarBinary`, whose scalars are hashes).
+///
+/// The out-of-`Scalar` direction is only correct when every value fits the target
+/// type's range and scale; that guarantee is the responsibility of the composite
+/// expression constructing the relabel (see `sql::proof_exprs::composites`).
+pub fn try_relabel_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult<()> {
+    (to == ColumnType::Scalar
+        || (from == ColumnType::Scalar
+            && !matches!(to, ColumnType::VarChar | ColumnType::VarBinary)))
+    .then_some(())
+    .ok_or(ColumnOperationError::CastingError {
+        left_type: from,
+        right_type: to,
+    })
+}
+
 /// Verifies that `from` can be cast to `to`.
 /// Casting can only be supported if the resulting data type is a superset of the input data type.
 /// For example Deciaml(6,1) can be cast to Decimal(7,1), but not vice versa.

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -32,7 +32,7 @@ pub use column_type_operation::{
     try_add_subtract_column_types_with_scaling, try_cast_types, try_divide_column_types,
     try_equals_types, try_equals_types_with_scaling, try_inequality_types,
     try_inequality_types_with_scaling, try_multiply_column_types, try_neg_type,
-    try_scale_cast_types,
+    try_relabel_cast_types, try_scale_cast_types,
 };
 
 mod column_arithmetic_operation;

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -1,7 +1,7 @@
 use super::{EVMProofPlanError, EVMProofPlanResult};
 use crate::{
     base::{
-        database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+        database::{try_cast_types, ColumnRef, ColumnType, LiteralValue, TableRef},
         map::IndexSet,
     },
     sql::proof_exprs::{
@@ -561,6 +561,10 @@ impl EVMCastExpr {
         expr: &CastExpr,
         column_refs: &IndexSet<ColumnRef>,
     ) -> EVMProofPlanResult<Self> {
+        // The EVM verifier only supports checked casts; unchecked relabeling casts
+        // (e.g. from the CASE lowering) must not be serialized for it.
+        try_cast_types(expr.get_from_expr().data_type(), *expr.to_type())
+            .map_err(|_| EVMProofPlanError::NotSupported)?;
         Ok(EVMCastExpr {
             from_expr: Box::new(EVMDynProofExpr::try_from_proof_expr(
                 expr.get_from_expr(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -65,6 +65,10 @@ impl ProofExpr for AddExpr {
         let lhs_column: Column<'a, S> = self.lhs.first_round_evaluate(alloc, table, params)?;
         let rhs_column: Column<'a, S> = self.rhs.first_round_evaluate(alloc, table, params)?;
         let res = add_subtract_columns(lhs_column, rhs_column, alloc, false);
+        // Scalar-typed sums (e.g. from the CASE lowering) have no precision/scale
+        if self.data_type() == ColumnType::Scalar {
+            return Ok(Column::Scalar(res));
+        }
         Ok(Column::Decimal75(self.precision(), self.scale(), res))
     }
 
@@ -91,6 +95,10 @@ impl ProofExpr for AddExpr {
         let res = add_subtract_columns(lhs_column, rhs_column, alloc, false);
         log::log_memory_usage("End");
 
+        // Scalar-typed sums (e.g. from the CASE lowering) have no precision/scale
+        if self.data_type() == ColumnType::Scalar {
+            return Ok(Column::Scalar(res));
+        }
         Ok(Column::Decimal75(self.precision(), self.scale(), res))
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -1,7 +1,10 @@
-use super::{numerical_util::cast_column, DynProofExpr, ProofExpr};
+use super::{numerical_util::unchecked_cast_column, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{try_cast_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{
+            try_cast_types, try_relabel_cast_types, Column, ColumnRef, ColumnType, LiteralValue,
+            Table,
+        },
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -35,6 +38,30 @@ impl CastExpr {
             })
     }
 
+    /// Creates a new `CastExpr` that relabels the raw scalar encoding instead of
+    /// performing a checked cast. The pair must be in the relabel whitelist
+    /// ([`try_relabel_cast_types`]): anything into `Scalar`, or `Scalar` back out to
+    /// a materializable type.
+    ///
+    /// The prover and verifier treat such a cast as a pure relabeling of the raw
+    /// scalar encoding: no constraint is added and no scaling occurs. The caller must
+    /// guarantee that, for every row the expression can produce, the raw scalar is a
+    /// valid encoding of a `to_type` value (correct range and scale). This is only
+    /// intended for composite expressions (see `super::composites`) that can make
+    /// that argument structurally; misuse produces wrong results.
+    pub(super) fn try_new_relabel(
+        from_expr: Box<DynProofExpr>,
+        to_type: ColumnType,
+    ) -> AnalyzeResult<Self> {
+        let from_datatype = from_expr.data_type();
+        try_relabel_cast_types(from_datatype, to_type)
+            .map(|()| Self { from_expr, to_type })
+            .map_err(|_| AnalyzeError::DataTypeMismatch {
+                left_type: from_datatype.to_string(),
+                right_type: to_type.to_string(),
+            })
+    }
+
     /// Returns the from expression
     pub fn get_from_expr(&self) -> &DynProofExpr {
         &self.from_expr
@@ -58,7 +85,7 @@ impl ProofExpr for CastExpr {
         params: &[LiteralValue],
     ) -> PlaceholderResult<Column<'a, S>> {
         let uncasted_result = self.from_expr.first_round_evaluate(alloc, table, params)?;
-        Ok(cast_column(
+        Ok(unchecked_cast_column(
             alloc,
             uncasted_result,
             self.from_expr.data_type(),
@@ -76,7 +103,7 @@ impl ProofExpr for CastExpr {
         let uncasted_result = self
             .from_expr
             .final_round_evaluate(builder, alloc, table, params)?;
-        Ok(cast_column(
+        Ok(unchecked_cast_column(
             alloc,
             uncasted_result,
             self.from_expr.data_type(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/composites.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/composites.rs
@@ -1,0 +1,97 @@
+//! Higher-level SQL constructs built by composing existing provable expressions.
+//!
+//! The constructions in this module produce plain [`DynProofExpr`] trees - no new
+//! expression variants, no proof-system changes, and no new serialization formats.
+//! This is also the only place allowed to use [`CastExpr::try_new_relabel`]: each
+//! construction must argue structurally that the raw scalar encodings it relabels
+//! are valid for the claimed types.
+use super::{CastExpr, DynProofExpr, ProofExpr};
+use crate::{
+    base::database::ColumnType,
+    sql::{AnalyzeError, AnalyzeResult},
+};
+use alloc::{boxed::Box, string::ToString, vec::Vec};
+
+/// Relabel an expression's raw scalar encoding as `to_type` without a checked cast.
+/// Only for use by constructions in this module that guarantee the encoding is valid.
+fn relabel_cast(from_expr: DynProofExpr, to_type: ColumnType) -> AnalyzeResult<DynProofExpr> {
+    Ok(DynProofExpr::Cast(CastExpr::try_new_relabel(
+        Box::new(from_expr),
+        to_type,
+    )?))
+}
+
+/// Create an expression equivalent to
+/// `CASE WHEN c_1 THEN v_1 ... WHEN c_n THEN v_n ELSE v_else END`
+/// by composing existing provable expressions.
+///
+/// Each arm gets a first-match-wins guard `g_i = NOT c_1 AND ... AND NOT c_{i-1} AND c_i`
+/// (the ELSE guard negates every condition). The guards are relabeled as raw scalars
+/// (0 or 1), each value is relabeled as its raw scalar encoding, and the result is
+/// `g_1 * v_1 + ... + g_n * v_n + g_else * v_else`, relabeled back to the branch type.
+///
+/// The final relabeling is sound because the guards are boolean and mutually
+/// exclusive by construction, and exactly one of them is 1 for every row - so the
+/// sum always equals the raw encoding of exactly one branch value, which has the
+/// result type already.
+///
+/// Requirements:
+/// - every condition must be boolean
+/// - every branch value (including ELSE) must have the same type
+/// - the branch type must not be `VarChar`/`VarBinary` (their scalars are hashes,
+///   which cannot be materialized back into strings/bytes)
+/// - there must be at least one WHEN arm
+pub fn try_new_case(
+    when_thens: Vec<(DynProofExpr, DynProofExpr)>,
+    else_expr: DynProofExpr,
+) -> AnalyzeResult<DynProofExpr> {
+    let result_type = else_expr.data_type();
+    if matches!(
+        result_type,
+        ColumnType::VarChar | ColumnType::VarBinary | ColumnType::Scalar
+    ) {
+        return Err(AnalyzeError::InvalidDataType {
+            expr_type: result_type,
+        });
+    }
+    for (condition, value) in &when_thens {
+        if condition.data_type() != ColumnType::Boolean {
+            return Err(AnalyzeError::DataTypeMismatch {
+                left_type: condition.data_type().to_string(),
+                right_type: ColumnType::Boolean.to_string(),
+            });
+        }
+        if value.data_type() != result_type {
+            return Err(AnalyzeError::DataTypeMismatch {
+                left_type: value.data_type().to_string(),
+                right_type: result_type.to_string(),
+            });
+        }
+    }
+    // Seed the accumulators with the first arm, then fold the rest in.
+    // `no_prior_match` accumulates `NOT c_1 AND ... AND NOT c_i`; `masked_sum`
+    // accumulates the guarded terms.
+    let mut when_thens = when_thens.into_iter();
+    let Some((first_condition, first_value)) = when_thens.next() else {
+        // A CASE without any WHEN arm is not valid
+        return Err(AnalyzeError::InvalidDataType {
+            expr_type: result_type,
+        });
+    };
+    let term = |guard: DynProofExpr, value: DynProofExpr| -> AnalyzeResult<DynProofExpr> {
+        DynProofExpr::try_new_multiply(
+            relabel_cast(guard, ColumnType::Scalar)?,
+            relabel_cast(value, ColumnType::Scalar)?,
+        )
+    };
+    let mut masked_sum = term(first_condition.clone(), first_value)?;
+    let mut no_prior_match = DynProofExpr::try_new_not(first_condition)?;
+    for (condition, value) in when_thens {
+        let guard = DynProofExpr::try_new_and(no_prior_match.clone(), condition.clone())?;
+        masked_sum = DynProofExpr::try_new_add(masked_sum, term(guard, value)?)?;
+        no_prior_match =
+            DynProofExpr::try_new_and(no_prior_match, DynProofExpr::try_new_not(condition)?)?;
+    }
+    let sum = DynProofExpr::try_new_add(masked_sum, term(no_prior_match, else_expr)?)?;
+    relabel_cast(sum, result_type)
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -23,6 +23,9 @@ mod multiply_expr_test;
 mod dyn_proof_expr;
 pub use dyn_proof_expr::DynProofExpr;
 
+mod composites;
+pub use composites::try_new_case;
+
 mod literal_expr;
 pub(crate) use literal_expr::LiteralExpr;
 #[cfg(all(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -64,6 +64,10 @@ impl ProofExpr for MultiplyExpr {
         let lhs_column: Column<'a, S> = self.lhs.first_round_evaluate(alloc, table, params)?;
         let rhs_column: Column<'a, S> = self.rhs.first_round_evaluate(alloc, table, params)?;
         let res = multiply_columns(&lhs_column, &rhs_column, alloc);
+        // Scalar-typed products (e.g. from the CASE lowering) have no precision/scale
+        if self.data_type() == ColumnType::Scalar {
+            return Ok(Column::Scalar(res));
+        }
         Ok(Column::Decimal75(self.precision(), self.scale(), res))
     }
 
@@ -96,7 +100,12 @@ impl ProofExpr for MultiplyExpr {
                 (-S::one(), vec![Box::new(lhs_column), Box::new(rhs_column)]),
             ],
         );
-        let res = Column::Decimal75(self.precision(), self.scale(), lhs_times_rhs);
+        // Scalar-typed products (e.g. from the CASE lowering) have no precision/scale
+        let res = if self.data_type() == ColumnType::Scalar {
+            Column::Scalar(lhs_times_rhs)
+        } else {
+            Column::Decimal75(self.precision(), self.scale(), lhs_times_rhs)
+        };
 
         log::log_memory_usage("End");
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -612,6 +612,64 @@ pub fn cast_column<'a, S: Scalar>(
     }
 }
 
+/// Handles the casting of one column to another, including the relabeling casts that
+/// [`CastExpr::try_new_relabel`](super::CastExpr) produces and [`try_cast_types`]
+/// rejects (see `try_relabel_cast_types`): any column type to `Scalar` (the raw
+/// encoding every column already lives in) and `Scalar` back to a typed column. The
+/// latter is only correct when every value's raw scalar is a valid encoding of
+/// `to_type`; the constructor of the relabel cast is responsible for guaranteeing
+/// that (see `super::composites`).
+///
+/// Checked casts are delegated to [`cast_column`] unchanged.
+///
+/// # Panics
+/// Panics if casting is not supported between the two types or a value does not fit
+/// the target type.
+pub(crate) fn unchecked_cast_column<'a, S: Scalar>(
+    alloc: &'a Bump,
+    from_column: Column<'a, S>,
+    from_type: ColumnType,
+    to_type: ColumnType,
+) -> Column<'a, S> {
+    if try_cast_types(from_type, to_type).is_ok() {
+        return cast_column(alloc, from_column, from_type, to_type);
+    }
+    match (from_column, to_type) {
+        (Column::Scalar(vals), ColumnType::Scalar) => Column::Scalar(vals),
+        // Relabel any column as its raw scalar encoding
+        (_, ColumnType::Scalar) => Column::Scalar(
+            alloc.alloc_slice_fill_with(from_column.len(), |i| from_column.scalar_at(i).unwrap())
+                as &[_],
+        ),
+        // Materialize raw scalars back into a typed column
+        (Column::Scalar(vals), ColumnType::Boolean) => {
+            Column::Boolean(alloc.alloc_slice_fill_with(vals.len(), |i| {
+                TryInto::<bool>::try_into(vals[i])
+                    .unwrap_or_else(|_| panic!("unchecked cast to Boolean requires 0/1 scalars"))
+            }) as &[_])
+        }
+        (
+            Column::Scalar(vals),
+            ColumnType::Uint8
+            | ColumnType::TinyInt
+            | ColumnType::SmallInt
+            | ColumnType::Int
+            | ColumnType::BigInt
+            | ColumnType::Int128,
+        ) => cast_scalar_slice_to_int_column(alloc, vals, to_type),
+        (Column::Scalar(vals), ColumnType::TimestampTZ(tu, tz)) => Column::TimestampTZ(
+            tu,
+            tz,
+            cast_scalar_slice_to_int_slice::<i64, S>(alloc, vals),
+        ),
+        // Decimal columns store raw scalars directly; the relabel is free
+        (Column::Scalar(vals), ColumnType::Decimal75(precision, scale)) => {
+            Column::Decimal75(precision, scale, vals)
+        }
+        _ => panic!("Unchecked casting not supported between {from_type} and {to_type}"),
+    }
+}
+
 /// Tries to get the scale factor between the from and to types.
 /// The precision and scale are returned along with the scale so that the unwrapping
 /// can occur in the function that confirms that the types are castable


### PR DESCRIPTION
# Rationale for this change

SQL `CASE WHEN` wasn't supported by the planner. This adds it by composing existing provable expressions, so there is no new proof expr.

`CASE WHEN c1 THEN v1 ... ELSE e END` lowers to a masked sum: each arm gets a first-match-wins boolean guard (`NOT c1 AND ... AND ci`), guards and branch values are relabeled as raw scalars, and `g1*v1 + ... + g_else*e` is relabeled back to the branch type. The final relabel is sound because exactly one 0/1 guard is active per row, so the sum always equals one branch value, which already has the result type.

# What changes are included in this PR?

- `try_relabel_cast_types`: a whitelist for relabeling casts — anything into `Scalar` (which is what allows a boolean guard to be multiplied with any type), and `Scalar` back out to any materializable type.
- `CastExpr::try_new_relabel` (`pub(super)`): builds a relabeling cast, validated against that whitelist. Only reachable through composite constructors.
- `proof_exprs/composites.rs`: home for SQL constructs built by composing existing exprs; contains `try_new_case`, which validates conditions/branch types and owns the soundness argument for the relabels.
- Planner: lowers searched and simple CASE forms, nested CASE, and CASE inside aggregates. CASE without ELSE (implicit NULL) and varchar branch values are rejected at planning time.
- EVM serializer rejects relabeling casts (`NotSupported`) until the Solidity verifier supports them.
- Fixes a latent panic in `AddExpr`/`MultiplyExpr` provers, which assumed all results are decimal; `Scalar`-typed arithmetic now yields `Scalar` columns.

# Are these changes tested?

Yes — end-to-end prove/verify for searched/multi-arm/simple-form/nested CASE and conditional aggregation (`SUM(CASE ...)`, with and without GROUP BY), plus planning-time rejection tests for missing ELSE and varchar branches.
