### PR TITLE
feat: add trait implementations for `OwnedTable`

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -146,6 +146,24 @@ impl<S: Scalar> OwnedTable<S> {
     }
 }
 
+impl<S: Scalar> IntoIterator for OwnedTable<S> {
+    type Item = (Ident, OwnedColumn<S>);
+
+    type IntoIter = indexmap::map::IntoIter<Ident, OwnedColumn<S>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.table.into_iter()
+    }
+}
+
+impl<S: Scalar> TryFrom<IndexMap<Ident, OwnedColumn<S>>> for OwnedTable<S> {
+    type Error = OwnedTableError;
+
+    fn try_from(value: IndexMap<Ident, OwnedColumn<S>>) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
 // Note: we modify the default PartialEq for IndexMap to also check for column ordering.
 // This is to align with the behaviour of a `RecordBatch`.
 impl<S: Scalar> PartialEq for OwnedTable<S> {
@@ -196,12 +214,13 @@ mod tests {
     use super::OwnedTable;
     use crate::base::{
         database::{
-            owned_table_utility::*, table_utility::*, ColumnCoercionError, Table,
+            owned_table_utility::*, table_utility::*, ColumnCoercionError, OwnedColumn, Table,
             TableCoercionError, TableOptions,
         },
         map::indexmap,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
         scalar::test_scalar::TestScalar,
+        IndexMap,
     };
     use bumpalo::Bump;
 
@@ -378,5 +397,19 @@ mod tests {
                 source: ColumnCoercionError::Overflow
             })
         ));
+    }
+
+    #[test]
+    fn test_try_from() {
+        let index_map = [
+            bigint("bigint", [0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]),
+            scalar("scalar", [0, 1, 2, 3, 4, 5, 6, 7, i64::MAX]),
+        ]
+        .into_iter()
+        .collect::<IndexMap<_, OwnedColumn<TestScalar>>>();
+        let table = OwnedTable::try_from(index_map.clone()).unwrap();
+
+        let iter_value: IndexMap<_, _> = table.into_iter().collect();
+        assert_eq!(iter_value, index_map);
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This will enable serialization of OwnedTable a little more easily.

# What changes are included in this PR?

Adding some trait implementations

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
