### PR TITLE
refactor: make Scalar VarInt implementation blanket (#228, third item)

### DIFF
--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -1,8 +1,7 @@
 use crate::base::{
     encode::{ZigZag, U256},
-    scalar::MontScalar,
+    scalar::Scalar,
 };
-use ark_ff::MontConfig;
 use core::cmp::{max, Ordering};
 
 /// This function writes the input scalar x as a varint encoding to buf slice
@@ -14,7 +13,7 @@ use core::cmp::{max, Ordering};
 ///
 /// crash:
 /// - in case N is bigger than `buf.len()`
-pub fn write_scalar_varint<T: MontConfig<4>>(buf: &mut [u8], x: &MontScalar<T>) -> usize {
+pub fn write_scalar_varint<S: Scalar>(buf: &mut [u8], x: &S) -> usize {
     write_u256_varint(buf, x.zigzag())
 }
 
@@ -61,7 +60,7 @@ pub fn write_u256_varint(buf: &mut [u8], mut zig_x: U256) -> usize {
 ///  Since read-scalar stores the buf into a U256 type, which can only
 ///  hold up to 256 bit numbers, the non-continuation bits
 ///  257 up to 259 from buf are ignored.
-pub fn read_scalar_varint<T: MontConfig<4>>(buf: &[u8]) -> Option<(MontScalar<T>, usize)> {
+pub fn read_scalar_varint<S: Scalar>(buf: &[u8]) -> Option<(S, usize)> {
     read_u256_varint(buf).map(|(val, s)| (val.zigzag(), s))
 }
 pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
@@ -113,7 +112,7 @@ pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
 /// error:
 /// - in case buf has not enough space to hold all the scalars encoding.
 #[cfg(test)]
-pub fn write_scalar_varints<T: MontConfig<4>>(buf: &mut [u8], scals: &[MontScalar<T>]) -> usize {
+pub fn write_scalar_varints<S: Scalar>(buf: &mut [u8], scals: &[S]) -> usize {
     let mut total_bytes_written = 0;
 
     for scal in scals {
@@ -133,10 +132,7 @@ pub fn write_scalar_varints<T: MontConfig<4>>(buf: &mut [u8], scals: &[MontScala
 /// error:
 /// - in case it's not possible to read all specified scalars from `input_buf`
 #[cfg(test)]
-pub fn read_scalar_varints<T: MontConfig<4>>(
-    scals_buf: &mut [MontScalar<T>],
-    input_buf: &[u8],
-) -> Option<()> {
+pub fn read_scalar_varints<S: Scalar>(scals_buf: &mut [S], input_buf: &[u8]) -> Option<()> {
     let mut buf = input_buf;
 
     for scal_buf in scals_buf.iter_mut() {
@@ -153,7 +149,7 @@ pub fn read_scalar_varints<T: MontConfig<4>>(
 ///
 /// This function should be used to get an upper bound on the buffer size
 /// used by the `write_scalar_varint` function.
-pub fn scalar_varint_size<T: MontConfig<4>>(x: &MontScalar<T>) -> usize {
+pub fn scalar_varint_size<S: Scalar>(x: &S) -> usize {
     u256_varint_size(x.zigzag())
 }
 pub fn u256_varint_size(zig_x: U256) -> usize {
@@ -173,7 +169,7 @@ pub fn u256_varint_size(zig_x: U256) -> usize {
 /// This function should be used to get an upper bound on the buffer size
 /// used by the `write_scalar_varints` function.
 #[cfg(test)]
-pub fn scalar_varints_size<T: MontConfig<4>>(scals: &[MontScalar<T>]) -> usize {
+pub fn scalar_varints_size<S: Scalar>(scals: &[S]) -> usize {
     let mut all_size: usize = 0;
 
     for x in scals {

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -16,6 +16,26 @@ impl U256 {
     pub const fn from_words(low: u128, high: u128) -> Self {
         U256 { low, high }
     }
+
+    /// Creates a `U256` from little-endian 64-bit limbs.
+    #[inline]
+    pub const fn from_limbs(limbs: [u64; 4]) -> Self {
+        let low = limbs[0] as u128 | ((limbs[1] as u128) << 64);
+        let high = limbs[2] as u128 | ((limbs[3] as u128) << 64);
+        U256 { low, high }
+    }
+
+    /// Converts this `U256` into little-endian 64-bit limbs.
+    #[expect(clippy::cast_possible_truncation)]
+    #[inline]
+    pub const fn to_limbs(self) -> [u64; 4] {
+        [
+            self.low as u64,
+            (self.low >> 64) as u64,
+            self.high as u64,
+            (self.high >> 64) as u64,
+        ]
+    }
 }
 
 /// This trait converts a dalek scalar into a U256 integer

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -41,17 +41,13 @@ impl U256 {
 /// This trait converts a dalek scalar into a U256 integer
 impl<T: MontConfig<4>> From<&MontScalar<T>> for U256 {
     fn from(val: &MontScalar<T>) -> Self {
-        let buf: [u64; 4] = val.into();
-        let low: u128 = u128::from(buf[0]) | (u128::from(buf[1]) << 64);
-        let high: u128 = u128::from(buf[2]) | (u128::from(buf[3]) << 64);
-        U256::from_words(low, high)
+        U256::from_limbs(val.into())
     }
 }
 
 /// This trait converts a U256 integer into a dalek scalar
 impl<T: MontConfig<4>> From<&U256> for MontScalar<T> {
     fn from(val: &U256) -> Self {
-        let bytes = [val.low.to_le_bytes(), val.high.to_le_bytes()].concat();
-        MontScalar::<T>::from_le_bytes_mod_order(&bytes)
+        MontScalar::<T>::from(val.to_limbs())
     }
 }

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -16,10 +16,9 @@ use super::{
     },
     U256,
 };
-use crate::base::scalar::MontScalar;
+use crate::base::scalar::Scalar;
 #[cfg(test)]
 use alloc::{vec, vec::Vec};
-use ark_ff::MontConfig;
 
 /// Most-significant byte, == 0x80
 pub const MSB: u8 = 0b1000_0000;
@@ -282,7 +281,7 @@ impl VarInt for i128 {
     }
 }
 
-impl<T: MontConfig<4>> VarInt for MontScalar<T> {
+impl<S: Scalar> VarInt for S {
     fn required_space(self) -> usize {
         scalar_varint_size(&self)
     }

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -1,4 +1,4 @@
-use super::VarInt;
+use super::{VarInt, U256};
 use crate::base::scalar::{test_scalar::TestScalar, Scalar};
 use alloc::{vec, vec::Vec};
 use core::{
@@ -444,3 +444,38 @@ fn we_can_encode_and_decode_u64_and_u128_the_same() {
 // ----------------------
 // End VarInt trait tests
 // ----------------------
+
+// ---------------------------
+// Blanket impl + U256 helpers
+// ---------------------------
+
+/// Compile-time check that `Scalar` types get `VarInt` via the blanket impl.
+#[test]
+fn scalar_types_get_varint_via_blanket_impl() {
+    fn requires_varint<T: VarInt>() {}
+    requires_varint::<TestScalar>();
+}
+
+#[test]
+fn u256_limb_roundtrips_preserve_values() {
+    let limbs = [
+        0x0011_2233_4455_6677_u64,
+        0x8899_aabb_ccdd_eeff,
+        0x1020_3040_5060_7080,
+        0x90a0_b0c0_d0e0_f001,
+    ];
+    assert_eq!(U256::from_limbs(limbs).to_limbs(), limbs);
+
+    // roundtrip from words -> limbs -> words
+    let value = U256::from_words(
+        0x8899_aabb_ccdd_eeff_0011_2233_4455_6677,
+        0x90a0_b0c0_d0e0_f001_1020_3040_5060_7080,
+    );
+    assert_eq!(
+        U256::from_limbs(value.to_limbs()).to_limbs(),
+        value.to_limbs()
+    );
+
+    // zero roundtrips
+    assert_eq!(U256::from_limbs([0; 4]).to_limbs(), [0; 4]);
+}

--- a/crates/proof-of-sql/src/base/encode/zigzag.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag.rs
@@ -1,5 +1,4 @@
-use crate::base::{encode::U256, scalar::MontScalar};
-use ark_ff::MontConfig;
+use crate::base::{encode::U256, scalar::Scalar};
 
 /// A trait for enabling zig-zag encoding
 ///
@@ -24,12 +23,12 @@ pub trait ZigZag<T> {
 /// which represents a positive [`ZigZag`] encoding.
 /// Otherwise, we remap `y` to `2 * y + 1` u256 integer,
 /// which represents a negative [`ZigZag`] encoding (-y).
-impl<T: MontConfig<4>> ZigZag<U256> for MontScalar<T> {
+impl<S: Scalar> ZigZag<U256> for S {
     fn zigzag(&self) -> U256 {
         // since self is a dalek scalar, we never have the last bit 255 set
         // therefore, we should never expect overflow when multiplying by 2
-        let mut x: U256 = self.into();
-        let mut y: U256 = (&-self).into(); // x + y = 0 ==> y = -x
+        let mut x: U256 = U256::from_limbs(self.ref_into());
+        let mut y: U256 = U256::from_limbs((-*self).ref_into()); // x + y = 0 ==> y = -x
 
         // we return the smallest ZigZag number between x and y
         // in case x is bigger than y, we return -y (encoded in the ZigZag format)
@@ -74,8 +73,8 @@ impl<T: MontConfig<4>> ZigZag<U256> for MontScalar<T> {
 ///
 /// Finally, we return either `-1 * dalek::Scalar(y)` or `dalek::Scalar(x)`,
 /// which in both cases represents the `x` scalar.
-impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
-    fn zigzag(&self) -> MontScalar<T> {
+impl<S: Scalar> ZigZag<S> for U256 {
+    fn zigzag(&self) -> S {
         // we need to divide self by 2 to remove the ZigZag encoding
         let mut zig_val = U256 {
             low: (self.low >> 1) | ((self.high & 1) << 127),
@@ -98,11 +97,11 @@ impl<T: MontConfig<4>> ZigZag<MontScalar<T>> for U256 {
             // even though the encoding represented a -y,
             // zig_val actually represents a `y` (we simply divided self by 2).
             // Also, since x + y = 0, we need to compute -(zig_val.into()) to return x
-            let scal: MontScalar<T> = (&zig_val).into();
+            let scal: S = S::from(zig_val.to_limbs());
 
             -scal
         } else {
-            let scal: MontScalar<T> = (&zig_val).into();
+            let scal: S = S::from(zig_val.to_limbs());
 
             // return x
             scal

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
+use crate::base::{ref_into::RefInto, scalar::ScalarConversionError};
 use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
@@ -53,7 +53,6 @@ pub trait Scalar:
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
     + for<'a> core::convert::From<&'a String>
-    + VarInt
     + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>


### PR DESCRIPTION
/claim #228

## Summary

This PR implements the **third** checklist item of #228: removing the `VarInt` supertrait bound from `Scalar` and replacing the `MontScalar<T>`-specific `VarInt` implementation with a blanket `impl<S: Scalar> VarInt for S`.

Per the issue, the blanket implementation "relies on the limb conversions only" (`RefInto<[u64; 4]>` and `From<[u64; 4]>`). The `ZigZag` impls and scalar varint helpers are generalized from `MontScalar<T>` to `S: Scalar`, routing all conversions through the existing limb-based trait bounds.

This PR is intentionally scoped to the third checklist item only. It does **not** touch the limb-conversion bounds (first item) or the string-hash conversion (second item).

## Changes

- **`scalar.rs`**: Remove `+ VarInt` from the `Scalar` supertrait bounds and the unused `VarInt` import.
- **`varint_trait.rs`**: Replace `impl<T: MontConfig<4>> VarInt for MontScalar<T>` with a blanket `impl<S: Scalar> VarInt for S`.
- **`zigzag.rs`**: Generalize `ZigZag<U256> for MontScalar<T>` and `ZigZag<MontScalar<T>> for U256` to `ZigZag<U256> for S` and `ZigZag<S> for U256` where `S: Scalar`. Conversions now use `self.ref_into()` + `U256::from_limbs(...)` and `S::from(zig_val.to_limbs())`, relying on the existing limb-conversion bounds only.
- **`scalar_varint.rs`**: Generalize helper function signatures from `<T: MontConfig<4>>` / `MontScalar<T>` to `<S: Scalar>` / `S`.
- **`u256.rs`**: Add `U256::from_limbs([u64; 4])` and `U256::to_limbs() -> [u64; 4]` inherent methods to bridge between the limb representation and `U256` without relying on `MontScalar`-specific `From` impls.
- **`varint_trait_test.rs`**: Add a compile-time test verifying `TestScalar` receives `VarInt` via the blanket impl, and a roundtrip test for the new `U256` limb helpers.

## Semantic equivalence

The previous `ZigZag<S> for U256` impl used `From<&U256> for MontScalar<T>` (`from_le_bytes_mod_order`) to convert back to a scalar. The new impl uses `S::from(zig_val.to_limbs())` (`From<[u64; 4]>`, i.e. `Fp::new(BigInt(value))`). Both perform `value mod p` reduction and produce identical results. This is verified by the existing test `valid_varint_encoded_input_that_map_to_test_scalars_bigger_than_the_p_field_order_in_the_read_scalar_will_wrap_around_p` which constructs values larger than `p` and checks the wrapping behavior.

## Testing

- `cargo fmt --check` — clean
- `cargo check -p proof-of-sql --no-default-features` — passed
- `cargo check -p proof-of-sql --no-default-features --features="test"` — passed
- `cargo check -p proof-of-sql --no-default-features --features="arrow"` — passed
- `cargo test -p proof-of-sql --no-default-features --features="test" --lib base::encode` — 53 tests passed
- `cargo test -p proof-of-sql --no-default-features --features="test" --lib base::scalar` — 12 tests passed
- `cargo clippy` — no new warnings in modified files

## Notes

- The existing `From<&MontScalar<T>> for U256` and `From<&U256> for MontScalar<T>` impls in `u256.rs` are retained because they are still used by test code. They can be cleaned up in a follow-up PR once all three subtasks of #228 are addressed.
- This PR does not use `closes #228` since it only addresses the third of three checklist items.

Refs #228