### PR TITLE
feat: derive `Clone` on some error types

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -17,7 +17,7 @@ use bumpalo::Bump;
 use core::ops::Range;
 use snafu::Snafu;
 
-#[derive(Snafu, Debug, PartialEq)]
+#[derive(Snafu, Debug, PartialEq, Clone)]
 /// Errors caused by conversions between Arrow and owned types.
 pub enum ArrowArrayToColumnConversionError {
     /// This error occurs when an array contains a non-zero number of null elements

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use snafu::Snafu;
 
 /// Errors related to the processing of decimal values in proof-of-sql
-#[derive(Snafu, Debug, PartialEq)]
+#[derive(Snafu, Debug, PartialEq, Clone)]
 pub enum IntermediateDecimalError {
     /// Represents an error encountered during the parsing of a decimal string.
     #[snafu(display("{error}"))]
@@ -31,7 +31,7 @@ pub enum IntermediateDecimalError {
 impl Eq for IntermediateDecimalError {}
 
 /// Errors related to decimal operations.
-#[derive(Snafu, Debug, Eq, PartialEq)]
+#[derive(Snafu, Debug, Eq, PartialEq, Clone)]
 pub enum DecimalError {
     #[snafu(display("Invalid decimal format or value: {error}"))]
     /// Error when a decimal format or value is incorrect,

--- a/crates/proof-of-sql/src/base/posql_time/error.rs
+++ b/crates/proof-of-sql/src/base/posql_time/error.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 /// Errors related to time operations, including timezone and timestamp conversions.
-#[derive(Snafu, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Snafu, Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub enum PoSQLTimestampError {
     /// Error when the timezone string provided cannot be parsed into a valid timezone.
     #[snafu(display("invalid timezone string: {timezone}"))]

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -61,7 +61,7 @@ pub enum ProofSizeMismatch {
 }
 
 /// Errors related to placeholders
-#[derive(Snafu, Debug, PartialEq, Eq)]
+#[derive(Snafu, Debug, PartialEq, Eq, Clone)]
 pub enum PlaceholderError {
     #[snafu(display("Invalid placeholder index: {index}, number of params: {num_params}"))]
     /// Placeholder id is invalid


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

There is a need to be able to clone some of these types.

# What changes are included in this PR?

New implementations of Clone on some existing error types.

# Are these changes tested?
Not relevant
