### PR TITLE
refactor!: make string to `Scalar` conversions explicit

### DIFF
--- a/crates/proof-of-sql-benches/src/utils/random_util.rs
+++ b/crates/proof-of-sql-benches/src/utils/random_util.rs
@@ -99,7 +99,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         });
                         Column::VarChar((
                             strs,
-                            alloc.alloc_slice_fill_iter(strs.iter().map(|&s| Into::into(s))),
+                            alloc.alloc_slice_fill_iter(
+                                strs.iter().map(|&s| S::from_str_via_hash(s)),
+                            ),
                         ))
                     }
                     (ColumnType::Scalar, _) => {
@@ -114,7 +116,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
                             ) as &str
                         });
                         Column::Scalar(
-                            alloc.alloc_slice_fill_iter(strs.iter().map(|&s| Into::into(s))),
+                            alloc.alloc_slice_fill_iter(
+                                strs.iter().map(|&s| S::from_str_via_hash(s)),
+                            ),
                         )
                     }
                     (ColumnType::Decimal75(p, s), _) => {
@@ -131,7 +135,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::Decimal75(
                             *p,
                             *s,
-                            alloc.alloc_slice_fill_iter(strs.iter().map(|&s| Into::into(s))),
+                            alloc.alloc_slice_fill_iter(
+                                strs.iter().map(|&s| S::from_str_via_hash(s)),
+                            ),
                         )
                     }
                     (ColumnType::TimestampTZ(u, z), None) => Column::TimestampTZ(

--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -279,7 +279,9 @@ impl ArrayRefExt for ArrayRef {
                     let scals = if let Some(scals) = precomputed_scals {
                         &scals[range.start..range.end]
                     } else {
-                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S { vals[i].into() })
+                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S {
+                            S::from_str_via_hash(vals[i])
+                        })
                     };
 
                     Ok(Column::VarChar((vals, scals)))

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -162,7 +162,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
             OwnedColumn::VarChar(strings) => CommittableColumn::VarChar(
                 strings
                     .iter()
-                    .map(Into::<S>::into)
+                    .map(|s| S::from_str_via_hash(s))
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -139,7 +139,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, S::from(string)),
+                alloc.alloc_slice_fill_copy(length, S::from_str_via_hash(string)),
             )),
             LiteralValue::VarBinary(bytes) => {
                 // Convert the bytes to a slice of bytes references
@@ -177,7 +177,10 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
             OwnedColumn::VarChar(col) => {
-                let scalars = col.iter().map(S::from).collect::<Vec<_>>();
+                let scalars = col
+                    .iter()
+                    .map(|s| S::from_str_via_hash(s))
+                    .collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -81,7 +81,7 @@ impl LiteralValue {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar(str) => str.into(),
+            Self::VarChar(str) => S::from_str_via_hash(str),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -10,7 +10,7 @@ use crate::base::{
     },
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::Scalar,
-    slice_ops::{inner_product_ref_cast, inner_product_with_bytes},
+    slice_ops::{inner_product_ref_cast, inner_product_with_bytes, inner_product_with_strings},
 };
 use alloc::{
     string::{String, ToString},
@@ -65,7 +65,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {
                 inner_product_ref_cast(col, vec)
             }
-            OwnedColumn::VarChar(col) => inner_product_ref_cast(col, vec),
+            OwnedColumn::VarChar(col) => inner_product_with_strings(col, vec),
             OwnedColumn::VarBinary(col) => inner_product_with_bytes(col, vec),
             OwnedColumn::Int128(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => {

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
     map::IndexMap,
-    scalar::ScalarExt,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
@@ -108,7 +108,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
                 let scals: &mut [_] = self
                     .alloc
-                    .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
+                    .alloc_slice_fill_iter(col.iter().map(|s| CP::Scalar::from_str_via_hash(s)));
                 Column::VarChar((col, scals))
             }
             OwnedColumn::VarBinary(col) => {

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -288,7 +288,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
         })
         .collect();
     let alloc_strings = alloc.alloc_slice_clone(&strings);
-    let scalars: Vec<S> = strings.iter().map(|s| (*s).into()).collect();
+    let scalars: Vec<S> = strings.iter().map(|s| S::from_str_via_hash(s)).collect();
     let alloc_scalars = alloc.alloc_slice_copy(&scalars);
     (name.into(), Column::VarChar((alloc_strings, alloc_scalars)))
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,7 +1,10 @@
 #![expect(clippy::module_inception)]
 
-use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
-use alloc::string::String;
+use crate::base::{
+    encode::VarInt,
+    ref_into::RefInto,
+    scalar::{ScalarConversionError, ScalarExt},
+};
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
@@ -13,7 +16,6 @@ pub trait Scalar:
     + core::fmt::Display
     + PartialEq
     + Default
-    + for<'a> From<&'a str>
     + Sync
     + Send
     + num_traits::One
@@ -52,9 +54,7 @@ pub trait Scalar:
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
-    + for<'a> core::convert::From<&'a String>
     + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>
@@ -85,4 +85,18 @@ pub trait Scalar:
     const MAX_BITS: u8;
     /// A U256 representation of the largest signed value in the field.
     const MAX_SIGNED_U256: U256;
+
+    /// Converts a string to a `Scalar` by hashing its bytes.
+    ///
+    /// This is not a parsing method: the resulting field element bears no numeric
+    /// relationship to the contents of `val`. Strings have no natural embedding into
+    /// the field, so they are hashed down into the field's range and the resulting
+    /// bits are then converted through the limb representation.
+    ///
+    /// The empty string is the one exception: it maps to [`Scalar::ZERO`] directly,
+    /// without hashing.
+    #[must_use]
+    fn from_str_via_hash(val: &str) -> Self {
+        <Self as ScalarExt>::from_byte_slice_via_hash(val.as_bytes())
+    }
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -111,6 +111,29 @@ mod tests {
     }
 
     #[test]
+    fn we_can_get_zero_from_empty_string() {
+        assert_eq!(TestScalar::from_str_via_hash(""), TestScalar::ZERO);
+    }
+
+    #[test]
+    fn we_can_get_scalar_from_hashed_string() {
+        assert_eq!(
+            TestScalar::from_str_via_hash("abc"),
+            TestScalar::from_byte_slice_via_hash(b"abc"),
+            "hashing a string must agree with hashing its UTF-8 bytes"
+        );
+    }
+
+    #[test]
+    fn we_can_get_scalar_from_hashed_multibyte_string() {
+        let multibyte = "âbĉ→";
+        assert_eq!(
+            TestScalar::from_str_via_hash(multibyte),
+            TestScalar::from_byte_slice_via_hash(multibyte.as_bytes())
+        );
+    }
+
+    #[test]
     fn we_can_compute_powers_of_10() {
         for i in 0..=u128::MAX.ilog10() {
             assert_eq!(

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -2,7 +2,7 @@ use crate::base::{
     if_rayon,
     scalar::{Scalar, ScalarExt},
 };
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::{iter::Sum, ops::Mul};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
@@ -38,5 +38,13 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
     if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
         .zip(b)
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
+        .sum()
+}
+
+/// Cannot use blanket impls for `String` because strings might have different embeddings as scalars
+pub fn inner_product_with_strings<S: Scalar>(a: &[String], b: &[S]) -> S {
+    if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
+        .zip(b)
+        .map(|(lhs_str, &rhs)| S::from_str_via_hash(lhs_str) * rhs)
         .sum()
 }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -117,7 +117,12 @@ impl ProvableQueryResult {
                         decode_and_convert::<S, S>(&self.data[offset..])
                     }
 
-                    ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
+                    ColumnType::VarChar => {
+                        let (raw_str, used) =
+                            decode_and_convert::<&str, &str>(&self.data[offset..])?;
+                        let x = S::from_str_via_hash(raw_str);
+                        Ok((x, used))
+                    }
                     ColumnType::VarBinary => {
                         let (raw_bytes, used) =
                             decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;


### PR DESCRIPTION
# Make string → `Scalar` conversions explicit

Closes the second checklist item of #228.

## What changed

`Scalar` no longer requires `From<&str>`, `From<String>`, or `From<&String>`. Those three bounds are replaced by a single trait method with a default implementation:

```rust
fn from_str_via_hash(val: &str) -> Self {
    <Self as ScalarExt>::from_byte_slice_via_hash(val.as_bytes())
}
```

Strings have no natural embedding into the field — they are hashed — so a silent `.into()` at the call site hid a Keccak invocation behind syntax that reads like a numeric conversion. Every generic call site now names the hash explicitly.

## Why the default implementation delegates

All three removed conversions already funnelled into the same place: `From<&str>`/`From<String>` called `x.as_bytes().into()`, which hit `From<&[u8]>`, which called `ScalarExt::from_byte_slice_via_hash`. `From<&String>` reached `From<String>` through the blanket `impl<F, T> From<&T> for MontScalar<F>`. The default implementation therefore delegates rather than re-deriving the hash, so the masking and limb-conversion logic stays in exactly one place.

**This refactor is behaviour-preserving at every call site** — the bytes hashed and the resulting field element are unchanged.

## Call sites updated

| File | Was |
| --- | --- |
| `base/arrow/arrow_array_to_column_conversion.rs` | `vals[i].into()` |
| `base/commitment/committable_column.rs` | `.map(Into::<S>::into)` |
| `base/database/column.rs` (×2) | `S::from(string)`, `.map(S::from)` |
| `base/database/literal_value.rs` | `str.into()` |
| `base/database/owned_column.rs` | `inner_product_ref_cast` |
| `base/database/owned_table_test_accessor.rs` | `(*s).into()` |
| `base/database/table_utility.rs` | `(*s).into()` |
| `sql/proof/provable_query_result.rs` | `decode_and_convert::<&str, S>` |
| `proof-of-sql-benches/src/utils/random_util.rs` (×3) | `Into::into(s)` |

Two of these follow patterns the codebase had already established for `VarBinary`, which does not have a natural embedding either:

- **`inner_product_with_strings`** mirrors the existing `inner_product_with_bytes`, including its comment (*"Cannot use blanket impls for `Vec<u8>` because bytes might have different embeddings as scalars"*) — the same reasoning applies verbatim to `String`.
- **`provable_query_result.rs`** now decodes `&str` and hashes it in a second step, exactly as the neighbouring `VarBinary` arm already decoded `&[u8]` and called `from_byte_slice_via_hash`.

`literal_value.rs::to_scalar` is a good illustration of the inconsistency this removes — `VarBinary` was already explicit while `VarChar` right above it was not:

```rust
 Self::VarChar(str) => S::from_str_via_hash(str),
 Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
```

## Tests

Three tests added next to the existing hashing tests in `scalar_ext.rs`:

- `we_can_get_scalar_from_hashed_string` — agreement with `from_byte_slice_via_hash` on the same bytes, i.e. the delegation contract.
- `we_can_get_scalar_from_hashed_multibyte_string` — multi-byte UTF-8 hashes its encoded bytes.
- `we_can_get_zero_from_empty_string` — the empty string maps to `ZERO`, matching the empty byte slice.

I deliberately did not add a "different strings give different scalars" test, since `curve_25519_tests::two_different_strings_map_to_different_scalars` already covers that property.

## Verification

```
cargo check --workspace --all-features      # clean, no warnings
cargo test --all-features                   # CI's test command
cargo clippy --all-targets --all-features
cargo fmt --all --check
```

## One open question

I limited this to the trait bounds, which is what the checklist item asks for. The concrete `impl From<&str> for MontScalar` / `impl From<String> for MontScalar` still exist, so `MontScalar::from("…")` continues to compile even though generic code can no longer convert opaquely. Removing those two impls as well would finish the job for concrete types, at the cost of touching a fair number of call sites in tests. Happy to do that here or in a follow-up — whichever you prefer.

/claim #228
