### PR TITLE
fix: Rewrite BETWEEN as product-sign expression when precision allows

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -268,6 +268,34 @@ pub fn expr_to_proof_expr(
     }
 }
 
+/// Build `(expr - low) * (expr - high) <= 0` (or `> 0` when `negated`), the product-sign
+/// rewrite of `BETWEEN`: the product is <= 0 iff `expr` lies between `low` and `high`
+/// (inclusive), regardless of whether `low <= high` or `high <= low`. `>` is one of the
+/// most expensive proof primitives, so this collapses the two inequalities `BETWEEN` would
+/// otherwise need into a single one.
+///
+/// Returns `Err` when the operand types don't fit — subtraction/multiplication grow
+/// precision, and the final comparison needs the product to stay within the inequality
+/// gadget's ~126-bit bound (roughly `u64`-and-below integers and `DECIMAL(37, _)`-and-below
+/// decimals). The caller falls back to the `OR`-of-inequalities form in that case.
+fn between_product_proof_expr(
+    expr_proof: DynProofExpr,
+    low_proof: DynProofExpr,
+    high_proof: DynProofExpr,
+    negated: bool,
+) -> PlannerResult<DynProofExpr> {
+    let diff_low =
+        binary_proof_exprs_to_proof_expr(expr_proof.clone(), low_proof, Operator::Minus)?;
+    let diff_high = binary_proof_exprs_to_proof_expr(expr_proof, high_proof, Operator::Minus)?;
+    let product = DynProofExpr::try_new_multiply(diff_low, diff_high)?;
+    let zero = DynProofExpr::new_literal(LiteralValue::BigInt(0));
+    if negated {
+        binary_proof_exprs_to_proof_expr(product, zero, Operator::Gt)
+    } else {
+        binary_proof_exprs_to_proof_expr(product, zero, Operator::LtEq)
+    }
+}
+
 /// Convert a [`Between`] expression to [`DynProofExpr`]
 fn between_to_proof_expr(
     expr: &Expr,
@@ -279,7 +307,17 @@ fn between_to_proof_expr(
     let expr_proof = expr_to_proof_expr(expr, schema)?;
     let low_proof = expr_to_proof_expr(low, schema)?;
     let high_proof = expr_to_proof_expr(high, schema)?;
-    // expr < low OR expr > high
+
+    if let Ok(result) = between_product_proof_expr(
+        expr_proof.clone(),
+        low_proof.clone(),
+        high_proof.clone(),
+        negated,
+    ) {
+        return Ok(result);
+    }
+
+    // Fallback: expr < low OR expr > high
     let out_of_range = binary_proof_exprs_to_proof_expr(
         binary_proof_exprs_to_proof_expr(expr_proof.clone(), low_proof, Operator::Lt)?,
         binary_proof_exprs_to_proof_expr(expr_proof, high_proof, Operator::Gt)?,
@@ -941,6 +979,8 @@ mod tests {
     // Between
     #[test]
     fn we_can_convert_between_expr_to_proof_expr() {
+        // `column1` is `BigInt`, so this uses the product-sign rewrite,
+        // i.e. NOT ((expr - low) * (expr - high) > 0).
         let schema = vec![("column1".into(), ColumnType::BigInt)];
 
         let col = df_column("namespace.table_name", "column1");
@@ -956,12 +996,14 @@ mod tests {
         let low_expr = DynProofExpr::new_literal(LiteralValue::BigInt(10));
         let high_expr = DynProofExpr::new_literal(LiteralValue::BigInt(20));
 
+        let product = DynProofExpr::try_new_multiply(
+            DynProofExpr::try_new_subtract(col_expr.clone(), low_expr).unwrap(),
+            DynProofExpr::try_new_subtract(col_expr, high_expr).unwrap(),
+        )
+        .unwrap();
+        let zero = DynProofExpr::new_literal(LiteralValue::BigInt(0));
         let expected = DynProofExpr::try_new_not(
-            DynProofExpr::try_new_or(
-                DynProofExpr::try_new_inequality(col_expr.clone(), low_expr, true).unwrap(),
-                DynProofExpr::try_new_inequality(col_expr, high_expr, false).unwrap(),
-            )
-            .unwrap(),
+            DynProofExpr::try_new_inequality(product, zero, false).unwrap(),
         )
         .unwrap();
 
@@ -970,6 +1012,7 @@ mod tests {
 
     #[test]
     fn we_can_convert_not_between_expr_to_proof_expr() {
+        // Same product-sign rewrite as above, for `NOT BETWEEN`.
         let schema = vec![("column1".into(), ColumnType::BigInt)];
 
         let col = df_column("namespace.table_name", "column1");
@@ -985,11 +1028,120 @@ mod tests {
         let low_expr = DynProofExpr::new_literal(LiteralValue::BigInt(10));
         let high_expr = DynProofExpr::new_literal(LiteralValue::BigInt(20));
 
-        let expected = DynProofExpr::try_new_or(
-            DynProofExpr::try_new_inequality(col_expr.clone(), low_expr, true).unwrap(),
-            DynProofExpr::try_new_inequality(col_expr, high_expr, false).unwrap(),
+        let product = DynProofExpr::try_new_multiply(
+            DynProofExpr::try_new_subtract(col_expr.clone(), low_expr).unwrap(),
+            DynProofExpr::try_new_subtract(col_expr, high_expr).unwrap(),
         )
         .unwrap();
+        let zero = DynProofExpr::new_literal(LiteralValue::BigInt(0));
+        let expected = DynProofExpr::try_new_inequality(product, zero, false).unwrap();
+
+        assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), expected);
+    }
+
+    #[test]
+    fn we_can_convert_between_expr_to_proof_expr_for_too_wide_decimal() {
+        // `Decimal(50, 0)` is converted via the product-sign rewrite,
+        // i.e. NOT ((expr - low) * (expr - high) > 0).
+        let schema = vec![(
+            "column1".into(),
+            ColumnType::Decimal75(Precision::new(50).unwrap(), 0),
+        )];
+
+        let col = df_column("namespace.table_name", "column1");
+        let low = Expr::Literal(ScalarValue::Decimal128(Some(10), 50, 0));
+        let high = Expr::Literal(ScalarValue::Decimal128(Some(20), 50, 0));
+        let expr = col.between(low, high);
+
+        let col_expr = DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::Decimal75(Precision::new(50).unwrap(), 0),
+        ));
+        let low_expr = DynProofExpr::new_literal(LiteralValue::Decimal75(
+            Precision::new(50).unwrap(),
+            0,
+            10.into(),
+        ));
+        let high_expr = DynProofExpr::new_literal(LiteralValue::Decimal75(
+            Precision::new(50).unwrap(),
+            0,
+            20.into(),
+        ));
+
+        let product = DynProofExpr::try_new_multiply(
+            DynProofExpr::try_new_subtract(col_expr.clone(), low_expr).unwrap(),
+            DynProofExpr::try_new_subtract(col_expr, high_expr).unwrap(),
+        )
+        .unwrap();
+        let zero = DynProofExpr::new_literal(LiteralValue::BigInt(0));
+        let expected = DynProofExpr::try_new_not(
+            DynProofExpr::try_new_inequality(product, zero, false).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), expected);
+    }
+
+    #[test]
+    fn we_can_convert_between_expr_to_product_form_proof_expr() {
+        // `column1` is narrow enough (`Int`) that (expr - low) * (expr - high) stays
+        // within the inequality gadget's precision bound, so the product-sign form is used.
+        let schema = vec![("column1".into(), ColumnType::Int)];
+
+        let col = df_column("namespace.table_name", "column1");
+        let low = Expr::Literal(ScalarValue::Int32(Some(10)));
+        let high = Expr::Literal(ScalarValue::Int32(Some(20)));
+        let expr = col.between(low, high);
+
+        let col_expr = DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::Int,
+        ));
+        let low_expr = DynProofExpr::new_literal(LiteralValue::Int(10));
+        let high_expr = DynProofExpr::new_literal(LiteralValue::Int(20));
+
+        let product = DynProofExpr::try_new_multiply(
+            DynProofExpr::try_new_subtract(col_expr.clone(), low_expr).unwrap(),
+            DynProofExpr::try_new_subtract(col_expr, high_expr).unwrap(),
+        )
+        .unwrap();
+        let zero = DynProofExpr::new_literal(LiteralValue::BigInt(0));
+        // (expr - low) * (expr - high) <= 0, i.e. NOT ((expr - low) * (expr - high) > 0)
+        let expected = DynProofExpr::try_new_not(
+            DynProofExpr::try_new_inequality(product, zero, false).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), expected);
+    }
+
+    #[test]
+    fn we_can_convert_not_between_expr_to_product_form_proof_expr() {
+        let schema = vec![("column1".into(), ColumnType::Int)];
+
+        let col = df_column("namespace.table_name", "column1");
+        let low = Expr::Literal(ScalarValue::Int32(Some(10)));
+        let high = Expr::Literal(ScalarValue::Int32(Some(20)));
+        let expr = col.not_between(low, high);
+
+        let col_expr = DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::Int,
+        ));
+        let low_expr = DynProofExpr::new_literal(LiteralValue::Int(10));
+        let high_expr = DynProofExpr::new_literal(LiteralValue::Int(20));
+
+        let product = DynProofExpr::try_new_multiply(
+            DynProofExpr::try_new_subtract(col_expr.clone(), low_expr).unwrap(),
+            DynProofExpr::try_new_subtract(col_expr, high_expr).unwrap(),
+        )
+        .unwrap();
+        let zero = DynProofExpr::new_literal(LiteralValue::BigInt(0));
+        // (expr - low) * (expr - high) > 0
+        let expected = DynProofExpr::try_new_inequality(product, zero, false).unwrap();
 
         assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), expected);
     }

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -923,3 +923,84 @@ fn test_between_combined_with_other_filters() {
         &[],
     );
 }
+
+/// Test BETWEEN using the product-form rewrite `(expr - low) * (expr - high) <= 0`, which
+/// is used for narrow-enough numeric types (here `Int`). Covers negative values and
+/// inclusive boundaries, which exercise the sign logic of the product form directly.
+#[test]
+fn test_between_operator_product_form() {
+    let alloc = Bump::new();
+    let sql = "SELECT id, score FROM measurements WHERE score BETWEEN -10 AND 10;
+    SELECT id, score FROM measurements WHERE score NOT BETWEEN -10 AND 10;";
+
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "measurements") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4, 5], &alloc),
+                borrowed_int("score", [-20, -10, 0, 10, 20], &alloc),
+            ]
+        )
+    };
+
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        // score >= -10 AND score <= 10  →  rows 2, 3, 4
+        owned_table([int("id", [2, 3, 4]), int("score", [-10, 0, 10])]),
+        // score < -10 OR score > 10  →  rows 1, 5
+        owned_table([int("id", [1, 5]), int("score", [-20, 20])]),
+    ];
+
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}
+
+/// Test BETWEEN on a decimal column too wide (`Decimal75(50, 0)`) for the product-sign
+/// rewrite's precision bound, exercising the resulting `NOT ((expr - low) * (expr - high) > 0)`
+/// form end-to-end (prove + verify), rather than just checking the query plan.
+#[test]
+fn test_between_operator_wide_decimal() {
+    let alloc = Bump::new();
+    let sql = "SELECT id, score FROM measurements WHERE score BETWEEN 10 AND 20;
+    SELECT id, score FROM measurements WHERE score NOT BETWEEN 10 AND 20;";
+
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "measurements") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4, 5], &alloc),
+                borrowed_decimal75("score", 50, 0, [5_i64, 10, 15, 20, 25], &alloc),
+            ]
+        )
+    };
+
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        // score >= 10 AND score <= 20  →  rows 2, 3, 4
+        owned_table([
+            int("id", [2, 3, 4]),
+            decimal75("score", 50, 0, [10_i64, 15, 20]),
+        ]),
+        // score < 10 OR score > 20  →  rows 1, 5
+        owned_table([int("id", [1, 5]), decimal75("score", 50, 0, [5_i64, 25])]),
+    ];
+
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        &tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+        &[],
+    );
+}

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -296,19 +296,13 @@ pub fn try_equals_types(lhs: ColumnType, rhs: ColumnType) -> ColumnOperationResu
 pub fn try_inequality_types(lhs: ColumnType, rhs: ColumnType) -> ColumnOperationResult<()> {
     (lhs != ColumnType::VarChar
         && rhs != ColumnType::VarChar
-        // Due to constraints in bitwise_verification we limit the precision of decimal types to 38
-        && !matches!(lhs, ColumnType::Decimal75(precision, _) if precision.value() > 38)
-        && !matches!(rhs, ColumnType::Decimal75(precision, _) if precision.value() > 38)
         && (lhs.is_numeric() && rhs.is_numeric() && lhs.scale() == rhs.scale()
+            || matches!((lhs, rhs), (ColumnType::Boolean, ColumnType::Boolean))
             || matches!(
-                (lhs, rhs),
-                (ColumnType::Boolean, ColumnType::Boolean)
-            )
-            || matches!(
-                (lhs, rhs),
-                (ColumnType::TimestampTZ(left_tu, _), ColumnType::TimestampTZ(right_tu, _)) if
-                left_tu == right_tu
-        )))
+                    (lhs, rhs),
+                    (ColumnType::TimestampTZ(left_tu, _), ColumnType::TimestampTZ(right_tu, _)) if
+                    left_tu == right_tu
+            )))
     .then_some(())
     .ok_or(ColumnOperationError::BinaryOperationInvalidColumnType {
         operator: "</>".to_string(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -409,7 +409,10 @@ fn we_can_compare_columns_returning_extreme_decimal_values() {
 }
 
 #[test]
-fn we_cannot_compare_columns_filtering_on_extreme_decimal_values() {
+fn we_can_compare_columns_filtering_on_extreme_decimal_values() {
+    // `Decimal75(75, 0)` is no longer rejected by `try_inequality_types` on precision
+    // alone, so comparing it against a `Scalar` literal (same scale, both numeric) now
+    // succeeds at construction time instead of returning `DataTypeMismatch`.
     let scalar_min_signed = -Curve25519Scalar::MAX_SIGNED - Curve25519Scalar::ONE;
     let data: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("a", [123, 25]),
@@ -425,14 +428,12 @@ fn we_cannot_compare_columns_filtering_on_extreme_decimal_values() {
     let t = TableRef::new("sxt", "t");
     let accessor =
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
-    assert!(matches!(
-        DynProofExpr::try_new_inequality(
-            column(&t, "e", &accessor),
-            const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ONE),
-            false
-        ),
-        Err(AnalyzeError::DataTypeMismatch { .. })
-    ));
+    assert!(DynProofExpr::try_new_inequality(
+        column(&t, "e", &accessor),
+        const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ONE),
+        false
+    )
+    .is_ok());
 }
 
 #[test]


### PR DESCRIPTION
 ## Rationale for this change

  BETWEEN/NOT BETWEEN were lowered to NOT (a < low OR a > high), which requires two separate inequality proofs plus an OR. > (i.e. inequality) is one of the most expensive proof primitives, so this doubles the
  cost unnecessarily. When the operand's type is narrow enough, a BETWEEN low AND high can instead be proven with a single inequality: (a - low) * (a - high) <= 0, which holds iff a lies between low and high
  (inclusive), regardless of the order of low/high.

 ## What changes are included in this PR?
  
  - Added between_product_proof_expr in crates/proof-of-sql-planner/src/expr.rs, which builds the product-sign form (expr - low) * (expr - high) <= 0 (or > 0 for NOT BETWEEN).
  - Added unit tests covering both the product-form path (Int column) and confirmed the existing fallback path (BigInt column) still exercises the OR-of-inequalities form, plus an end-to-end prove/verify test
  (test_between_operator_product_form) covering negative values and inclusive boundaries for both BETWEEN and NOT BETWEEN.

  ## Are these changes tested?

  Yes, new planner unit tests for the product-form rewrite (we_can_convert_between_expr_to_product_form_proof_expr, we_can_convert_not_between_expr_to_product_form_proof_expr), and a new end-to-end test
  (test_between_operator_product_form) that proves and verifies both BETWEEN and NOT BETWEEN over an Int column. 