### PR TITLE
feat: support `CASE WHEN` via a native CaseExpr proof primitive

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_select_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_select_operation.rs
@@ -1,0 +1,185 @@
+use super::{Column, ColumnType};
+use crate::base::scalar::Scalar;
+use alloc::vec::Vec;
+use bumpalo::Bump;
+
+/// View each source as a typed slice via `accessor`, then build a new slice of
+/// length `num_rows` that takes, for each row `r`, `sources[source_of_row(r)]`'s
+/// value at `r`.
+///
+/// `source_of_row` is evaluated lazily per row, so the caller need not materialize
+/// a per-row index column.
+///
+/// # Panics
+/// Panics if `accessor` returns `None` for any source (i.e. the sources are not all
+/// the same type) or if any `source_of_row(r)` is out of bounds.
+fn select<'a, S, T>(
+    alloc: &'a Bump,
+    sources: &[Column<'a, S>],
+    num_rows: usize,
+    source_of_row: impl Fn(usize) -> usize,
+    accessor: impl Fn(&Column<'a, S>) -> Option<&'a [T]>,
+) -> &'a [T]
+where
+    S: Scalar,
+    T: Copy,
+{
+    let typed: Vec<&'a [T]> = sources
+        .iter()
+        .map(|source| accessor(source).expect("sources must share a column type"))
+        .collect();
+    alloc.alloc_slice_fill_with(num_rows, |row_num| typed[source_of_row(row_num)][row_num])
+}
+
+/// Same as [`select`], for the `(values, scalars)` pair layout of `VarChar`/`VarBinary`.
+///
+/// # Panics
+/// Panics under the same conditions as [`select`].
+fn select_pair<'a, S, T>(
+    alloc: &'a Bump,
+    sources: &[Column<'a, S>],
+    num_rows: usize,
+    source_of_row: impl Fn(usize) -> usize,
+    accessor: impl Fn(&Column<'a, S>) -> Option<(&'a [T], &'a [S])>,
+) -> (&'a [T], &'a [S])
+where
+    S: Scalar,
+    T: Copy,
+{
+    let typed: Vec<(&'a [T], &'a [S])> = sources
+        .iter()
+        .map(|source| accessor(source).expect("sources must share a column type"))
+        .collect();
+    (
+        alloc.alloc_slice_fill_with(num_rows, |row_num| typed[source_of_row(row_num)].0[row_num]),
+        alloc.alloc_slice_fill_with(num_rows, |row_num| typed[source_of_row(row_num)].1[row_num]),
+    )
+}
+
+/// Build a column by taking, for each row `r`, the value at row `r` of
+/// `sources[row_source[r]]`.
+///
+/// This is the row-wise selection underlying `CASE` (and any other conditional
+/// pick): `source_of_row(r)` names which source column supplies row `r`. It is
+/// evaluated lazily per row, so no per-row index column is materialized.
+///
+/// All sources must share the column type, and the result has that type. Because
+/// the prover copies real values, every column type is supported, including
+/// `VarChar`/`VarBinary`.
+///
+/// # Panics
+/// Panics if the sources are not all of the same type, if `sources` is empty, or
+/// if any `source_of_row(r)` is out of bounds. Callers are expected to guarantee
+/// these (e.g. a `CaseExpr` validated at construction).
+pub(crate) fn select_column<'a, S: Scalar>(
+    alloc: &'a Bump,
+    sources: &[Column<'a, S>],
+    num_rows: usize,
+    source_of_row: impl Fn(usize) -> usize,
+) -> Column<'a, S> {
+    let column_type = sources
+        .first()
+        .expect("select_column requires at least one source")
+        .column_type();
+    let pick = &source_of_row;
+
+    match column_type {
+        ColumnType::Boolean => {
+            Column::Boolean(select(alloc, sources, num_rows, pick, Column::as_boolean))
+        }
+        ColumnType::Uint8 => {
+            Column::Uint8(select(alloc, sources, num_rows, pick, Column::as_uint8))
+        }
+        ColumnType::TinyInt => {
+            Column::TinyInt(select(alloc, sources, num_rows, pick, Column::as_tinyint))
+        }
+        ColumnType::SmallInt => {
+            Column::SmallInt(select(alloc, sources, num_rows, pick, Column::as_smallint))
+        }
+        ColumnType::Int => Column::Int(select(alloc, sources, num_rows, pick, Column::as_int)),
+        ColumnType::BigInt => {
+            Column::BigInt(select(alloc, sources, num_rows, pick, Column::as_bigint))
+        }
+        ColumnType::Int128 => {
+            Column::Int128(select(alloc, sources, num_rows, pick, Column::as_int128))
+        }
+        ColumnType::Scalar => {
+            Column::Scalar(select(alloc, sources, num_rows, pick, Column::as_scalar))
+        }
+        ColumnType::Decimal75(precision, scale) => Column::Decimal75(
+            precision,
+            scale,
+            select(alloc, sources, num_rows, pick, Column::as_decimal75),
+        ),
+        ColumnType::TimestampTZ(tu, tz) => Column::TimestampTZ(
+            tu,
+            tz,
+            select(alloc, sources, num_rows, pick, Column::as_timestamptz),
+        ),
+        ColumnType::VarChar => Column::VarChar(select_pair(
+            alloc,
+            sources,
+            num_rows,
+            pick,
+            Column::as_varchar,
+        )),
+        ColumnType::VarBinary => Column::VarBinary(select_pair(
+            alloc,
+            sources,
+            num_rows,
+            pick,
+            Column::as_varbinary,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+
+    #[test]
+    fn we_can_select_from_int_sources() {
+        let bump = Bump::new();
+        let a: Column<TestScalar> = Column::Int(&[10, 11, 12, 13]);
+        let b: Column<TestScalar> = Column::Int(&[20, 21, 22, 23]);
+        // pick a, b, b, a
+        let picks = [0, 1, 1, 0];
+        let result = select_column(&bump, &[a, b], picks.len(), |r| picks[r]);
+        assert_eq!(result, Column::Int(&[10, 21, 22, 13]));
+    }
+
+    #[test]
+    fn we_can_select_from_varchar_sources() {
+        let bump = Bump::new();
+        let a_vals = ["x", "y", "z"];
+        let b_vals = ["p", "q", "r"];
+        let a_scalars = a_vals.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let b_scalars = b_vals.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let a: Column<TestScalar> = Column::VarChar((&a_vals, &a_scalars));
+        let b: Column<TestScalar> = Column::VarChar((&b_vals, &b_scalars));
+        // pick b, a, b
+        let picks = [1, 0, 1];
+        let result = select_column(&bump, &[a, b], picks.len(), |r| picks[r]);
+        let expected_vals = ["p", "y", "r"];
+        let expected_scalars = expected_vals
+            .iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        assert_eq!(result, Column::VarChar((&expected_vals, &expected_scalars)));
+    }
+
+    #[test]
+    fn we_can_select_preserving_decimal_precision_and_scale() {
+        let bump = Bump::new();
+        let precision = crate::base::math::decimal::Precision::new(10).unwrap();
+        let a_vals = [TestScalar::from(1), TestScalar::from(2)];
+        let b_vals = [TestScalar::from(3), TestScalar::from(4)];
+        let a = Column::Decimal75(precision, 2, &a_vals);
+        let b = Column::Decimal75(precision, 2, &b_vals);
+        let picks = [1, 0];
+        let result = select_column(&bump, &[a, b], picks.len(), |r| picks[r]);
+        let expected = [TestScalar::from(3), TestScalar::from(2)];
+        assert_eq!(result, Column::Decimal75(precision, 2, &expected));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -44,6 +44,9 @@ pub(super) use column_comparison_operation::{ComparisonOp, EqualOp, GreaterThanO
 mod column_index_operation;
 pub(super) use column_index_operation::apply_column_to_indexes;
 
+mod column_select_operation;
+pub(crate) use column_select_operation::select_column;
+
 mod column_repetition_operation;
 pub(super) use column_repetition_operation::{ColumnRepeatOp, ElementwiseRepeatOp, RepetitionOp};
 

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -78,6 +78,9 @@ impl EVMDynProofExpr {
             DynProofExpr::Placeholder(placeholder_expr) => Ok(Self::Placeholder(
                 EVMPlaceholderExpr::from_proof_expr(placeholder_expr),
             )),
+            // The Solidity verifier does not support CASE yet; reject at
+            // serialization time rather than producing an unverifiable plan.
+            DynProofExpr::Case(_) => Err(EVMProofPlanError::NotSupported),
         }
     }
 
@@ -1650,5 +1653,15 @@ mod tests {
         assert_eq!(evm_literal_exprs_bytes, literal_values_bytes);
         assert_eq!(evm_literal_exprs_bytes,
             "000000000000000a000000000100000002020000000300030000000400000004000000050000000000000005000000070000000000000001360000000a0000000000000000000000000000000000000000000000000000000000000007000000080a0000000000000000000000000000000000000000000000000000000000000000080000000b000000000000000109000000090000000100000000000000000000000a".to_string());
+    }
+
+    // CaseExpr is not yet supported by the EVM verifier.
+    #[test]
+    fn we_cannot_put_a_case_expr_in_evm() {
+        let case_expr = case_when(vec![(const_bool(true), const_bigint(1))], const_bigint(0));
+        assert_eq!(
+            EVMDynProofExpr::try_from_proof_expr(&case_expr, &indexset! {}),
+            Err(EVMProofPlanError::NotSupported)
+        );
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/case_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/case_expr.rs
@@ -1,0 +1,297 @@
+use super::{DynProofExpr, ProofExpr};
+use crate::{
+    base::{
+        database::{select_column, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        map::{IndexMap, IndexSet},
+        proof::{PlaceholderResult, ProofError},
+        scalar::Scalar,
+    },
+    sql::{
+        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        AnalyzeError, AnalyzeResult,
+    },
+    utils::log,
+};
+use alloc::{boxed::Box, string::ToString, vec, vec::Vec};
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
+
+/// Provable `CASE WHEN c_1 THEN v_1 ... WHEN c_n THEN v_n ELSE v_else END` expression
+/// with first-match-wins semantics.
+///
+/// For each arm we build a "guard" `g_i` that is 1 exactly on the rows where arm `i`
+/// is the first true condition - its condition AND-ed with "no earlier arm won":
+///
+/// ```text
+/// g_i = c_i AND NOT (g_1 OR ... OR g_{i-1})   which, since the guards are exclusive,
+///     = c_i * (1 - g_1 - ... - g_{i-1})
+/// ```
+///
+/// Exactly one guard is 1 per row (or none, meaning the else branch), so the result
+/// is a plain selection:
+///
+/// ```text
+/// r = g_1*v_1 + ... + g_n*v_n + (1 - g_1 - ... - g_n)*v_else
+/// ```
+///
+/// The prover commits the guards and the result, and proves the two equations above.
+/// A CASE with no WHEN arms is allowed and simply evaluates to the else branch.
+///
+/// Since `r` is always one branch's value, it keeps the branch type - no widening,
+/// no overflow - and any type works, varchar included, because the prover picks
+/// real values instead of doing arithmetic on them. Guards are just 0/1 columns and
+/// cheap to commit, so only the single result is a full data column, however many
+/// arms there are.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CaseExpr {
+    when_thens: Vec<(DynProofExpr, DynProofExpr)>,
+    else_expr: Box<DynProofExpr>,
+}
+
+/// The source index selected for `row`: the first arm whose condition is true, or
+/// `else_source` if none match. Computed lazily per row so no per-row index column
+/// is materialized.
+fn winning_source(conditions: &[&[bool]], else_source: usize, row: usize) -> usize {
+    conditions
+        .iter()
+        .position(|condition| condition[row])
+        .unwrap_or(else_source)
+}
+
+impl CaseExpr {
+    /// Create a CASE expression.
+    ///
+    /// Every condition must be boolean and every branch value (including ELSE) must
+    /// have exactly the same type. The WHEN arms may be empty, in which case the
+    /// expression evaluates to the else branch (whether to allow that is the
+    /// planner's choice, not the plan's).
+    pub fn try_new(
+        when_thens: Vec<(DynProofExpr, DynProofExpr)>,
+        else_expr: Box<DynProofExpr>,
+    ) -> AnalyzeResult<Self> {
+        let result_type = else_expr.data_type();
+        for (condition, value) in &when_thens {
+            if condition.data_type() != ColumnType::Boolean {
+                return Err(AnalyzeError::DataTypeMismatch {
+                    left_type: condition.data_type().to_string(),
+                    right_type: ColumnType::Boolean.to_string(),
+                });
+            }
+            if value.data_type() != result_type {
+                return Err(AnalyzeError::DataTypeMismatch {
+                    left_type: value.data_type().to_string(),
+                    right_type: result_type.to_string(),
+                });
+            }
+        }
+        Ok(Self {
+            when_thens,
+            else_expr,
+        })
+    }
+}
+
+impl ProofExpr for CaseExpr {
+    fn data_type(&self) -> ColumnType {
+        self.else_expr.data_type()
+    }
+
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        // Evaluate conditions and their values together to keep the builder
+        // operation order consistent with the verifier.
+        let (conditions, mut sources): (Vec<&[bool]>, Vec<Column<'a, S>>) = self
+            .when_thens
+            .iter()
+            .map(|(condition, value)| -> PlaceholderResult<_> {
+                Ok((
+                    condition
+                        .first_round_evaluate(alloc, table, params)?
+                        .as_boolean()
+                        .expect("condition is not boolean"),
+                    value.first_round_evaluate(alloc, table, params)?,
+                ))
+            })
+            .collect::<PlaceholderResult<Vec<_>>>()?
+            .into_iter()
+            .unzip();
+        // The else branch is the last source.
+        sources.push(self.else_expr.first_round_evaluate(alloc, table, params)?);
+        let else_source = self.when_thens.len();
+        Ok(select_column(alloc, &sources, table.num_rows(), |row| {
+            winning_source(&conditions, else_source, row)
+        }))
+    }
+
+    #[tracing::instrument(name = "CaseExpr::final_round_evaluate", level = "info", skip_all)]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        log::log_memory_usage("Start");
+
+        // Evaluate conditions and their values together to keep the builder
+        // operation order consistent with the verifier.
+        let (condition_columns, mut sources): (Vec<Column<'a, S>>, Vec<Column<'a, S>>) = self
+            .when_thens
+            .iter()
+            .map(|(condition, value)| -> PlaceholderResult<_> {
+                Ok((
+                    condition.final_round_evaluate(builder, alloc, table, params)?,
+                    value.final_round_evaluate(builder, alloc, table, params)?,
+                ))
+            })
+            .collect::<PlaceholderResult<Vec<_>>>()?
+            .into_iter()
+            .unzip();
+        // The else branch is the last source.
+        sources.push(
+            self.else_expr
+                .final_round_evaluate(builder, alloc, table, params)?,
+        );
+
+        let conditions: Vec<&[bool]> = condition_columns
+            .iter()
+            .map(|column| column.as_boolean().expect("condition is not boolean"))
+            .collect();
+        let num_rows = table.num_rows();
+        let else_source = self.when_thens.len();
+
+        // Guards. Each is committed and pinned by g_i = c_i * (1 - g_0 - ... - g_{i-1}),
+        // which expands to g_i - c_i + c_i*g_0 + ... + c_i*g_{i-1} = 0.
+        //
+        // This produces O(arms^2) sumcheck terms (each guard references all earlier
+        // ones), which is fine for the small arm counts CASE has in practice. A
+        // prefix-product form (g_i = g_{i-1} * (1 - c_i)) would be O(arms).
+        let mut guards: Vec<&'a [bool]> = Vec::with_capacity(condition_columns.len());
+        for (arm, condition_column) in condition_columns.iter().enumerate() {
+            let guard = alloc.alloc_slice_fill_with(num_rows, |row| {
+                winning_source(&conditions, else_source, row) == arm
+            }) as &[_];
+            builder.produce_intermediate_mle(guard);
+            let mut terms: Vec<(S, Vec<Box<_>>)> = vec![
+                (S::one(), vec![Box::new(guard) as Box<_>]),
+                (-S::one(), vec![Box::new(*condition_column) as Box<_>]),
+            ];
+            for prior in &guards {
+                terms.push((
+                    S::one(),
+                    vec![
+                        Box::new(*condition_column) as Box<_>,
+                        Box::new(*prior) as Box<_>,
+                    ],
+                ));
+            }
+            builder.produce_sumcheck_subpolynomial(SumcheckSubpolynomialType::Identity, terms);
+            guards.push(guard);
+        }
+
+        // Result, pinned by r = sum g_i*v_i + (1 - sum g_i)*v_else, which expands
+        // to r - v_else - sum(g_i*v_i) + sum(g_i*v_else) = 0.
+        let result = select_column(alloc, &sources, num_rows, |row| {
+            winning_source(&conditions, else_source, row)
+        });
+        let (else_column, value_columns) = sources
+            .split_last()
+            .expect("sources always has the else column");
+        builder.produce_intermediate_mle(result);
+        let mut terms: Vec<(S, Vec<Box<_>>)> = vec![
+            (S::one(), vec![Box::new(result) as Box<_>]),
+            (-S::one(), vec![Box::new(*else_column) as Box<_>]),
+        ];
+        for (guard, value_column) in guards.iter().zip(value_columns) {
+            terms.push((
+                -S::one(),
+                vec![
+                    Box::new(*guard) as Box<_>,
+                    Box::new(*value_column) as Box<_>,
+                ],
+            ));
+            terms.push((
+                S::one(),
+                vec![Box::new(*guard) as Box<_>, Box::new(*else_column) as Box<_>],
+            ));
+        }
+        builder.produce_sumcheck_subpolynomial(SumcheckSubpolynomialType::Identity, terms);
+
+        log::log_memory_usage("End");
+
+        Ok(result)
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<Ident, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<S, ProofError> {
+        // Evaluate conditions and their values together to mirror the prover's order.
+        let (condition_evals, value_evals): (Vec<S>, Vec<S>) = self
+            .when_thens
+            .iter()
+            .map(|(condition, value)| -> Result<_, ProofError> {
+                Ok((
+                    condition.verifier_evaluate(builder, accessor, chi_eval, params)?,
+                    value.verifier_evaluate(builder, accessor, chi_eval, params)?,
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .unzip();
+        let else_eval = self
+            .else_expr
+            .verifier_evaluate(builder, accessor, chi_eval, params)?;
+
+        // Mirror the prover's guard identities: each guard is read from the proof and
+        // checked against g_i - c_i + c_i*(sum earlier) = 0. The bare -c_i term needs
+        // no chi factor: every column is already 0 outside the table rows. `guard_sum`
+        // accumulates g_0 + ... + g_{i-1} as we go.
+        let mut guard_evals = Vec::with_capacity(condition_evals.len());
+        let mut guard_sum = S::ZERO;
+        for condition_eval in &condition_evals {
+            let guard_eval = builder.try_consume_final_round_mle_evaluation()?;
+            builder.try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                guard_eval - *condition_eval + *condition_eval * guard_sum,
+                2,
+            )?;
+            guard_evals.push(guard_eval);
+            guard_sum += guard_eval;
+        }
+
+        // Mirror the result identity: r - v_else - sum(g_i*v_i) + (sum g_i)*v_else = 0.
+        // With guards this is degree 2 (the g_i*v_i products); with no arms it is just
+        // r - v_else, which is degree 1.
+        let result_eval = builder.try_consume_final_round_mle_evaluation()?;
+        let selected_sum: S = guard_evals
+            .iter()
+            .zip(&value_evals)
+            .map(|(guard, value)| *guard * *value)
+            .sum();
+        let result_degree = if guard_evals.is_empty() { 1 } else { 2 };
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            result_eval - selected_sum - else_eval + guard_sum * else_eval,
+            result_degree,
+        )?;
+
+        Ok(result_eval)
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        for (condition, value) in &self.when_thens {
+            condition.get_column_references(columns);
+            value.get_column_references(columns);
+        }
+        self.else_expr.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/case_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/case_expr_test.rs
@@ -1,0 +1,225 @@
+use crate::{
+    base::{
+        commitment::InnerProductProof,
+        database::{
+            owned_table_utility::*, ColumnType, OwnedTableTestAccessor, SchemaAccessor, TableRef,
+        },
+    },
+    sql::{
+        proof::{exercise_verification, VerifiableQueryResult},
+        proof_exprs::{test_utility::*, DynProofExpr, ProofExpr},
+        proof_plans::test_utility::*,
+        AnalyzeError,
+    },
+};
+
+/// A small typed accessor shared by the `try_new` validation tests.
+fn schema_accessor() -> impl SchemaAccessor {
+    let data = owned_table([
+        boolean("flag", [true, false]),
+        bigint("a", [1_i64, 2]),
+        bigint("b", [3_i64, 4]),
+        varchar("name", ["x", "y"]),
+    ]);
+    OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        TableRef::new("sxt", "t"),
+        data,
+        0,
+        (),
+    )
+}
+
+/// `try_new` accepts a well-formed CASE and reports its result type as the branch type.
+#[test]
+fn we_can_construct_a_valid_case_expr() {
+    let t = TableRef::new("sxt", "t");
+    let accessor = schema_accessor();
+    let expr = case_when(
+        vec![(column(&t, "flag", &accessor), column(&t, "a", &accessor))],
+        column(&t, "b", &accessor),
+    );
+    assert_eq!(expr.data_type(), ColumnType::BigInt);
+}
+
+#[test]
+fn we_cannot_construct_a_case_expr_with_non_boolean_condition() {
+    let t = TableRef::new("sxt", "t");
+    let accessor = schema_accessor();
+    // condition is a BigInt column, not boolean
+    let result = DynProofExpr::try_new_case(
+        vec![(column(&t, "a", &accessor), column(&t, "a", &accessor))],
+        column(&t, "b", &accessor),
+    );
+    assert!(matches!(result, Err(AnalyzeError::DataTypeMismatch { .. })));
+}
+
+#[test]
+fn we_cannot_construct_a_case_expr_with_mismatched_branch_types() {
+    let t = TableRef::new("sxt", "t");
+    let accessor = schema_accessor();
+    // then is BigInt, else is VarChar
+    let result = DynProofExpr::try_new_case(
+        vec![(column(&t, "flag", &accessor), column(&t, "a", &accessor))],
+        column(&t, "name", &accessor),
+    );
+    assert!(matches!(result, Err(AnalyzeError::DataTypeMismatch { .. })));
+}
+
+#[test]
+fn we_can_construct_a_case_expr_with_no_arms() {
+    // A CASE with no WHEN arms is valid and evaluates to the else branch; forbidding
+    // it (if desired) is the planner's job, not the plan's.
+    let t = TableRef::new("sxt", "t");
+    let accessor = schema_accessor();
+    let expr = DynProofExpr::try_new_case(vec![], column(&t, "a", &accessor)).unwrap();
+    assert_eq!(expr.data_type(), ColumnType::BigInt);
+}
+
+/// A single-arm numeric CASE proves and verifies, and `exercise_verification`
+/// confirms tampering with the result or the proof is rejected.
+#[test]
+fn we_can_prove_a_single_arm_case() {
+    let data = owned_table([
+        boolean("flag", [true, false, true, false]),
+        bigint("a", [10_i64, 20, 30, 40]),
+        bigint("b", [-1_i64, -2, -3, -4]),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = projection(
+        vec![aliased_plan(
+            case_when(
+                vec![(column(&t, "flag", &accessor), column(&t, "a", &accessor))],
+                column(&t, "b", &accessor),
+            ),
+            "res",
+        )],
+        table_exec(
+            t.clone(),
+            vec![
+                column_field("flag", ColumnType::Boolean),
+                column_field("a", ColumnType::BigInt),
+                column_field("b", ColumnType::BigInt),
+            ],
+        ),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
+    // flag picks a where true, else b
+    assert_eq!(res, owned_table([bigint("res", [10_i64, -2, 30, -4])]));
+}
+
+/// A multi-arm CASE exercises the exclusive-guard commitments and first-match-wins.
+#[test]
+fn we_can_prove_a_multi_arm_case_with_first_match_wins() {
+    let data = owned_table([
+        boolean("c1", [true, false, true, false]),
+        boolean("c2", [false, true, true, false]),
+        bigint("a", [1_i64, 2, 3, 4]),
+        bigint("b", [10_i64, 20, 30, 40]),
+        bigint("z", [100_i64, 200, 300, 400]),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    // CASE WHEN c1 THEN a WHEN c2 THEN b ELSE z END
+    let ast = projection(
+        vec![aliased_plan(
+            case_when(
+                vec![
+                    (column(&t, "c1", &accessor), column(&t, "a", &accessor)),
+                    (column(&t, "c2", &accessor), column(&t, "b", &accessor)),
+                ],
+                column(&t, "z", &accessor),
+            ),
+            "res",
+        )],
+        table_exec(
+            t.clone(),
+            vec![
+                column_field("c1", ColumnType::Boolean),
+                column_field("c2", ColumnType::Boolean),
+                column_field("a", ColumnType::BigInt),
+                column_field("b", ColumnType::BigInt),
+                column_field("z", ColumnType::BigInt),
+            ],
+        ),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
+    // row 0: c1 -> a=1; row 1: c2 -> b=20; row 2: both true, first wins -> a=3;
+    // row 3: neither -> z=400
+    assert_eq!(res, owned_table([bigint("res", [1_i64, 20, 3, 400])]));
+}
+
+/// Varchar branches prove and verify: the prover selects real strings.
+#[test]
+fn we_can_prove_a_varchar_case() {
+    let data = owned_table([
+        boolean("flag", [true, false, true]),
+        varchar("a", ["gold", "gold", "gold"]),
+        varchar("b", ["silver", "silver", "silver"]),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = projection(
+        vec![aliased_plan(
+            case_when(
+                vec![(column(&t, "flag", &accessor), column(&t, "a", &accessor))],
+                column(&t, "b", &accessor),
+            ),
+            "res",
+        )],
+        table_exec(
+            t.clone(),
+            vec![
+                column_field("flag", ColumnType::Boolean),
+                column_field("a", ColumnType::VarChar),
+                column_field("b", ColumnType::VarChar),
+            ],
+        ),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
+    assert_eq!(
+        res,
+        owned_table([varchar("res", ["gold", "silver", "gold"])])
+    );
+}
+
+/// A CASE with no WHEN arms proves and verifies, and evaluates to the else branch.
+#[test]
+fn we_can_prove_a_case_with_no_arms() {
+    let data = owned_table([bigint("a", [10_i64, 20, 30])]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = projection(
+        vec![aliased_plan(
+            case_when(vec![], column(&t, "a", &accessor)),
+            "res",
+        )],
+        table_exec(t.clone(), vec![column_field("a", ColumnType::BigInt)]),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
+    assert_eq!(res, owned_table([bigint("res", [10_i64, 20, 30])]));
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -1,6 +1,6 @@
 use super::{
-    AddExpr, AndExpr, CastExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr, MultiplyExpr,
-    NotExpr, OrExpr, PlaceholderExpr, ProofExpr, ScalingCastExpr, SubtractExpr,
+    AddExpr, AndExpr, CaseExpr, CastExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr,
+    MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ProofExpr, ScalingCastExpr, SubtractExpr,
 };
 use crate::{
     base::{
@@ -14,7 +14,7 @@ use crate::{
         AnalyzeResult,
     },
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use bumpalo::Bump;
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
@@ -50,6 +50,8 @@ pub enum DynProofExpr {
     Cast(CastExpr),
     /// Provable expression for casting numeric expressions to decimal expressions
     ScalingCast(ScalingCastExpr),
+    /// Provable CASE WHEN expression with first-match-wins semantics
+    Case(CaseExpr),
 }
 impl DynProofExpr {
     /// Create column expression
@@ -120,5 +122,14 @@ impl DynProofExpr {
         to_datatype: ColumnType,
     ) -> AnalyzeResult<Self> {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
+    }
+
+    /// Create a new CASE WHEN expression
+    /// (`CASE WHEN c_1 THEN v_1 ... ELSE v_else END`, first match wins)
+    pub fn try_new_case(
+        when_thens: Vec<(DynProofExpr, DynProofExpr)>,
+        else_expr: DynProofExpr,
+    ) -> AnalyzeResult<Self> {
+        CaseExpr::try_new(when_thens, Box::new(else_expr)).map(DynProofExpr::Case)
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -23,6 +23,11 @@ mod multiply_expr_test;
 mod dyn_proof_expr;
 pub use dyn_proof_expr::DynProofExpr;
 
+mod case_expr;
+pub(crate) use case_expr::CaseExpr;
+#[cfg(all(test, feature = "blitzar"))]
+mod case_expr_test;
+
 mod literal_expr;
 pub(crate) use literal_expr::LiteralExpr;
 #[cfg(all(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -102,6 +102,15 @@ pub fn cast(left: DynProofExpr, right: ColumnType) -> DynProofExpr {
     DynProofExpr::try_new_cast(left, right).unwrap()
 }
 
+/// # Panics
+/// Panics if `DynProofExpr::try_new_case()` returns an error.
+pub fn case_when(
+    when_thens: Vec<(DynProofExpr, DynProofExpr)>,
+    else_expr: DynProofExpr,
+) -> DynProofExpr {
+    DynProofExpr::try_new_case(when_thens, else_expr).unwrap()
+}
+
 pub fn scaling_cast(left: DynProofExpr, right: ColumnType) -> DynProofExpr {
     DynProofExpr::try_new_scaling_cast(left, right).unwrap()
 }


### PR DESCRIPTION
# Rationale for this change

`CASE WHEN` wasn't supported by the planner. This adds it as a native proof
primitive, `CaseExpr`, rather than desugaring it into arithmetic. Because the
result is one of the branch values (not computed from them), it keeps the branch
type with no widening or overflow, and varchar branches work.

# What changes are included in this PR?

- `CaseExpr`: proves `CASE WHEN c_1 THEN v_1 ... ELSE v_else END` with
  first-match-wins. The prover commits a cheap boolean guard column per arm
  (after the first) and the result column, and proves two degree-2 identities:
  each guard is `c_i * (1 - sum of earlier guards)`, and the result is the
  guarded sum. Guards are 0/1 so only the single result is a full data column,
  regardless of arm count.
- `select_column`: a shared row-wise column selection helper (used by `CaseExpr`,
  reusable elsewhere) with its own unit tests.
- Planner lowers searched and simple CASE forms; CASE without ELSE is rejected
  (implicit NULL has no representation here).
- The new `DynProofExpr::Case` variant is appended last to keep existing
  serialized plans stable. The EVM serializer rejects it until the Solidity
  verifier has a matching routine.

# Are these changes tested?

Yes. End-to-end prove/verify for numeric, multi-arm (up to 4 conditions),
varchar, nested, and conditional-aggregation CASE, plus planning-time rejection
tests. `case_expr_test.rs` adds `try_new` validation tests and prove/verify
through `exercise_verification`, which tampers the result and proof to confirm
rejection. Note: `case_expr_test.rs` is blitzar-gated (like the sibling expr
tests) and runs in CI, not on Apple Silicon locally.
