### PR TITLE
feat!: add structured planner errors

### DIFF
--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -113,14 +113,32 @@ pub fn get_table_refs_from_statement(
 #[cfg(test)]
 mod tests {
     use super::get_table_refs_from_statement;
-    use crate::{conversion::sql_to_posql_plans, PlannerResult};
+    use crate::{
+        conversion::sql_to_posql_plans, sql_to_proof_plans, AggregatePlanError, PlannerError,
+        PlannerResult,
+    };
+    use ahash::AHasher;
     use datafusion::{config::ConfigOptions, logical_expr::LogicalPlan};
-    use indexmap::IndexSet;
+    use indexmap::{indexmap_with_default, IndexSet};
     use proof_of_sql::{
-        base::database::{TableRef, TableTestAccessor},
+        base::database::{
+            ColumnType, SchemaAccessor, SchemaAccessorImpl, TableRef, TableTestAccessor,
+        },
         proof_primitive::dory::DynamicDoryEvaluationProof,
+        sql::proof_plans::{AggregateExecError, DynProofPlan},
     };
     use sqlparser::{dialect::GenericDialect, parser::Parser};
+
+    #[expect(non_snake_case)]
+    fn SQL_SCHEMAS() -> impl SchemaAccessor + Clone {
+        SchemaAccessorImpl::new(indexmap_with_default! {AHasher;
+            TableRef::new("", "test_table") => vec![
+                ("id".into(), ColumnType::BigInt),
+                ("name".into(), ColumnType::VarChar),
+                ("payload".into(), ColumnType::VarBinary),
+            ],
+        })
+    }
 
     #[test]
     fn we_can_get_table_references() {
@@ -174,5 +192,61 @@ AND s.salary > (
             |a, _| -> PlannerResult<LogicalPlan> { Ok(a.clone()) },
         )
         .unwrap();
+    }
+
+    #[test]
+    fn sql_distinct_reports_aggregate_construction_error() {
+        let statements =
+            Parser::parse_sql(&GenericDialect {}, "SELECT DISTINCT name FROM test_table;").unwrap();
+
+        let err =
+            sql_to_proof_plans(&statements, &SQL_SCHEMAS(), &ConfigOptions::default()).unwrap_err();
+
+        assert!(matches!(
+            err,
+            PlannerError::UnsupportedAggregatePlan {
+                source: AggregatePlanError::AggregateExec {
+                    source: AggregateExecError::UnsupportedGroupByExpressionType {
+                        data_type: ColumnType::VarChar,
+                    },
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn sql_grouping_reports_aggregate_construction_error() {
+        let statements = Parser::parse_sql(
+            &GenericDialect {},
+            "SELECT payload FROM test_table GROUP BY payload;",
+        )
+        .unwrap();
+
+        let err =
+            sql_to_proof_plans(&statements, &SQL_SCHEMAS(), &ConfigOptions::default()).unwrap_err();
+
+        assert!(matches!(
+            err,
+            PlannerError::UnsupportedAggregatePlan {
+                source: AggregatePlanError::AggregateExec {
+                    source: AggregateExecError::UnsupportedGroupByExpressionType {
+                        data_type: ColumnType::VarBinary,
+                    },
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn sql_distinct_on_supported_type_still_converts() {
+        let statements =
+            Parser::parse_sql(&GenericDialect {}, "SELECT DISTINCT id FROM test_table;").unwrap();
+
+        let plans =
+            sql_to_proof_plans(&statements, &SQL_SCHEMAS(), &ConfigOptions::default()).unwrap();
+
+        assert!(matches!(plans.as_slice(), [DynProofPlan::Projection(_)]));
     }
 }

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -281,3 +281,44 @@ pub enum PlannerError {
 
 /// Proof of SQL Planner result
 pub type PlannerResult<T> = Result<T, PlannerError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proof_of_sql::base::database::ColumnType;
+
+    #[test]
+    fn planner_sub_errors_include_actionable_context() {
+        assert_eq!(
+            AggregatePlanError::MissingGroupExpressionAlias {
+                expression: "table.id".to_string(),
+            }
+            .to_string(),
+            "group expression table.id has no output alias"
+        );
+        assert_eq!(
+            AggregatePlanError::AggregateExec {
+                source: AggregateExecError::UnsupportedGroupByExpressionType {
+                    data_type: ColumnType::VarChar,
+                },
+            }
+            .to_string(),
+            "grouping and deduplication do not support expressions of type VARCHAR"
+        );
+        assert_eq!(
+            JoinPlanError::UnsupportedPredicate {
+                left: "left.a".to_string(),
+                right: "right.b".to_string(),
+            }
+            .to_string(),
+            "join predicate must pair supported columns with the same unqualified name, found left.a and right.b"
+        );
+    }
+
+    #[test]
+    fn logical_plan_node_kinds_have_human_readable_labels() {
+        assert_eq!(LogicalPlanNodeKind::CrossJoin.to_string(), "cross join");
+        assert_eq!(LogicalPlanNodeKind::Distinct.to_string(), "distinct");
+        assert_eq!(LogicalPlanNodeKind::Dml.to_string(), "data manipulation");
+    }
+}

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -1,17 +1,175 @@
 use arrow::datatypes::DataType;
+use core::fmt::{self, Display, Formatter};
 use datafusion::{
-    common::DataFusionError,
+    common::{DataFusionError, JoinConstraint, JoinType},
     logical_expr::{
         expr::{AggregateFunction, Placeholder},
         Expr, LogicalPlan, Operator,
     },
     physical_plan,
 };
-use proof_of_sql::{base::math::decimal::DecimalError, sql::AnalyzeError};
+use proof_of_sql::{
+    base::math::decimal::DecimalError,
+    sql::{proof_plans::AggregateExecError, AnalyzeError},
+};
 use snafu::Snafu;
 use sqlparser::parser::ParserError;
 
+/// Errors encountered while converting an aggregate logical plan.
+#[non_exhaustive]
+#[derive(Clone, Debug, Eq, PartialEq, Snafu)]
+pub enum AggregatePlanError {
+    /// A grouping expression was absent from `DataFusion`'s output alias map.
+    #[snafu(display("group expression {expression} has no output alias"))]
+    MissingGroupExpressionAlias {
+        /// Display name used to look up the expression.
+        expression: String,
+    },
+    /// An aggregate expression was absent from `DataFusion`'s output alias map.
+    #[snafu(display("aggregate expression {expression} has no output alias"))]
+    MissingAggregateExpressionAlias {
+        /// Display name used to look up the expression.
+        expression: String,
+    },
+    /// `DataFusion` placed a non-aggregate expression in the aggregate expression list.
+    #[snafu(display("aggregate expression list contains non-aggregate expression {expression}"))]
+    UnexpectedAggregateExpression {
+        /// Unexpected expression.
+        expression: String,
+    },
+    /// The aggregate proof-plan constructor rejected the requested shape.
+    #[snafu(transparent)]
+    AggregateExec {
+        /// Authoritative aggregate construction error.
+        source: AggregateExecError,
+    },
+}
+
+/// Errors encountered while converting a join logical plan.
+#[non_exhaustive]
+#[derive(Clone, Debug, Eq, PartialEq, Snafu)]
+pub enum JoinPlanError {
+    /// Only inner joins can be converted to the current proof plan.
+    #[snafu(display("join type {join_type} is not supported"))]
+    UnsupportedJoinType {
+        /// Unsupported join type.
+        join_type: JoinType,
+    },
+    /// Only `ON` join constraints can be converted to the current proof plan.
+    #[snafu(display("join constraint {constraint:?} is not supported"))]
+    UnsupportedJoinConstraint {
+        /// Unsupported join constraint.
+        constraint: JoinConstraint,
+    },
+    /// The join predicate is not a supported pair of matching column references.
+    #[snafu(display(
+        "join predicate must pair supported columns with the same unqualified name, found {left} and {right}"
+    ))]
+    UnsupportedPredicate {
+        /// Left-hand join expression.
+        left: String,
+        /// Right-hand join expression.
+        right: String,
+    },
+}
+
+/// Kind of `DataFusion` logical plan node presented to the Proof of SQL converter.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LogicalPlanNodeKind {
+    /// Projection node.
+    Projection,
+    /// Filter node.
+    Filter,
+    /// Window node.
+    Window,
+    /// Aggregate node.
+    Aggregate,
+    /// Sort node.
+    Sort,
+    /// Join node.
+    Join,
+    /// Cross-join node.
+    CrossJoin,
+    /// Repartition node.
+    Repartition,
+    /// Union node.
+    Union,
+    /// Table-scan node.
+    TableScan,
+    /// Empty-relation node.
+    EmptyRelation,
+    /// Subquery node.
+    Subquery,
+    /// Subquery-alias node.
+    SubqueryAlias,
+    /// Limit node.
+    Limit,
+    /// Statement node.
+    Statement,
+    /// Values node.
+    Values,
+    /// Explain node.
+    Explain,
+    /// Analyze node.
+    Analyze,
+    /// Extension node.
+    Extension,
+    /// Distinct node.
+    Distinct,
+    /// Prepare node.
+    Prepare,
+    /// Data-manipulation node.
+    Dml,
+    /// Data-definition node.
+    Ddl,
+    /// Copy node.
+    Copy,
+    /// Describe-table node.
+    DescribeTable,
+    /// Unnest node.
+    Unnest,
+    /// Recursive-query node.
+    RecursiveQuery,
+}
+
+impl Display for LogicalPlanNodeKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::Projection => "projection",
+            Self::Filter => "filter",
+            Self::Window => "window",
+            Self::Aggregate => "aggregate",
+            Self::Sort => "sort",
+            Self::Join => "join",
+            Self::CrossJoin => "cross join",
+            Self::Repartition => "repartition",
+            Self::Union => "union",
+            Self::TableScan => "table scan",
+            Self::EmptyRelation => "empty relation",
+            Self::Subquery => "subquery",
+            Self::SubqueryAlias => "subquery alias",
+            Self::Limit => "limit",
+            Self::Statement => "statement",
+            Self::Values => "values",
+            Self::Explain => "explain",
+            Self::Analyze => "analyze",
+            Self::Extension => "extension",
+            Self::Distinct => "distinct",
+            Self::Prepare => "prepare",
+            Self::Dml => "data manipulation",
+            Self::Ddl => "data definition",
+            Self::Copy => "copy",
+            Self::DescribeTable => "describe table",
+            Self::Unnest => "unnest",
+            Self::RecursiveQuery => "recursive query",
+        };
+        f.write_str(label)
+    }
+}
+
 /// Proof of SQL Planner error
+#[non_exhaustive]
 #[derive(Debug, Snafu)]
 pub enum PlannerError {
     /// Returned when the internal analyze process fails
@@ -89,9 +247,27 @@ pub enum PlannerError {
         /// Unsupported logical expression
         expr: Box<Expr>,
     },
-    /// Returned when a `LogicalPlan` is not supported
-    #[snafu(display("LogicalPlan is not supported"))]
+    /// Returned when an aggregate logical plan cannot be converted.
+    #[snafu(display("Aggregate logical plan is not supported: {source}"))]
+    UnsupportedAggregatePlan {
+        /// Specific aggregate conversion error.
+        source: AggregatePlanError,
+        /// Complete offending logical plan.
+        plan: Box<LogicalPlan>,
+    },
+    /// Returned when a join logical plan cannot be converted.
+    #[snafu(display("Join logical plan is not supported: {source}"))]
+    UnsupportedJoinPlan {
+        /// Specific join conversion error.
+        source: JoinPlanError,
+        /// Complete offending logical plan.
+        plan: Box<LogicalPlan>,
+    },
+    /// Returned when a `LogicalPlan` node or shape is not supported.
+    #[snafu(display("Logical plan node or shape {node} is not supported"))]
     UnsupportedLogicalPlan {
+        /// Kind of node whose particular shape was unsupported.
+        node: LogicalPlanNodeKind,
         /// Unsupported `LogicalPlan`
         plan: Box<LogicalPlan>,
     },

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -17,7 +17,9 @@ mod expr;
 pub use expr::expr_to_proof_expr;
 pub(crate) use expr::get_column_idents_from_expr;
 mod error;
-pub use error::{PlannerError, PlannerResult};
+pub use error::{
+    AggregatePlanError, JoinPlanError, LogicalPlanNodeKind, PlannerError, PlannerResult,
+};
 mod plan;
 pub use plan::logical_plan_to_proof_plan;
 mod uppercase_column_visitor;

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1112,6 +1112,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::too_many_lines)]
     fn we_can_aggregate_with_multiple_sum_expressions() {
         // Setup group expression
         let group_expr = vec![df_column("table", "a")];

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -290,7 +290,7 @@ fn aggregate_to_proof_plan(
         input_plan,
         DynProofExpr::new_literal(LiteralValue::Boolean(true)),
     )
-    .ok_or_else(|| PlannerError::UnsupportedLogicalPlan {
+    .map_err(|_| PlannerError::UnsupportedLogicalPlan {
         plan: Box::new(input.clone()),
     })?;
     Ok(DynProofPlan::new_projection(

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1,6 +1,7 @@
 use super::{
     aggregate_function_to_proof_expr, expr_to_proof_expr, get_column_idents_from_expr,
-    table_reference_to_table_ref, AggregateFunc, PlannerError, PlannerResult,
+    table_reference_to_table_ref, AggregateFunc, AggregatePlanError, JoinPlanError,
+    LogicalPlanNodeKind, PlannerError, PlannerResult,
 };
 use alloc::vec::Vec;
 use datafusion::{
@@ -170,6 +171,7 @@ fn aggregate_to_proof_plan(
     aggr_expr: &[Expr],
     schemas: &impl SchemaAccessor,
     alias_map: &IndexMap<String, String>,
+    aggregate_plan: &LogicalPlan,
 ) -> PlannerResult<DynProofPlan> {
     let input_plan = logical_plan_to_proof_plan(input, schemas)?;
     let input_schema = input_plan
@@ -188,8 +190,11 @@ fn aggregate_to_proof_plan(
             let aggregate_proof_expr = expr_to_proof_expr(e, &input_schema)?;
             let name_string = e.clone().unalias().display_name()?;
             let alias = alias_map.get(&name_string).ok_or_else(|| {
-                PlannerError::UnsupportedLogicalPlan {
-                    plan: Box::new(input.clone()),
+                PlannerError::UnsupportedAggregatePlan {
+                    source: AggregatePlanError::MissingGroupExpressionAlias {
+                        expression: name_string,
+                    },
+                    plan: Box::new(aggregate_plan.clone()),
                 }
             })?;
             let proof_expr = DynProofExpr::new_column(ColumnRef::new(
@@ -219,8 +224,11 @@ fn aggregate_to_proof_plan(
                 Expr::AggregateFunction(agg) => {
                     let name_string = expr.display_name()?;
                     let alias = alias_map.get(&name_string).ok_or_else(|| {
-                        PlannerError::UnsupportedLogicalPlan {
-                            plan: Box::new(input.clone()),
+                        PlannerError::UnsupportedAggregatePlan {
+                            source: AggregatePlanError::MissingAggregateExpressionAlias {
+                                expression: name_string,
+                            },
+                            plan: Box::new(aggregate_plan.clone()),
                         }
                     })?;
                     Ok((
@@ -228,8 +236,11 @@ fn aggregate_to_proof_plan(
                         alias.as_str().into(),
                     ))
                 }
-                _ => Err(PlannerError::UnsupportedLogicalPlan {
-                    plan: Box::new(input.clone()),
+                _ => Err(PlannerError::UnsupportedAggregatePlan {
+                    source: AggregatePlanError::UnexpectedAggregateExpression {
+                        expression: expr.to_string(),
+                    },
+                    plan: Box::new(aggregate_plan.clone()),
                 }),
             }
         })
@@ -290,8 +301,9 @@ fn aggregate_to_proof_plan(
         input_plan,
         DynProofExpr::new_literal(LiteralValue::Boolean(true)),
     )
-    .map_err(|_| PlannerError::UnsupportedLogicalPlan {
-        plan: Box::new(input.clone()),
+    .map_err(|source| PlannerError::UnsupportedAggregatePlan {
+        source: AggregatePlanError::AggregateExec { source },
+        plan: Box::new(aggregate_plan.clone()),
     })?;
     Ok(DynProofPlan::new_projection(
         projection_exprs,
@@ -304,8 +316,19 @@ fn join_to_proof_plan(
     schema_accessor: &impl SchemaAccessor,
     plan: &LogicalPlan,
 ) -> PlannerResult<DynProofPlan> {
-    if join.join_type != JoinType::Inner || join.join_constraint != JoinConstraint::On {
-        return Err(PlannerError::UnsupportedLogicalPlan {
+    if join.join_type != JoinType::Inner {
+        return Err(PlannerError::UnsupportedJoinPlan {
+            source: JoinPlanError::UnsupportedJoinType {
+                join_type: join.join_type,
+            },
+            plan: Box::new(plan.clone()),
+        });
+    }
+    if join.join_constraint != JoinConstraint::On {
+        return Err(PlannerError::UnsupportedJoinPlan {
+            source: JoinPlanError::UnsupportedJoinConstraint {
+                constraint: join.join_constraint,
+            },
             plan: Box::new(plan.clone()),
         });
     }
@@ -336,7 +359,11 @@ fn join_to_proof_plan(
                         column_id,
                     ))
                 }
-                _ => Err(PlannerError::UnsupportedLogicalPlan {
+                _ => Err(PlannerError::UnsupportedJoinPlan {
+                    source: JoinPlanError::UnsupportedPredicate {
+                        left: left_expr.to_string(),
+                        right: right_expr.to_string(),
+                    },
                     plan: Box::new(plan.clone()),
                 }),
             })
@@ -420,7 +447,14 @@ pub fn logical_plan_to_proof_plan(
                 .zip(schema.fields().iter())
                 .map(|(name_string, field)| Ok((name_string, field.name().clone())))
                 .collect::<PlannerResult<IndexMap<_, _>>>()?;
-            aggregate_to_proof_plan(input, group_expr, aggr_expr, schema_accessor, &alias_map)
+            aggregate_to_proof_plan(
+                input,
+                group_expr,
+                aggr_expr,
+                schema_accessor,
+                &alias_map,
+                plan,
+            )
         }
         // Projection
         LogicalPlan::Projection(Projection {
@@ -479,8 +513,41 @@ pub fn logical_plan_to_proof_plan(
             logical_plan_to_proof_plan(input, schema_accessor)
         }
         _ => Err(PlannerError::UnsupportedLogicalPlan {
+            node: logical_plan_node(plan),
             plan: Box::new(plan.clone()),
         }),
+    }
+}
+
+fn logical_plan_node(plan: &LogicalPlan) -> LogicalPlanNodeKind {
+    match plan {
+        LogicalPlan::Projection(_) => LogicalPlanNodeKind::Projection,
+        LogicalPlan::Filter(_) => LogicalPlanNodeKind::Filter,
+        LogicalPlan::Window(_) => LogicalPlanNodeKind::Window,
+        LogicalPlan::Aggregate(_) => LogicalPlanNodeKind::Aggregate,
+        LogicalPlan::Sort(_) => LogicalPlanNodeKind::Sort,
+        LogicalPlan::Join(_) => LogicalPlanNodeKind::Join,
+        LogicalPlan::CrossJoin(_) => LogicalPlanNodeKind::CrossJoin,
+        LogicalPlan::Repartition(_) => LogicalPlanNodeKind::Repartition,
+        LogicalPlan::Union(_) => LogicalPlanNodeKind::Union,
+        LogicalPlan::TableScan(_) => LogicalPlanNodeKind::TableScan,
+        LogicalPlan::EmptyRelation(_) => LogicalPlanNodeKind::EmptyRelation,
+        LogicalPlan::Subquery(_) => LogicalPlanNodeKind::Subquery,
+        LogicalPlan::SubqueryAlias(_) => LogicalPlanNodeKind::SubqueryAlias,
+        LogicalPlan::Limit(_) => LogicalPlanNodeKind::Limit,
+        LogicalPlan::Statement(_) => LogicalPlanNodeKind::Statement,
+        LogicalPlan::Values(_) => LogicalPlanNodeKind::Values,
+        LogicalPlan::Explain(_) => LogicalPlanNodeKind::Explain,
+        LogicalPlan::Analyze(_) => LogicalPlanNodeKind::Analyze,
+        LogicalPlan::Extension(_) => LogicalPlanNodeKind::Extension,
+        LogicalPlan::Distinct(_) => LogicalPlanNodeKind::Distinct,
+        LogicalPlan::Prepare(_) => LogicalPlanNodeKind::Prepare,
+        LogicalPlan::Dml(_) => LogicalPlanNodeKind::Dml,
+        LogicalPlan::Ddl(_) => LogicalPlanNodeKind::Ddl,
+        LogicalPlan::Copy(_) => LogicalPlanNodeKind::Copy,
+        LogicalPlan::DescribeTable(_) => LogicalPlanNodeKind::DescribeTable,
+        LogicalPlan::Unnest(_) => LogicalPlanNodeKind::Unnest,
+        LogicalPlan::RecursiveQuery(_) => LogicalPlanNodeKind::RecursiveQuery,
     }
 }
 
@@ -506,7 +573,10 @@ mod tests {
             database::{ColumnField, SchemaAccessorImpl},
             math::decimal::Precision,
         },
-        sql::proof_exprs::{ColumnExpr, TableExpr},
+        sql::{
+            proof_exprs::{ColumnExpr, TableExpr},
+            proof_plans::AggregateExecError,
+        },
     };
 
     const SUM: AggregateFunctionDefinition =
@@ -788,9 +858,15 @@ mod tests {
         };
 
         // Test the function
-        let result =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
-                .unwrap();
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        )
+        .unwrap();
 
         let dummy_ref_table = TableRef::from_names(None, "");
 
@@ -885,9 +961,15 @@ mod tests {
         };
 
         // Test the function
-        let result =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
-                .unwrap();
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        )
+        .unwrap();
 
         let dummy_ref_table = TableRef::from_names(None, "");
 
@@ -971,19 +1053,30 @@ mod tests {
             .unwrap(),
         );
         let alias_map = indexmap! {
-            "a".to_string() => "a".to_string(),
-            "c".to_string() => "c".to_string(),
+            "table.a".to_string() => "a".to_string(),
+            "table.c".to_string() => "c".to_string(),
             "SUM(table.b)".to_string() => "sum_b".to_string(),
             "COUNT(Int64(1))".to_string() => "count_1".to_string(),
         };
 
         // Test the function
-        let err =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
-                .unwrap_err();
+        let err = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
-            PlannerError::UnsupportedLogicalPlan { plan: _ }
+            PlannerError::UnsupportedAggregatePlan {
+                source: AggregatePlanError::AggregateExec {
+                    source: AggregateExecError::UnsupportedGroupByExpressionCount { count: 2 }
+                },
+                ..
+            }
         ));
 
         // Expected result
@@ -1049,9 +1142,15 @@ mod tests {
         };
 
         // Test the function
-        let result =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
-                .unwrap();
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        )
+        .unwrap();
 
         let dummy_ref_table = TableRef::from_names(None, "");
 
@@ -1157,9 +1256,15 @@ mod tests {
         };
 
         // Test the function
-        let result =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
-                .unwrap();
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        )
+        .unwrap();
 
         let dummy_ref_table = TableRef::from_names(None, "");
 
@@ -1237,16 +1342,165 @@ mod tests {
             .unwrap(),
         );
         let alias_map = indexmap! {
-            "a+b".to_string() => "res".to_string(),
+            group_expr[0].clone().unalias().display_name().unwrap() => "res".to_string(),
             "COUNT(Int64(1))".to_string() => "count_1".to_string(),
         };
 
         // Test the function - should return an error
-        let result =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(PlannerError::UnsupportedAggregatePlan {
+                    source: AggregatePlanError::UnexpectedAggregateExpression { .. },
+                    ..
+                })
+            ),
+            "{result:?}"
+        );
+    }
+
+    #[test]
+    fn we_report_unsupported_grouping_types() {
+        for data_type in [ColumnType::VarChar, ColumnType::VarBinary] {
+            let table_ref = TableRef::new("", "table");
+            let schemas = SchemaAccessorImpl::new(indexmap_with_default! {AHasher;
+                table_ref => vec![("value".into(), data_type)]
+            });
+            let source: Arc<dyn TableSource> =
+                Arc::new(PoSqlTableSource::new(vec![ColumnField::new(
+                    "value".into(),
+                    data_type,
+                )]));
+            let input_plan = LogicalPlan::TableScan(
+                TableScan::try_new("table", source, Some(vec![0]), vec![], None).unwrap(),
+            );
+            let group_expr = vec![df_column("table", "value")];
+            let alias_map = indexmap! {
+                "table.value".to_string() => "value".to_string(),
+            };
+
+            let err = aggregate_to_proof_plan(
+                &input_plan,
+                &group_expr,
+                &[],
+                &schemas,
+                &alias_map,
+                &input_plan,
+            )
+            .unwrap_err();
+
+            assert!(
+                matches!(
+                    err,
+                    PlannerError::UnsupportedAggregatePlan {
+                        source: AggregatePlanError::AggregateExec {
+                            source: AggregateExecError::UnsupportedGroupByExpressionType {
+                                data_type: actual_type
+                            }
+                        },
+                        ..
+                    } if actual_type == data_type
+                ),
+                "{err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn we_report_missing_group_expression_alias_with_complete_plan() {
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let group_expr = vec![df_column("table", "a")];
+        let aggr_expr = vec![COUNT_1()];
+        let aggregate_plan = LogicalPlan::Aggregate(
+            Aggregate::try_new(
+                Arc::new(input_plan.clone()),
+                group_expr.clone(),
+                aggr_expr.clone(),
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "COUNT(Int64(1))".to_string() => "count_1".to_string(),
+        };
+
+        let err = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &aggregate_plan,
+        )
+        .unwrap_err();
+
         assert!(matches!(
-            result,
-            Err(PlannerError::UnsupportedLogicalPlan { .. })
+            err,
+            PlannerError::UnsupportedAggregatePlan {
+                source: AggregatePlanError::MissingGroupExpressionAlias { expression },
+                plan,
+            } if expression == "table.a" && *plan == aggregate_plan
+        ));
+    }
+
+    #[test]
+    fn we_report_missing_aggregate_expression_alias_with_complete_plan() {
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let group_expr = vec![df_column("table", "a")];
+        let aggr_expr = vec![COUNT_1()];
+        let aggregate_plan = LogicalPlan::Aggregate(
+            Aggregate::try_new(
+                Arc::new(input_plan.clone()),
+                group_expr.clone(),
+                aggr_expr.clone(),
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "table.a".to_string() => "a".to_string(),
+        };
+
+        let err = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &aggregate_plan,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            PlannerError::UnsupportedAggregatePlan {
+                source: AggregatePlanError::MissingAggregateExpressionAlias { expression },
+                plan,
+            } if expression == "COUNT(Int64(1))" && *plan == aggregate_plan
         ));
     }
 
@@ -1286,16 +1540,29 @@ mod tests {
             .unwrap(),
         );
         let alias_map = indexmap! {
-            "b+c".to_string() => "b_plus_c".to_string(),
+            "table.a".to_string() => "a".to_string(),
+            aggr_expr[0].clone().unalias().display_name().unwrap() => "b_plus_c".to_string(),
         };
 
         // Test the function - should return an error
-        let result =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
-        assert!(matches!(
-            result,
-            Err(PlannerError::UnsupportedLogicalPlan { .. })
-        ));
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(PlannerError::UnsupportedAggregatePlan {
+                    source: AggregatePlanError::UnexpectedAggregateExpression { .. },
+                    ..
+                })
+            ),
+            "{result:?}"
+        );
     }
 
     #[test]
@@ -1338,22 +1605,31 @@ mod tests {
             .unwrap(),
         );
         let alias_map = indexmap! {
-            "a".to_string() => "a".to_string(),
+            "table.a".to_string() => "a".to_string(),
             "AVG(table.b)".to_string() => "avg_b".to_string(),
             "COUNT(Int64(1))".to_string() => "count_1".to_string(),
         };
 
         // Test the function - should return an error
-        let result =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
-        assert!(matches!(
-            result,
-            Err(PlannerError::UnsupportedLogicalPlan { .. })
-        ));
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(PlannerError::UnsupportedAggregateOperation { .. })
+            ),
+            "{result:?}"
+        );
     }
 
     #[test]
-    fn we_cannot_aggregate_with_non_count_last_aggregate() {
+    fn we_can_aggregate_without_count_expression() {
         // Setup group expression
         let group_expr = vec![df_column("table", "a")];
 
@@ -1369,7 +1645,7 @@ mod tests {
 
         let sum_expr2 = Expr::AggregateFunction(AggregateFunction {
             func_def: SUM,
-            args: vec![df_column("table", "c")],
+            args: vec![df_column("table", "a")],
             distinct: false,
             filter: None,
             order_by: None,
@@ -1386,14 +1662,11 @@ mod tests {
         let aliased_sum2 = Expr::Alias(Alias {
             expr: Box::new(sum_expr2),
             relation: None,
-            name: "sum_c".to_string(),
+            name: "sum_a".to_string(),
         });
 
-        // Create the aggregate expressions with no COUNT at the end
-        let aggr_expr = vec![
-            aliased_sum1, // SUM
-            aliased_sum2, // Another SUM (should be COUNT)
-        ];
+        // Create aggregate expressions without an explicit COUNT result.
+        let aggr_expr = vec![aliased_sum1, aliased_sum2];
 
         // Create the input plan
         let input_plan = LogicalPlan::TableScan(
@@ -1407,22 +1680,33 @@ mod tests {
             .unwrap(),
         );
         let alias_map = indexmap! {
-            "a".to_string() => "a".to_string(),
+            "table.a".to_string() => "a".to_string(),
             "SUM(table.b)".to_string() => "sum_b".to_string(),
-            "SUM(c)".to_string() => "sum_c".to_string(),
+            "SUM(table.a)".to_string() => "sum_a".to_string(),
         };
 
-        // Test the function - should return an error
-        let result =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
-        assert!(matches!(
-            result,
-            Err(PlannerError::UnsupportedLogicalPlan { .. })
-        ));
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        )
+        .unwrap();
+        assert!(matches!(&result, DynProofPlan::Projection(_)));
+        assert_eq!(
+            result.get_column_result_fields(),
+            vec![
+                ColumnField::new("a".into(), ColumnType::BigInt),
+                ColumnField::new("sum_b".into(), ColumnType::Int),
+                ColumnField::new("sum_a".into(), ColumnType::BigInt),
+            ]
+        );
     }
 
     #[test]
-    fn we_cannot_aggregate_with_fetch_limit() {
+    fn we_can_aggregate_with_fetch_limit() {
         // Setup group expression
         let group_expr = vec![df_column("table", "a")];
 
@@ -1443,17 +1727,27 @@ mod tests {
             .unwrap(),
         );
         let alias_map = indexmap! {
-            "a".to_string() => "a".to_string(),
+            "table.a".to_string() => "a".to_string(),
             "COUNT(Int64(1))".to_string() => "count_1".to_string(),
         };
 
-        // Test the function - should return an error because fetch limit is not supported
-        let result =
-            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
-        assert!(matches!(
-            result,
-            Err(PlannerError::UnsupportedLogicalPlan { .. })
-        ));
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &alias_map,
+            &input_plan,
+        )
+        .unwrap();
+        assert!(matches!(&result, DynProofPlan::Projection(_)));
+        assert_eq!(
+            result.get_column_result_fields(),
+            vec![
+                ColumnField::new("a".into(), ColumnType::BigInt),
+                ColumnField::new("count_1".into(), ColumnType::BigInt),
+            ]
+        );
     }
 
     // EmptyRelation
@@ -2188,14 +2482,16 @@ mod tests {
         let schemas = SCHEMAS();
         assert!(matches!(
             logical_plan_to_proof_plan(&plan, &schemas),
-            Err(PlannerError::UnsupportedLogicalPlan { .. })
+            Err(PlannerError::UnsupportedLogicalPlan {
+                node: LogicalPlanNodeKind::Prepare,
+                ..
+            })
         ));
     }
 
     #[test]
     fn we_can_error_if_not_inner_join() {
-        // Most of the arguments here are bogus. The only thing that really matters is the join type.
-        let plan = LogicalPlan::Prepare(Prepare {
+        let input_plan = LogicalPlan::Prepare(Prepare {
             name: "not_a_real_plan".to_string(),
             data_types: vec![],
             input: Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {
@@ -2203,25 +2499,83 @@ mod tests {
                 schema: Arc::new(DFSchema::empty()),
             })),
         });
+        let plan = LogicalPlan::Join(Join {
+            left: Arc::new(input_plan.clone()),
+            right: Arc::new(input_plan),
+            on: Vec::new(),
+            filter: None,
+            join_type: JoinType::Left,
+            join_constraint: JoinConstraint::On,
+            schema: Arc::new(DFSchema::empty()),
+            null_equals_null: false,
+        });
         let schemas = SCHEMAS();
-        let join_err = join_to_proof_plan(
-            &Join {
-                left: Arc::new(plan.clone()),
-                right: Arc::new(plan.clone()),
-                on: Vec::new(),
-                filter: None,
-                join_type: JoinType::Left,
-                join_constraint: JoinConstraint::On,
-                schema: Arc::new(DFSchema::empty()),
-                null_equals_null: false,
-            },
-            &schemas,
-            &plan,
-        )
-        .unwrap_err();
-        assert!(
-            matches!(join_err, PlannerError::UnsupportedLogicalPlan { plan: logical_plan } if *logical_plan == plan )
-        );
+        let join_err = logical_plan_to_proof_plan(&plan, &schemas).unwrap_err();
+        assert!(matches!(
+            join_err,
+            PlannerError::UnsupportedJoinPlan {
+                source: JoinPlanError::UnsupportedJoinType {
+                    join_type: JoinType::Left
+                },
+                plan: logical_plan,
+            } if *logical_plan == plan
+        ));
+    }
+
+    #[test]
+    fn we_report_unsupported_join_constraint() {
+        let input_plan = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(DFSchema::empty()),
+        });
+        let plan = LogicalPlan::Join(Join {
+            left: Arc::new(input_plan.clone()),
+            right: Arc::new(input_plan),
+            on: Vec::new(),
+            filter: None,
+            join_type: JoinType::Inner,
+            join_constraint: JoinConstraint::Using,
+            schema: Arc::new(DFSchema::empty()),
+            null_equals_null: false,
+        });
+        let join_err = logical_plan_to_proof_plan(&plan, &EMPTY_SCHEMAS()).unwrap_err();
+
+        assert!(matches!(
+            join_err,
+            PlannerError::UnsupportedJoinPlan {
+                source: JoinPlanError::UnsupportedJoinConstraint {
+                    constraint: JoinConstraint::Using
+                },
+                plan: logical_plan,
+            } if *logical_plan == plan
+        ));
+    }
+
+    #[test]
+    fn we_report_unsupported_join_predicate() {
+        let input_plan = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(DFSchema::empty()),
+        });
+        let plan = LogicalPlan::Join(Join {
+            left: Arc::new(input_plan.clone()),
+            right: Arc::new(input_plan),
+            on: vec![(df_column("left", "a"), df_column("right", "b"))],
+            filter: None,
+            join_type: JoinType::Inner,
+            join_constraint: JoinConstraint::On,
+            schema: Arc::new(DFSchema::empty()),
+            null_equals_null: false,
+        });
+        let join_err = logical_plan_to_proof_plan(&plan, &EMPTY_SCHEMAS()).unwrap_err();
+
+        assert!(matches!(
+            join_err,
+            PlannerError::UnsupportedJoinPlan {
+                source: JoinPlanError::UnsupportedPredicate { left, right },
+                plan: logical_plan,
+            } if left == "left.a" && right == "right.b" && *logical_plan == plan
+        ));
     }
 
     // Filter (LogicalPlan::Filter) tests - Happy paths

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -695,7 +695,7 @@ impl EVMAggregateExec {
             self.where_clause
                 .try_into_proof_expr(&input_result_column_refs)?,
         )
-        .ok_or(EVMProofPlanError::NotSupported)
+        .map_err(|_| EVMProofPlanError::NotSupported)
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec.rs
@@ -29,8 +29,27 @@ use bumpalo::Bump;
 use core::iter;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
+use snafu::Snafu;
 use sqlparser::ast::Ident;
 use tracing::{span, Level};
+
+/// Errors returned when an aggregate proof plan cannot be constructed.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Snafu)]
+pub enum AggregateExecError {
+    /// Grouping and deduplication support at most one expression.
+    #[snafu(display("grouping and deduplication support at most one expression, found {count}"))]
+    UnsupportedGroupByExpressionCount {
+        /// Number of grouping expressions found.
+        count: usize,
+    },
+    /// The grouping expression has a datatype for which uniqueness cannot be proven.
+    #[snafu(display("grouping and deduplication do not support expressions of type {data_type}"))]
+    UnsupportedGroupByExpressionType {
+        /// Unsupported grouping datatype.
+        data_type: ColumnType,
+    },
+}
 
 /// Provable expressions for queries of the form
 /// ```ignore
@@ -60,7 +79,7 @@ impl AggregateExec {
         count_alias: Ident,
         input: Box<DynProofPlan>,
         where_clause: DynProofExpr,
-    ) -> Option<Self> {
+    ) -> Result<Self, AggregateExecError> {
         let group_by = Self {
             group_by_exprs,
             sum_expr,
@@ -68,7 +87,8 @@ impl AggregateExec {
             input,
             where_clause,
         };
-        group_by.try_get_is_uniqueness_provable().map(|_| group_by)
+        group_by.try_get_is_uniqueness_provable()?;
+        Ok(group_by)
     }
 
     /// Get a reference to the input plan
@@ -98,20 +118,23 @@ impl AggregateExec {
 
     /// Checks if the group by expression can prove uniqueness
     /// This is true if there is only one group by column and its type is not `VarChar` and not `VarBinary`
-    pub fn try_get_is_uniqueness_provable(&self) -> Option<bool> {
+    pub fn try_get_is_uniqueness_provable(&self) -> Result<bool, AggregateExecError> {
         match (
             self.group_by_exprs.len(),
             self.group_by_exprs
                 .first()
                 .map(|aliased_expr| aliased_expr.expr.data_type()),
         ) {
-            (0, _) => Some(false),
+            (0, _) => Ok(false),
             (1, Some(data_type))
                 if !matches!(data_type, ColumnType::VarChar | ColumnType::VarBinary) =>
             {
-                Some(true)
+                Ok(true)
             }
-            _ => None,
+            (1, Some(data_type)) => {
+                Err(AggregateExecError::UnsupportedGroupByExpressionType { data_type })
+            }
+            (count, _) => Err(AggregateExecError::UnsupportedGroupByExpressionCount { count }),
         }
     }
 }
@@ -182,7 +205,7 @@ impl ProofPlan for AggregateExec {
             .0;
 
         match self.try_get_is_uniqueness_provable() {
-            Some(true) => {
+            Ok(true) => {
                 verify_monotonic::<S, true, true>(
                     builder,
                     alpha,
@@ -191,8 +214,8 @@ impl ProofPlan for AggregateExec {
                     output_chi_eval.0,
                 )?;
             }
-            Some(false) => (),
-            None => {
+            Ok(false) => (),
+            Err(_) => {
                 Err(ProofError::UnsupportedQueryPlan {
                 error: "AggregateExec with nonzero grouping columns and without provable uniqueness check not supported.",
             })?;

--- a/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/aggregate_exec_test.rs
@@ -11,7 +11,7 @@ use crate::{
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::test_utility::*,
-        proof_plans::AggregateExec,
+        proof_plans::{AggregateExec, AggregateExecError},
     },
 };
 use bumpalo::Bump;
@@ -257,7 +257,10 @@ fn we_cannot_prove_a_complex_aggregate_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    assert!(expr.is_none());
+    assert!(matches!(
+        expr,
+        Err(AggregateExecError::UnsupportedGroupByExpressionCount { count: 3 })
+    ));
     // let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     // exercise_verification(&res, &expr, &accessor, &t);
     // let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -133,14 +133,13 @@ impl DynProofPlan {
     }
 
     /// Creates a new aggregate plan.
-    #[must_use]
     pub fn try_new_aggregate(
         group_by_exprs: Vec<AliasedDynProofExpr>,
         sum_expr: Vec<AliasedDynProofExpr>,
         count_alias: Ident,
         input: DynProofPlan,
         where_clause: DynProofExpr,
-    ) -> Option<Self> {
+    ) -> Result<Self, super::AggregateExecError> {
         AggregateExec::try_new(
             group_by_exprs,
             sum_expr,

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -43,6 +43,7 @@ mod filter_exec_test;
 
 mod aggregate_exec;
 pub(crate) use aggregate_exec::AggregateExec;
+pub use aggregate_exec::AggregateExecError;
 
 #[cfg(all(test, feature = "blitzar"))]
 mod aggregate_exec_test;


### PR DESCRIPTION
# Rationale for this change

Planner failures often retained the offending logical plan but exposed only a generic “not supported” error. This change makes existing failure paths actionable and machine-readable without duplicating planner validation.

Aggregate construction now returns its authoritative failure reason, allowing the planner to report it directly.

# What changes are included in this PR?

- Return typed `AggregateExecError` construction failures.
- Add structured SNAFU sub-errors for aggregate and join conversion failures.
- Identify unsupported logical-plan node kinds.
- Improve human-readable diagnostics while retaining the complete offending plan.
- Mark public error taxonomies as non-exhaustive.
- Add unit and SQL-level diagnostic coverage.

## Breaking changes

- `DynProofPlan::try_new_aggregate` now returns `Result<_, AggregateExecError>` instead of `Option`.
- Internal aggregate construction and uniqueness checks also return typed `Result` values.
- `PlannerError` is now non-exhaustive and includes structured aggregate and join variants.
- `UnsupportedLogicalPlan` now includes a `node` field.

# Are these changes tested?

Yes. Unit and SQL-level tests cover the structured errors, displayed messages, offending plans, and supported and unsupported aggregate and join paths.