### PR TITLE
refactor: make string scalar hashing explicit

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -279,7 +279,9 @@ impl ArrayRefExt for ArrayRef {
                     let scals = if let Some(scals) = precomputed_scals {
                         &scals[range.start..range.end]
                     } else {
-                        alloc.alloc_slice_fill_with(vals.len(), |i| -> S { vals[i].into() })
+                        alloc.alloc_slice_fill_with(vals.len(), |i| {
+                            S::from_str_via_hash(vals[i])
+                        })
                     };
 
                     Ok(Column::VarChar((vals, scals)))
@@ -1007,7 +1009,10 @@ mod tests {
     fn we_can_convert_valid_string_array_refs_into_valid_columns() {
         let alloc = Bump::new();
         let data = vec!["ab", "-f34"];
-        let scals: Vec<_> = data.iter().map(core::convert::Into::into).collect();
+        let scals: Vec<_> = data
+            .iter()
+            .map(|s| DoryScalar::from_str_via_hash(s))
+            .collect();
         let array: ArrayRef = Arc::new(arrow::array::StringArray::from(data.clone()));
         assert_eq!(
             array
@@ -1141,7 +1146,10 @@ mod tests {
     {
         let alloc = Bump::new();
         let data = ["ab", "-f34", "ehfh43"];
-        let scals: Vec<_> = data.iter().map(core::convert::Into::into).collect();
+        let scals: Vec<_> = data
+            .iter()
+            .map(|s| DoryScalar::from_str_via_hash(s))
+            .collect();
 
         let array: ArrayRef = Arc::new(arrow::array::StringArray::from(data.to_vec()));
         assert_eq!(
@@ -1176,7 +1184,10 @@ mod tests {
     fn we_can_convert_valid_string_array_refs_into_valid_columns_using_precomputed_scalars() {
         let alloc = Bump::new();
         let data = vec!["ab", "-f34"];
-        let scals: Vec<_> = data.iter().map(core::convert::Into::into).collect();
+        let scals: Vec<_> = data
+            .iter()
+            .map(|s| TestScalar::from_str_via_hash(s))
+            .collect();
         let array: ArrayRef = Arc::new(arrow::array::StringArray::from(data.clone()));
         assert_eq!(
             array

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -162,7 +162,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
             OwnedColumn::VarChar(strings) => CommittableColumn::VarChar(
                 strings
                     .iter()
-                    .map(Into::<S>::into)
+                    .map(|s| S::from_str_via_hash(s))
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),
@@ -480,7 +480,7 @@ mod tests {
         let bigint_committable_column = CommittableColumn::VarChar(
             ["12", "34", "56"]
                 .map(Into::<String>::into)
-                .map(Into::<TestScalar>::into)
+                .map(|s| TestScalar::from_str_via_hash(&s))
                 .map(Into::<[u64; 4]>::into)
                 .into(),
         );
@@ -663,7 +663,7 @@ mod tests {
         assert_eq!(from_borrowed_column, CommittableColumn::VarChar(Vec::new()));
 
         let varchar_data = ["12", "34", "56"];
-        let scalars = varchar_data.map(TestScalar::from);
+        let scalars = varchar_data.map(TestScalar::from_str_via_hash);
         let from_borrowed_column =
             CommittableColumn::from(&Column::VarChar((&varchar_data, &scalars)));
         assert_eq!(
@@ -807,7 +807,12 @@ mod tests {
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
-            CommittableColumn::VarChar(strings.map(TestScalar::from).map(<[u64; 4]>::from).into())
+            CommittableColumn::VarChar(
+                strings
+                    .map(|s| TestScalar::from_str_via_hash(&s))
+                    .map(<[u64; 4]>::from)
+                    .into()
+            )
         );
     }
 
@@ -1032,7 +1037,9 @@ mod tests {
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);
-        let scalars = values.map(TestScalar::from).map(<[u64; 4]>::from);
+        let scalars = values
+            .map(|s| TestScalar::from_str_via_hash(&s))
+            .map(<[u64; 4]>::from);
         let sequence_expected = Sequence::from(scalars.as_slice());
         let mut commitment_buffer = [CompressedRistretto::default(); 2];
         compute_curve25519_commitments(

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -177,7 +177,7 @@ mod tests {
     use crate::base::{
         commitment::naive_commitment::NaiveCommitment,
         database::{Column, OwnedColumn},
-        scalar::test_scalar::TestScalar,
+        scalar::{test_scalar::TestScalar, ScalarExt},
     };
     #[test]
     fn we_can_convert_from_columns() {
@@ -206,7 +206,7 @@ mod tests {
             CommittableColumn::VarChar(
                 column_b
                     .iter()
-                    .map(TestScalar::from)
+                    .map(|s| TestScalar::from_str_via_hash(s))
                     .map(<[u64; 4]>::from)
                     .collect(),
             ),
@@ -242,7 +242,7 @@ mod tests {
             CommittableColumn::VarChar(
                 column_b
                     .iter()
-                    .map(TestScalar::from)
+                    .map(|s| TestScalar::from_str_via_hash(s))
                     .map(<[u64; 4]>::from)
                     .collect(),
             ),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -139,7 +139,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, S::from(string)),
+                alloc.alloc_slice_fill_copy(length, S::from_str_via_hash(string)),
             )),
             LiteralValue::VarBinary(bytes) => {
                 // Convert the bytes to a slice of bytes references
@@ -177,7 +177,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             }
             OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
             OwnedColumn::VarChar(col) => {
-                let scalars = col.iter().map(S::from).collect::<Vec<_>>();
+                let scalars = col.iter().map(|s| S::from_str_via_hash(s)).collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)
@@ -460,7 +460,10 @@ mod tests {
             "Spațiu și Timp",
             "Spazju u Ħin",
         ];
-        let scalars = strs.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strs
+            .iter()
+            .map(|s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let owned_col = OwnedColumn::VarChar(
             strs.iter()
                 .map(ToString::to_string)

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -120,7 +120,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::ColumnOperationError, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        database::ColumnOperationError,
+        scalar::{test_scalar::TestScalar, ScalarExt},
+    };
 
     #[test]
     fn test_apply_index_op() {
@@ -138,14 +141,17 @@ mod tests {
         assert_eq!(result, Column::Scalar(&expected_scalars));
 
         let strings = vec!["a", "b", "c"];
-        let scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strings
+            .iter()
+            .map(|s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let column: Column<TestScalar> = Column::VarChar((&strings, &scalars));
         let indexes = [2, 1, 1];
         let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
         let expected_strings = vec!["c", "b", "b"];
         let expected_scalars = expected_strings
             .iter()
-            .map(TestScalar::from)
+            .map(|s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         assert_eq!(
             result,

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -153,7 +153,7 @@ impl RepetitionOp for ElementwiseRepeatOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::test_scalar::TestScalar;
+    use crate::base::scalar::{test_scalar::TestScalar, ScalarExt};
 
     #[test]
     fn test_column_repetition_op() {
@@ -165,13 +165,16 @@ mod tests {
 
         // Varchar
         let strings = vec!["a", "b", "c"];
-        let scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strings
+            .iter()
+            .map(|s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let column: Column<TestScalar> = Column::VarChar((&strings, &scalars));
         let result = ColumnRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
         let doubled_strings = vec!["a", "b", "c", "a", "b", "c"];
         let doubled_scalars = doubled_strings
             .iter()
-            .map(TestScalar::from)
+            .map(|s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         assert_eq!(
             result,
@@ -189,13 +192,16 @@ mod tests {
 
         // Varchar
         let strings = vec!["a", "b", "c"];
-        let scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strings
+            .iter()
+            .map(|s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let column: Column<TestScalar> = Column::VarChar((&strings, &scalars));
         let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
         let doubled_strings = vec!["a", "a", "b", "b", "c", "c"];
         let doubled_scalars = doubled_strings
             .iter()
-            .map(TestScalar::from)
+            .map(|s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         assert_eq!(
             result,

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,14 +1,15 @@
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
-    scalar::test_scalar::TestScalar,
+    scalar::{test_scalar::TestScalar, ScalarExt},
 };
 use bumpalo::Bump;
 
 #[test]
 fn we_can_filter_columns() {
     let selection = vec![true, false, true, false, true];
-    let str_scalars: [TestScalar; 5] = ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let str_scalars: [TestScalar; 5] = ["1", "2", "3", "4", "5"]
+        .map(TestScalar::from_str_via_hash);
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![
@@ -26,7 +27,10 @@ fn we_can_filter_columns() {
         vec![
             Column::BigInt(&[1, 3, 5]),
             Column::Int128(&[1, 3, 5]),
-            Column::VarChar((&["1", "3", "5"], &["1".into(), "3".into(), "5".into()])),
+            Column::VarChar((
+                &["1", "3", "5"],
+                &["1", "3", "5"].map(TestScalar::from_str_via_hash)
+            )),
             Column::Scalar(&[1.into(), 3.into(), 5.into()]),
             Column::Decimal75(
                 Precision::new(75).unwrap(),
@@ -39,7 +43,8 @@ fn we_can_filter_columns() {
 #[test]
 fn we_can_filter_columns_with_empty_result() {
     let selection = vec![false, false, false, false, false];
-    let str_scalars: [TestScalar; 5] = ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let str_scalars: [TestScalar; 5] = ["1", "2", "3", "4", "5"]
+        .map(TestScalar::from_str_via_hash);
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         database::{group_by_util::*, Column},
-        scalar::test_scalar::TestScalar,
+        scalar::{test_scalar::TestScalar, ScalarExt},
     },
     proof_primitive::dory::DoryScalar,
 };
@@ -162,7 +162,10 @@ fn we_can_aggregate_columns() {
     let selection = &[
         false, true, true, true, true, true, true, true, true, true, true, true,
     ];
-    let scals_b: Vec<TestScalar> = slice_b.iter().map(core::convert::Into::into).collect();
+    let scals_b: Vec<TestScalar> = slice_b
+        .iter()
+        .map(|s| TestScalar::from_str_via_hash(s))
+        .collect();
     let scals_d: Vec<TestScalar> = slice_d.iter().map(core::convert::Into::into).collect();
     let column_a = Column::BigInt(slice_a);
     let column_b = Column::VarChar((slice_b, &scals_b));
@@ -183,12 +186,12 @@ fn we_can_aggregate_columns() {
     )
     .expect("Aggregation should succeed");
     let scals_res = [
-        TestScalar::from("Cat"),
-        TestScalar::from("Dog"),
-        TestScalar::from("Cat"),
-        TestScalar::from("Dog"),
-        TestScalar::from("Cat"),
-        TestScalar::from("Dog"),
+        TestScalar::from_str_via_hash("Cat"),
+        TestScalar::from_str_via_hash("Dog"),
+        TestScalar::from_str_via_hash("Cat"),
+        TestScalar::from_str_via_hash("Dog"),
+        TestScalar::from_str_via_hash("Cat"),
+        TestScalar::from_str_via_hash("Dog"),
     ];
     let expected_group_by_result = &[
         Column::BigInt(&[1, 1, 2, 2, 3, 3]),

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -81,7 +81,7 @@ impl LiteralValue {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar(str) => str.into(),
+            Self::VarChar(str) => S::from_str_via_hash(str),
             Self::VarBinary(bytes) => S::from_byte_slice_via_hash(bytes),
             Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         database::{order_by_util::*, Column, ColumnType, TableOperationError},
-        scalar::test_scalar::TestScalar,
+        scalar::{test_scalar::TestScalar, ScalarExt},
     },
     proof_primitive::dory::DoryScalar,
 };
@@ -50,7 +50,10 @@ fn we_can_compare_indexes_by_columns_for_mixed_columns() {
     let slice_a = &["55", "44", "66", "66", "66", "77", "66", "66", "66", "66"];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];
     let slice_c = &[11, 55, 11, 44, 77, 11, 22, 55, 11, 22];
-    let scals_a: Vec<TestScalar> = slice_a.iter().map(core::convert::Into::into).collect();
+    let scals_a: Vec<TestScalar> = slice_a
+        .iter()
+        .map(|s| TestScalar::from_str_via_hash(s))
+        .collect();
     let column_a = Column::VarChar((slice_a, &scals_a));
     let column_b = Column::Int128(slice_b);
     let column_c = Column::BigInt(slice_c);

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -514,7 +514,10 @@ mod test {
             "ቦታ እና ጊዜ",
             "სივრცე და დრო",
         ];
-        let scalars = strs.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let scalars = strs
+            .iter()
+            .map(|s| TestScalar::from_str_via_hash(s))
+            .collect::<Vec<_>>();
         let col: Column<'_, TestScalar> = Column::VarChar((&strs, &scalars));
         let owned_col: OwnedColumn<TestScalar> = (&col).into();
         assert_eq!(
@@ -581,7 +584,7 @@ mod test {
     fn we_cannot_convert_scalars_to_owned_columns_if_varchar() {
         let scalars = ["a", "b", "c", "d", "e"]
             .iter()
-            .map(TestScalar::from)
+            .map(|s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         let column_type = ColumnType::VarChar;
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
@@ -659,7 +662,7 @@ mod test {
     fn we_cannot_convert_option_scalars_to_owned_columns_if_varchar() {
         let option_scalars = ["a", "b", "c", "d", "e"]
             .iter()
-            .map(|s| Some(TestScalar::from(*s)))
+            .map(|s| Some(TestScalar::from_str_via_hash(s)))
             .collect::<Vec<_>>();
         let column_type = ColumnType::VarChar;
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -108,7 +108,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
                 let scals: &mut [_] = self
                     .alloc
-                    .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
+                    .alloc_slice_fill_iter(col.iter().map(|s| CP::Scalar::from_str_via_hash(s)));
                 Column::VarChar((col, scals))
             }
             OwnedColumn::VarBinary(col) => {

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -9,7 +9,7 @@ use crate::base::{
     },
     database::{owned_table_utility::*, TableRef},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::test_scalar::TestScalar,
+    scalar::{test_scalar::TestScalar, ScalarExt},
 };
 
 #[test]
@@ -78,7 +78,7 @@ fn we_can_access_the_columns_of_a_table() {
     let col_slice: Vec<_> = vec!["a", "bc", "d", "e"];
     let col_scalars: Vec<_> = ["a", "bc", "d", "e"]
         .iter()
-        .map(core::convert::Into::into)
+        .map(|s| TestScalar::from_str_via_hash(s))
         .collect();
     match accessor.get_column(&table_ref_2, &"varchar".into()) {
         Column::VarChar((col, scals)) => {

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -9,7 +9,7 @@ use crate::base::{
     },
     database::{table_utility::*, TableRef},
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::test_scalar::TestScalar,
+    scalar::{test_scalar::TestScalar, ScalarExt},
 };
 use bumpalo::Bump;
 
@@ -91,7 +91,7 @@ fn we_can_access_the_columns_of_a_table() {
     let col_slice: Vec<_> = vec!["a", "bc", "d", "e"];
     let col_scalars: Vec<_> = ["a", "bc", "d", "e"]
         .iter()
-        .map(core::convert::Into::into)
+        .map(|s| TestScalar::from_str_via_hash(s))
         .collect();
     match accessor.get_column(&table_ref_2, &"varchar".into()) {
         Column::VarChar((col, scals)) => {

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -20,7 +20,7 @@
 use super::{Column, Table, TableOptions};
 use crate::base::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
-    scalar::Scalar,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
@@ -288,7 +288,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
         })
         .collect();
     let alloc_strings = alloc.alloc_slice_clone(&strings);
-    let scalars: Vec<S> = strings.iter().map(|s| (*s).into()).collect();
+    let scalars: Vec<S> = strings.iter().map(|s| S::from_str_via_hash(s)).collect();
     let alloc_scalars = alloc.alloc_slice_copy(&scalars);
     (name.into(), Column::VarChar((alloc_strings, alloc_scalars)))
 }

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -245,7 +245,10 @@ pub fn table_union<'a, S: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{map::IndexMap, scalar::test_scalar::TestScalar};
+    use crate::base::{
+        map::IndexMap,
+        scalar::{test_scalar::TestScalar, ScalarExt},
+    };
 
     #[test]
     fn we_can_union_no_columns() {
@@ -268,7 +271,7 @@ mod tests {
         let strings = vec!["a", "b", "c"];
         let scalars = strings
             .iter()
-            .map(|s| TestScalar::from(*s))
+            .map(|s| TestScalar::from_str_via_hash(s))
             .collect::<Vec<_>>();
         let col0: Column<TestScalar> = Column::VarChar((&strings, &scalars));
         let col1: Column<TestScalar> = Column::VarChar((&strings, &scalars));

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -138,17 +138,6 @@ impl<T: MontConfig<4>> From<&[u8]> for MontScalar<T> {
     }
 }
 
-/// Implements `From<T>` for [`MontScalar`] for string-like types by hashing the bytes.
-macro_rules! impl_from_for_mont_scalar_for_string {
-    ($tt:ty) => {
-        impl<T: MontConfig<4>> From<$tt> for MontScalar<T> {
-            fn from(x: $tt) -> Self {
-                x.as_bytes().into()
-            }
-        }
-    };
-}
-
 impl_from_for_mont_scalar_for_type_supported_by_from!(bool);
 impl_from_for_mont_scalar_for_type_supported_by_from!(u8);
 impl_from_for_mont_scalar_for_type_supported_by_from!(u16);
@@ -160,8 +149,6 @@ impl_from_for_mont_scalar_for_type_supported_by_from!(i16);
 impl_from_for_mont_scalar_for_type_supported_by_from!(i32);
 impl_from_for_mont_scalar_for_type_supported_by_from!(i64);
 impl_from_for_mont_scalar_for_type_supported_by_from!(i128);
-impl_from_for_mont_scalar_for_string!(&str);
-impl_from_for_mont_scalar_for_string!(String);
 
 impl<F: MontConfig<4>, T> From<&T> for MontScalar<F>
 where

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,7 +1,6 @@
 #![expect(clippy::module_inception)]
 
 use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
-use alloc::string::String;
 use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
@@ -13,7 +12,6 @@ pub trait Scalar:
     + core::fmt::Display
     + PartialEq
     + Default
-    + for<'a> From<&'a str>
     + Sync
     + Send
     + num_traits::One
@@ -52,9 +50,7 @@ pub trait Scalar:
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
     + RefInto<[u64; 4]>
-    + for<'a> core::convert::From<&'a String>
     + VarInt
-    + core::convert::From<String>
     + core::convert::From<i128>
     + core::convert::From<i64>
     + core::convert::From<i32>

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -51,6 +51,12 @@ pub trait ScalarExt: Scalar {
         let masked_val = hashed_val & Self::CHALLENGE_MASK;
         Self::from_wrapping(masked_val)
     }
+
+    /// Converts a string to a Scalar using a hash function.
+    #[must_use]
+    fn from_str_via_hash(value: &str) -> Self {
+        Self::from_byte_slice_via_hash(value.as_bytes())
+    }
 }
 
 impl<S: Scalar> ScalarExt for S {}
@@ -107,6 +113,14 @@ mod tests {
         assert_eq!(
             scalar_from_bytes, scalar_from_ref,
             "The masked keccak v256 of 'abc' must match"
+        );
+    }
+
+    #[test]
+    fn we_can_get_scalar_from_hashed_strings() {
+        assert_eq!(
+            TestScalar::from_str_via_hash("abc"),
+            TestScalar::from_byte_slice_via_hash(b"abc")
         );
     }
 

--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
@@ -1,7 +1,10 @@
 use crate::{
     base::{
         map::IndexSet,
-        scalar::{test_scalar::TestScalar, test_scalar_constants, Scalar, ScalarConversionError},
+        scalar::{
+            test_scalar::TestScalar, test_scalar_constants, Scalar, ScalarConversionError,
+            ScalarExt,
+        },
         slice_ops::{slice_cast, slice_cast_with},
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
@@ -370,9 +373,12 @@ fn the_one_scalar_is_the_multiplicative_identity() {
 
 #[test]
 fn the_empty_string_will_be_mapped_to_the_zero_scalar() {
-    assert_eq!(Curve25519Scalar::from(""), Curve25519Scalar::zero());
     assert_eq!(
-        Curve25519Scalar::from(<&str>::default()),
+        Curve25519Scalar::from_str_via_hash(""),
+        Curve25519Scalar::zero()
+    );
+    assert_eq!(
+        Curve25519Scalar::from_str_via_hash(<&str>::default()),
         Curve25519Scalar::zero()
     );
 }
@@ -380,8 +386,14 @@ fn the_empty_string_will_be_mapped_to_the_zero_scalar() {
 #[test]
 fn two_different_strings_map_to_different_scalars() {
     let s = "abc12";
-    assert_ne!(Curve25519Scalar::from(s), Curve25519Scalar::zero());
-    assert_ne!(Curve25519Scalar::from(s), Curve25519Scalar::from("abc123"));
+    assert_ne!(
+        Curve25519Scalar::from_str_via_hash(s),
+        Curve25519Scalar::zero()
+    );
+    assert_ne!(
+        Curve25519Scalar::from_str_via_hash(s),
+        Curve25519Scalar::from_str_via_hash("abc123")
+    );
 }
 
 #[test]
@@ -416,7 +428,7 @@ fn strings_of_arbitrary_size_map_to_different_scalars() {
             i,
             "testing string to scalar".repeat(dist.sample(&mut rng))
         );
-        assert!(prev_scalars.insert(Curve25519Scalar::from(s.as_str())));
+        assert!(prev_scalars.insert(Curve25519Scalar::from_str_via_hash(s.as_str())));
     }
 }
 
@@ -446,7 +458,7 @@ fn the_string_hash_implementation_uses_the_full_range_of_bits() {
         let mut bset = IndexSet::default();
 
         loop {
-            let s: Curve25519Scalar = dist.sample(&mut rng).to_string().as_str().into();
+            let s = Curve25519Scalar::from_str_via_hash(dist.sample(&mut rng).to_string().as_str());
             let bytes = s.to_bytes_le(); //Note: this is the only spot that these tests are different from the to_curve25519_scalar tests.
 
             let is_ith_bit_set = bytes[i / 8] & (1 << (i % 8)) != 0;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -117,7 +117,12 @@ impl ProvableQueryResult {
                         decode_and_convert::<S, S>(&self.data[offset..])
                     }
 
-                    ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
+                    ColumnType::VarChar => {
+                        let (value, used) =
+                            decode_and_convert::<&str, &str>(&self.data[offset..])?;
+                        let x = S::from_str_via_hash(value);
+                        Ok((x, used))
+                    }
                     ColumnType::VarBinary => {
                         let (raw_bytes, used) =
                             decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -1,5 +1,5 @@
 use super::{ProvableQueryResult, QueryError};
-use crate::base::scalar::test_scalar::TestScalar;
+use crate::base::scalar::{test_scalar::TestScalar, ScalarExt};
 use crate::{
     base::{
         database::{Column, ColumnField, ColumnType},
@@ -288,7 +288,7 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_mixed_data_types() {
     let values3 = ["abc", "de"];
     let scalars3 = values3
         .iter()
-        .map(|v| TestScalar::from(*v))
+        .map(|v| TestScalar::from_str_via_hash(v))
         .collect::<Vec<_>>();
     let values4 = [TestScalar::from(10), TestScalar::MAX_SIGNED];
 

--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -125,7 +125,10 @@ pub fn decode_multiple_elements<'a, T: ProvableResultElement<'a>>(
 mod tests {
 
     use super::*;
-    use crate::proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar;
+    use crate::{
+        base::scalar::ScalarExt,
+        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+    };
     use rand::{
         distributions::{Distribution, Uniform},
         rngs::StdRng,
@@ -230,10 +233,10 @@ mod tests {
         let value = "test string";
         let mut out = vec![0_u8; value.required_bytes()];
         value.encode(&mut out[..]);
-        let (decoded_value, read_bytes) =
-            decode_and_convert::<&str, Curve25519Scalar>(&out[..]).unwrap();
+        let (decoded_string, read_bytes) = <&str>::decode(&out[..]).unwrap();
+        let decoded_value = Curve25519Scalar::from_str_via_hash(decoded_string);
         assert_eq!(read_bytes, out.len());
-        assert_eq!(decoded_value, value.into());
+        assert_eq!(decoded_value, Curve25519Scalar::from_str_via_hash(value));
     }
 
     #[test]
@@ -311,10 +314,10 @@ mod tests {
             assert_eq!(read_bytes, out.len());
             assert_eq!(decoded_value, str_slice);
 
-            let (decoded_value, read_bytes) =
-                decode_and_convert::<&str, Curve25519Scalar>(&out[..]).unwrap();
+            let (decoded_string, read_bytes) = <&str>::decode(&out[..]).unwrap();
+            let decoded_value = Curve25519Scalar::from_str_via_hash(decoded_string);
             assert_eq!(read_bytes, out.len());
-            assert_eq!(decoded_value, str_slice.into());
+            assert_eq!(decoded_value, Curve25519Scalar::from_str_via_hash(str_slice));
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -1,6 +1,6 @@
 use super::{fold_columns, fold_vals};
 use crate::{
-    base::{database::Column, math::decimal::Precision},
+    base::{database::Column, math::decimal::Precision, scalar::ScalarExt},
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
 };
 use bumpalo::Bump;
@@ -10,19 +10,19 @@ use num_traits::Zero;
 fn we_can_fold_columns_with_scalars() {
     let expected = vec![
         Curve25519Scalar::from(77 + 1602 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("1"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("1"),
         Curve25519Scalar::from(77 + 2703 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("2"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("2"),
         Curve25519Scalar::from(77 + 3805 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("3"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("3"),
         Curve25519Scalar::from(77 + 4907 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("4"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("4"),
         Curve25519Scalar::from(77 + 5001 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("5"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("5"),
     ];
 
     let str_scalars: [Curve25519Scalar; 5] =
-        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+        ["1", "2", "3", "4", "5"].map(Curve25519Scalar::from_str_via_hash);
     let scalars = [2.into(), 3.into(), 5.into(), 7.into(), 1.into()];
     let mut columns = vec![
         Column::BigInt(&[1, 2, 3, 4, 5]),
@@ -51,11 +51,11 @@ fn we_can_fold_columns_with_scalars() {
 fn we_can_fold_columns_with_that_get_padded() {
     let expected = vec![
         Curve25519Scalar::from(77 + 1602 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("1"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("1"),
         Curve25519Scalar::from(77 + 2703 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("2"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("2"),
         Curve25519Scalar::from(77 + 3800 * 33)
-            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("3"),
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from_str_via_hash("3"),
         Curve25519Scalar::from(77 + 4900 * 33),
         Curve25519Scalar::from(77 + 5000 * 33),
         Curve25519Scalar::from(77),
@@ -66,7 +66,8 @@ fn we_can_fold_columns_with_that_get_padded() {
         Curve25519Scalar::from(77),
     ];
 
-    let str_scalars: [Curve25519Scalar; 3] = ["1".into(), "2".into(), "3".into()];
+    let str_scalars: [Curve25519Scalar; 3] =
+        ["1", "2", "3"].map(Curve25519Scalar::from_str_via_hash);
     let scalars = [2.into(), 3.into()];
     let mut columns = vec![
         Column::BigInt(&[1, 2, 3, 4, 5]),


### PR DESCRIPTION
Refs #228

@algora-pbc This implements the string-conversion checklist item from #228.

Changes:
- remove string-like `From` bounds from `Scalar`
- remove `From<&str>` / `From<String>` implementations for `MontScalar`
- add `ScalarExt::from_str_via_hash` as the explicit string hashing API
- update VarChar evaluation/conversion paths and tests to use the explicit method

Verification:
- `git diff --check`

Note: I could not run `cargo check` or `cargo test` locally because this environment does not have `cargo` installed.