### PR TITLE
fix: correct data accessor `get_length`

### DIFF
--- a/crates/proof-of-sql/src/base/database/data_accessor_impl.rs
+++ b/crates/proof-of-sql/src/base/database/data_accessor_impl.rs
@@ -68,7 +68,8 @@ impl<S: Scalar> MetadataAccessor for DataAccessorImpl<'_, S> {
             .get(table_ref)
             .expect("table does not exist")
             .table_data
-            .len()
+            .first()
+            .map_or(0, |(_, col)| col.len())
     }
 
     fn get_offset(&self, table_ref: &TableRef) -> usize {
@@ -109,7 +110,7 @@ mod tests {
     #[test]
     fn we_can_get_offset_and_length() {
         let column_id = Ident::from("test");
-        let column = Column::<TestScalar>::BigInt(&[3i64]);
+        let column = Column::<TestScalar>::BigInt(&[3i64, -2]);
         let table_data_accessor =
             TableDataAccessor::new(2, [(column_id.clone(), column)].into_iter().collect());
         let table_ref = TableRef::from_names(Some("test"), "table");
@@ -118,9 +119,21 @@ mod tests {
                 .into_iter()
                 .collect(),
         );
-        assert_eq!(data_accessor.get_length(&table_ref), 1);
+        assert_eq!(data_accessor.get_length(&table_ref), 2);
         assert_eq!(data_accessor.get_offset(&table_ref), 2);
         assert_eq!(data_accessor.get_column(&table_ref, &column_id), column);
+    }
+
+    #[test]
+    fn we_can_get_length_for_empty_tables() {
+        let table_data_accessor = TableDataAccessor::<TestScalar>::new(2, [].into_iter().collect());
+        let table_ref = TableRef::from_names(Some("test"), "table");
+        let data_accessor = DataAccessorImpl::new(
+            [(table_ref.clone(), table_data_accessor)]
+                .into_iter()
+                .collect(),
+        );
+        assert_eq!(data_accessor.get_length(&table_ref), 0);
     }
 
     #[cfg(feature = "arrow")]
@@ -142,7 +155,7 @@ mod tests {
                 .collect(),
         );
 
-        assert_eq!(data_accessor_impl.get_length(&table_ref), 1);
+        assert_eq!(data_accessor_impl.get_length(&table_ref), 2);
         assert_eq!(data_accessor_impl.get_offset(&table_ref), 1);
         assert_eq!(
             data_accessor_impl.get_column(&table_ref, &Ident::new("BOOLS")),


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The `DataAccessorImpl` is incorrectly returning the number of columns for `get_length`, not the number of rows.

# What changes are included in this PR?

Correcting the logic for `get_length`

# Are these changes tested?
Yes
