### PR TITLE
perf: optimize proof verification performance and memory allocations

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -83,18 +83,16 @@ impl<S: Scalar> SumcheckProof<S> {
         let mut expected_evaluation = *claimed_sum;
         for round_index in 0..num_variables {
             let start_index = round_index * (max_multiplicands + 1);
-            transcript.extend_scalars_as_be(
-                &self.coefficients[start_index..=(start_index + max_multiplicands)],
-            );
+            let round_coeffs = &self.coefficients[start_index..=(start_index + max_multiplicands)];
+            transcript.extend_scalars_as_be(round_coeffs);
             let round_evaluation_point = transcript.scalar_challenge_as_be();
             evaluation_point.push(round_evaluation_point);
-            let mut round_evaluation = self.coefficients[start_index];
-            let mut actual_sum =
-                round_evaluation + self.coefficients[start_index + max_multiplicands];
-            for coefficient_index in (start_index + 1)..=(start_index + max_multiplicands) {
+            let mut round_evaluation = round_coeffs[0];
+            let mut actual_sum = round_coeffs[0] + round_coeffs[max_multiplicands];
+            for &coeff in &round_coeffs[1..] {
                 round_evaluation *= round_evaluation_point;
-                round_evaluation += self.coefficients[coefficient_index];
-                actual_sum += self.coefficients[coefficient_index];
+                round_evaluation += coeff;
+                actual_sum += coeff;
             }
             if actual_sum != expected_evaluation {
                 return Err(ProofError::VerificationError {

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -389,11 +389,11 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         // Specifically, these are the challenges that the verifier sends to
         // the prover after the prover sends the result, but before the prover
         // send commitments to the intermediate witness columns.
-        // Note: the last challenge in the vec is the first one that is consumed.
-        let post_result_challenges =
-            core::iter::repeat_with(|| transcript.scalar_challenge_as_be())
-                .take(self.first_round_message.post_result_challenge_count)
-                .collect();
+        let post_result_challenge_count = self.first_round_message.post_result_challenge_count;
+        let mut post_result_challenges = Vec::with_capacity(post_result_challenge_count);
+        for _ in 0..post_result_challenge_count {
+            post_result_challenges.push(transcript.scalar_challenge_as_be());
+        }
 
         // add the commitments and bit distributions to the proof
         transcript.challenge_as_le();
@@ -402,10 +402,10 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         // draw the random scalars for sumcheck
         let num_random_scalars =
             num_sumcheck_variables + self.final_round_message.subpolynomial_constraint_count;
-        let random_scalars: Vec<_> =
-            core::iter::repeat_with(|| transcript.scalar_challenge_as_be())
-                .take(num_random_scalars)
-                .collect();
+        let mut random_scalars = Vec::with_capacity(num_random_scalars);
+        for _ in 0..num_random_scalars {
+            random_scalars.push(transcript.scalar_challenge_as_be());
+        }
         let sumcheck_random_scalars = SumcheckRandomScalars::new(
             &random_scalars,
             self.first_round_message.range_length,
@@ -425,14 +425,13 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         // draw the random scalars for the evaluation proof
         // (i.e. the folding/random linear combination of the pcs_proof_mles)
-        let evaluation_random_scalars: Vec<_> =
-            core::iter::repeat_with(|| transcript.scalar_challenge_as_be())
-                .take(
-                    self.pcs_proof_evaluations.first_round.len()
-                        + self.pcs_proof_evaluations.column_ref.len()
-                        + self.pcs_proof_evaluations.final_round.len(),
-                )
-                .collect();
+        let eval_random_count = self.pcs_proof_evaluations.first_round.len()
+            + self.pcs_proof_evaluations.column_ref.len()
+            + self.pcs_proof_evaluations.final_round.len();
+        let mut evaluation_random_scalars = Vec::with_capacity(eval_random_count);
+        for _ in 0..eval_random_count {
+            evaluation_random_scalars.push(transcript.scalar_challenge_as_be());
+        }
 
         // Always prepend input lengths to the chi evaluation lengths
         let table_length_map = table_refs
@@ -452,7 +451,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let sumcheck_evaluations = SumcheckMleEvaluations::new(
             self.first_round_message.range_length,
             chi_evaluation_lengths,
-            self.first_round_message.rho_evaluation_lengths.clone(),
+            self.first_round_message.rho_evaluation_lengths.iter().copied(),
             &subclaim.evaluation_point,
             &sumcheck_random_scalars,
             &self.pcs_proof_evaluations.first_round,
@@ -471,24 +470,24 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             sumcheck_evaluations,
             &self.final_round_message.bit_distributions,
             sumcheck_random_scalars.subpolynomial_multipliers,
-            post_result_challenges,
-            self.first_round_message.chi_evaluation_lengths.clone(),
-            self.first_round_message.rho_evaluation_lengths.clone(),
+            &post_result_challenges,
+            &self.first_round_message.chi_evaluation_lengths,
+            &self.first_round_message.rho_evaluation_lengths,
             subclaim.max_multiplicands,
         );
 
-        let pcs_proof_commitments: Vec<_> = self
-            .first_round_message
-            .round_commitments
-            .iter()
-            .cloned()
-            .chain(
-                column_references
-                    .iter()
-                    .map(|col| accessor.get_commitment(&col.table_ref(), &col.column_id())),
-            )
-            .chain(self.final_round_message.round_commitments.iter().cloned())
-            .collect();
+        let total_commitments = self.first_round_message.round_commitments.len()
+            + column_references.len()
+            + self.final_round_message.round_commitments.len();
+        let mut pcs_proof_commitments = Vec::with_capacity(total_commitments);
+        pcs_proof_commitments.extend(self.first_round_message.round_commitments.iter().cloned());
+        pcs_proof_commitments.extend(
+            column_references
+                .iter()
+                .map(|col| accessor.get_commitment(&col.table_ref(), &col.column_id())),
+        );
+        pcs_proof_commitments.extend(self.final_round_message.round_commitments.iter().cloned());
+
         let evaluation_accessor: IndexMap<_, _> = column_references
             .into_iter()
             .zip(self.pcs_proof_evaluations.column_ref.iter().copied())
@@ -518,14 +517,10 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             })?;
         }
 
-        let pcs_proof_evaluations: Vec<_> = self
-            .pcs_proof_evaluations
-            .first_round
-            .iter()
-            .chain(self.pcs_proof_evaluations.column_ref.iter())
-            .chain(self.pcs_proof_evaluations.final_round.iter())
-            .copied()
-            .collect();
+        let mut pcs_proof_evaluations = Vec::with_capacity(eval_random_count);
+        pcs_proof_evaluations.extend_from_slice(&self.pcs_proof_evaluations.first_round);
+        pcs_proof_evaluations.extend_from_slice(&self.pcs_proof_evaluations.column_ref);
+        pcs_proof_evaluations.extend_from_slice(&self.pcs_proof_evaluations.final_round);
 
         // finally, check the MLE evaluations with the inner product proof
         self.evaluation_proof

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations.rs
@@ -87,7 +87,7 @@ impl<'a, S: Scalar> SumcheckMleEvaluations<'a, S> {
         );
         let unique_chi_evaluation_lengths: IndexSet<usize> =
             chi_evaluation_lengths.into_iter().collect();
-        let chi_evaluations = unique_chi_evaluation_lengths
+        let chi_evaluations: IndexMap<usize, S> = unique_chi_evaluation_lengths
             .iter()
             .map(|&length| {
                 (
@@ -96,11 +96,16 @@ impl<'a, S: Scalar> SumcheckMleEvaluations<'a, S> {
                 )
             })
             .collect();
-        let rho_evaluations = rho_evaluation_lengths
-            .into_iter()
-            .map(|length| (length, compute_rho_eval(length, evaluation_point)))
+        let unique_rho_evaluation_lengths: IndexSet<usize> =
+            rho_evaluation_lengths.into_iter().collect();
+        let rho_evaluations = unique_rho_evaluation_lengths
+            .iter()
+            .map(|&length| (length, compute_rho_eval(length, evaluation_point)))
             .collect();
-        let singleton_chi_evaluation = compute_truncated_lagrange_basis_sum(1, evaluation_point);
+        let singleton_chi_evaluation = chi_evaluations
+            .get(&1)
+            .copied()
+            .unwrap_or_else(|| compute_truncated_lagrange_basis_sum(1, evaluation_point));
         Self {
             chi_evaluations,
             rho_evaluations,

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -1,7 +1,6 @@
 use super::{SumcheckMleEvaluations, SumcheckSubpolynomialType};
 use crate::base::{bit::BitDistribution, proof::ProofSizeMismatch, scalar::Scalar};
-use alloc::{collections::VecDeque, vec::Vec};
-use core::iter;
+use alloc::vec::Vec;
 
 pub trait VerificationBuilder<S: Scalar> {
     /// Consume the evaluation of a chi evaluation
@@ -70,12 +69,10 @@ pub struct VerificationBuilderImpl<'a, S: Scalar> {
     /// Specifically, these are the challenges that the verifier sends to
     /// the prover after the prover sends the result, but before the prover
     /// send commitments to the intermediate witness columns.
-    ///
-    /// Note: this vector is treated as a stack and the first
-    /// challenge is the last entry in the vector.
-    post_result_challenges: VecDeque<S>,
-    chi_evaluation_length_queue: Vec<usize>,
-    rho_evaluation_length_queue: Vec<usize>,
+    post_result_challenges: &'a [S],
+    consumed_post_result_challenges: usize,
+    chi_evaluation_length_queue: &'a [usize],
+    rho_evaluation_length_queue: &'a [usize],
     subpolynomial_max_multiplicands: usize,
 }
 
@@ -84,9 +81,9 @@ impl<'a, S: Scalar> VerificationBuilderImpl<'a, S> {
         mle_evaluations: SumcheckMleEvaluations<'a, S>,
         bit_distributions: &'a [BitDistribution],
         subpolynomial_multipliers: &'a [S],
-        post_result_challenges: VecDeque<S>,
-        chi_evaluation_length_queue: Vec<usize>,
-        rho_evaluation_length_queue: Vec<usize>,
+        post_result_challenges: &'a [S],
+        chi_evaluation_length_queue: &'a [usize],
+        rho_evaluation_length_queue: &'a [usize],
         subpolynomial_max_multiplicands: usize,
     ) -> Self {
         Self {
@@ -100,6 +97,7 @@ impl<'a, S: Scalar> VerificationBuilderImpl<'a, S> {
             consumed_final_round_pcs_proof_mles: 0,
             produced_subpolynomials: 0,
             post_result_challenges,
+            consumed_post_result_challenges: 0,
             chi_evaluation_length_queue,
             rho_evaluation_length_queue,
             subpolynomial_max_multiplicands,
@@ -124,7 +122,7 @@ impl<'a, S: Scalar> VerificationBuilderImpl<'a, S> {
                 == self.mle_evaluations.first_round_pcs_proof_evaluations.len()
             && self.consumed_final_round_pcs_proof_mles
                 == self.mle_evaluations.final_round_pcs_proof_evaluations.len()
-            && self.post_result_challenges.is_empty()
+            && self.consumed_post_result_challenges == self.post_result_challenges.len()
     }
 }
 
@@ -176,9 +174,13 @@ impl<S: Scalar> VerificationBuilder<S> for VerificationBuilderImpl<'_, S> {
         &mut self,
         count: usize,
     ) -> Result<Vec<S>, ProofSizeMismatch> {
-        iter::repeat_with(|| self.try_consume_first_round_mle_evaluation())
-            .take(count)
-            .collect()
+        let start = self.consumed_first_round_pcs_proof_mles;
+        let end = start
+            .checked_add(count)
+            .filter(|&end| end <= self.mle_evaluations.first_round_pcs_proof_evaluations.len())
+            .ok_or(ProofSizeMismatch::TooFewMLEEvaluations)?;
+        self.consumed_first_round_pcs_proof_mles = end;
+        Ok(self.mle_evaluations.first_round_pcs_proof_evaluations[start..end].to_vec())
     }
 
     fn try_consume_final_round_mle_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
@@ -195,9 +197,13 @@ impl<S: Scalar> VerificationBuilder<S> for VerificationBuilderImpl<'_, S> {
         &mut self,
         count: usize,
     ) -> Result<Vec<S>, ProofSizeMismatch> {
-        iter::repeat_with(|| self.try_consume_final_round_mle_evaluation())
-            .take(count)
-            .collect()
+        let start = self.consumed_final_round_pcs_proof_mles;
+        let end = start
+            .checked_add(count)
+            .filter(|&end| end <= self.mle_evaluations.final_round_pcs_proof_evaluations.len())
+            .ok_or(ProofSizeMismatch::TooFewMLEEvaluations)?;
+        self.consumed_final_round_pcs_proof_mles = end;
+        Ok(self.mle_evaluations.final_round_pcs_proof_evaluations[start..end].to_vec())
     }
 
     fn try_consume_bit_distribution(&mut self) -> Result<BitDistribution, ProofSizeMismatch> {
@@ -239,16 +245,15 @@ impl<S: Scalar> VerificationBuilder<S> for VerificationBuilderImpl<'_, S> {
         Ok(())
     }
 
-    /// # Panics
-    /// This function will panic if there are no post-result challenges available to pop from the stack.
-    ///
-    /// # Panics
-    /// This function will panic if `post_result_challenges` is empty,
-    /// as it attempts to pop an element from the vector and unwraps the result.
     fn try_consume_post_result_challenge(&mut self) -> Result<S, ProofSizeMismatch> {
-        self.post_result_challenges
-            .pop_front()
-            .ok_or(ProofSizeMismatch::PostResultCountMismatch)
+        let index = self.consumed_post_result_challenges;
+        let challenge = self
+            .post_result_challenges
+            .get(index)
+            .copied()
+            .ok_or(ProofSizeMismatch::PostResultCountMismatch)?;
+        self.consumed_post_result_challenges += 1;
+        Ok(challenge)
     }
 
     fn singleton_chi_evaluation(&self) -> S {
@@ -259,3 +264,4 @@ impl<S: Scalar> VerificationBuilder<S> for VerificationBuilderImpl<'_, S> {
         self.mle_evaluations.rho_256_evaluation
     }
 }
+

--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -3,7 +3,6 @@ use crate::{
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::proof::{SumcheckSubpolynomialType, VerificationBuilder},
 };
-use alloc::collections::VecDeque;
 use num_traits::Zero;
 
 #[test]
@@ -15,9 +14,9 @@ fn an_empty_sumcheck_polynomial_evaluates_to_zero() {
         mle_evaluations,
         &[][..],
         &[][..],
-        VecDeque::new(),
-        Vec::new(),
-        Vec::new(),
+        &[],
+        &[],
+        &[],
         0,
     );
     assert_eq!(builder.sumcheck_evaluation(), Curve25519Scalar::zero());
@@ -36,9 +35,9 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
         mle_evaluations,
         &[][..],
         &subpolynomial_multipliers,
-        VecDeque::new(),
-        Vec::new(),
-        Vec::new(),
+        &[],
+        &[],
+        &[],
         1,
     );
     builder
@@ -62,18 +61,18 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
 
 #[test]
 fn we_can_consume_post_result_challenges_in_verification_builder() {
+    let challenges = [
+        Curve25519Scalar::from(123),
+        Curve25519Scalar::from(456),
+        Curve25519Scalar::from(789),
+    ];
     let mut builder = VerificationBuilderImpl::new(
         SumcheckMleEvaluations::default(),
         &[][..],
         &[][..],
-        [
-            Curve25519Scalar::from(123),
-            Curve25519Scalar::from(456),
-            Curve25519Scalar::from(789),
-        ]
-        .into(),
-        Vec::new(),
-        Vec::new(),
+        &challenges,
+        &[],
+        &[],
         0,
     );
     assert_eq!(
@@ -89,3 +88,4 @@ fn we_can_consume_post_result_challenges_in_verification_builder() {
         builder.try_consume_post_result_challenge().unwrap()
     );
 }
+


### PR DESCRIPTION
### Summary
This PR optimizes proof verification throughput and eliminates redundant memory allocations across the `proof-of-sql` crate verification pipeline.

### Key Improvements
1. **Zero-Allocation `VerificationBuilderImpl`**:
   - Replaced owned `VecDeque<S>` for `post_result_challenges` with a borrowed slice `&'a [S]` and positional index tracking.
   - Converted `chi_evaluation_length_queue` and `rho_evaluation_length_queue` fields to borrowed `&'a [usize]`, eliminating vector clones on every verification round.
2. **Polynomial Evaluation Deduplication (`SumcheckMleEvaluations`)**:
   - Added length deduplication using `IndexSet<usize>` for `rho_evaluation_lengths` prior to `compute_rho_eval` mapping.
   - Reused length-1 evaluations from `chi_evaluations` for `singleton_chi_evaluation` when present.
3. **Preallocated Capacities (`QueryProof::verify`)**:
   - Added exact capacity preallocations for scalar vectors and used `extend_from_slice` to prevent heap reallocations.

### Verification
- Tested and verified with `cargo test -p proof-of-sql --no-default-features --features arrow,cpu-perf`.