### PR TITLE
refactor: replace opaque Scalar string conversions with from_str_via_hash

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -279,7 +279,9 @@ impl ArrayRefExt for ArrayRef {
                     let scals = if let Some(scals) = precomputed_scals {
                         &scals[range.start..range.end]
                     } else {
-                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S { vals[i].into() })
+                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S {
+                            S::from_str_via_hash(vals[i])
+                        })
                     };
 
                     Ok(Column::VarChar((vals, scals)))

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -162,7 +162,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
             OwnedColumn::VarChar(strings) => CommittableColumn::VarChar(
                 strings
                     .iter()
-                    .map(Into::<S>::into)
+                    .map(|s| S::from_str_via_hash(s))
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -139,7 +139,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, S::from(string)),
+                alloc.alloc_slice_fill_copy(length, S::from_str_via_hash(string)),
             )),
             LiteralValue::VarBinary(bytes) => {
                 // Convert the bytes to a slice of bytes references
@@ -177,7 +177,10 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
             OwnedColumn::VarChar(col) => {
-                let scalars = col.iter().map(S::from).collect::<Vec<_>>();
+                let scalars = col
+                    .iter()
+                    .map(|s| S::from_str_via_hash(s))
+                    .collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -81,7 +81,7 @@ impl LiteralValue {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar(str) => str.into(),
+            Self::VarChar(str) => S::from_str_via_hash(str),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -10,7 +10,7 @@ use crate::base::{
     },
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     scalar::Scalar,
-    slice_ops::{inner_product_ref_cast, inner_product_with_bytes},
+    slice_ops::{inner_product_ref_cast, inner_product_with_bytes, inner_product_with_strings},
 };
 use alloc::{
     string::{String, ToString},
@@ -65,7 +65,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {
                 inner_product_ref_cast(col, vec)
             }
-            OwnedColumn::VarChar(col) => inner_product_ref_cast(col, vec),
+            OwnedColumn::VarChar(col) => inner_product_with_strings(col, vec),
             OwnedColumn::VarBinary(col) => inner_product_with_bytes(col, vec),
             OwnedColumn::Int128(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => {

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -108,7 +108,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
                 let scals: &mut [_] = self
                     .alloc
-                    .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
+                    .alloc_slice_fill_iter(col.iter().map(|s| CP::Scalar::from_str_via_hash(s)));
                 Column::VarChar((col, scals))
             }
             OwnedColumn::VarBinary(col) => {

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -20,7 +20,7 @@
 use super::{Column, Table, TableOptions};
 use crate::base::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::Scalar,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
@@ -288,7 +288,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
         })
         .collect();
     let alloc_strings = alloc.alloc_slice_clone(&strings);
-    let scalars: Vec<S> = strings.iter().map(|s| (*s).into()).collect();
+    let scalars: Vec<S> = strings.iter().map(|s| S::from_str_via_hash(s)).collect();
     let alloc_scalars = alloc.alloc_slice_copy(&scalars);
     (name.into(), Column::VarChar((alloc_strings, alloc_scalars)))
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,7 +1,6 @@
 #![expect(clippy::module_inception)]
 
 use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
-use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
@@ -13,7 +12,6 @@ pub trait Scalar:
     + core::fmt::Display
     + PartialEq
     + Default
-    + for<'a> From<&'a str>
     + Sync
     + Send
     + num_traits::One
@@ -52,9 +50,7 @@ pub trait Scalar:
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
-    + for<'a> core::convert::From<&'a String>
     + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -51,6 +51,20 @@ pub trait ScalarExt: Scalar {
         let masked_val = hashed_val & Self::CHALLENGE_MASK;
         Self::from_wrapping(masked_val)
     }
+
+    /// Converts a string to a Scalar using a hash function, preventing collisions.
+    ///
+    /// Note that this is a hash, not a parse: `from_str_via_hash("1")` is *not*
+    /// `Self::ONE`. Strings have no natural embedding into the field, so this
+    /// conversion is deliberately explicit rather than a `From` implementation.
+    ///
+    /// WARNING: Only up to 31 bytes (2^248 bits) are supported by `PoSQL` cryptographic
+    /// objects. This function masks off the last byte of the hash to ensure the result
+    /// fits in this range.
+    #[must_use]
+    fn from_str_via_hash(val: &str) -> Self {
+        Self::from_byte_slice_via_hash(val.as_bytes())
+    }
 }
 
 impl<S: Scalar> ScalarExt for S {}
@@ -108,6 +122,44 @@ mod tests {
             scalar_from_bytes, scalar_from_ref,
             "The masked keccak v256 of 'abc' must match"
         );
+    }
+
+    #[test]
+    fn we_can_get_zero_from_an_empty_string() {
+        assert_eq!(TestScalar::from_str_via_hash(""), TestScalar::ZERO);
+    }
+
+    #[test]
+    fn we_can_get_scalar_from_hashed_string() {
+        // `from_str_via_hash` must agree with hashing the string's UTF-8 bytes directly.
+        assert_eq!(
+            TestScalar::from_str_via_hash("abc"),
+            TestScalar::from_byte_slice_via_hash(b"abc")
+        );
+    }
+
+    #[test]
+    fn we_can_get_different_scalars_from_different_strings() {
+        assert_ne!(
+            TestScalar::from_str_via_hash("abc"),
+            TestScalar::from_str_via_hash("abd")
+        );
+    }
+
+    #[test]
+    fn we_can_hash_multibyte_strings() {
+        // Non-ASCII input must hash its UTF-8 encoding, not its chars.
+        let s = "ありがとう";
+        assert_eq!(
+            TestScalar::from_str_via_hash(s),
+            TestScalar::from_byte_slice_via_hash(s.as_bytes())
+        );
+    }
+
+    #[test]
+    fn we_can_see_that_hashing_a_string_is_not_parsing_it() {
+        // `from_str_via_hash` is a hash, not a parse: "1" must not become ONE.
+        assert_ne!(TestScalar::from_str_via_hash("1"), TestScalar::ONE);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -2,7 +2,7 @@ use crate::base::{
     if_rayon,
     scalar::{Scalar, ScalarExt},
 };
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::{iter::Sum, ops::Mul};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
@@ -38,5 +38,14 @@ pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
     if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
         .zip(b)
         .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
+        .sum()
+}
+
+/// Cannot use blanket impls for `String` because strings have no natural embedding as scalars;
+/// they are hashed. See [`ScalarExt::from_str_via_hash`].
+pub fn inner_product_with_strings<S: Scalar>(a: &[String], b: &[S]) -> S {
+    if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
+        .zip(b)
+        .map(|(lhs_str, &rhs)| S::from_str_via_hash(lhs_str) * rhs)
         .sum()
 }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -117,7 +117,12 @@ impl ProvableQueryResult {
                         decode_and_convert::<S, S>(&self.data[offset..])
                     }
 
-                    ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
+                    ColumnType::VarChar => {
+                        let (raw_str, used) =
+                            decode_and_convert::<&str, &str>(&self.data[offset..])?;
+                        let x = S::from_str_via_hash(raw_str);
+                        Ok((x, used))
+                    }
                     ColumnType::VarBinary => {
                         let (raw_bytes, used) =
                             decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;


### PR DESCRIPTION
Closes the string-conversion checkbox of #228.

/claim #228

## What and why

`Scalar` required `for<'a> From<&'a str>`, `for<'a> From<&'a String>` and `From<String>`.
These are exactly the "opaque" conversions #228 is about: a string has **no natural
embedding** into the field, so the conversion hashes the UTF-8 bytes and masks the result.
Exposing that as `From` made a lossy, collision-resistant hash look like an ordinary
numeric conversion at every generic call site — `str.into()` reads like `1i64.into()` but
does something completely different.

Per the rule stated in the issue — `From` only for types with a natural embedding,
a trait method otherwise — this replaces the three bounds with an explicit method.

## Approach

`ScalarExt` already exists for precisely this ("blanket implementations for `Scalar` types …
to avoid cluttering the core `Scalar` implementation with default implementations") and
already houses the byte-slice sibling, `from_byte_slice_via_hash`. So:

- Added `ScalarExt::from_str_via_hash(val: &str) -> Self` with a **default implementation**
  delegating to `from_byte_slice_via_hash`. Since `impl<S: Scalar> ScalarExt for S {}` is a
  blanket impl, every `Scalar` gets it for free and no implementor has to write anything.
- Removed the three bounds from `Scalar` (and the now-unused `alloc::string::String` import).
- Updated the call sites that relied on those bounds to call the method explicitly. Each one
  now reads the same way as the `VarBinary` arm sitting next to it, which already used
  `from_byte_slice_via_hash`. For example, in `LiteralValue::to_scalar`:

  ```rust
  Self::VarChar(str)     => S::from_str_via_hash(str),
  Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
  ```

- Added `slice_ops::inner_product_with_strings`, mirroring the existing
  `inner_product_with_bytes`, for the one site that needed it. Its doc comment gives the same
  rationale the bytes version already gives.

## Scope note (deliberate, happy to change)

The concrete `impl From<&str> for MontScalar` / `From<String> for MontScalar` impls are
**left in place**. Removing the *bounds* is what removes the opacity from all generic
`S: Scalar` code, which is the actual complaint. Removing the concrete impls as well would
touch **210+ call sites** (overwhelmingly `TestScalar::from("Cat")` in tests) and would bury
this change in churn. Happy to do that as a follow-up if you'd like it.

Also scoped to one checkbox, since the issue says each should be a separate PR. The limbs
and `VarInt` checkboxes are untouched here.

## Tests

Added five tests to `scalar_ext`:

- empty string hashes to `ZERO` (consistent with the empty byte slice)
- `from_str_via_hash("abc")` equals `from_byte_slice_via_hash(b"abc")`
- different strings produce different scalars
- multibyte/non-ASCII input hashes its UTF-8 encoding
- `from_str_via_hash("1") != ONE` — this is a hash, not a parse

## Verification

Run locally on Windows. `blitzar` is Linux-only, so I used the same feature set as your
`--no-default-features --features="arrow"` CI job:

- `cargo test -p proof-of-sql --no-default-features --features="arrow" --lib`
  → **1061 passed; 0 failed**
- `cargo fmt --all -- --check --config imports_granularity=Crate,group_imports=One` → clean
- `cargo clippy -p proof-of-sql --all-targets --no-default-features --features="arrow"`
  → no findings in any file this PR touches

I could not build the `blitzar`/`perf` feature paths locally, so those are relying on CI.
